### PR TITLE
E2E Smoke hardening + NestJS refactor spec & Phase 0 plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,24 @@ BlastBench/
 | `pnpm lint` | Biome lint over `web/src/` |
 | `pnpm format` | Biome format over `web/src/` |
 | `pnpm type-check` | TypeScript no-emit check |
-| `pnpm test` | Vitest run |
+| `pnpm test` | Vitest run (web, jsdom + setup files wired in) |
 | `pnpm test:watch` | Vitest watch mode |
+| `pnpm test:backend` | Vitest for the Express backend (uses `vitest.backend.config.ts`) |
+
+> **Always run `pnpm test`**, not a bare `vitest` or `pnpm exec vitest ...`. The
+> configured script wires up `jsdom`, test setup files (`@testing-library/jest-dom`
+> matchers), and the correct config path. Running vitest outside this script
+> will skip setup and trip spurious "localStorage is not defined" failures.
+
+Before a PR lands, all three of these must pass:
+
+```bash
+pnpm type-check
+pnpm lint
+pnpm test
+```
+
+Conventions and the full debt list live in [`docs/project-standards.md`](docs/project-standards.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ pnpm dev
 
 Vite serves the frontend on <http://localhost:5173>. Express serves the API on <http://localhost:3001>. Vite proxies `/api/*` through to Express. Edit files in `web/src/`; HMR updates the browser.
 
+### Running multiple worktrees in parallel
+
+This repo is typically checked out as a bare + worktree layout (`main/` + `feat/<name>/`). Each worktree has its own `node_modules` and can run `pnpm dev` independently, **as long as the ports differ**. Override via env:
+
+```bash
+# worktree A (defaults)
+pnpm dev
+
+# worktree B (in another shell)
+VITE_PORT=5174 API_PORT=3002 pnpm dev
+```
+
+The Vite config forwards `/api/*` to `http://localhost:${API_PORT}` so both pairs stay self-consistent. `strictPort: true` means a wrong setting fails loudly instead of auto-falling-back.
+
 ## Production build
 
 ```bash

--- a/docs/project-standards.md
+++ b/docs/project-standards.md
@@ -135,6 +135,18 @@ export const useXxxStore = create<XxxState>()(
 - **`components/common/*` & `components/connection/*`** 可以 i18n、可以读全局 store,但**不得**读 feature store。
 - **feature 子组件** 放 `features/<name>/` 下,可以自由读该 feature 的 store。
 
+### 连接组件:`EndpointPicker` vs `EndpointSelector`
+
+两者都在 `components/connection/`,但定位不同,不得互换:
+
+| 组件 | 位置 | 用于 |
+|---|---|---|
+| **`EndpointPicker`** | 内嵌在页面 body 的 Endpoint 卡片里 | 用户需要**同时看到并编辑** API URL / Key / Model 的主流程页(E2E Smoke、Load Test) |
+| **`EndpointSelector`** | 页面 header 的右上角紧凑位 | 端点是辅助性的、用户主要**只是切换**已保存连接(Request Debug) |
+
+判断规则:**如果页面主流程里用户要改 URL / Key / Model,用 `EndpointPicker`;如果只是从下拉里挑一个已保存的,用 `EndpointSelector`。**
+不要在同一个页面里同时出现两个连接组件。
+
 ### 可访问性(最低要求)
 
 - 所有 `Input` / `Textarea` 必须有 `<Label htmlFor>` 关联,或有 `aria-label`。当前 `EndpointPicker` 里没绑定 id,后续修改该文件时请一并修掉。

--- a/docs/project-standards.md
+++ b/docs/project-standards.md
@@ -1,0 +1,298 @@
+# ModelDoctor · 前端工程约束
+
+> 指导后续任务迭代开发。**凡新增页面、组件、store、API 必须遵守本文**;有冲突以此文为准,修改本文前需在 PR 描述里说明动机。
+
+---
+
+## 1. 技术栈与工具(不随意新增依赖)
+
+| 领域 | 选型 | 备注 |
+|---|---|---|
+| 构建 | Vite 5 | 配置在 `web/vite.config.ts` |
+| 框架 | React 18 + TypeScript 严格模式 | `strict`, `noUnusedLocals`, `noUnusedParameters`, `noFallthroughCasesInSwitch` 全开 |
+| 路由 | react-router-dom 7 | 声明式 `RouteObject[]`,集中在 `web/src/router/index.tsx` |
+| 状态 | Zustand 4 + `persist` 中间件 | 不引入 Redux / Jotai / MobX |
+| 异步数据 | @tanstack/react-query 5 | 只用于**有副作用的异步**(mutation + 服务端请求),不用作全局状态 |
+| 表单 | react-hook-form + zod(`@hookform/resolvers/zod`) | 有校验要求的表单走 RHF;仅 UI 暂存可直接由 Zustand store 托管 |
+| 样式 | Tailwind 3.4 + 设计 token + shadcn/ui 风格 | **禁止写原生 HEX / RGB 颜色**,一律走 `bg-background` / `text-foreground` / `text-destructive` 等 token |
+| 图标 | lucide-react | 不混入其它图标库 |
+| i18n | i18next + react-i18next | 所有用户可见文案都走 `t()`;每个 feature 一个命名空间 |
+| Lint / 格式化 | Biome 1.9 一键 | `pnpm lint` / `pnpm format`;无 ESLint / Prettier |
+| 测试 | Vitest + jsdom + testing-library | `pnpm test`;每个 store 至少一个 happy-path 单测 |
+
+**新增依赖**需在 PR 描述里说明理由。能用现有依赖解决的问题不引入新库。
+
+---
+
+## 2. 目录分层
+
+```
+web/src/
+├── components/
+│   ├── ui/          ← shadcn/ui 原子组件(Button、Select、Dialog …)。不含业务。
+│   ├── common/      ← 跨 feature 的展示型组件(PageHeader、EmptyState …)
+│   ├── sidebar/     ← 顶层布局外壳所需组件
+│   └── connection/  ← 与 connections 概念绑定的业务通用组件(EndpointPicker …)
+├── features/<name>/ ← 一个功能一个文件夹,自包含
+│   ├── <Name>Page.tsx   ← 顶层页面
+│   ├── store.ts         ← Zustand store(见 §3)
+│   ├── types.ts         ← 该 feature 的类型定义
+│   └── …                ← 子组件、子 store、子 schemas
+├── stores/          ← 跨 feature 的全局 store(connections、theme、locale、sidebar)
+├── lib/             ← 纯函数工具(api-client、curl-parser、i18n、utils)
+├── types/           ← 跨 feature 的 domain 类型(Connection、EndpointValues …)
+├── router/          ← 路由表
+├── layouts/         ← AppShell 外壳
+├── locales/<lang>/  ← i18n 资源,一个命名空间一份 JSON
+└── styles/          ← 全局样式 + tokens
+```
+
+**边界规则:**
+- `components/ui/*` 不得依赖 `features/*` 或业务 store。
+- `components/common/*` 不得依赖 `features/*`,但可以读**全局** store(theme/locale)。
+- `features/<a>/*` **禁止**从 `features/<b>/*` import。跨 feature 的东西抽到 `components/` 或 `lib/`。
+- `stores/` 下只放跨 feature 的 store,feature 内部 store 放回各 `features/<name>/store.ts`。
+
+---
+
+## 3. State 管理规范(Zustand 模式)
+
+### 每个 store 的标准骨架
+
+```ts
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface XxxState {
+  // ---- data ----
+  // (按语义分组,瞬态字段写明 "Transient — not persisted")
+
+  // ---- actions ----
+  resetResults: () => void;  // 只清运行态产出(results / error / progress / running)
+  reset: () => void;         // 全量回到 INITIAL
+}
+
+/** 数据字段默认值的唯一真实源。actions 不能进 INITIAL。 */
+const INITIAL = { /* only data fields */ } satisfies Omit<XxxState, keyof Actions>;
+
+export const useXxxStore = create<XxxState>()(
+  persist(
+    (set) => ({
+      ...INITIAL,
+      // actions
+      resetResults: () => set({ /* transient subset */ }),
+      reset: () => set(INITIAL),
+    }),
+    {
+      name: "md.<feature>.v<n>",
+      partialize: (s) => ({ /* only user-input fields, NOT transient output */ }),
+    },
+  ),
+);
+```
+
+### 硬性约定
+
+1. **`INITIAL` 常量作为 defaults 与 `reset()` 的唯一来源**;默认值不允许重复写两遍。
+2. **每个有「运行态 + 输入态」区别的 store 必须暴露 `resetResults()`**;没有运行态的 store 可以省略。
+3. **`partialize` 白名单**明确列出要持久化的字段。瞬态字段(`error` / `progress` / `running` / `lastResult` / `lastResponse` / `lastError` 等)**禁止**持久化,避免刷新页面看到陈旧数据。
+4. **持久化 key 命名 `md.<feature>.v<n>`**;schema 不兼容改动时 `v` 递增,不要就地改结构。
+5. **瞬态运行态也进 store,不散在组件 `useState`**(理由:便于 `resetResults` 一次清干净、也便于跨组件共享、易测试)。**例外**:纯 UI 开关(`revealKey`、`detailsOpen` 这类)留在组件局部 `useState` 即可。
+6. **切换连接时调 `slice.setSelected(id); slice.resetResults();`** —— 这是页面编排,不是通用组件的职责。不要给 `EndpointPicker` 加 `onReset` prop。
+7. **Action 命名**:`setXxx`(局部 setter)、`patch(key, value)`(通用 patch,仅在字段过多时使用)、`resetResults`、`reset`。避免 `clearAll`、`doReset` 等不一致命名。
+8. **Selector 粒度:** 组件只订阅自己需要的字段,`const x = useStore((s) => s.x)`;不要全量 `const s = useStore()` 然后取属性,会导致无关更新也重渲染。**例外**:页面顶层可以全量订阅,子组件必须粒度订阅。
+
+### 已有 store 的范例
+
+- 参照 `features/e2e-smoke/store.ts` 与 `features/load-test/store.ts`(已按此范式重构)。
+- 全局 store 不需要 `INITIAL` 约定(字段少、无「运行态」概念),按 `stores/theme-store.ts` 的形态写。
+
+---
+
+## 4. API 调用规范
+
+1. **前端一律走 `@/lib/api-client`**(`api.get` / `api.post`)。**禁止**直接 `fetch('/api/...')`。
+2. **错误类型:** `ApiError(status, message)`;所有调用方要准备 `catch (e) { if (e instanceof ApiError) … }` 或通过 react-query 的 `onError`。
+3. **异步副作用:** 用 `useMutation`(或 `useQuery`),不要手写 `useState({ loading, data, error })` 模板。
+4. **服务端所有路由挂在 `/api/*`**(见 `server.js`)。前端 dev 通过 Vite 的 `proxy` 走到 `:3001`。
+5. **SSE / streaming**:目前未使用;如需引入,应走 `api-client` 新增 `stream` 方法统一封装。
+6. **Schema 校验:** 来自**用户输入**或**不可信源**的数据用 zod 校验(参考 `features/connections/schema.ts`);**可信本地 API** 的响应可以直接类型断言,但应拿到回复后立刻归一化,**不要把任意 JSON 散播到组件树**。
+
+---
+
+## 5. UI / 组件规范
+
+### 颜色与排版
+
+- 只用 token:`bg-background` / `bg-card` / `bg-muted` / `text-foreground` / `text-muted-foreground` / `text-destructive` / `text-success` / `text-warning` / `border-border` / `border-input` / `ring-ring`。
+- **禁止**在 JSX / className 里写 `#fff` / `rgb(…)` / `red-500` 之类的裸色值。新增 token 改 `web/src/styles/globals.css` 与 `web/tailwind.config.ts`,同时改亮色和暗色两套。
+- 字体:通过 `body` 的 `font-sans`(tailwind 默认 stack)。代码 / 数据用 `font-mono`。
+- 圆角一律走 `rounded-md` / `rounded-lg`,半径 token 是 `--radius: 0.5rem`。
+
+### 组件分层
+
+- **`components/ui/*`** 等同于 shadcn/ui 的原子层。**禁止**加业务文案、禁止 i18n;只接受 `className` 和基础 props。
+- **`components/common/*` & `components/connection/*`** 可以 i18n、可以读全局 store,但**不得**读 feature store。
+- **feature 子组件** 放 `features/<name>/` 下,可以自由读该 feature 的 store。
+
+### 可访问性(最低要求)
+
+- 所有 `Input` / `Textarea` 必须有 `<Label htmlFor>` 关联,或有 `aria-label`。当前 `EndpointPicker` 里没绑定 id,后续修改该文件时请一并修掉。
+- 可交互元素(button、label)必须有可见焦点样式(shadcn 组件默认带 `focus-visible:ring-*`,不要删除)。
+- 图标按钮必须加 `aria-label`。
+- 表单错误:inline 展示 + `text-destructive` token,**禁止** `window.alert()`(历史遗留在 `E2ESmokePage.runProbes` 要改)。
+
+### 反馈模式
+
+| 场景 | 正确做法 | 禁止 |
+|---|---|---|
+| 表单校验错误 | inline `<p className="text-destructive">` 或 shadcn `<Alert variant="destructive">` | `alert()` / `confirm()` |
+| 异步成功提示 | shadcn `<Alert>` 或 inline 小 chip | `alert()` |
+| 需要用户决策 | shadcn `<AlertDialog>` | `confirm()` / `prompt()` |
+| 即将引入(尚未引入) | 全局 toast 系统(建议 `sonner`) | —— |
+
+---
+
+## 6. i18n 规范
+
+1. **所有用户可见字符串必须走 `t()`**,包括占位符 `placeholder`、`aria-label`、错误文案、Badge 文字。**禁止**在 JSX / JS 字面量中写中文或英文文案。
+2. **命名空间划分:** 每个 feature 一个 namespace(`load-test` / `e2e` / `debug` / `connections` / `settings` / `sidebar`),跨 feature 复用的放 `common`。
+3. **新 key 必须同时加 `zh-CN` 和 `en-US` 两份**,并在 `lib/i18n.ts` 的 resources / ns 数组里注册。缺失的 key 在构建时会穿透显示,视为严重 UI bug。
+4. **key 命名:**`<section>.<field>` 两层即可(`fields.apiUrl`、`actions.save`、`alerts.failure`);过多层级难维护。
+5. **插值用 `{{var}}`,不要字符串拼接**(`t("alerts.failure", { error: msg })`)。
+
+---
+
+## 7. 表单规范
+
+- **有服务端持久化、有校验要求的表单**(如「新建/编辑连接」)走 react-hook-form + zod + shadcn `form`。参考 `ConnectionDialog`。
+- **仅 UI 暂存的表单**(Load Test 参数、Request Debug 请求体等)直接受 Zustand store 托管即可,不必引 RHF。理由:每个字段都要跨导航持久化,RHF 的本地 form state 反而绕道。
+- **cURL 解析的填充逻辑**已在 `lib/curl-parser.ts` 提供统一入口,新的导入场景应复用它,不要再各自实现一遍。**TODO** —— 当前 `EndpointPicker.onParseCurl` 与 `ConnectionDialog.onParseCurl` 有重复逻辑,后续应抽到 `lib/apply-curl-to-endpoint.ts`。
+
+---
+
+## 8. 路由与侧边栏
+
+1. 路由配置唯一入口:`web/src/router/index.tsx`。新增页面 = 加一条 `{ path, element }`。
+2. 侧边栏是**数据驱动**的(`components/sidebar/sidebar-config.tsx`),新功能:
+   - 在 `sidebarGroups` 里加一条 `SidebarItem`;
+   - 如果尚未实装,`comingSoon: true` 会自动挂 Badge 并走 `ComingSoonRoute` 占位;
+   - 新功能的 `labelKey` 必须同步更新 `locales/<lang>/sidebar.json`。
+3. 错误兜底:根路由的 `errorElement: <ErrorPage />` 处理未捕获异常;`*` catch-all 指向 `<NotFoundPage />`。业务代码不需要自己加 top-level try/catch。
+
+---
+
+## 9. 测试基线
+
+1. **`pnpm test` 必须绿**(CI 前置条件)。跑法:`pnpm test` 而不是任意自定义命令(会漏掉 `setupFiles` 和 jsdom env)。
+2. **每个 Zustand store 至少一条 happy-path 测试**(参见 `connections-store.test.ts`、`theme-store.test.ts`)。
+3. **纯函数(parser、formatter、utils)必须带测试**,`curl-parser.test.ts` 是范式。
+4. **UI 组件**目前不强制单测,但复杂交互页(E2E、Load Test)后续应加 `@testing-library/react` 的集成测试。
+5. 后端跑 `pnpm test:backend`(独立 config `vitest.backend.config.ts`)。
+
+---
+
+## 10. 服务端规范(supplementary)
+
+- 路由分模块:`src/routes/<feature>.js`,通过 `app.use("/api", <router>)` 挂载。
+- Probe / builder 分层:`src/probes/*.js` 组合 `src/builders/*.js` 得到请求体。**禁止**在 route 里直接写请求体字面量。
+- 新增 API 必须在前端 `lib/api-client.ts` 调用时用明确 TypeScript 类型,不滥用 `any`。
+
+---
+
+## 11. Git / 分支工作流
+
+- 仓库是 **bare + worktree 布局**(`/Users/fangyong/vllm/modeldoctor/` 下的 `.bare` + `main/` + `feat/<name>/`)。
+- **feature 开发只在对应 worktree 里改**,**不要**同时改 `main/` 工作区(即使开发服务器跑在另一个 worktree,也不要双写)。让 `main` 通过合并获取变更。
+- 开发服务器端口冲突处理:每个 worktree 用不同的 `VITE_PORT` / `API_PORT`,见 README(TODO:写清楚)。
+- 提交信息沿用 `type: short desc` 前缀(feat/fix/refactor/ui/chore/docs/i18n),参见 `git log`。
+
+---
+
+## 12. 反模式清单(代码评审时逐条检查)
+
+- [ ] 在 JSX 里用 `alert()` / `confirm()` / `prompt()`
+- [ ] 用裸色值(`#fff`、`red-500`)代替 token
+- [ ] 在组件里硬编码中英文文案
+- [ ] 把瞬态运行态(error / progress / loading)留在组件 `useState`
+- [ ] 绕过 `api-client`,直接 `fetch('/api/...')`
+- [ ] 跨 feature 直接 import(`features/a` → `features/b`)
+- [ ] store 里 defaults 和 `reset` 两处写默认值
+- [ ] 新 i18n key 只加中文或只加英文
+- [ ] `components/ui/*` 里加业务逻辑或 `useTranslation`
+- [ ] 组件暴露命令式 `ref.reset()`(React 社区反模式;declarative store action 才是标准)
+- [ ] 把 `any` 引入公共类型
+- [ ] Zustand selector 全量订阅 + 属性读取(应粒度订阅)
+
+---
+
+## 13. 当前待清理清单(存量债务)
+
+以下是本次审计出的具体问题,按优先级排列。**每条都应转成一个任务或 issue**,逐条消化。
+
+### 高优先级(影响用户体验或正确性)
+
+1. **`LocaleStore` 初次访问可能语言错配**
+   `lib/i18n.ts` 硬写 `lng: "en-US"`;`stores/locale-store.ts` 的 `onRehydrateStorage` 只在 `state` 有值时改语言。首次访问 zh 浏览器的用户理论上可能看到英文闪现。
+   **改法:** `main.tsx` 在 `createRoot(...).render(...)` 之前同步执行
+   `i18n.changeLanguage(useLocaleStore.getState().locale)`。
+
+2. **`E2ESmokePage.runProbes` 用 `window.alert()`**(file:`features/e2e-smoke/E2ESmokePage.tsx:24`)
+   违反反模式清单。改法:禁用「运行」按钮当 `apiUrl/apiKey/model` 任一为空,tooltip 提示原因。
+
+3. **`EndpointPicker` 表单里的 `<Label>` 没有 `htmlFor`**(多处)
+   无障碍问题。给所有 `Input`/`Textarea` 加 `id`,`Label` 加 `htmlFor`。
+
+### 中优先级(结构 / 可维护性)
+
+4. **两个连接组件并存:`EndpointPicker`(表单型)与 `EndpointSelector`(下拉型)**
+   Request Debug 用前者顶部 bar,其它页面用后者内嵌。建议:
+   - 保留 `EndpointPicker` 作为「完整表单 + 切换」入口(嵌在页面卡片里);
+   - 保留 `EndpointSelector` 作为「紧凑切换 + 管理入口」(放页面 header);
+   - 在本文档中登记两者各自职责,不再混用。
+   ⇒ **已登记到 §5**。
+
+5. **`EndpointPicker.saveOpen` 浮层 vs `EndpointSelector.namePromptOpen` 浮层重复**
+   两处都实现了「另存为...」名字输入的小浮层,UI 不一致。统一到 `ConnectionDialog`(dialog 已支持 create 模式),去掉这两个浮层。
+
+6. **cURL 解析填表逻辑重复两处**(`EndpointPicker.onParseCurl` / `ConnectionDialog.onParseCurl`)
+   抽到 `lib/apply-curl-to-endpoint.ts` 返回 `{ next: EndpointValues; filled: string[] }`。
+
+7. **`LoadTestSlice.modified` / `LoadTestSlice.curlExpanded` 是死字段**
+   没有任何读点。删除。
+
+8. **Request Debug 的 `modified={false}` 硬编码**(`RequestDebugPage.tsx:139`)
+   要么接入真实 dirty 计算,要么从 `EndpointSelector` props 里摘掉 `modified`。
+
+### 低优先级(收尾)
+
+9. **`E2EApiResponse` / 其它本地接口响应 interface 分散在各页面**
+   抽到 `features/<name>/types.ts` 或 `lib/api-types.ts`。
+
+10. **`E2ESmokePage` 清空结果按钮与「切换连接自动清空」现在独立**
+    可以考虑在 `resetResults` 之外再加 `resetEndpoint()`,给未来的「全部重置」按钮铺路。暂不紧急。
+
+---
+
+## 14. 新增 feature 的标准动作清单
+
+面对「加一个新页面」的任务时,按这个 checklist 走:
+
+1. **路由:** `web/src/router/index.tsx` 加 `{ path: "/<name>", element: <XxxPage /> }`;占位阶段可用 `<ComingSoonRoute icon={…} itemKey="…" />`。
+2. **侧边栏:** `components/sidebar/sidebar-config.tsx` 在对应 group 加 `SidebarItem`;未实装写 `comingSoon: true`。
+3. **i18n:** `locales/zh-CN/<name>.json` 与 `locales/en-US/<name>.json` 两份,`lib/i18n.ts` 注册新 namespace。
+4. **目录:** 新建 `features/<name>/`,最小包含 `XxxPage.tsx` + `store.ts` + `types.ts`。
+5. **Store:** 按 §3 模板写,包含 `INITIAL` / `resetResults` / `reset` / `partialize`。
+6. **连接:** 需要调模型 API 的页面,直接用 `EndpointPicker` 内嵌于 Endpoint 卡片。
+7. **切换连接编排:** 页面 `onSelect={(id) => { slice.setSelected(id); slice.resetResults(); }}`。
+8. **调用后端:** `api.post<TResponse>("/api/<feature>", body)` + `useMutation`,**不要**直接 `fetch`。
+9. **测试:** 至少为新 store 写 happy-path 测试;纯函数逻辑补单测。
+10. **验证:** `pnpm type-check && pnpm lint && pnpm test` 全绿。
+
+---
+
+## 15. 变更本文
+
+本文是**单一真实源**。修改规则或新增约定时:
+- 在 PR 描述里列出变更条款;
+- 如果变更会让既有代码违规,PR 必须一并修掉既有违规,或新增条目到「存量债务」。

--- a/docs/project-standards.md
+++ b/docs/project-standards.md
@@ -158,10 +158,12 @@ export const useXxxStore = create<XxxState>()(
 
 | 场景 | 正确做法 | 禁止 |
 |---|---|---|
-| 表单校验错误 | inline `<p className="text-destructive">` 或 shadcn `<Alert variant="destructive">` | `alert()` / `confirm()` |
-| 异步成功提示 | shadcn `<Alert>` 或 inline 小 chip | `alert()` |
+| 表单校验错误(随输入即时反馈) | inline `<p className="text-destructive">` 紧贴字段 | `alert()` / `confirm()` |
+| 结果区常驻状态(压测完成、E2E 各 probe 成败) | shadcn `<Alert>` 或结果卡片(保留细节、可复制) | 用 toast 顶掉详细数据 |
+| 瞬态操作反馈(cURL 解析成功 / 保存成功 / 连接已更新) | sonner `toast.success` / `toast.error`(右下角、2 秒自动消失) | inline 小 chip + `setTimeout` 手动消失 |
 | 需要用户决策 | shadcn `<AlertDialog>` | `confirm()` / `prompt()` |
-| 即将引入(尚未引入) | 全局 toast 系统(建议 `sonner`) | —— |
+
+sonner 的 `<Toaster />` 在 `App.tsx` 里挂载,自动跟随 `useThemeStore.mode`。页面内引入 `import { toast } from "sonner"` 直接用。
 
 ---
 

--- a/docs/project-standards.md
+++ b/docs/project-standards.md
@@ -218,7 +218,11 @@ sonner 的 `<Toaster />` 在 `App.tsx` 里挂载,自动跟随 `useThemeStore.mod
 
 - 仓库是 **bare + worktree 布局**(`/Users/fangyong/vllm/modeldoctor/` 下的 `.bare` + `main/` + `feat/<name>/`)。
 - **feature 开发只在对应 worktree 里改**,**不要**同时改 `main/` 工作区(即使开发服务器跑在另一个 worktree,也不要双写)。让 `main` 通过合并获取变更。
-- 开发服务器端口冲突处理:每个 worktree 用不同的 `VITE_PORT` / `API_PORT`,见 README(TODO:写清楚)。
+- 开发服务器端口:默认 Vite `5173` / Express `3001`。多 worktree 同时跑 `pnpm dev` 时,后续的 worktree 用 env 覆盖,例如
+  ```bash
+  VITE_PORT=5174 API_PORT=3002 pnpm dev
+  ```
+  `vite.config.ts` 里 `server.port` 和 `proxy["/api"].target` 都读这对环境变量,保证 Vite→Express 的代理对齐(见 README)。
 - 提交信息沿用 `type: short desc` 前缀(feat/fix/refactor/ui/chore/docs/i18n),参见 `git log`。
 
 ---

--- a/docs/project-standards.md
+++ b/docs/project-standards.md
@@ -256,14 +256,13 @@ sonner 的 `<Toaster />` 在 `App.tsx` 里挂载,自动跟随 `useThemeStore.mod
 5. ✅ **「另存为」UI 重复** —— 已统一到 `ConnectionDialog`,`EndpointSelector` 的 `NamePrompt` 与无人使用的 save 回调已删。
 6. ✅ **cURL 解析填表重复** —— 已抽到 `lib/apply-curl-to-endpoint.ts`,两处消费者共用。
 7. ✅ **`LoadTestSlice.modified` / `curlExpanded`** —— 已删除(含 `setModified` 与 `@deprecated ManualEndpoint` 类型别名)。
-8. **`RequestDebugPage` 的 `modified={false}` 硬编码**(`RequestDebugPage.tsx`)
-   `EndpointSelector.modified?` 已保留为可选。要么接入真实 dirty 计算(比较当前 `url` / `headers` / `body` 与选中连接派生值),要么直接去掉 prop 传递。
+8. ✅ **`RequestDebugPage` 的 `modified={false}`** —— 已删除该 prop 传递。Request Debug 不承载「保存当前修改回连接」语义,dirty 指示器在此无意义。
 
 ### 低优先级(收尾)
 
 9. ✅ **本地接口响应 interface 散在 Page** —— 已移到各 feature 的 `types.ts`(`E2ETestResponse` / `DebugProxyResponse`)。
 
-10. **未提供「全部重置」按钮** —— 各 store 已有 `reset()` 动作,但没有页面 UI 触发。等有明确需求再加,不急。
+10. ✅ **`reset()` 无 UI 触发** —— Settings 页新增「清除测试数据」按钮,调用三个 feature store 的 `reset()`,保留连接库和外观偏好。与原「重置应用状态」(nuclear,清 localStorage + reload)形成两档粒度。
 
 ---
 

--- a/docs/project-standards.md
+++ b/docs/project-standards.md
@@ -268,6 +268,12 @@ sonner 的 `<Toaster />` 在 `App.tsx` 里挂载,自动跟随 `useThemeStore.mod
 
 10. ✅ **`reset()` 无 UI 触发** —— Settings 页新增「清除测试数据」按钮,调用三个 feature store 的 `reset()`,保留连接库和外观偏好。与原「重置应用状态」(nuclear,清 localStorage + reload)形成两档粒度。
 
+### 刻意不做的事(反向决议,避免反复提起)
+
+- **移动端 / 小屏响应式侧边栏**:目前只做了桌面可折叠的 icon-only 轨(56px),未做 Sheet/Drawer 的 mobile 模式。原因:项目是面向开发者的诊断工具,存在大量宽表格 / monospace 输出,移动端使用场景少;投入产出比低。未来如有真实移动用户需求再加。
+- **本地 API 响应 zod 运行时校验**:§4 已明确「可信本地 API 类型断言即可」。只有**用户输入**与**不可信源**才用 zod(参考 `features/connections/schema.ts`)。在可信边界内引入 zod 只增加样板,不买额外安全。
+- **侧边栏按 locale 重排**:当前 en/zh 两种语言的 group 逻辑顺序相同,没有真实错位。不做字母序重排,保持作者指定的语义顺序(performance / correctness / observability / debug)。
+
 ---
 
 ## 14. 新增 feature 的标准动作清单

--- a/docs/project-standards.md
+++ b/docs/project-standards.md
@@ -179,7 +179,7 @@ export const useXxxStore = create<XxxState>()(
 
 - **有服务端持久化、有校验要求的表单**(如「新建/编辑连接」)走 react-hook-form + zod + shadcn `form`。参考 `ConnectionDialog`。
 - **仅 UI 暂存的表单**(Load Test 参数、Request Debug 请求体等)直接受 Zustand store 托管即可,不必引 RHF。理由:每个字段都要跨导航持久化,RHF 的本地 form state 反而绕道。
-- **cURL 解析的填充逻辑**已在 `lib/curl-parser.ts` 提供统一入口,新的导入场景应复用它,不要再各自实现一遍。**TODO** —— 当前 `EndpointPicker.onParseCurl` 与 `ConnectionDialog.onParseCurl` 有重复逻辑,后续应抽到 `lib/apply-curl-to-endpoint.ts`。
+- **cURL 解析的填充逻辑**已在 `lib/curl-parser.ts`(词法 / 语法)与 `lib/apply-curl-to-endpoint.ts`(ParsedCurl → EndpointValues 的 patch)分两层提供;新的导入场景复用这两个,不要各自实现一遍。
 
 ---
 
@@ -240,49 +240,28 @@ export const useXxxStore = create<XxxState>()(
 
 ## 13. 当前待清理清单(存量债务)
 
-以下是本次审计出的具体问题,按优先级排列。**每条都应转成一个任务或 issue**,逐条消化。
+以下是审计出的具体问题,按优先级排列。**每条都应转成一个任务或 issue**,逐条消化。✅ 表示已完成。
 
 ### 高优先级(影响用户体验或正确性)
 
-1. **`LocaleStore` 初次访问可能语言错配**
-   `lib/i18n.ts` 硬写 `lng: "en-US"`;`stores/locale-store.ts` 的 `onRehydrateStorage` 只在 `state` 有值时改语言。首次访问 zh 浏览器的用户理论上可能看到英文闪现。
-   **改法:** `main.tsx` 在 `createRoot(...).render(...)` 之前同步执行
-   `i18n.changeLanguage(useLocaleStore.getState().locale)`。
-
-2. **`E2ESmokePage.runProbes` 用 `window.alert()`**(file:`features/e2e-smoke/E2ESmokePage.tsx:24`)
-   违反反模式清单。改法:禁用「运行」按钮当 `apiUrl/apiKey/model` 任一为空,tooltip 提示原因。
-
-3. **`EndpointPicker` 表单里的 `<Label>` 没有 `htmlFor`**(多处)
-   无障碍问题。给所有 `Input`/`Textarea` 加 `id`,`Label` 加 `htmlFor`。
+1. ✅ **`LocaleStore` 初次访问可能语言错配** —— 已修(`main.tsx` 渲染前同步 `i18n.changeLanguage(store.locale)`,`i18n.init` 去掉硬写 `lng`)。
+2. ✅ **`E2ESmokePage` 用 `window.alert()`** —— 已改为 Run 按钮 `disabled` + `title` tooltip。
+3. ✅ **`EndpointPicker` Label 未绑 Input** —— 已用 `useId()` 绑定 `htmlFor` / `id`。
 
 ### 中优先级(结构 / 可维护性)
 
-4. **两个连接组件并存:`EndpointPicker`(表单型)与 `EndpointSelector`(下拉型)**
-   Request Debug 用前者顶部 bar,其它页面用后者内嵌。建议:
-   - 保留 `EndpointPicker` 作为「完整表单 + 切换」入口(嵌在页面卡片里);
-   - 保留 `EndpointSelector` 作为「紧凑切换 + 管理入口」(放页面 header);
-   - 在本文档中登记两者各自职责,不再混用。
-   ⇒ **已登记到 §5**。
-
-5. **`EndpointPicker.saveOpen` 浮层 vs `EndpointSelector.namePromptOpen` 浮层重复**
-   两处都实现了「另存为...」名字输入的小浮层,UI 不一致。统一到 `ConnectionDialog`(dialog 已支持 create 模式),去掉这两个浮层。
-
-6. **cURL 解析填表逻辑重复两处**(`EndpointPicker.onParseCurl` / `ConnectionDialog.onParseCurl`)
-   抽到 `lib/apply-curl-to-endpoint.ts` 返回 `{ next: EndpointValues; filled: string[] }`。
-
-7. **`LoadTestSlice.modified` / `LoadTestSlice.curlExpanded` 是死字段**
-   没有任何读点。删除。
-
-8. **Request Debug 的 `modified={false}` 硬编码**(`RequestDebugPage.tsx:139`)
-   要么接入真实 dirty 计算,要么从 `EndpointSelector` props 里摘掉 `modified`。
+4. ✅ **两个连接组件职责** —— 已在 §5 登记并在两者 JSDoc 中说明。
+5. ✅ **「另存为」UI 重复** —— 已统一到 `ConnectionDialog`,`EndpointSelector` 的 `NamePrompt` 与无人使用的 save 回调已删。
+6. ✅ **cURL 解析填表重复** —— 已抽到 `lib/apply-curl-to-endpoint.ts`,两处消费者共用。
+7. ✅ **`LoadTestSlice.modified` / `curlExpanded`** —— 已删除(含 `setModified` 与 `@deprecated ManualEndpoint` 类型别名)。
+8. **`RequestDebugPage` 的 `modified={false}` 硬编码**(`RequestDebugPage.tsx`)
+   `EndpointSelector.modified?` 已保留为可选。要么接入真实 dirty 计算(比较当前 `url` / `headers` / `body` 与选中连接派生值),要么直接去掉 prop 传递。
 
 ### 低优先级(收尾)
 
-9. **`E2EApiResponse` / 其它本地接口响应 interface 分散在各页面**
-   抽到 `features/<name>/types.ts` 或 `lib/api-types.ts`。
+9. ✅ **本地接口响应 interface 散在 Page** —— 已移到各 feature 的 `types.ts`(`E2ETestResponse` / `DebugProxyResponse`)。
 
-10. **`E2ESmokePage` 清空结果按钮与「切换连接自动清空」现在独立**
-    可以考虑在 `resetResults` 之外再加 `resetEndpoint()`,给未来的「全部重置」按钮铺路。暂不紧急。
+10. **未提供「全部重置」按钮** —— 各 store 已有 `reset()` 动作,但没有页面 UI 触发。等有明确需求再加,不急。
 
 ---
 

--- a/docs/superpowers/plans/2026-04-22-nestjs-refactor-phase-0-workspace-scaffold.md
+++ b/docs/superpowers/plans/2026-04-22-nestjs-refactor-phase-0-workspace-scaffold.md
@@ -1,0 +1,1403 @@
+# NestJS Refactor — Phase 0 Implementation Plan (Workspace Scaffold)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish the pnpm-workspace layout (`apps/web`, `apps/api`, `packages/contracts`) and scaffold an empty NestJS 10 app at `apps/api`, while keeping the existing frontend fully functional. No existing routes are ported in this plan. After this plan merges, `pnpm dev` runs the old Express backend alongside the new Nest scaffold — Phase 1 (not in this plan) will cut over.
+
+**Architecture:** Three-package pnpm workspace rooted at the repo. `apps/web` is the existing frontend relocated verbatim. `apps/api` is a fresh NestJS 10 scaffold using Express adapter, with Nest's default Jest setup replaced by Vitest to match the rest of the repo. `packages/contracts` is an empty shared-schemas package with Zod as its only runtime dependency. The legacy Express app (`server.js` + `src/*.js`) remains in place and runnable — it is deleted by Phase 1, not this phase.
+
+**Tech Stack:** pnpm workspaces, TypeScript 5.4 strict, NestJS 10 (Express adapter), Vitest (both FE and BE), Zod, Node ≥ 20. Frontend unchanged: Vite 5, React 18, Tailwind, shadcn/ui, Zustand.
+
+**Source spec:** `docs/superpowers/specs/2026-04-22-nestjs-backend-refactor-design.md` (Phase 0, §5)
+
+**Testing discipline:**
+- **Verification steps, not TDD.** Phase 0 is config and scaffolding; runtime business logic arrives in later phases. Each task ends with a concrete verification command (install succeeds, dev server boots, type-check passes, URL responds) — not a unit test.
+- **One runtime-code commit happens in this phase:** replacing Nest's default `AppController` spec with a Vitest-flavored equivalent (Task 9). That single spec serves as a smoke test proving the Vitest runner is wired correctly against Nest.
+- Manual smoke checks at Task 6 (FE), Task 10 (API), and Task 16 (full end-to-end). Each has explicit success criteria.
+
+**Commit cadence:** One commit per task. Message prefix convention:
+- `chore:` workspace plumbing, config
+- `build:` package.json / tsconfig / scripts changes
+- `feat:` new runtime code (rare in this phase)
+- `test:` test-only changes
+- `docs:` README / plan / spec updates
+
+**Environment assumptions:**
+- Working directory: `/Users/fangyong/vllm/modeldoctor/feat/e2e-smoke` (or whatever worktree the user is on). **Commands are written as repo-root-relative** (no leading `./`); run them from the repo root.
+- **Node ≥ 20 required** (bumping engines is part of this plan; Phase 0 both declares and requires it).
+- **pnpm 9.x required** (pnpm 8 works too but the plan targets 9).
+- Vegeta and any Phase 1+ runtime prerequisites are NOT needed to complete Phase 0.
+
+---
+
+## Pre-flight
+
+- [ ] **Step 0.1: Confirm a clean working tree**
+
+Run:
+```bash
+git status
+```
+Expected: `nothing to commit, working tree clean` (or only untracked files you don't mind carrying). If dirty, commit or stash before proceeding — this plan produces a long sequence of commits and merging them into an unclean tree is error-prone.
+
+- [ ] **Step 0.2: Confirm tooling versions**
+
+Run:
+```bash
+node --version
+pnpm --version
+```
+Expected: Node `v20.*` or newer; pnpm `9.*` (8.15+ works but untested with this plan). If Node is `v18.*`, upgrade before proceeding (e.g. `nvm install 20 && nvm use 20`). If pnpm is missing: `npm install -g pnpm@9`.
+
+- [ ] **Step 0.3: Create the Phase 0 branch**
+
+Run:
+```bash
+git checkout -b feat/nestjs-phase-0
+```
+Expected: `Switched to a new branch 'feat/nestjs-phase-0'`. All commits in this plan land on this branch. When the plan is complete, open a single PR `feat/nestjs-phase-0 → main` (or whatever integration branch your repo uses).
+
+- [ ] **Step 0.4: Baseline smoke — the old stack still works**
+
+Run (in one terminal):
+```bash
+pnpm install
+pnpm dev
+```
+In a second terminal or browser:
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:5173
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3001/api/health
+```
+Expected: `200` from each. **If either fails, stop** — Phase 0 must start from a working baseline. Kill `pnpm dev` (`Ctrl-C`) once verified.
+
+---
+
+## Phase 0 Tasks
+
+Phase goal (restated): repo has `apps/web`, `apps/api`, `packages/contracts` as workspace packages; `pnpm dev` brings up FE on 5173 and a new Nest scaffold on 3001; old `server.js` + `src/*.js` still present but unused-by-dev. Type-check, lint, and test commands work across all three packages.
+
+### Task 1: Add workspace skeleton and shared base tsconfig
+
+**Files:**
+- Create: `pnpm-workspace.yaml`
+- Create: `tsconfig.base.json`
+- Create: `apps/.gitkeep`
+- Create: `packages/.gitkeep`
+
+- [ ] **Step 1.1: Create `pnpm-workspace.yaml`**
+
+Write this exact content to the repo root:
+```yaml
+packages:
+  - apps/*
+  - packages/*
+```
+
+- [ ] **Step 1.2: Create `tsconfig.base.json`**
+
+Write this exact content to the repo root:
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": false,
+    "sourceMap": true
+  }
+}
+```
+Rationale: the three packages each extend this and add their own overrides (`web` adds DOM libs + jsx; `api` adds Node lib + decorators + emitDecoratorMetadata; `contracts` is library-style).
+
+- [ ] **Step 1.3: Create `apps/` and `packages/` directories with placeholder files**
+
+Run:
+```bash
+mkdir -p apps packages
+touch apps/.gitkeep packages/.gitkeep
+```
+The placeholders keep the empty directories in git until the next tasks populate them.
+
+- [ ] **Step 1.4: Verify `pnpm install` still works with an empty workspace**
+
+Run:
+```bash
+pnpm install
+```
+Expected: installs as before; a `Scope: all 1 workspace projects` (the root) line may appear. No errors. Because `apps/*` and `packages/*` are empty directory globs, pnpm reports one workspace (the root) and does not complain.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add pnpm-workspace.yaml tsconfig.base.json apps/.gitkeep packages/.gitkeep
+git commit -m "chore: introduce pnpm workspace skeleton and base tsconfig"
+```
+
+---
+
+### Task 2: Relocate `web/` to `apps/web/`
+
+**Files:**
+- Move: `web/` → `apps/web/`
+
+- [ ] **Step 2.1: Move the directory preserving git history**
+
+Run:
+```bash
+git mv web apps/web
+```
+Expected: `git status` now shows `renamed: web/... -> apps/web/...` for every file. No file content has changed.
+
+- [ ] **Step 2.2: Inspect the move summary**
+
+Run:
+```bash
+git status | head -30
+ls apps/web
+```
+Expected: all former `web/*` entries now under `apps/web/`, including `src/`, `vite.config.ts`, `vitest.config.ts`, `tsconfig.json`, `tsconfig.node.json`, `tailwind.config.ts`, `biome.json`, `postcss.config.cjs`, `index.html`.
+
+- [ ] **Step 2.3: Commit the move as a rename**
+
+```bash
+git commit -m "chore: relocate web/ to apps/web/"
+```
+Keeping this commit rename-only (no content changes) ensures `git log --follow` tracks each file through the move.
+
+---
+
+### Task 3: Give `apps/web` its own `package.json` with frontend-scoped deps
+
+**Files:**
+- Create: `apps/web/package.json`
+- Modify: `apps/web/tsconfig.json` (next task)
+
+- [ ] **Step 3.1: Create `apps/web/package.json`**
+
+Write this exact content:
+```json
+{
+  "name": "@modeldoctor/web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --config vite.config.ts",
+    "build": "vite build --config vite.config.ts",
+    "preview": "vite preview",
+    "lint": "biome check src",
+    "format": "biome format --write src",
+    "type-check": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run --config vitest.config.ts",
+    "test:watch": "vitest --config vitest.config.ts"
+  },
+  "dependencies": {
+    "@hookform/resolvers": "^3",
+    "@radix-ui/react-alert-dialog": "^1",
+    "@radix-ui/react-dialog": "^1",
+    "@radix-ui/react-dropdown-menu": "^2",
+    "@radix-ui/react-label": "^2",
+    "@radix-ui/react-progress": "^1",
+    "@radix-ui/react-radio-group": "^1",
+    "@radix-ui/react-scroll-area": "^1",
+    "@radix-ui/react-select": "^2",
+    "@radix-ui/react-separator": "^1",
+    "@radix-ui/react-slot": "^1",
+    "@radix-ui/react-switch": "^1",
+    "@radix-ui/react-tabs": "^1",
+    "@radix-ui/react-tooltip": "^1",
+    "@tanstack/react-query": "^5",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2",
+    "date-fns": "^3",
+    "i18next": "^23",
+    "lucide-react": "^0.453",
+    "react": "^18.3",
+    "react-dom": "^18.3",
+    "react-hook-form": "^7",
+    "react-i18next": "^14",
+    "react-router-dom": "^7",
+    "sonner": "^2.0.7",
+    "tailwind-merge": "^2",
+    "zod": "^3.23",
+    "zustand": "^4.5"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6",
+    "@testing-library/react": "^16",
+    "@testing-library/user-event": "^14",
+    "@types/react": "^18.3",
+    "@types/react-dom": "^18.3",
+    "@vitejs/plugin-react": "^4",
+    "@vitest/ui": "^1",
+    "autoprefixer": "^10",
+    "jsdom": "^24",
+    "postcss": "^8",
+    "tailwindcss": "^3.4",
+    "tailwindcss-animate": "^1",
+    "vite": "^5",
+    "vitest": "^1"
+  }
+}
+```
+Notes on what's included vs excluded:
+- `zod` is listed here because the FE uses it directly. When `@modeldoctor/contracts` consumes it too, pnpm will dedupe.
+- `typescript` and `@biomejs/biome` are NOT here — they are shared dev tools hoisted at the repo root (Task 14).
+- The scripts deliberately use `--config vite.config.ts` explicit paths so `pnpm --filter @modeldoctor/web dev` works from any cwd.
+
+- [ ] **Step 3.2: Verify pnpm sees the new workspace package**
+
+Run:
+```bash
+pnpm install
+pnpm -r list --depth 0 | head -20
+```
+Expected: output lists `@modeldoctor/web` as a workspace package. `pnpm install` may download new packages but should not error.
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add apps/web/package.json
+git commit -m "build: add apps/web package.json with FE-scoped dependencies"
+```
+
+---
+
+### Task 4: Adjust `apps/web/vite.config.ts` build outDir to be package-local
+
+**Files:**
+- Modify: `apps/web/vite.config.ts:55-58`
+
+The current config writes the build to `path.resolve(__dirname, "..", "dist")`, which after the move points to `apps/dist/` — wrong. The spec (§5 Phase 6) requires FE build output at `apps/web/dist/` so the Docker stage can copy it directly.
+
+- [ ] **Step 4.1: Edit `apps/web/vite.config.ts`**
+
+Find the `build` block (lines 54–58):
+```typescript
+  build: {
+    outDir: path.resolve(__dirname, "..", "dist"),
+    emptyOutDir: true,
+    sourcemap: true,
+  },
+```
+
+Replace with:
+```typescript
+  build: {
+    outDir: path.resolve(__dirname, "dist"),
+    emptyOutDir: true,
+    sourcemap: true,
+  },
+```
+
+- [ ] **Step 4.2: Verify the build lands in the expected place**
+
+Run:
+```bash
+pnpm -F @modeldoctor/web build
+ls apps/web/dist | head -5
+```
+Expected: `apps/web/dist/index.html` and `apps/web/dist/assets/` exist. (This also validates that the relocated Vite config still resolves its tailwind/postcss imports correctly after the move.)
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add apps/web/vite.config.ts
+git commit -m "build: scope apps/web vite build output to package-local dist/"
+```
+
+---
+
+### Task 5: Update `apps/web/tsconfig.json` to extend the shared base
+
+**Files:**
+- Modify: `apps/web/tsconfig.json`
+
+- [ ] **Step 5.1: Edit `apps/web/tsconfig.json`**
+
+Replace the entire file with:
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@modeldoctor/contracts": ["../../packages/contracts/src"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}
+```
+Changes from the previous file:
+- `extends` the workspace base (removes duplication of `target`, `module`, `strict`, etc.)
+- Adds path alias `@modeldoctor/contracts` → `packages/contracts/src` so FE can import the shared schemas once Task 12 publishes them.
+- Removes redundant fields now inherited from base.
+
+- [ ] **Step 5.2: Verify type-check still passes**
+
+Run:
+```bash
+pnpm -F @modeldoctor/web type-check
+```
+Expected: zero errors. (The `@modeldoctor/contracts` alias resolves to an empty placeholder file created in Task 11, but no FE code imports it yet, so the alias is silently unused — fine.)
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add apps/web/tsconfig.json
+git commit -m "build: extend apps/web tsconfig from shared workspace base"
+```
+
+---
+
+### Task 6: Smoke-test `apps/web` independently
+
+**Files:** (no changes)
+
+- [ ] **Step 6.1: Start the FE dev server via the workspace filter**
+
+In one terminal:
+```bash
+pnpm -F @modeldoctor/web dev
+```
+Expected: Vite prints `Local: http://localhost:5173/`. Open the URL in a browser — the ModelDoctor UI renders (sidebar, Load Test tab).
+
+API calls will 502 in the network tab because the backend isn't running. That's expected for this smoke — we're verifying the FE move alone.
+
+- [ ] **Step 6.2: Run FE unit tests**
+
+In a second terminal:
+```bash
+pnpm -F @modeldoctor/web test
+```
+Expected: all existing tests pass. (Relocation shouldn't have broken any test — they use `__dirname`-relative imports and the vitest config auto-adjusts.)
+
+- [ ] **Step 6.3: Stop the dev server**
+
+`Ctrl-C` in the terminal running `pnpm dev`. No commit — this task is verification only.
+
+---
+
+### Task 7: Trim root `package.json` of FE-only dependencies
+
+**Files:**
+- Modify: `package.json`
+
+The root `package.json` currently holds **all** FE deps (which are now duplicated into `apps/web/package.json`) plus the three Express-era BE deps. We strip it to a workspace-coordination shell. Express/body-parser/cors stay **for now** — the old `server.js` still needs them until Phase 1 deletes it.
+
+- [ ] **Step 7.1: Rewrite `package.json`**
+
+Replace the entire file with:
+```json
+{
+  "name": "modeldoctor",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Troubleshooting toolkit for model-serving APIs",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "dev:legacy": "concurrently -k -n web,api -c cyan,magenta \"pnpm -F @modeldoctor/web dev\" \"node server.js\"",
+    "dev": "pnpm dev:legacy",
+    "build": "pnpm -F @modeldoctor/web build",
+    "start": "node server.js",
+    "lint": "pnpm -r --if-present lint",
+    "format": "pnpm -r --if-present format",
+    "type-check": "pnpm -r --if-present type-check",
+    "test": "pnpm -r --if-present test",
+    "test:backend": "vitest run --config vitest.backend.config.ts"
+  },
+  "dependencies": {
+    "body-parser": "^1.20.2",
+    "cors": "^2.8.5",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9",
+    "@types/node": "^20",
+    "concurrently": "^8",
+    "supertest": "^7",
+    "typescript": "^5.4",
+    "vitest": "^1"
+  }
+}
+```
+
+Notes:
+- `dev` currently aliases `dev:legacy` (the old Express backend). Task 15 updates `dev` to run the new Nest scaffold once `apps/api` is viable.
+- Express, body-parser, cors stay in root `dependencies` because `server.js` needs them. They are deleted in Phase 1.
+- `build` only builds web for now. `apps/api` will plug in here once it has something to build.
+- `typescript`, `@biomejs/biome`, `vitest`, `concurrently`, `supertest`, `@types/node` are hoisted at root so all workspace packages share one version. pnpm's hoisting is on by default.
+- `test:backend` keeps working against the existing `vitest.backend.config.ts` so Phase 0 doesn't break the current backend test (`src/routes/debug-proxy.test.js`).
+
+- [ ] **Step 7.2: Reinstall to apply the dep split**
+
+Run:
+```bash
+rm -rf node_modules apps/web/node_modules
+pnpm install
+```
+Expected: clean install. The FE deps now live under `apps/web/node_modules` (hoisted where safe). No `ERESOLVE` or peer errors.
+
+- [ ] **Step 7.3: Verify the legacy dev flow still works**
+
+Run:
+```bash
+pnpm dev:legacy
+```
+In another terminal:
+```bash
+curl -s http://localhost:3001/api/health
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:5173
+```
+Expected: health JSON from Express; `200` from Vite. Kill the dev process.
+
+- [ ] **Step 7.4: Commit**
+
+```bash
+git add package.json
+git commit -m "build: trim root package.json to workspace shell, keep legacy backend runnable"
+```
+
+---
+
+### Task 8: Scaffold `apps/api` via @nestjs/cli
+
+**Files:**
+- Create: `apps/api/` (entire Nest scaffold subtree, then trimmed in later tasks)
+
+- [ ] **Step 8.1: Generate the scaffold in a temp dir, then relocate**
+
+Run:
+```bash
+TMP_API_DIR="$(mktemp -d)"
+(cd "$TMP_API_DIR" && pnpm dlx @nestjs/cli@^10 new api --package-manager pnpm --skip-git)
+mv "$TMP_API_DIR/api" apps/api
+rm -rf "$TMP_API_DIR"
+```
+Expected: `apps/api/` exists with Nest's default structure: `src/app.module.ts`, `src/app.controller.ts`, `src/app.service.ts`, `src/main.ts`, plus `test/`, `package.json`, `tsconfig.json`, `tsconfig.build.json`, `nest-cli.json`, `.prettierrc`, `.eslintrc.js`.
+
+Why `--skip-git`: the scaffold tries to `git init` which would conflict with the outer repo. `--package-manager pnpm` makes Nest emit a `pnpm-lock.yaml` inside `apps/api/` — we delete that in Step 8.3 because the workspace uses a single root lockfile.
+
+- [ ] **Step 8.2: Delete scaffold cruft that conflicts with our conventions**
+
+Run:
+```bash
+rm -rf apps/api/node_modules
+rm -f apps/api/pnpm-lock.yaml apps/api/.eslintrc.js apps/api/.prettierrc
+rm -f apps/api/README.md
+```
+Rationale: we use Biome (not ESLint + Prettier); we use one workspace lockfile; the generated README is generic boilerplate we'll overwrite later.
+
+- [ ] **Step 8.3: Rename the package to `@modeldoctor/api` and align scripts**
+
+Open `apps/api/package.json` and replace its entire content with:
+```json
+{
+  "name": "@modeldoctor/api",
+  "version": "0.1.0",
+  "private": true,
+  "description": "ModelDoctor API (NestJS)",
+  "scripts": {
+    "build": "nest build",
+    "start": "node dist/main.js",
+    "start:dev": "nest start --watch",
+    "start:debug": "nest start --debug --watch",
+    "start:prod": "node dist/main.js",
+    "type-check": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10",
+    "@nestjs/config": "^3",
+    "@nestjs/core": "^10",
+    "@nestjs/platform-express": "^10",
+    "@nestjs/swagger": "^7",
+    "nestjs-pino": "^4",
+    "nestjs-zod": "^3",
+    "pino": "^9",
+    "pino-http": "^10",
+    "reflect-metadata": "^0.2",
+    "rxjs": "^7",
+    "zod": "^3.23"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10",
+    "@nestjs/schematics": "^10",
+    "@nestjs/testing": "^10",
+    "@types/express": "^4",
+    "@types/supertest": "^6",
+    "pino-pretty": "^11",
+    "vite-tsconfig-paths": "^5"
+  }
+}
+```
+Notes:
+- Jest and its ecosystem (`jest`, `ts-jest`, `@types/jest`, `jest-environment-node`) are gone. Vitest replaces them (Task 9).
+- `typescript`, `@biomejs/biome`, `vitest`, `supertest`, `@types/node` are hoisted from root — not duplicated here.
+- `start:prod` duplicates `start` deliberately; Docker (`CMD`) will use one name and `pnpm start` the other.
+- **Deps installed but not yet wired in Phase 0:** `@nestjs/config`, `@nestjs/swagger`, `nestjs-pino`, `nestjs-zod`, `pino`, `pino-http`, `pino-pretty`, `zod`. Per spec §5 Phase 0, the full Phase-2-and-earlier dep set installs now so Phase 2's PR can focus entirely on wiring, not on `pnpm install`. They produce zero runtime footprint until imported.
+- **Deferred to their own phases:** Prisma (Phase 4), Passport + JWT + argon2 (Phase 5), throttler (Phase 5), terminus (Phase 6).
+
+- [ ] **Step 8.4: Verify the scaffold installs cleanly**
+
+Run:
+```bash
+pnpm install
+pnpm -F @modeldoctor/api type-check
+```
+Expected: install succeeds; `type-check` passes against the default scaffold. If type-check fails, it is almost certainly because the scaffold's `tsconfig.json` sets options incompatible with our base — continue to Task 9 where we adjust tsconfig as part of Vitest wiring.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add apps/api
+git commit -m "build: scaffold apps/api via @nestjs/cli, strip defaults we don't use"
+```
+
+---
+
+### Task 9: Replace Nest's Jest setup with Vitest
+
+**Files:**
+- Delete: `apps/api/test/` (Jest e2e scaffold)
+- Delete: `apps/api/src/app.controller.spec.ts` (will be recreated as Vitest)
+- Modify: `apps/api/tsconfig.json`
+- Create: `apps/api/tsconfig.build.json` (simplified)
+- Create: `apps/api/vitest.config.ts`
+- Create: `apps/api/vitest.e2e.config.ts`
+- Create: `apps/api/src/app.controller.spec.ts` (Vitest version)
+
+- [ ] **Step 9.1: Delete the Jest scaffold**
+
+Run:
+```bash
+rm -rf apps/api/test
+rm -f apps/api/src/app.controller.spec.ts
+```
+
+- [ ] **Step 9.2: Replace `apps/api/tsconfig.json`**
+
+Write this exact content:
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "types": ["node", "vitest/globals"],
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "ES2022",
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "incremental": true,
+    "declaration": false,
+    "sourceMap": true,
+    "paths": {
+      "@modeldoctor/contracts": ["../../packages/contracts/src"]
+    }
+  },
+  "include": ["src/**/*", "vitest.config.ts", "vitest.e2e.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+Notes:
+- `module: commonjs` + `moduleResolution: node` is the Nest-on-Node convention — matches what `nest build` expects. Our base uses `ESNext`/`bundler`, which is FE-oriented. We override here.
+- `emitDecoratorMetadata` + `experimentalDecorators` are mandatory for NestJS DI.
+- `types: ["node", "vitest/globals"]` enables Vitest globals (`describe`, `it`, `expect`) without per-file imports.
+
+- [ ] **Step 9.3: Replace `apps/api/tsconfig.build.json`**
+
+Write this exact content:
+```json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "sourceMap": true
+  },
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.e2e-spec.ts", "test"]
+}
+```
+
+- [ ] **Step 9.4: Create `apps/api/vitest.config.ts` (unit tests)**
+
+Write this exact content:
+```typescript
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+import swc from "unplugin-swc";
+
+export default defineConfig({
+  plugins: [
+    tsconfigPaths(),
+    swc.vite({
+      module: { type: "es6" },
+      jsc: {
+        parser: { syntax: "typescript", decorators: true },
+        transform: { legacyDecorator: true, decoratorMetadata: true },
+        target: "es2022",
+      },
+    }),
+  ],
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.spec.ts"],
+    exclude: ["node_modules", "dist", "test/**"],
+  },
+});
+```
+
+Explanation: Vitest defaults to `esbuild` which doesn't emit decorator metadata. Nest DI requires that metadata, so we swap in `@swc/core` via `unplugin-swc` (the standard Vitest-on-Nest recipe). Add the plugin deps in the next step.
+
+- [ ] **Step 9.5: Create `apps/api/vitest.e2e.config.ts` (e2e tests)**
+
+Write this exact content:
+```typescript
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+import swc from "unplugin-swc";
+
+export default defineConfig({
+  plugins: [
+    tsconfigPaths(),
+    swc.vite({
+      module: { type: "es6" },
+      jsc: {
+        parser: { syntax: "typescript", decorators: true },
+        transform: { legacyDecorator: true, decoratorMetadata: true },
+        target: "es2022",
+      },
+    }),
+  ],
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["test/**/*.e2e-spec.ts"],
+    exclude: ["node_modules", "dist"],
+    // e2e suites need enough time to boot an INestApplication per suite.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});
+```
+
+- [ ] **Step 9.6: Add SWC and paths plugin deps to `apps/api/package.json`**
+
+Edit `apps/api/package.json` — in `devDependencies` add two keys (keep existing alphabetical ordering):
+```json
+    "@swc/core": "^1",
+    "unplugin-swc": "^1",
+    "vite-tsconfig-paths": "^5"
+```
+(`vite-tsconfig-paths` was already added in Task 8.3; keep it there if present.)
+
+After the edit, the devDependencies block should contain at least:
+```json
+  "devDependencies": {
+    "@nestjs/cli": "^10",
+    "@nestjs/schematics": "^10",
+    "@nestjs/testing": "^10",
+    "@swc/core": "^1",
+    "@types/express": "^4",
+    "@types/supertest": "^6",
+    "unplugin-swc": "^1",
+    "vite-tsconfig-paths": "^5"
+  }
+```
+
+- [ ] **Step 9.7: Write the Vitest-flavored AppController spec**
+
+Create `apps/api/src/app.controller.spec.ts` with this exact content:
+```typescript
+import { Test, TestingModule } from "@nestjs/testing";
+import { AppController } from "./app.controller";
+import { AppService } from "./app.service";
+
+describe("AppController", () => {
+  let appController: AppController;
+
+  beforeEach(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      controllers: [AppController],
+      providers: [AppService],
+    }).compile();
+
+    appController = moduleRef.get(AppController);
+  });
+
+  it("returns the default greeting", () => {
+    expect(appController.getHello()).toBe("Hello World!");
+  });
+});
+```
+This single spec is the smoke test that proves Vitest + SWC + Nest DI wire together correctly. It will be deleted in Phase 1 when `AppController` itself is removed.
+
+- [ ] **Step 9.8: Install new deps and run the unit test**
+
+Run:
+```bash
+pnpm install
+pnpm -F @modeldoctor/api test
+```
+Expected: `Test Files  1 passed (1)` and `Tests  1 passed (1)`. If you see `ReferenceError: Reflect.getMetadata is not a function`, ensure `reflect-metadata` is imported early (Task 10 handles this for the runtime; the test passes because `@nestjs/testing` imports it).
+
+If the test fails with a SWC-related error, confirm `@swc/core` installed correctly with `pnpm -F @modeldoctor/api list @swc/core unplugin-swc`.
+
+- [ ] **Step 9.9: Verify `type-check` passes**
+
+Run:
+```bash
+pnpm -F @modeldoctor/api type-check
+```
+Expected: zero errors. If `Cannot find type definition file for 'vitest/globals'` appears, confirm `vitest` installed via `pnpm list vitest` at repo root.
+
+- [ ] **Step 9.10: Commit**
+
+```bash
+git add apps/api/tsconfig.json apps/api/tsconfig.build.json apps/api/vitest.config.ts apps/api/vitest.e2e.config.ts apps/api/src/app.controller.spec.ts apps/api/package.json
+git commit -m "build: swap Nest's Jest scaffold for Vitest + SWC (decorator metadata preserved)"
+```
+
+---
+
+### Task 10: Customize `apps/api/src/main.ts` — port 3001, `/api` global prefix, dev CORS
+
+**Files:**
+- Modify: `apps/api/src/main.ts`
+
+The scaffold defaults to port 3000 with no prefix. Our dev proxy expects `http://localhost:3001/api/*`. Without these changes, the Vite dev proxy (Task 6's config) would 502 against the Nest scaffold.
+
+- [ ] **Step 10.1: Replace `apps/api/src/main.ts`**
+
+Write this exact content:
+```typescript
+import { NestFactory } from "@nestjs/core";
+import type { INestApplication } from "@nestjs/common";
+import { AppModule } from "./app.module";
+
+async function bootstrap(): Promise<void> {
+  const app: INestApplication = await NestFactory.create(AppModule);
+
+  app.setGlobalPrefix("api");
+
+  // Dev-time CORS: Vite dev server runs on 5173; browser calls here hit the
+  // Vite proxy server-to-server, so CORS is not strictly needed for the FE
+  // dev loop. But developers occasionally curl/fetch the API from other
+  // origins (notebooks, Postman browser), and permissive dev CORS is harmless.
+  // Production CORS policy is revisited in Phase 2 with @nestjs/config.
+  if (process.env.NODE_ENV !== "production") {
+    app.enableCors({
+      origin: ["http://localhost:5173"],
+      credentials: true,
+    });
+  }
+
+  const port = Number(process.env.PORT ?? 3001);
+  await app.listen(port);
+  console.log(`[api] listening on http://localhost:${port}`);
+}
+
+void bootstrap();
+```
+
+Notes on what changed from the scaffold:
+- Global prefix `/api` so the scaffold's `GET /` becomes `GET /api/`.
+- Explicit port from env with a 3001 default to match current Express behavior.
+- Dev-only CORS wrapping.
+- `void bootstrap()` instead of `bootstrap()` to satisfy strict TS no-floating-promises lint (which we don't enforce yet but may later).
+
+- [ ] **Step 10.2: Boot the API standalone and probe it**
+
+In one terminal:
+```bash
+pnpm -F @modeldoctor/api start:dev
+```
+Wait for `[api] listening on http://localhost:3001` (may take 2–3 seconds for first compile).
+
+In another terminal:
+```bash
+curl -s http://localhost:3001/api
+```
+Expected: `Hello World!`
+
+The scaffold's `AppController` exposes `@Get()` at the root, which with the `/api` prefix becomes `/api`. A request to `/api/health` returns 404 — that endpoint belongs to the old Express server and arrives in Phase 1 of the Nest port.
+
+- [ ] **Step 10.3: Kill the dev server**
+
+`Ctrl-C` the Nest process.
+
+- [ ] **Step 10.4: Commit**
+
+```bash
+git add apps/api/src/main.ts
+git commit -m "feat(api): set /api global prefix, bind to 3001, enable dev CORS"
+```
+
+---
+
+### Task 11: Create `packages/contracts/` skeleton
+
+**Files:**
+- Create: `packages/contracts/package.json`
+- Create: `packages/contracts/tsconfig.json`
+- Create: `packages/contracts/src/index.ts`
+
+- [ ] **Step 11.1: Create `packages/contracts/package.json`**
+
+Write this exact content:
+```json
+{
+  "name": "@modeldoctor/contracts",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared Zod schemas and inferred types between apps/web and apps/api",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "type-check": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "zod": "^3.23"
+  }
+}
+```
+
+Notes:
+- No build step. Consumers (`apps/web` via Vite, `apps/api` via ts-node-like runtime through `vite-tsconfig-paths` + SWC) read the `.ts` sources directly via the workspace path alias. This avoids the classic "publish-to-consume" cycle during early development.
+- `"type": "module"` aligns with the spec's ESM direction for new code (even though `apps/api` is CJS for now, its bundler/tsconfig resolves the `.ts` source directly — no module-interop problem).
+
+- [ ] **Step 11.2: Create `packages/contracts/tsconfig.json`**
+
+Write this exact content:
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+- [ ] **Step 11.3: Create `packages/contracts/src/index.ts`**
+
+Write this exact content:
+```typescript
+/**
+ * @modeldoctor/contracts
+ *
+ * Shared Zod schemas that define the HTTP wire format between the web UI and
+ * the API. Consumers import schemas from here and derive types via z.infer.
+ *
+ * Phase 0 scaffold: no schemas yet. Phase 1 populates health, e2e-test,
+ * load-test, and debug-proxy schemas.
+ */
+
+export {};
+```
+
+- [ ] **Step 11.4: Install and sanity-check**
+
+Run:
+```bash
+pnpm install
+pnpm -F @modeldoctor/contracts type-check
+```
+Expected: install links the workspace package; type-check passes on the empty scaffold.
+
+- [ ] **Step 11.5: Commit**
+
+```bash
+git add packages/contracts
+git commit -m "build: add empty packages/contracts scaffold (no schemas yet)"
+```
+
+---
+
+### Task 12: Wire `@modeldoctor/contracts` as a workspace dependency of `apps/web` and `apps/api`
+
+**Files:**
+- Modify: `apps/web/package.json` (add dep)
+- Modify: `apps/api/package.json` (add dep)
+
+- [ ] **Step 12.1: Add `@modeldoctor/contracts` to `apps/web/package.json`**
+
+In `apps/web/package.json`, extend the `dependencies` block to include:
+```json
+    "@modeldoctor/contracts": "workspace:*",
+```
+(Insert alphabetically; it sorts between `@hookform/resolvers` and `@radix-ui/...`.)
+
+- [ ] **Step 12.2: Add `@modeldoctor/contracts` to `apps/api/package.json`**
+
+In `apps/api/package.json`, extend the `dependencies` block to include:
+```json
+    "@modeldoctor/contracts": "workspace:*",
+```
+(Insert alphabetically; it sorts before `@nestjs/common`.)
+
+- [ ] **Step 12.3: Reinstall to link the workspace package**
+
+Run:
+```bash
+pnpm install
+```
+Expected: pnpm reports linking `@modeldoctor/contracts` into both `apps/web` and `apps/api` via symlink. Verify with:
+```bash
+ls -la apps/web/node_modules/@modeldoctor/
+ls -la apps/api/node_modules/@modeldoctor/
+```
+Each should show a `contracts` entry that is a symlink pointing to `../../../packages/contracts` (or similar).
+
+- [ ] **Step 12.4: Smoke-verify TS can resolve the import**
+
+Create a scratch file `apps/api/src/_contracts-smoke.ts` with:
+```typescript
+// Deleted at end of this task — temporary resolution smoke check.
+import type {} from "@modeldoctor/contracts";
+```
+
+Run:
+```bash
+pnpm -F @modeldoctor/api type-check
+```
+Expected: zero errors.
+
+Then delete the scratch file:
+```bash
+rm apps/api/src/_contracts-smoke.ts
+```
+
+- [ ] **Step 12.5: Commit**
+
+```bash
+git add apps/web/package.json apps/api/package.json
+git commit -m "build: wire @modeldoctor/contracts as workspace dep in web and api"
+```
+
+---
+
+### Task 13: Extend `.gitignore` for the new workspace layout
+
+**Files:**
+- Modify: `.gitignore`
+
+- [ ] **Step 13.1: Append workspace patterns to `.gitignore`**
+
+Edit `.gitignore`. Find the current "Web workspace" block near the bottom (lines 50-53):
+```
+# Web workspace
+web/node_modules/
+.vite/
+```
+Replace with:
+```
+# Workspace packages
+apps/*/node_modules/
+apps/*/dist/
+packages/*/node_modules/
+packages/*/dist/
+
+# Build caches
+*.tsbuildinfo
+.vite/
+
+# Local Postgres data (arrives in Phase 4)
+postgres-data/
+```
+
+Also confirm these lines still exist higher up:
+- `node_modules/`
+- `dist/` (matches legacy repo-root dist; later phases' `apps/*/dist/` is also excluded above)
+
+Note: Prisma migration files **are** committed, so we do NOT add `apps/api/prisma/migrations/` to `.gitignore`. This matches the spec's explicit policy (§2.4).
+
+- [ ] **Step 13.2: Verify the ignore rules don't exclude anything we need**
+
+Run:
+```bash
+git status --ignored | head -30
+```
+Expected: `apps/web/node_modules/`, `apps/api/node_modules/`, `packages/contracts/node_modules/` each appear under "Ignored files". No tracked file is now reported as ignored (pnpm's `node_modules` directories should be the only newly-ignored paths).
+
+- [ ] **Step 13.3: Commit**
+
+```bash
+git add .gitignore
+git commit -m "chore: extend .gitignore for workspace dist/ and node_modules/"
+```
+
+---
+
+### Task 14: Update root scripts to default `pnpm dev` to the new Nest scaffold
+
+**Files:**
+- Modify: `package.json` (scripts block only)
+
+At the end of Task 7 we aliased `dev` to `dev:legacy` so the plan kept working while `apps/api` didn't exist. Now the Nest scaffold is live — repoint `dev` at it and keep `dev:legacy` as an escape hatch.
+
+- [ ] **Step 14.1: Rewrite the `scripts` block in root `package.json`**
+
+Open `package.json` and replace the `scripts` block with:
+```json
+  "scripts": {
+    "dev": "concurrently -k -n web,api -c cyan,magenta \"pnpm -F @modeldoctor/web dev\" \"pnpm -F @modeldoctor/api start:dev\"",
+    "dev:legacy": "concurrently -k -n web,api -c cyan,magenta \"pnpm -F @modeldoctor/web dev\" \"node server.js\"",
+    "build": "pnpm -F @modeldoctor/contracts type-check && pnpm -F @modeldoctor/web build && pnpm -F @modeldoctor/api build",
+    "start": "node apps/api/dist/main.js",
+    "lint": "pnpm -r --if-present lint",
+    "format": "pnpm -r --if-present format",
+    "type-check": "pnpm -r --if-present type-check",
+    "test": "pnpm -r --if-present test",
+    "test:e2e": "pnpm -F @modeldoctor/api test:e2e",
+    "test:backend:legacy": "vitest run --config vitest.backend.config.ts"
+  },
+```
+
+Changes from Task 7:
+- `dev` now runs Nest by default.
+- `dev:legacy` preserved — run it when you need to compare against the old Express behavior (Phase 1 fixture capture).
+- `build` compiles contracts (type-check only; no emit), then web, then api.
+- `start` runs the new Nest build artifact, not the old `server.js`. This will fail if you haven't run `pnpm build` first — expected.
+- `test:backend:legacy` renamed from `test:backend` to flag that it targets the old JS backend tests, which are deleted by Phase 1.
+
+- [ ] **Step 14.2: Verify `pnpm dev` brings up both servers**
+
+Run:
+```bash
+pnpm dev
+```
+Wait for both `[web]` (Vite on 5173) and `[api]` (Nest on 3001) startup lines. In a second terminal:
+```bash
+curl -s http://localhost:3001/api
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:5173
+curl -s http://localhost:5173/api
+```
+Expected:
+- `http://localhost:3001/api` → `Hello World!`
+- `http://localhost:5173` → `200`
+- `http://localhost:5173/api` → `Hello World!` (via Vite proxy)
+
+The third probe is the important one: it proves the Vite dev proxy reaches Nest.
+
+- [ ] **Step 14.3: Verify `pnpm type-check` sweeps all three packages**
+
+Kill `pnpm dev`, then run:
+```bash
+pnpm type-check
+```
+Expected: runs three type-checks (web, api, contracts — the root doesn't have one), all pass.
+
+- [ ] **Step 14.4: Commit**
+
+```bash
+git add package.json
+git commit -m "build: default pnpm dev to apps/api (Nest), keep dev:legacy escape hatch"
+```
+
+---
+
+### Task 15: Update README Install / Develop / Scripts sections
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 15.1: Rewrite the Install, Develop, Production build, Repo layout, Scripts sections**
+
+The current `README.md` describes a single-package layout. Update these four sections to reflect the workspace:
+
+Replace the content between `## Prerequisites` (keep the header) and `## License` with:
+
+```markdown
+## Prerequisites
+
+- Node.js **≥ 20** (upgraded from 18 in Phase 0 of the NestJS refactor)
+- pnpm 9 (`npm install -g pnpm@9`)
+- Vegeta for Load Test (`brew install vegeta` on macOS, or releases at <https://github.com/tsenart/vegeta/releases>)
+
+## Install
+
+```bash
+pnpm install
+```
+
+## Develop
+
+```bash
+pnpm dev
+```
+
+Vite serves the frontend on <http://localhost:5173>. NestJS serves the API on <http://localhost:3001>. Vite proxies `/api/*` through to NestJS.
+
+**Legacy Express backend** (temporarily preserved through Phase 0 and Phase 1 of the refactor): `pnpm dev:legacy` runs Vite against the old `server.js` + `src/*.js` implementation. Phase 1 deletes those files and this script.
+
+### Running multiple worktrees in parallel
+
+Each worktree has its own `node_modules` and can run `pnpm dev` independently **as long as the ports differ**. Override via env:
+
+```bash
+# worktree A (defaults)
+pnpm dev
+
+# worktree B (in another shell)
+VITE_PORT=5174 API_PORT=3002 pnpm dev
+```
+
+`strictPort: true` in Vite and an explicit port in Nest's `main.ts` mean a wrong setting fails loudly instead of auto-falling-back.
+
+## Production build
+
+```bash
+pnpm build
+pnpm start
+```
+
+`pnpm build` compiles `@modeldoctor/contracts` (type-check only), then `apps/web` (Vite → `apps/web/dist/`), then `apps/api` (Nest → `apps/api/dist/`). `pnpm start` runs the compiled API (`node apps/api/dist/main.js`). Static web serving from Nest arrives in Phase 2 — for now, `pnpm start` serves API only.
+
+## Repo layout
+
+```
+modeldoctor/
+├── apps/
+│   ├── web/                # React + Vite + TS frontend (@modeldoctor/web)
+│   └── api/                # NestJS 10 backend (@modeldoctor/api) — scaffold only, routes arrive in Phase 1
+├── packages/
+│   └── contracts/          # Shared Zod schemas (@modeldoctor/contracts) — empty in Phase 0
+├── server.js               # LEGACY Express entry — deleted by Phase 1
+├── src/                    # LEGACY backend — deleted by Phase 1
+├── docs/superpowers/       # Specs and implementation plans
+├── tmp/                    # Runtime artifacts (Vegeta request.txt)
+├── pnpm-workspace.yaml
+├── tsconfig.base.json
+└── package.json            # Workspace coordinator
+```
+
+## Scripts
+
+| Command | Purpose |
+|---------|---------|
+| `pnpm dev` | Run Vite + NestJS together (new backend) |
+| `pnpm dev:legacy` | Run Vite + legacy Express (remove after Phase 1) |
+| `pnpm build` | Build contracts, web, and api |
+| `pnpm start` | Run compiled NestJS (`node apps/api/dist/main.js`) |
+| `pnpm lint` | Biome lint across all packages |
+| `pnpm format` | Biome format across all packages |
+| `pnpm type-check` | `tsc --noEmit` across all packages |
+| `pnpm test` | Vitest across all packages |
+| `pnpm test:e2e` | Nest e2e tests (supertest, empty until Phase 1) |
+| `pnpm test:backend:legacy` | Legacy Express tests (removed after Phase 1) |
+
+Before a PR lands, all three must pass:
+
+```bash
+pnpm type-check
+pnpm lint
+pnpm test
+```
+
+Conventions and the full debt list live in [`docs/project-standards.md`](docs/project-standards.md).
+```
+
+Keep the existing `# ModelDoctor` title, tagline, and `## License` section unchanged.
+
+- [ ] **Step 15.2: Verify markdown renders cleanly**
+
+Run:
+```bash
+# If you have a markdown linter or just eyeball it:
+head -80 README.md
+```
+Expected: section headers are sane; no duplicated text from the old version; the scripts table has aligned columns.
+
+- [ ] **Step 15.3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: update README for workspace layout and Nest-by-default pnpm dev"
+```
+
+---
+
+### Task 16: End-to-end smoke — clean install, full stack boots, all checks pass
+
+**Files:** (no changes)
+
+This is the final acceptance gate for Phase 0. Treat any failure here as blocking: fix it in a follow-up step within this task, re-run from the top, then commit the fix.
+
+- [ ] **Step 16.1: Clean reinstall**
+
+Run:
+```bash
+rm -rf node_modules apps/web/node_modules apps/api/node_modules packages/contracts/node_modules
+pnpm install
+```
+Expected: clean install, no `ERESOLVE` or peer-dep warnings treated as errors. The root lockfile (`pnpm-lock.yaml`) covers all workspace packages.
+
+- [ ] **Step 16.2: Type-check all packages**
+
+Run:
+```bash
+pnpm type-check
+```
+Expected: three packages (`web`, `api`, `contracts`) type-check, zero errors.
+
+- [ ] **Step 16.3: Lint all packages**
+
+Run:
+```bash
+pnpm lint
+```
+Expected: zero errors. Only `apps/web` has a `lint` script defined in Phase 0 (its Biome config is `apps/web/biome.json`). `apps/api` and `packages/contracts` intentionally have no `lint` / `format` scripts yet — Phase 2 introduces a shared Biome config and adds them back. `pnpm -r --if-present lint` therefore runs lint only for web.
+
+- [ ] **Step 16.4: Run all unit tests**
+
+Run:
+```bash
+pnpm test
+```
+Expected:
+- `@modeldoctor/web` — all existing tests pass (sidebar-store, load-test store, e2e-smoke store, etc.).
+- `@modeldoctor/api` — 1 passed (the `AppController` smoke from Task 9).
+- `@modeldoctor/contracts` — 0 tests (no `*.spec.ts` files exist; Vitest reports "No test files found" but exits 0 with `--if-present` — if it exits non-zero, remove the contracts `test` script or add a placeholder spec).
+
+- [ ] **Step 16.5: Run the full stack via `pnpm dev`**
+
+In one terminal:
+```bash
+pnpm dev
+```
+Wait until both `[web]` and `[api]` lines appear.
+
+In another terminal:
+```bash
+# FE reachable
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:5173
+
+# API reachable directly
+curl -s http://localhost:3001/api
+
+# API reachable through Vite proxy
+curl -s http://localhost:5173/api
+```
+Expected: `200`, `Hello World!`, `Hello World!`.
+
+Then open `http://localhost:5173` in a browser:
+- Sidebar renders.
+- Clicking Load Test / E2E Smoke / Request Debug tabs loads their UIs (FE-only, no backend calls yet for these tabs in Phase 0 — the calls will 404 because those `/api/load-test`, `/api/e2e-test`, `/api/debug/proxy` routes don't exist on the Nest scaffold. This is expected and documented: Phase 1 ports them.)
+- Clicking any action button that fires an API request will show a network error. **This is expected Phase 0 behavior** and not a regression — it's the whole reason Phase 1 exists.
+
+If you need to smoke-test actual API functionality, run `pnpm dev:legacy` instead.
+
+Kill `pnpm dev` when done.
+
+- [ ] **Step 16.6: Production build dry-run**
+
+Run:
+```bash
+pnpm build
+ls apps/web/dist | head -3
+ls apps/api/dist | head -3
+```
+Expected:
+- `apps/web/dist/index.html` and `apps/web/dist/assets/` present.
+- `apps/api/dist/main.js` present.
+- No errors from any step.
+
+- [ ] **Step 16.7: Production start dry-run**
+
+Run:
+```bash
+pnpm start &
+sleep 2
+curl -s http://localhost:3001/api
+kill %1
+```
+Expected: `Hello World!`. The Nest bundle boots from `apps/api/dist/main.js` using only prod deps. No Vite/FE served here — that's Phase 2.
+
+- [ ] **Step 16.8: Final commit if any tweaks were needed**
+
+If Steps 16.1–16.7 required any config tweaks (e.g. missing `--if-present` flag, a script name adjustment), commit them:
+```bash
+git status
+# review any uncommitted changes
+git add -A
+git commit -m "chore: Phase 0 smoke fixups"
+```
+If there are no changes, skip this step.
+
+---
+
+## Phase 0 Definition of Done Checklist
+
+All of these must be true before opening the PR:
+
+- [ ] `pnpm install` succeeds on a clean clone with zero warnings treated as errors.
+- [ ] `pnpm dev` starts both `apps/web` (5173) and `apps/api` (3001); `curl http://localhost:5173/api` returns `Hello World!` via the Vite proxy.
+- [ ] `pnpm type-check` passes for `apps/web`, `apps/api`, `packages/contracts` — all three.
+- [ ] `pnpm test` passes across all packages (includes the `AppController` Vitest smoke in `apps/api`).
+- [ ] `pnpm build` produces `apps/web/dist/` and `apps/api/dist/`.
+- [ ] `pnpm start` boots `apps/api/dist/main.js` and responds on `/api`.
+- [ ] `pnpm dev:legacy` still works — the old Express backend is runnable as a fallback.
+- [ ] Old `server.js`, `src/*.js`, and `vitest.backend.config.ts` remain unchanged and in their original locations (Phase 1 deletes them, not this phase).
+- [ ] README accurately describes the new workspace layout and scripts.
+- [ ] Node `engines` is `>=20.0.0`.
+- [ ] `.gitignore` covers `apps/*/node_modules`, `apps/*/dist`, `packages/*/node_modules`, `packages/*/dist`, `*.tsbuildinfo`.
+- [ ] Workspace dependency `@modeldoctor/contracts@workspace:*` is linked in both `apps/web` and `apps/api`.
+- [ ] Git log shows one commit per task, prefixed per the commit cadence convention.
+
+---
+
+## Out of Scope for This Plan (Phase 1+)
+
+Recorded so a reader doesn't mistake absence for oversight:
+
+- **Porting the 4 existing Express routes to Nest.** That is Phase 1 and will get its own plan document written via `writing-plans` after this plan merges.
+- **Deleting `server.js` and `src/*.js`.** Phase 1.
+- **Populating `packages/contracts/src/*`** with Zod schemas. Phase 1.
+- **@nestjs/config, nestjs-pino, swagger, AllExceptionsFilter, ServeStaticModule.** Phase 2.
+- **FE consuming `@modeldoctor/contracts`.** Phase 3.
+- **Prisma, Postgres, testcontainers.** Phase 4.
+- **Auth (Passport, JWT, guards, throttler).** Phase 5.
+- **Docker, GitHub Actions CI, terminus DB health probe.** Phase 6.
+
+Attempting any of these inside this plan is scope creep. If a step in this plan would require one of them to complete, stop and adjust the plan — don't smuggle the next phase in.
+
+---
+
+**End of Phase 0 plan.**

--- a/docs/superpowers/specs/2026-04-22-nestjs-backend-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-22-nestjs-backend-refactor-design.md
@@ -1,0 +1,600 @@
+# NestJS Backend Refactor — Industrial Rewrite
+
+**Status:** Approved design — ready for implementation planning
+**Date:** 2026-04-22
+**Predecessor:** Spec 1 (`2026-04-20-modeldoctor-restructure-design.md`) — frontend rewrite to Vite + React + TypeScript. Backend remained CommonJS Express.
+**Successor:** None yet. Subsequent specs will extend auth (SSO/OIDC), add async run queue (BullMQ), and ship additional feature tabs (Soak, Streaming TTFT, Regression, Health Monitor, History) using the infrastructure this spec establishes.
+
+## 1. Purpose and Scope
+
+### 1.1 Problem Statement
+
+The frontend is fully TypeScript and production-ready. The backend is not. It is:
+
+- **Plain JavaScript, CommonJS**, no type-checking (`pnpm type-check` only covers `web/`).
+- **Unstructured Express** — 4 route files, hand-wired middleware, no DI, no module boundaries.
+- **Stateless** — no database, no authentication, no persisted history. Every run is ephemeral.
+- **Not ready for industrial deployment** — no structured logging, no request correlation, no OpenAPI, no rate limiting, no health checks beyond a static `{ok:true}`.
+
+ModelDoctor is now positioned as an industrial-grade product. The backend must support multi-user authentication, persisted history, RBAC, observability, and a stable API contract. A framework rewrite to **NestJS** is justified at this scale because:
+
+- Planned growth exceeds 20+ endpoints across 8 feature tabs.
+- Auth, DB, background jobs, and WebSocket needs are all in roadmap.
+- A shared TypeScript contract with the frontend eliminates an entire class of bugs.
+
+### 1.2 This Spec's Delivery Scope
+
+This spec delivers a **full backend rewrite from Express/JS to NestJS/TS**, plus the supporting workspace restructure. It is delivered in 7 numbered phases (Phase 0–6), each independently reviewable and PR-able.
+
+High-level deliverables:
+
+- **pnpm workspace** restructure: `apps/web`, `apps/api`, `packages/contracts`.
+- **NestJS 10 API** at `apps/api`, replacing `server.js` + `src/`.
+- **Wire-format parity** — the 4 existing endpoints (`/api/health`, `/api/e2e-test`, `/api/load-test`, `/api/debug/proxy`) respond byte-identically to the current Express implementation. Frontend needs no changes to keep working.
+- **Shared contracts package** — Zod schemas for every request/response pair, consumed by both FE and BE.
+- **Infrastructure**: config validation, structured logging, OpenAPI at `/api/docs`, unified error shape, requestId correlation.
+- **Database layer** (Postgres + Prisma) with initial entities: `User`, `RefreshToken`, `LoadTestRun`.
+- **Authentication**: `@nestjs/passport` + JWT access + refresh tokens, `argon2` password hashing, `JwtAuthGuard` global + `@Public()` whitelist, `@Roles()` RBAC, `@nestjs/throttler` rate limiting.
+- **Productionization**: multi-stage Dockerfile, GitHub Actions CI, `@nestjs/terminus` health with DB liveness probe.
+
+### 1.3 Explicit Non-Goals
+
+Recorded now so scope is unambiguous during implementation planning:
+
+- **No FE product-feature additions.** The 3 implemented tabs (Load Test, E2E Smoke, Request Debug) behave the same to the end user, and no new tabs ship. Phase 3 swaps type imports (invisible to users) and Phase 5 adds login/register pages plus a login gate (auth infrastructure, not a product feature). No other FE UI changes.
+- **No new feature tabs.** Soak, Streaming TTFT, Regression, Health Monitor, and History remain placeholders. They arrive in subsequent specs.
+- **No async run queue in this spec.** `/api/load-test` continues to run Vegeta synchronously inside a single HTTP request. BullMQ + worker is deferred to a later spec (flagged as Phase 6+ follow-up, not part of this scope).
+- **No WebSocket / streaming endpoints.** Streaming TTFT tab will need them; not here.
+- **No SSO / OIDC / LDAP.** Local username/password only. Enterprise auth is a future spec.
+- **No internationalization of backend error messages.** Error `code` is a stable machine-readable identifier; FE does the translation (existing `errors` i18n namespace).
+- **No data migration from old ephemeral state.** Nothing is persisted today; there is nothing to migrate. First-run DB is empty.
+- **No backwards compatibility with `node server.js`.** After cutover, that entry point and all of `src/*.js` are deleted.
+- **No monitoring/tracing stack choice** (Prometheus / OpenTelemetry). Logs are structured JSON, which is sufficient for ingestion into any log aggregator; wiring to a specific stack is deferred.
+
+### 1.4 Deployment Target
+
+Unchanged from Spec 1: single-tenant, internal corporate network. Authentication added here is for multi-user *accountability* and API protection, not for untrusted-internet exposure.
+
+## 2. Workspace Layout and Migration Strategy
+
+### 2.1 Target Structure
+
+```
+modeldoctor/
+├── apps/
+│   ├── web/                            # Relocated from ./web/, FE code unchanged
+│   │   ├── index.html
+│   │   ├── vite.config.ts
+│   │   ├── tsconfig.json
+│   │   ├── tailwind.config.ts
+│   │   ├── biome.json
+│   │   ├── package.json                # name @modeldoctor/web
+│   │   └── src/                        # (all FE code as-is)
+│   └── api/                            # NEW — NestJS, replaces src/ + server.js
+│       ├── src/
+│       │   ├── main.ts                 # bootstrap (replaces server.js)
+│       │   ├── app.module.ts
+│       │   ├── modules/
+│       │   │   ├── health/             # Phase 1 (+ DB probe in Phase 4)
+│       │   │   ├── debug-proxy/        # Phase 1
+│       │   │   ├── load-test/          # Phase 1 (+ persistence in Phase 4)
+│       │   │   ├── e2e-test/           # Phase 1
+│       │   │   ├── auth/               # Phase 5
+│       │   │   └── users/              # Phase 5
+│       │   ├── common/                 # Phase 2
+│       │   │   ├── filters/            # AllExceptionsFilter
+│       │   │   ├── interceptors/       # RequestIdInterceptor, LoggingInterceptor
+│       │   │   ├── middleware/         # RequestIdMiddleware
+│       │   │   ├── pipes/              # ZodValidationPipe
+│       │   │   ├── decorators/         # @Public(), @Roles(), @CurrentUser()
+│       │   │   └── guards/             # JwtAuthGuard, RolesGuard (Phase 5)
+│       │   ├── config/                 # Phase 2 — env schema, ConfigModule wiring
+│       │   ├── database/               # Phase 4 — PrismaModule, PrismaService
+│       │   └── integrations/           # Ported pure-function layers (no DI, no state)
+│       │       ├── builders/           # chat, embeddings, rerank, images, multimodal
+│       │       ├── probes/             # text, image, audio
+│       │       ├── parsers/            # vegeta-report
+│       │       └── utils/              # tiny-png, wav
+│       ├── prisma/
+│       │   ├── schema.prisma           # Phase 4
+│       │   └── migrations/
+│       ├── test/
+│       │   ├── fixtures/               # Captured Express responses (see §2.3)
+│       │   └── e2e/                    # supertest against INestApplication
+│       ├── nest-cli.json
+│       ├── tsconfig.json
+│       ├── tsconfig.build.json
+│       └── package.json                # name @modeldoctor/api
+├── packages/
+│   └── contracts/                      # Shared Zod schemas → TS types
+│       ├── src/
+│       │   ├── index.ts
+│       │   ├── health.ts
+│       │   ├── e2e-test.ts
+│       │   ├── load-test.ts
+│       │   ├── debug-proxy.ts
+│       │   ├── auth.ts                 # Phase 5
+│       │   └── errors.ts               # Standard error code enum
+│       ├── tsconfig.json
+│       └── package.json                # name @modeldoctor/contracts
+├── docker-compose.yml                  # Phase 4 — local Postgres
+├── Dockerfile                          # Phase 6 — multi-stage build
+├── .github/workflows/ci.yml            # Phase 6
+├── package.json                        # Root workspace definition
+├── pnpm-workspace.yaml
+├── tsconfig.base.json                  # Shared compiler options
+└── README.md                           # Rewrite once per phase that affects it
+```
+
+**Workspace manifest (`pnpm-workspace.yaml`):**
+
+```yaml
+packages:
+  - apps/*
+  - packages/*
+```
+
+**Root `package.json` scripts** (concrete values):
+
+| Script | Command |
+|---|---|
+| `dev` | `concurrently -k -n web,api -c cyan,magenta "pnpm -F @modeldoctor/web dev" "pnpm -F @modeldoctor/api start:dev"` |
+| `build` | `pnpm -F @modeldoctor/contracts build && pnpm -F @modeldoctor/web build && pnpm -F @modeldoctor/api build` |
+| `start` | `node apps/api/dist/main.js` |
+| `lint` | `pnpm -r lint` |
+| `format` | `pnpm -r format` |
+| `type-check` | `pnpm -r type-check` |
+| `test` | `pnpm -r test` |
+| `test:e2e` | `pnpm -F @modeldoctor/api test:e2e` |
+
+### 2.2 Migration Strategy — Big-Bang Cutover
+
+A **parallel branch, big-bang cutover** is chosen over strangler/gradual. Justification:
+
+1. **No persistent state** — zero data migration risk.
+2. **Small surface** — 4 endpoints, all stateless glue code. Full rewrite fits in a single focused effort.
+3. **Wire-format parity guarantees** that the FE continues to work unchanged when cutover lands.
+4. **Strangler's cost is not recouped** here: running Express and Nest simultaneously behind a reverse proxy adds configuration burden for an endpoint set that completes in 1–2 days.
+
+Mechanism:
+
+- All work happens on a feature branch (current or a fresh `feat/nestjs-rewrite`) in a git worktree.
+- Phase 0–1 end with the new Nest API matching the old Express API's wire format. Old files remain in-tree through Phase 0; Phase 1's PR deletes them.
+- If any Phase 1 e2e test diverges from the captured Express fixture, the new implementation is fixed — the old Express behavior is treated as the source of truth.
+
+### 2.3 Fixture Capture (Prerequisite Before Phase 1)
+
+Before the first Nest controller is written, a capture step runs against the current Express server:
+
+1. Start current `node server.js`.
+2. For each of the 4 endpoints, hit them with representative valid and invalid payloads.
+3. Record request + response (status, headers relevant to behavior, body) into JSON files under `apps/api/test/fixtures/`.
+4. These fixtures become the basis for Phase 1 e2e assertions.
+
+This is a small, one-person effort (~30 min) but is non-negotiable — without it, "wire-format parity" becomes a claim rather than a verified property.
+
+### 2.4 Files Deleted, Moved, Kept
+
+**Deleted (in Phase 1 final PR, not earlier):**
+
+- `server.js`
+- `src/` (entire tree — `builders/`, `parsers/`, `probes/`, `routes/`, `utils/`)
+- `vitest.backend.config.ts` (superseded by `apps/api/vitest.config.ts`)
+- Root `tsconfig.json` if it exists (moved to `tsconfig.base.json`)
+
+**Moved (in Phase 0):**
+
+- `web/*` → `apps/web/*` (verbatim move; `git mv` to preserve history)
+
+**Kept:**
+
+- `ai-docs/` — retained as-is.
+- `docs/` — retained; this spec and its predecessor live under `docs/superpowers/specs/`.
+- `tmp/` — retained (runtime artifacts directory).
+- `.gitignore` — extended to cover `apps/api/dist/`, `apps/*/node_modules/`, `packages/*/node_modules/`, `packages/*/dist/`, `*.tsbuildinfo`, and the Docker volume for local Postgres. Prisma migration files **are** committed (`apps/api/prisma/migrations/` is tracked) — only local DB data is ignored.
+- `README.md` — rewritten in Phase 0 and again in Phase 6.
+
+## 3. Technology Stack (Frozen)
+
+| Concern | Choice | Rationale (one line) |
+|---------|--------|---------------------|
+| Runtime | Node ≥ 20 | LTS, native fetch / test runner, Nest 10 compat |
+| Framework | NestJS 10 with Express adapter | Matches current stack, maximal plugin ecosystem |
+| Language | TypeScript 5.4+, `strict: true` | Parity with FE tsconfig |
+| Validation | Zod + `nestjs-zod` | Shared schemas with FE; single source of truth |
+| ORM | Prisma 5 | Best-in-class TS DX, mature migrations, typed client |
+| Database | PostgreSQL 16 | Industrial default; JSON, full-text, row-level locks |
+| Auth | `@nestjs/passport` + `@nestjs/jwt` + `argon2` | Standard Nest pattern; argon2 > bcrypt |
+| Config | `@nestjs/config` + Zod env schema | Fail-fast on bad env; typed `ConfigService<AppConfig>` |
+| Logging | `nestjs-pino` | 5–10× faster than Winston; structured JSON; requestId support |
+| API docs | `@nestjs/swagger` + `nestjs-zod` integration | Auto OpenAPI from Zod, `/api/docs` |
+| HTTP client | Native `fetch` (Node 20+) | No axios; used by `debug-proxy` |
+| Rate limiting | `@nestjs/throttler` | Official Nest rate limiter |
+| Testing (unit) | Vitest + `@nestjs/testing` | Reuse existing Vitest setup; DI-aware mocks |
+| Testing (e2e) | `supertest` against `INestApplication` | Already in devDeps |
+| Testing (DB) | `testcontainers` | Real Postgres in CI, no in-memory cheating |
+| Health checks | `@nestjs/terminus` | Phase 6 DB liveness probe |
+| Container | Multi-stage `Dockerfile` | Final image runs compiled `dist/main.js` + static web bundle |
+
+**Deliberately excluded:**
+
+| Excluded | Why |
+|---|---|
+| `class-validator` / `class-transformer` | Would create a second validation system alongside FE's Zod. Zod-only is a hard requirement. |
+| TypeORM / MikroORM | Prisma has significantly better TS DX and simpler migrations. |
+| axios / `@nestjs/axios` | Native fetch suffices. |
+| Redis (in this spec) | Not needed until rate-limit backend or queues arrive. Throttler can use in-memory store in Phase 5. |
+| BullMQ | Async run queue is a follow-up spec. |
+| Kafka / RabbitMQ | No event-driven need yet. |
+| GraphQL | All endpoints are simple REST; no consumer demand. |
+
+## 4. Cross-Cutting Design Decisions
+
+### 4.1 Shared Contracts (`packages/contracts`)
+
+**What goes in:**
+
+- Every request and response schema for HTTP endpoints.
+- Standard error code enum (string literal union, stable identifiers, e.g. `"AUTH_INVALID_CREDENTIALS"`).
+- Cross-cutting types that exist on the wire: `ApiError`, `Pagination`, `SortOrder`.
+
+**What does NOT go in:**
+
+- DB/Prisma types. `Prisma.User` is an internal representation; the API exposes a `PublicUser` DTO that strips `passwordHash`.
+- FE-only types (UI state, form state, Zustand slice shapes).
+- BE-only types (internal service interfaces, domain objects).
+
+**Naming convention:**
+
+```typescript
+// packages/contracts/src/load-test.ts
+export const LoadTestRunRequestSchema = z.object({ ... });
+export type LoadTestRunRequest = z.infer<typeof LoadTestRunRequestSchema>;
+
+export const LoadTestRunResponseSchema = z.object({ ... });
+export type LoadTestRunResponse = z.infer<typeof LoadTestRunResponseSchema>;
+```
+
+**Consumption:**
+
+- API: `@UsePipes(new ZodValidationPipe(LoadTestRunRequestSchema))` on controller method; `z.infer` type on the handler parameter.
+- FE: `const parsed = LoadTestRunResponseSchema.parse(await res.json())` in `api-client.ts` wrappers, returning the inferred type.
+
+### 4.2 Module Layout Inside `apps/api`
+
+- Each **feature module** (health, debug-proxy, load-test, e2e-test, auth, users) owns its folder: `module.ts`, `controller.ts`, `service.ts`, and optionally `dto/`, `guards/`, `strategies/`.
+- Feature modules do not import each other directly. Cross-feature needs go through a shared module.
+- **Common module (`common/`)** exports filters, interceptors, middleware, pipes, decorators, guards. Registered globally in `AppModule`.
+- **Database module (`database/`)** exports `PrismaService`; imported by feature modules that need DB access.
+- **Integrations layer (`integrations/`)** is **not** a Nest module — it's plain TS functions (builders, parsers, probes, utils) ported from old `src/`. Services import them like any library.
+
+### 4.3 Unified Error Response Shape
+
+Every error response — validation, auth, business logic, uncaught — has this body:
+
+```typescript
+{
+  error: {
+    code: string;              // stable identifier, e.g. "VALIDATION_FAILED", "AUTH_INVALID_TOKEN"
+    message: string;           // human-readable, English, not localized
+    details?: unknown;         // optional structured detail (e.g. Zod issues array)
+    requestId: string;         // correlation id, echoed from X-Request-Id header
+  }
+}
+```
+
+Implementation:
+
+- `AllExceptionsFilter` catches everything and maps to this shape.
+- Custom `AppException` base class carries `code` + HTTP status; domain modules throw subclasses.
+- `ZodValidationPipe` failures map to `VALIDATION_FAILED` with `details = zodError.issues`.
+- `HttpException` from Nest keeps its status code; `code` defaults to the HTTP reason phrase uppercased.
+- Uncaught throwables return 500 with `code: "INTERNAL_SERVER_ERROR"`; stack is logged, never returned in the body.
+
+### 4.4 Authentication Model
+
+**Token strategy:**
+
+- **Access token**: JWT, 15-minute lifetime, signed with `JWT_ACCESS_SECRET`. Claims: `sub` (user id), `roles`, `iat`, `exp`. Transmitted as `Authorization: Bearer <token>`.
+- **Refresh token**: opaque random 256-bit string, stored hashed (`argon2`) in the `RefreshToken` table with `userId`, `expiresAt` (7 days), `createdAt`, `revokedAt?`. Transmitted as an `HttpOnly; Secure; SameSite=Strict` cookie so JS cannot exfiltrate it.
+- **Refresh endpoint** (`POST /api/auth/refresh`): validates cookie, rotates refresh (old is revoked, new issued), returns new access token.
+- **Logout** (`POST /api/auth/logout`): revokes the refresh token, clears the cookie.
+- **Suspicious refresh detection**: if a revoked refresh token is reused, all tokens for that user are revoked (indicates theft).
+
+**Password hashing:** `argon2id` with library defaults (appropriate for modern CPUs). No pepper (deferred to future spec if key-management infra lands).
+
+**Guards:**
+
+- `JwtAuthGuard` registered as **global** guard in `AppModule`.
+- `@Public()` decorator (sets metadata) whitelists: `/api/health`, `/api/docs` and its assets, `/api/auth/register`, `/api/auth/login`, `/api/auth/refresh`.
+- `@Roles('admin')` + `RolesGuard` for admin-only endpoints. Bootstrap policy: **the first user to register receives the `admin` role automatically**; all subsequent users receive `user`. An admin can later promote/demote others via `POST /api/users/:id/roles`. This auto-bootstrap exists so a fresh deployment is usable without a manual DB seed; production operators may disable it via `DISABLE_FIRST_USER_ADMIN=true` and seed an admin manually.
+
+**Rate limiting:** `@nestjs/throttler` with per-IP limits. `/api/auth/login` and `/api/auth/refresh`: 10 requests / 60 seconds. Other endpoints: 100 / 60s. In-memory storage is acceptable for Phase 5; Redis backend is a later upgrade.
+
+### 4.5 Logging, Request Correlation, Observability
+
+**Logger:** `nestjs-pino` replaces Nest's default logger.
+
+**Request correlation:**
+
+- `RequestIdMiddleware` runs first: reads `X-Request-Id` header if present and well-formed (UUID v4 regex), else generates a new UUID v4. Writes it to `req.id` and to the response header.
+- Pino child logger is bound per-request with `{ requestId, userId?, ip, method, url }`. Every log line in the request lifecycle carries these.
+
+**Log levels (env-controlled):**
+
+- Dev: `debug`, transport = `pino-pretty`.
+- Prod: `info`, transport = stdout JSON.
+- Health-check requests suppressed from access logs (too noisy; explicit allowlist).
+
+**No tracing library in this spec.** OpenTelemetry is a future follow-up.
+
+### 4.6 OpenAPI
+
+- Mounted at `/api/docs` (Swagger UI) and `/api/docs-json` (raw JSON).
+- Authentication for the docs: none in Phase 2 (internal-network deployment). A future spec may gate behind admin auth.
+- Schemas drawn automatically from `nestjs-zod` via `@ApiBody(zodToOpenAPI(...))` or its auto-extraction helper. Example in one controller during Phase 2 sets the pattern; remaining modules follow it.
+- Auth header shows up in Swagger UI via `builder.addBearerAuth()` (Phase 5).
+
+### 4.7 Testing Strategy
+
+**Pyramid (from bottom up):**
+
+1. **Unit tests** — pure functions in `integrations/` (builders, parsers, probes, utils). Vitest, no Nest runtime. Cover full branch space.
+2. **Module/service tests** — `Test.createTestingModule` with mocked dependencies. Assert business logic in services.
+3. **e2e tests (HTTP)** — `supertest(app.getHttpServer())` against a bootstrapped `INestApplication`. Mock only external calls (vegeta, upstream model APIs). DB in e2e tests uses testcontainers Postgres.
+4. **Contract tests** — Zod schemas in `packages/contracts` have their own tests: parse good samples, reject bad ones. Catches breaking schema changes.
+
+**Fixtures:** captured Express responses (§2.3) become Vitest snapshots for Phase 1 e2e. Once parity is verified they can be retired or kept as regression oracle.
+
+**CI gates (all must pass):**
+
+- `pnpm -r type-check`
+- `pnpm -r lint`
+- `pnpm -r test`
+- `pnpm -F @modeldoctor/api test:e2e`
+- `pnpm build`
+
+### 4.8 Configuration
+
+Single source of truth: `apps/api/src/config/env.schema.ts` — a Zod schema of the complete environment.
+
+```typescript
+// Illustrative; actual set finalized per-phase
+export const EnvSchema = z.object({
+  NODE_ENV: z.enum(["development", "production", "test"]),
+  PORT: z.coerce.number().int().positive().default(3001),
+  LOG_LEVEL: z.enum(["trace","debug","info","warn","error"]).default("info"),
+
+  // Phase 4+
+  DATABASE_URL: z.string().url(),
+
+  // Phase 5+
+  JWT_ACCESS_SECRET: z.string().min(32),
+  JWT_ACCESS_EXPIRES_IN: z.string().default("15m"),
+  JWT_REFRESH_EXPIRES_DAYS: z.coerce.number().int().positive().default(7),
+  DISABLE_FIRST_USER_ADMIN: z.coerce.boolean().default(false),
+});
+export type Env = z.infer<typeof EnvSchema>;
+```
+
+- `ConfigModule.forRoot({ validate: (raw) => EnvSchema.parse(raw), isGlobal: true })`.
+- `.env.example` committed at repo root; `.env` gitignored.
+- Missing required env vars fail the bootstrap — no "silent default to insecure value."
+
+## 5. Phased Roadmap
+
+Each phase is self-contained: one PR, one review, one merge, one deploy (in principle). Effort estimates assume one experienced full-stack engineer, uninterrupted.
+
+### Phase 0 — Workspace Scaffold (~0.5 day)
+
+**Scope:**
+
+- Create `pnpm-workspace.yaml`, root `package.json` with scripts table from §2.1.
+- `tsconfig.base.json` with shared compiler options.
+- Create `apps/web/` by `git mv web/* apps/web/`; adjust `vite.config.ts` `root` if needed; adjust path alias.
+- Create `apps/api/` via `pnpm dlx @nestjs/cli@10 new api --package-manager pnpm` (then relocate), add stack dependencies from §3 **except Prisma, Passport, JWT, throttler, terminus** (those come in their own phases).
+- **Replace Nest's default Jest scaffold with Vitest** (remove `jest.config`, `test/` Jest setup, `@nestjs/testing`'s Jest-tied peers; add `vitest`, `vite-tsconfig-paths`, `apps/api/vitest.config.ts`). Rationale: repo already uses Vitest; one runner is cheaper than two.
+- Bump `engines.node` in root `package.json` from `>=18.0.0` to `>=20.0.0`. Document the bump in README.
+- Create `packages/contracts/` with empty index and a placeholder schema, wire tsconfig.
+- Old `web/`, `src/`, `server.js`, `vitest.backend.config.ts` still exist. They are deleted in Phase 1's final commit.
+- README updated with new dev commands.
+
+**DoD:**
+
+- `pnpm install` succeeds at repo root with zero warnings treated as errors.
+- `pnpm dev` starts both web (5173) and api (3001); visiting `http://localhost:5173` loads the existing FE; FE's `/api/*` proxies to the new Nest server's default `/api/hello` (for now it's just the scaffold).
+- `pnpm -r type-check` passes.
+- Old `node server.js` is still runnable as a fallback if needed.
+
+### Phase 1 — Port 4 Routes (~1.5–2 days)
+
+**Prerequisite:** fixture capture (§2.3) complete.
+
+**Scope:**
+
+- Translate `src/builders/`, `src/parsers/`, `src/probes/`, `src/utils/` from CommonJS JS to strict TS under `apps/api/src/integrations/`. Pure mechanical translation; add types, keep logic byte-identical.
+- Build 4 feature modules: `HealthModule`, `DebugProxyModule`, `LoadTestModule`, `E2eTestModule`. Controllers thin, services do the work.
+- Write Zod schemas in `packages/contracts` for all 4 endpoints (request + response).
+- Register `ZodValidationPipe` globally (via `APP_PIPE` provider).
+- e2e tests per endpoint assert responses match captured fixtures exactly.
+- **Final commit of this PR deletes:** `server.js`, `src/`, `vitest.backend.config.ts`, root-level Express-specific deps from `package.json`.
+
+**Key risk mitigations:**
+
+- **Vegeta subprocess**: use `child_process.spawn` with `AbortController`; write a dedicated unit test that kills the child and asserts cleanup; test Vegeta-missing case.
+- **Debug proxy header passthrough**: test strips `host`, `content-length`; test follows redirects (5 max); test binary body → base64; test 20MB limit enforced; test 60s timeout enforced.
+
+**DoD:**
+
+- All 4 endpoints e2e tests green.
+- FE in **dev mode** (`pnpm dev`), unchanged, successfully drives all 3 implemented tabs against the new Nest API.
+- Legacy files are gone: `test -e server.js` fails; `test -d src` fails. Tree-wide `git grep -E "^(const|let|var) .* = require\(" apps/api/src packages/contracts/src` returns nothing (no CommonJS leaked into TS code).
+- `pnpm -r type-check && pnpm -r test` green.
+
+**Known temporary regression:** production mode (`pnpm build && pnpm start`) does **not** serve the FE static bundle from Nest between the end of Phase 1 and the end of Phase 2 — `server.js`'s `express.static` is gone and `ServeStaticModule` is not yet wired. This is intentional and acceptable because Phase 1 is never deployed on its own; Phase 2 closes the gap. Dev mode is unaffected.
+
+### Phase 2 — Infrastructure (~1 day)
+
+**Scope:**
+
+- `ConfigModule` with Zod env validation (`EnvSchema` from §4.8 at the Phase 2 subset: NODE_ENV, PORT, LOG_LEVEL).
+- `nestjs-pino` wired as the Nest logger; `pino-pretty` in dev.
+- `RequestIdMiddleware` generates/propagates `X-Request-Id`.
+- `AllExceptionsFilter` globally registered; all errors conform to §4.3 shape.
+- `@nestjs/swagger` mounted at `/api/docs`, `/api/docs-json`. Health, e2e-test, load-test, debug-proxy controllers annotated; schemas auto-drawn from Zod.
+- Replace `express.static(DIST_DIR)` with `ServeStaticModule`, preserving SPA fallback (`index.html` on non-`/api` 404s).
+
+**DoD:**
+
+- `curl -s localhost:3001/api/docs-json | jq '.paths | keys'` lists all 4 endpoints with schemas.
+- Provoking a validation error returns `{error:{code:"VALIDATION_FAILED",...,requestId:"..."}}`; same `requestId` visible in structured logs.
+- `pnpm build && node apps/api/dist/main.js` serves both `/api/*` and the FE static bundle on port 3001 with one process.
+
+### Phase 3 — FE Consumes `packages/contracts` (~0.5–1 day)
+
+**Scope:**
+
+- `apps/web/src/features/*/types.ts` and `schema.ts` refactored to re-export (or replace) with imports from `@modeldoctor/contracts`.
+- `api-client.ts` return types derived from Zod `z.infer<typeof ResponseSchema>`.
+- Remove duplicated types in FE. `tsconfig` path alias `@modeldoctor/contracts` resolves through workspace linking.
+- Keep per-tab UI-only types (Zustand slices, form state) in FE as before.
+
+**DoD:**
+
+- Changing a field name in `packages/contracts/src/load-test.ts` breaks `pnpm -r type-check` in both FE and API with clear type errors.
+- FE `fetch('/api/...')` call sites have no `any` in their return path.
+- All FE component behavior unchanged; tests pass.
+
+### Phase 4 — Database (Prisma + Postgres) (~2 days)
+
+**Scope:**
+
+- `docker-compose.yml` at repo root with a `postgres:16` service, env `POSTGRES_USER`, `_PASSWORD`, `_DB`, volume for local persistence. A `.env.example` entry for `DATABASE_URL`.
+- `apps/api/prisma/schema.prisma` with initial models:
+  - `User { id, email, passwordHash, roles String[], createdAt, updatedAt }`
+  - `RefreshToken { id, userId, tokenHash, expiresAt, revokedAt?, createdAt }`
+  - `LoadTestRun { id, userId?, apiType, rate, duration, status, summaryJson Json, rawReport, createdAt, completedAt? }`
+- `PrismaService` extending `PrismaClient` with `onModuleInit` connect, `onModuleDestroy` disconnect, `enableShutdownHooks` wired.
+- `LoadTestService` persists each run to `LoadTestRun` on completion. A `userId` column exists but is nullable in Phase 4 (no auth yet); populated starting Phase 5.
+- New endpoint: `GET /api/load-test/runs` — paginated list of historical runs (most recent first). Schema in `packages/contracts`. Phase 4 semantics: returns all rows unconditionally. Phase 5 will tighten this to per-user scoping (admins continue to see all).
+- **Handling of pre-auth rows:** rows created during Phase 4 have `userId = null`. When Phase 5 ships, these rows are only visible to admin role (treated as "legacy/ownerless"). No retroactive assignment. A migration step in Phase 5 may optionally delete them; the default is to keep them read-only.
+- Integration tests with `testcontainers` spin up Postgres per-suite; `prisma migrate deploy` runs against it.
+
+**DoD:**
+
+- `docker compose up -d` + `pnpm -F @modeldoctor/api prisma migrate dev` creates the schema.
+- POSTing `/api/load-test` produces a row in `LoadTestRun`; `GET /api/load-test/runs` returns it.
+- `pnpm test` runs the testcontainers-backed integration suite locally and in CI.
+
+### Phase 5 — Auth (~2–3 days)
+
+**Scope:**
+
+- `AuthModule` + `UsersModule`:
+  - `POST /api/auth/register` — email + password; argon2 hash; first user → `admin` role; subsequent → `user`.
+  - `POST /api/auth/login` — verifies password; issues access JWT + sets refresh cookie.
+  - `POST /api/auth/refresh` — rotates refresh, returns new access.
+  - `POST /api/auth/logout` — revokes refresh token, clears cookie.
+  - `GET /api/auth/me` — returns `PublicUser` from access token.
+- `JwtStrategy` (`@nestjs/passport`), `JwtAuthGuard` as global guard.
+- `@Public()` decorator whitelists: `/api/health`, `/api/docs*`, `/api/auth/register`, `/api/auth/login`, `/api/auth/refresh`.
+- `@Roles('admin')` + `RolesGuard`. Admin-only: `GET /api/users` (list), `POST /api/users/:id/roles` (modify roles).
+- `@nestjs/throttler` per §4.4 limits.
+- Populate `LoadTestRun.userId` from `req.user.sub` on new runs. `GET /api/load-test/runs` scoped to current user (admins see all).
+- `packages/contracts/src/auth.ts` with all request/response schemas.
+- **Frontend integration** (coupled into this phase's PR):
+  - `/login` and `/register` pages.
+  - `auth-store` (Zustand) holding access token (in memory only — never localStorage). Refresh via HttpOnly cookie which JS cannot read.
+  - `api-client.ts` fetch wrapper attaches `Authorization: Bearer <access>`; on 401 attempts refresh once, retries, else redirects to `/login`.
+  - Protected route wrapper redirects unauthenticated users to `/login`.
+
+**DoD:**
+
+- Unauthenticated request to any protected endpoint returns 401 in the unified error shape.
+- Login → access + refresh cookie issued; refresh rotates and the old token is no longer accepted.
+- 11th login attempt in 60 seconds from same IP returns 429.
+- Re-using a revoked refresh triggers full user token revocation (logged at `warn`).
+- FE login flow works end-to-end; Load Test's run list shows only the current user's runs.
+
+### Phase 6 — Productionization (~1–2 days)
+
+**Scope:**
+
+- **Multi-stage `Dockerfile`:**
+  1. Install stage: copy `pnpm-lock.yaml` + workspace manifests, `pnpm install --frozen-lockfile`.
+  2. Build stage: `pnpm -F contracts build`, `pnpm -F web build`, `pnpm -F api build`; `prisma generate`.
+  3. Run stage: `node:20-alpine`, copy only `apps/api/dist`, `apps/web/dist` (served by ServeStaticModule), `node_modules` (prod only), `prisma/` (for migrations at startup). Entrypoint runs `prisma migrate deploy` then `node dist/main.js`.
+- **GitHub Actions** (`.github/workflows/ci.yml`):
+  - Matrix job on Node 20: install, type-check, lint, test, build.
+  - Separate job spins up a Postgres service and runs `test:e2e`.
+  - Docker build job (builds image but does not push in this spec).
+- **`@nestjs/terminus` health check** extends `/api/health`:
+  - Always-on: process info.
+  - DB probe: `prisma.$queryRaw\`SELECT 1\`` with 500ms timeout.
+  - Returns 503 if DB down.
+- **`.env.example`** at repo root listing every required variable with a placeholder comment.
+- **README** rewrite: deploy section, Docker usage, env variable documentation, architecture diagram (text/mermaid).
+
+**DoD:**
+
+- `docker build -t modeldoctor:local .` succeeds; `docker run -p 3001:3001 --env-file .env modeldoctor:local` brings up API + FE on a clean machine.
+- CI green on a fresh push including Postgres-backed e2e.
+- Stopping Postgres → `GET /api/health` returns 503 with error shape containing `code: "DB_UNAVAILABLE"`; restarting Postgres → 200 resumes.
+
+### Phase Dependency Graph
+
+```
+Phase 0 ──▶ Phase 1 ──▶ Phase 2 ──▶ Phase 4 ──▶ Phase 5 ──▶ Phase 6
+                            │
+                            └────▶ Phase 3 (parallelizable with Phase 4)
+```
+
+- Critical path: 0 → 1 → 2 → 4 → 5 → 6, ≈ 9–12 person-days.
+- Phase 3 can start as soon as Phase 2 merges and run concurrently with Phase 4 if two people are available.
+
+## 6. Risks and Mitigations
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|------|------------|--------|------------|
+| R1 | Phase 1 wire-format drift breaks FE silently | Med | High | Fixture capture (§2.3) mandatory before Phase 1 start; per-endpoint e2e asserts fixture parity |
+| R2 | Vegeta subprocess leaks or misbehaves in Nest lifecycle | Med | Med | `AbortController`-bound spawn; unit + integration tests covering happy path, cancel, Vegeta-missing |
+| R3 | Path alias inconsistency across Vite / Nest / Vitest | High | Low-Med | Phase 0 sets aliases in all three configs at once; CI type-check catches drift |
+| R4 | Prisma dev deps bloat Docker image | Low | Low | Multi-stage build; `prisma` stays in `devDependencies` except the generated client |
+| R5 | Auth implementation gaps (CSRF, refresh rotation, token theft detection) | Med | High | Follow OWASP ASVS L2 checklist as Phase 5 DoD; no custom crypto; argon2id, not bcrypt |
+| R6 | testcontainers flakiness in CI | Low-Med | Med | Pin Postgres tag; add retry in CI; provide GitHub Actions service-based fallback config |
+| R7 | Scope creep — "while we're rewriting, let's also do X" | High | High | Non-goals in §1.3 are binding; scope expansion requires a new spec, not a bigger PR |
+| R8 | Single-process FE+API cutover makes rollback painful | Low | Med | Phase 1 PR is revertable (nothing persisted yet); Phases 4+ require a DB rollback plan (use `prisma migrate resolve` + keep last 2 migrations backward-compatible) |
+| R9 | `nestjs-zod` API drift or unmaintained | Low | Med | Version pinned; if abandoned, fall back to hand-rolled `ZodValidationPipe` (already in scope) |
+| R10 | Refresh cookie settings wrong in dev (different origin) | Med | Low-Med | `SameSite=Strict` is too strict if FE dev server is on 5173 and API on 3001; use `SameSite=Lax` in dev via env-driven cookie options |
+
+## 7. Acceptance Criteria (Per Phase)
+
+Each phase's DoD in §5 is the acceptance criterion for that phase. Additionally, the spec as a whole is considered complete when:
+
+- [ ] All 7 phases are merged on the main branch.
+- [ ] `pnpm install && pnpm dev` on a clean clone brings up a working FE + API.
+- [ ] `docker build . && docker run -p 3001:3001 --env-file .env ...` produces a single-container deployment.
+- [ ] All FE features from Spec 1 (Load Test, E2E Smoke, Request Debug, Connections, Settings) work against the new Nest backend, including login gate.
+- [ ] CI green on main. No skipped tests.
+- [ ] README documents: dev setup, prod deploy, env variables, architecture overview, auth flow, API docs URL.
+- [ ] `pnpm -r type-check` passes across `apps/web`, `apps/api`, `packages/contracts`.
+- [ ] `grep -R "require(" apps/api/src packages/contracts/src` returns nothing. (ESM verified.)
+- [ ] OWASP ASVS L2 auth checklist reviewed; any unmet items explicitly logged as technical debt for a follow-up spec.
+
+## 8. Implementation Phases (Hand-off to Writing-Plans)
+
+The `writing-plans` skill will take this spec and produce a detailed task-by-task implementation plan. It should:
+
+1. **Respect phase boundaries.** Each of Phase 0–6 is its own section in the plan. Tasks within a phase may parallelize; phases do not, except where §5's dependency graph permits (Phase 3 ‖ Phase 4).
+2. **For each phase, produce:**
+   - Ordered task list, each task a single-PR-sized unit of work.
+   - Concrete file paths to create or edit.
+   - Test(s) that must exist at phase end.
+   - Verification commands mapped to each DoD bullet.
+3. **Call out cutover points explicitly.** Phase 1's final PR deletes old Express files — this is a cutover, not a cleanup task, and deserves its own named step with a pre-cutover checklist.
+4. **Not re-litigate spec decisions.** If the plan encounters a design ambiguity, the plan lists it as a clarifying question back to the spec author rather than silently picking an interpretation.
+5. **Include rollback notes** for Phase 4+ (migrations) and Phase 5 (auth) — what the rollback command looks like and when to use it.
+
+---
+
+**End of NestJS Backend Refactor design.**

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-hook-form": "^7",
     "react-i18next": "^14",
     "react-router-dom": "^7",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^2",
     "zod": "^3.23",
     "zustand": "^4.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       react-router-dom:
         specifier: ^7
         version: 7.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: ^2
         version: 2.6.1
@@ -2300,6 +2303,12 @@ packages:
   sirv@2.0.4:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4719,6 +4728,11 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+
+  sonner@2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   source-map-js@1.2.1: {}
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,9 @@
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { routes } from "@/router";
+import { useThemeStore } from "@/stores/theme-store";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
+import { Toaster } from "sonner";
 
 const router = createBrowserRouter(routes);
 const queryClient = new QueryClient({
@@ -9,10 +11,17 @@ const queryClient = new QueryClient({
 });
 
 export default function App() {
+	const themeMode = useThemeStore((s) => s.mode);
 	return (
 		<QueryClientProvider client={queryClient}>
 			<TooltipProvider delayDuration={150}>
 				<RouterProvider router={router} />
+				<Toaster
+					position="bottom-right"
+					richColors
+					closeButton
+					theme={themeMode}
+				/>
 			</TooltipProvider>
 		</QueryClientProvider>
 	);

--- a/web/src/components/connection/EndpointPicker.tsx
+++ b/web/src/components/connection/EndpointPicker.tsx
@@ -15,7 +15,7 @@ import { type ParsedCurl, parseCurlCommand } from "@/lib/curl-parser";
 import { useConnectionsStore } from "@/stores/connections-store";
 import { type EndpointValues, emptyEndpointValues } from "@/types/connection";
 import { ClipboardPaste, Eye, EyeOff } from "lucide-react";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 const MANUAL = "__manual__";
@@ -67,6 +67,12 @@ export function EndpointPicker({
 	const [saveName, setSaveName] = useState("");
 	const [saveError, setSaveError] = useState<string | null>(null);
 	const [newDialogOpen, setNewDialogOpen] = useState(false);
+
+	const apiUrlId = useId();
+	const apiKeyId = useId();
+	const modelId = useId();
+	const customHeadersId = useId();
+	const queryParamsId = useId();
 
 	const isDirty =
 		!!selectedConn &&
@@ -333,8 +339,9 @@ export function EndpointPicker({
 				</h2>
 				<div className="space-y-3">
 					<div>
-						<Label>{t("endpoint.apiUrl")}</Label>
+						<Label htmlFor={apiUrlId}>{t("endpoint.apiUrl")}</Label>
 						<Input
+							id={apiUrlId}
 							value={endpoint.apiUrl}
 							onChange={(e) => patchEndpoint({ apiUrl: e.target.value })}
 							placeholder="http://host:port/v1/chat/completions"
@@ -343,9 +350,10 @@ export function EndpointPicker({
 					</div>
 					<div className="grid grid-cols-1 gap-3 md:grid-cols-2">
 						<div>
-							<Label>{t("endpoint.apiKey")}</Label>
+							<Label htmlFor={apiKeyId}>{t("endpoint.apiKey")}</Label>
 							<div className="relative">
 								<Input
+									id={apiKeyId}
 									type={revealKey ? "text" : "password"}
 									value={endpoint.apiKey}
 									onChange={(e) => patchEndpoint({ apiKey: e.target.value })}
@@ -367,8 +375,9 @@ export function EndpointPicker({
 							</div>
 						</div>
 						<div>
-							<Label>{t("endpoint.model")}</Label>
+							<Label htmlFor={modelId}>{t("endpoint.model")}</Label>
 							<Input
+								id={modelId}
 								value={endpoint.model}
 								onChange={(e) => patchEndpoint({ model: e.target.value })}
 								placeholder="model-name"
@@ -382,8 +391,11 @@ export function EndpointPicker({
 						</summary>
 						<div className="mt-2 space-y-3">
 							<div>
-								<Label>{t("endpoint.customHeaders")}</Label>
+								<Label htmlFor={customHeadersId}>
+									{t("endpoint.customHeaders")}
+								</Label>
 								<Textarea
+									id={customHeadersId}
 									rows={2}
 									value={endpoint.customHeaders}
 									onChange={(e) =>
@@ -394,8 +406,11 @@ export function EndpointPicker({
 								/>
 							</div>
 							<div>
-								<Label>{t("endpoint.queryParams")}</Label>
+								<Label htmlFor={queryParamsId}>
+									{t("endpoint.queryParams")}
+								</Label>
 								<Textarea
+									id={queryParamsId}
 									rows={2}
 									value={endpoint.queryParams}
 									onChange={(e) =>

--- a/web/src/components/connection/EndpointPicker.tsx
+++ b/web/src/components/connection/EndpointPicker.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { ConnectionDialog } from "@/features/connections/ConnectionDialog";
+import { applyCurlToEndpoint } from "@/lib/apply-curl-to-endpoint";
 import { type ParsedCurl, parseCurlCommand } from "@/lib/curl-parser";
 import { useConnectionsStore } from "@/stores/connections-store";
 import { type EndpointValues, emptyEndpointValues } from "@/types/connection";
@@ -164,44 +165,13 @@ export function EndpointPicker({
 			setCurlFeedback(t("endpoint.filled", { fields: "—" }));
 			return;
 		}
-		const filled: string[] = [];
-		const next: EndpointValues = { ...endpoint };
-		if (parsed.url) {
-			next.apiUrl = parsed.url;
-			filled.push("apiUrl");
-		}
-		if (parsed.queryParams) {
-			next.queryParams = parsed.queryParams;
-			filled.push("queryParams");
-		}
-		const auth = parsed.headers.authorization;
-		if (auth) {
-			const key = auth.value.replace(/^Bearer\s+/i, "").trim();
-			if (key) {
-				next.apiKey = key;
-				filled.push("apiKey");
-			}
-		}
-		const customLines: string[] = [];
-		for (const [lower, entry] of Object.entries(parsed.headers)) {
-			if (lower === "authorization" || lower === "content-type") continue;
-			customLines.push(`${entry.originalKey}: ${entry.value}`);
-		}
-		if (customLines.length) {
-			next.customHeaders = customLines.join("\n");
-			filled.push("customHeaders");
-		}
-		const body = parsed.body as Record<string, unknown> | null;
-		if (body && typeof body.model === "string") {
-			next.model = body.model;
-			filled.push("model");
-		}
+		const { patch, filledKeys } = applyCurlToEndpoint(parsed);
 		// Parsing a curl moves us off any saved connection.
 		onSelect(null);
-		onEndpointChange(next);
+		onEndpointChange({ ...endpoint, ...patch });
 		onCurlParsed?.(parsed);
 
-		setCurlFeedback(t("endpoint.filled", { fields: filled.join(", ") }));
+		setCurlFeedback(t("endpoint.filled", { fields: filledKeys.join(", ") }));
 		setCurlText("");
 		setTimeout(() => {
 			setCurlOpen(false);

--- a/web/src/components/connection/EndpointPicker.tsx
+++ b/web/src/components/connection/EndpointPicker.tsx
@@ -64,7 +64,6 @@ export function EndpointPicker({
 	const { t } = useTranslation("common");
 	const conns = useConnectionsStore();
 	const connectionList = conns.list();
-	const createConn = useConnectionsStore((s) => s.create);
 	const updateConn = useConnectionsStore((s) => s.update);
 	const selectedConn = selectedConnectionId
 		? conns.get(selectedConnectionId)
@@ -74,10 +73,13 @@ export function EndpointPicker({
 	const [curlOpen, setCurlOpen] = useState(false);
 	const [curlText, setCurlText] = useState("");
 	const [curlFeedback, setCurlFeedback] = useState<string | null>(null);
-	const [saveOpen, setSaveOpen] = useState(false);
-	const [saveName, setSaveName] = useState("");
-	const [saveError, setSaveError] = useState<string | null>(null);
-	const [newDialogOpen, setNewDialogOpen] = useState(false);
+	/**
+	 * `null` = dialog closed.
+	 * `"new"` = "+ New connection" flow, start empty.
+	 * `"saveAs"` = "Save as…" flow, prefill with current endpoint values.
+	 */
+	const [dialogMode, setDialogMode] = useState<"new" | "saveAs" | null>(null);
+	const [updateError, setUpdateError] = useState<string | null>(null);
 
 	const apiUrlId = useId();
 	const apiKeyId = useId();
@@ -109,7 +111,7 @@ export function EndpointPicker({
 			return;
 		}
 		if (value === NEW_CONNECTION) {
-			setNewDialogOpen(true);
+			setDialogMode("new");
 			return;
 		}
 		const c = conns.get(value);
@@ -126,37 +128,16 @@ export function EndpointPicker({
 	};
 
 	const onSaveClick = () => {
-		setSaveError(null);
+		setUpdateError(null);
 		if (selectedConn) {
 			try {
 				updateConn(selectedConn.id, endpoint);
 			} catch (e) {
-				setSaveError(e instanceof Error ? e.message : "");
+				setUpdateError(e instanceof Error ? e.message : "");
 			}
 			return;
 		}
-		setSaveOpen(true);
-		setSaveName("");
-	};
-
-	const onSaveAsSubmit = () => {
-		setSaveError(null);
-		const name = saveName.trim();
-		if (!name) {
-			setSaveError(t("endpoint.nameRequired"));
-			return;
-		}
-		try {
-			const created = createConn({ name, ...endpoint });
-			onSelect(created.id);
-			setSaveOpen(false);
-			setSaveName("");
-		} catch (e) {
-			const msg = e instanceof Error ? e.message : "";
-			setSaveError(
-				msg.toLowerCase().includes("exists") ? t("endpoint.nameExists") : msg,
-			);
-		}
+		setDialogMode("saveAs");
 	};
 
 	const onParseCurl = () => {
@@ -271,8 +252,11 @@ export function EndpointPicker({
 			) : null}
 
 			<ConnectionDialog
-				open={newDialogOpen}
-				onOpenChange={setNewDialogOpen}
+				open={dialogMode !== null}
+				onOpenChange={(o) => {
+					if (!o) setDialogMode(null);
+				}}
+				initialValues={dialogMode === "saveAs" ? endpoint : undefined}
 				onSaved={(c) => {
 					onSelect(c.id);
 					onEndpointChange({
@@ -285,32 +269,8 @@ export function EndpointPicker({
 				}}
 			/>
 
-			{saveOpen ? (
-				<div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 p-2">
-					<Input
-						value={saveName}
-						onChange={(e) => setSaveName(e.target.value)}
-						placeholder={t("endpoint.nameConnection")}
-						className="h-8 font-mono text-xs"
-					/>
-					<Button
-						type="button"
-						size="sm"
-						variant="ghost"
-						onClick={() => {
-							setSaveOpen(false);
-							setSaveError(null);
-						}}
-					>
-						{t("actions.cancel")}
-					</Button>
-					<Button type="button" size="sm" onClick={onSaveAsSubmit}>
-						{t("actions.save")}
-					</Button>
-					{saveError ? (
-						<span className="text-xs text-destructive">{saveError}</span>
-					) : null}
-				</div>
+			{updateError ? (
+				<p className="text-xs text-destructive">{updateError}</p>
 			) : null}
 
 			<section className="rounded-lg border border-border bg-card p-4">

--- a/web/src/components/connection/EndpointPicker.tsx
+++ b/web/src/components/connection/EndpointPicker.tsx
@@ -88,6 +88,7 @@ export function EndpointPicker({
 	const onSelectValue = (value: string) => {
 		if (value === MANUAL) {
 			onSelect(null);
+			onEndpointChange(emptyEndpointValues);
 			return;
 		}
 		if (value === NEW_CONNECTION) {

--- a/web/src/components/connection/EndpointPicker.tsx
+++ b/web/src/components/connection/EndpointPicker.tsx
@@ -18,6 +18,7 @@ import { type EndpointValues, emptyEndpointValues } from "@/types/connection";
 import { ClipboardPaste, Eye, EyeOff } from "lucide-react";
 import { useId, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 
 const MANUAL = "__manual__";
 const NEW_CONNECTION = "__new__";
@@ -72,14 +73,12 @@ export function EndpointPicker({
 	const [revealKey, setRevealKey] = useState(false);
 	const [curlOpen, setCurlOpen] = useState(false);
 	const [curlText, setCurlText] = useState("");
-	const [curlFeedback, setCurlFeedback] = useState<string | null>(null);
 	/**
 	 * `null` = dialog closed.
 	 * `"new"` = "+ New connection" flow, start empty.
 	 * `"saveAs"` = "Save as…" flow, prefill with current endpoint values.
 	 */
 	const [dialogMode, setDialogMode] = useState<"new" | "saveAs" | null>(null);
-	const [updateError, setUpdateError] = useState<string | null>(null);
 
 	const apiUrlId = useId();
 	const apiKeyId = useId();
@@ -128,12 +127,12 @@ export function EndpointPicker({
 	};
 
 	const onSaveClick = () => {
-		setUpdateError(null);
 		if (selectedConn) {
 			try {
 				updateConn(selectedConn.id, endpoint);
+				toast.success(t("endpoint.saved", { name: selectedConn.name }));
 			} catch (e) {
-				setUpdateError(e instanceof Error ? e.message : "");
+				toast.error(e instanceof Error ? e.message : t("endpoint.saveFailed"));
 			}
 			return;
 		}
@@ -143,7 +142,7 @@ export function EndpointPicker({
 	const onParseCurl = () => {
 		const parsed = parseCurlCommand(curlText);
 		if (!parsed.url && !parsed.body) {
-			setCurlFeedback(t("endpoint.filled", { fields: "—" }));
+			toast.error(t("endpoint.curlInvalid"));
 			return;
 		}
 		const { patch, filledKeys } = applyCurlToEndpoint(parsed);
@@ -152,12 +151,9 @@ export function EndpointPicker({
 		onEndpointChange({ ...endpoint, ...patch });
 		onCurlParsed?.(parsed);
 
-		setCurlFeedback(t("endpoint.filled", { fields: filledKeys.join(", ") }));
+		toast.success(t("endpoint.filled", { fields: filledKeys.join(", ") }));
 		setCurlText("");
-		setTimeout(() => {
-			setCurlOpen(false);
-			setCurlFeedback(null);
-		}, 1200);
+		setCurlOpen(false);
 	};
 
 	return (
@@ -204,10 +200,7 @@ export function EndpointPicker({
 					type="button"
 					size="sm"
 					variant="outline"
-					onClick={() => {
-						setCurlOpen((v) => !v);
-						setCurlFeedback(null);
-					}}
+					onClick={() => setCurlOpen((v) => !v)}
 					className="shrink-0"
 				>
 					<ClipboardPaste className="h-3.5 w-3.5" />
@@ -237,16 +230,10 @@ export function EndpointPicker({
 							type="button"
 							size="sm"
 							variant="ghost"
-							onClick={() => {
-								setCurlOpen(false);
-								setCurlFeedback(null);
-							}}
+							onClick={() => setCurlOpen(false)}
 						>
 							{t("actions.cancel")}
 						</Button>
-						{curlFeedback ? (
-							<span className="text-xs text-success">{curlFeedback}</span>
-						) : null}
 					</div>
 				</div>
 			) : null}
@@ -268,10 +255,6 @@ export function EndpointPicker({
 					});
 				}}
 			/>
-
-			{updateError ? (
-				<p className="text-xs text-destructive">{updateError}</p>
-			) : null}
 
 			<section className="rounded-lg border border-border bg-card p-4">
 				<h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">

--- a/web/src/components/connection/EndpointPicker.tsx
+++ b/web/src/components/connection/EndpointPicker.tsx
@@ -39,9 +39,19 @@ export interface EndpointPickerProps {
 }
 
 /**
- * Unified endpoint editor + connection loader + curl import. The single
- * source of truth for the endpoint values is the controlled `endpoint` prop;
- * consumers own state.
+ * Full endpoint editor embedded inline in a page card: surface the API URL /
+ * Key / Model form, load values from a saved connection, import from cURL, and
+ * save current values as a new connection.
+ *
+ * **When to use:** a feature page that *needs the user to see and edit* the
+ * endpoint values as part of its primary flow (E2E Smoke, Load Test).
+ *
+ * **When NOT to use:** compact pages where the endpoint is incidental and the
+ * user just picks a saved connection — use {@link EndpointSelector} in the
+ * page header instead.
+ *
+ * The single source of truth for the endpoint values is the controlled
+ * `endpoint` prop; consumers own state (typically a Zustand store).
  */
 export function EndpointPicker({
 	endpoint,

--- a/web/src/components/connection/EndpointSelector.tsx
+++ b/web/src/components/connection/EndpointSelector.tsx
@@ -3,7 +3,6 @@ import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
-	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -15,7 +14,6 @@ import {
 } from "@/components/ui/select";
 import { ConnectionDialog } from "@/features/connections/ConnectionDialog";
 import { useConnectionsStore } from "@/stores/connections-store";
-import type { Connection } from "@/types/connection";
 import { ChevronDown, MoreHorizontal, Plus } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -25,36 +23,34 @@ const MANUAL = "__manual__";
 
 export interface EndpointSelectorProps {
 	selectedId: string | null;
+	/** When true, shows a small dot indicating the current endpoint differs from the loaded connection. */
 	modified?: boolean;
 	onSelect: (id: string | null) => void;
-	onSaveCurrent?: () => void; // "Save" — write current form back to selected connection
-	onSaveAsNew?: (name: string) => Connection;
 }
 
 /**
  * Compact connection picker intended for a page header / toolbar slot when the
- * endpoint form itself is not visible. Shows the dropdown, a modified dot, a
- * "+" to create a new connection, and a kebab menu for save / manage.
+ * endpoint form itself is not visible. Shows the dropdown, a modified dot,
+ * a "+" to create a new connection, and a kebab menu with a link to the
+ * connections library.
  *
  * **When to use:** pages where the endpoint is incidental (e.g. Request
  * Debug's top-right slot).
  *
  * **When NOT to use:** pages where the user edits API URL / Key / Model
  * inline — use {@link EndpointPicker} embedded in the page body instead.
+ * Save / Save-as-new live on the picker because only it has the current
+ * form values to persist.
  */
 export function EndpointSelector({
 	selectedId,
 	modified,
 	onSelect,
-	onSaveCurrent,
-	onSaveAsNew,
 }: EndpointSelectorProps) {
 	const { t } = useTranslation("common");
 	const navigate = useNavigate();
 	const list = useConnectionsStore((s) => s.list());
 	const [createOpen, setCreateOpen] = useState(false);
-	const [namePromptOpen, setNamePromptOpen] = useState(false);
-	const [draftName, setDraftName] = useState("");
 
 	const currentValue = selectedId ?? MANUAL;
 
@@ -94,22 +90,6 @@ export function EndpointSelector({
 					</Button>
 				</DropdownMenuTrigger>
 				<DropdownMenuContent align="end">
-					<DropdownMenuItem
-						disabled={!selectedId || !modified || !onSaveCurrent}
-						onClick={() => onSaveCurrent?.()}
-					>
-						{t("actions.save")}
-					</DropdownMenuItem>
-					<DropdownMenuItem
-						disabled={!onSaveAsNew}
-						onClick={() => {
-							setDraftName("");
-							setNamePromptOpen(true);
-						}}
-					>
-						{t("actions.saveAsNew")}
-					</DropdownMenuItem>
-					<DropdownMenuSeparator />
 					<DropdownMenuItem onClick={() => navigate("/connections")}>
 						{t("actions.manageConnections")}
 					</DropdownMenuItem>
@@ -129,51 +109,6 @@ export function EndpointSelector({
 				onOpenChange={setCreateOpen}
 				onSaved={(c) => onSelect(c.id)}
 			/>
-
-			{namePromptOpen ? (
-				<NamePrompt
-					value={draftName}
-					onChange={setDraftName}
-					onCancel={() => setNamePromptOpen(false)}
-					onSubmit={() => {
-						const created = onSaveAsNew?.(draftName.trim());
-						if (created) onSelect(created.id);
-						setNamePromptOpen(false);
-					}}
-				/>
-			) : null}
-		</div>
-	);
-}
-
-function NamePrompt({
-	value,
-	onChange,
-	onCancel,
-	onSubmit,
-}: {
-	value: string;
-	onChange: (v: string) => void;
-	onCancel: () => void;
-	onSubmit: () => void;
-}) {
-	const { t } = useTranslation("common");
-	return (
-		<div className="absolute right-8 top-16 z-50 flex w-72 items-center gap-2 rounded-md border border-border bg-card p-2 shadow-md">
-			<input
-				// biome-ignore lint/a11y/noAutofocus: floating name prompt intentionally focuses for fast keyboard entry
-				autoFocus
-				value={value}
-				onChange={(e) => onChange(e.target.value)}
-				placeholder="connection-name"
-				className="h-8 flex-1 rounded-md border border-input bg-background px-2 text-xs"
-			/>
-			<Button size="sm" variant="ghost" onClick={onCancel}>
-				{t("actions.cancel")}
-			</Button>
-			<Button size="sm" onClick={onSubmit} disabled={!value.trim()}>
-				{t("actions.save")}
-			</Button>
 		</div>
 	);
 }

--- a/web/src/components/connection/EndpointSelector.tsx
+++ b/web/src/components/connection/EndpointSelector.tsx
@@ -31,6 +31,17 @@ export interface EndpointSelectorProps {
 	onSaveAsNew?: (name: string) => Connection;
 }
 
+/**
+ * Compact connection picker intended for a page header / toolbar slot when the
+ * endpoint form itself is not visible. Shows the dropdown, a modified dot, a
+ * "+" to create a new connection, and a kebab menu for save / manage.
+ *
+ * **When to use:** pages where the endpoint is incidental (e.g. Request
+ * Debug's top-right slot).
+ *
+ * **When NOT to use:** pages where the user edits API URL / Key / Model
+ * inline — use {@link EndpointPicker} embedded in the page body instead.
+ */
 export function EndpointSelector({
 	selectedId,
 	modified,

--- a/web/src/components/sidebar/Sidebar.tsx
+++ b/web/src/components/sidebar/Sidebar.tsx
@@ -1,8 +1,13 @@
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { useSidebarStore } from "@/stores/sidebar-store";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { NavLink } from "react-router-dom";
 import {
@@ -11,32 +16,67 @@ import {
 	sidebarUtilityItems,
 } from "./sidebar-config";
 
-function ItemRow({ item, t }: { item: Item; t: (k: string) => string }) {
+interface ItemRowProps {
+	item: Item;
+	t: (k: string) => string;
+	railCollapsed: boolean;
+}
+
+function ItemRow({ item, t, railCollapsed }: ItemRowProps) {
 	const Icon = item.icon;
-	return (
+	const label = t(item.labelKey);
+	const link = (
 		<NavLink
 			to={item.to}
+			aria-label={railCollapsed ? label : undefined}
 			className={({ isActive }) =>
 				cn(
-					"group relative flex items-center gap-2 rounded-md px-3 py-1.5 text-sm",
+					"group relative flex items-center rounded-md text-sm",
 					"text-muted-foreground hover:bg-accent/50 hover:text-foreground",
 					isActive && "bg-accent/50 text-foreground",
+					railCollapsed ? "justify-center px-0 py-2" : "gap-2 px-3 py-1.5",
 				)
 			}
 		>
 			{({ isActive }) => (
 				<>
 					{isActive ? (
-						<span className="absolute left-0 top-1.5 h-5 w-0.5 rounded-r bg-foreground" />
+						<span
+							className={cn(
+								"absolute rounded-r bg-foreground",
+								railCollapsed
+									? "left-0 top-1/2 h-5 w-0.5 -translate-y-1/2"
+									: "left-0 top-1.5 h-5 w-0.5",
+							)}
+						/>
 					) : null}
-					<Icon className="h-4 w-4" strokeWidth={1.5} />
-					<span className="flex-1">{t(item.labelKey)}</span>
-					{item.comingSoon ? (
-						<Badge variant="outline">{t("status.comingSoon")}</Badge>
-					) : null}
+					<Icon className="h-4 w-4 shrink-0" strokeWidth={1.5} />
+					{railCollapsed ? (
+						item.comingSoon ? (
+							<span
+								aria-hidden
+								className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-warning"
+							/>
+						) : null
+					) : (
+						<>
+							<span className="flex-1">{label}</span>
+							{item.comingSoon ? (
+								<Badge variant="outline">{t("status.comingSoon")}</Badge>
+							) : null}
+						</>
+					)}
 				</>
 			)}
 		</NavLink>
+	);
+
+	if (!railCollapsed) return link;
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>{link}</TooltipTrigger>
+			<TooltipContent side="right">{label}</TooltipContent>
+		</Tooltip>
 	);
 }
 
@@ -45,43 +85,93 @@ export function Sidebar() {
 	const { t: tc } = useTranslation("common");
 	const collapsed = useSidebarStore((s) => s.collapsedGroups);
 	const toggleGroup = useSidebarStore((s) => s.toggleGroup);
+	const railCollapsed = useSidebarStore((s) => s.railCollapsed);
+	const toggleRail = useSidebarStore((s) => s.toggleRail);
 
 	return (
-		<aside className="flex h-screen w-64 flex-col border-r border-border bg-card">
-			<div className="px-5 py-5">
-				<div className="text-sm font-semibold tracking-tight">
-					{tc("appName")}
+		<aside
+			className={cn(
+				"flex h-screen flex-col border-r border-border bg-card transition-[width] duration-150",
+				railCollapsed ? "w-14" : "w-64",
+			)}
+		>
+			{railCollapsed ? (
+				<div className="flex items-center justify-center px-2 py-5">
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<button
+								type="button"
+								onClick={toggleRail}
+								aria-label={tc("sidebar.expand")}
+								className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+							>
+								<PanelLeftOpen className="h-4 w-4" strokeWidth={1.5} />
+							</button>
+						</TooltipTrigger>
+						<TooltipContent side="right">{tc("sidebar.expand")}</TooltipContent>
+					</Tooltip>
 				</div>
-				<div className="mt-0.5 text-[11px] text-muted-foreground">
-					{tc("tagline")}
+			) : (
+				<div className="flex items-start justify-between px-5 py-5">
+					<div className="min-w-0">
+						<div className="truncate text-sm font-semibold tracking-tight">
+							{tc("appName")}
+						</div>
+						<div className="mt-0.5 truncate text-[11px] text-muted-foreground">
+							{tc("tagline")}
+						</div>
+					</div>
+					<button
+						type="button"
+						onClick={toggleRail}
+						aria-label={tc("sidebar.collapse")}
+						title={tc("sidebar.collapse")}
+						className="-mr-1 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+					>
+						<PanelLeftClose className="h-4 w-4" strokeWidth={1.5} />
+					</button>
 				</div>
-			</div>
+			)}
 
 			<Separator />
 
-			<nav className="flex-1 overflow-y-auto px-2 py-3">
+			<nav
+				className={cn(
+					"flex-1 overflow-y-auto py-3",
+					railCollapsed ? "px-2" : "px-2",
+				)}
+			>
 				{sidebarGroups.map((group) => {
 					const isCollapsed = collapsed[group.id];
 					return (
 						<div key={group.id} className="mb-3">
-							<button
-								type="button"
-								onClick={() => toggleGroup(group.id)}
-								className="flex w-full items-center justify-between px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground"
-							>
-								<span>{t(group.labelKey)}</span>
-								<ChevronDown
-									className={cn(
-										"h-3 w-3 transition-transform",
-										isCollapsed && "-rotate-90",
-									)}
-									strokeWidth={2}
-								/>
-							</button>
-							{isCollapsed ? null : (
+							{railCollapsed ? (
+								<div className="mx-2 mb-1 h-px bg-border/60" aria-hidden />
+							) : (
+								<button
+									type="button"
+									onClick={() => toggleGroup(group.id)}
+									className="flex w-full items-center justify-between px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground"
+								>
+									<span>{t(group.labelKey)}</span>
+									<ChevronDown
+										className={cn(
+											"h-3 w-3 transition-transform",
+											isCollapsed && "-rotate-90",
+										)}
+										strokeWidth={2}
+									/>
+								</button>
+							)}
+							{!railCollapsed && isCollapsed ? null : (
 								<div className="mt-1 flex flex-col gap-px">
 									{group.items.map((item) => (
-										<ItemRow key={item.to} item={item} t={(k) => t(k)} />
+										<ItemRow
+											key={item.to}
+											item={item}
+											t={(k) => t(k)}
+											railCollapsed={railCollapsed}
+										/>
 									))}
 								</div>
 							)}
@@ -94,7 +184,12 @@ export function Sidebar() {
 
 			<div className="px-2 py-3">
 				{sidebarUtilityItems.map((item) => (
-					<ItemRow key={item.to} item={item} t={(k) => t(k)} />
+					<ItemRow
+						key={item.to}
+						item={item}
+						t={(k) => t(k)}
+						railCollapsed={railCollapsed}
+					/>
 				))}
 			</div>
 		</aside>

--- a/web/src/features/connections/ConnectionDialog.tsx
+++ b/web/src/features/connections/ConnectionDialog.tsx
@@ -26,7 +26,13 @@ import { type ConnectionInput, connectionInputSchema } from "./schema";
 interface ConnectionDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	connection?: Connection; // undefined → create mode
+	/** If provided, dialog is in edit mode for this connection. */
+	connection?: Connection;
+	/**
+	 * Create-mode prefill — e.g. "Save as new" from an inline endpoint form.
+	 * Ignored when `connection` is set.
+	 */
+	initialValues?: Partial<ConnectionInput>;
 	onSaved?: (c: Connection) => void;
 }
 
@@ -43,6 +49,7 @@ export function ConnectionDialog({
 	open,
 	onOpenChange,
 	connection,
+	initialValues,
 	onSaved,
 }: ConnectionDialogProps) {
 	const { t } = useTranslation("connections");
@@ -64,13 +71,13 @@ export function ConnectionDialog({
 
 	useEffect(() => {
 		if (open) {
-			form.reset(connection ?? empty);
+			form.reset(connection ?? { ...empty, ...initialValues });
 			setSubmitError(null);
 			setRevealKey(false);
 			setCurlInput("");
 			setCurlFeedback(null);
 		}
-	}, [open, connection, form]);
+	}, [open, connection, initialValues, form]);
 
 	const onParseCurl = () => {
 		const trimmed = curlInput.trim();

--- a/web/src/features/connections/ConnectionDialog.tsx
+++ b/web/src/features/connections/ConnectionDialog.tsx
@@ -21,6 +21,7 @@ import { Eye, EyeOff } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { type ConnectionInput, connectionInputSchema } from "./schema";
 
 interface ConnectionDialogProps {
@@ -59,10 +60,6 @@ export function ConnectionDialog({
 	const [revealKey, setRevealKey] = useState(false);
 	const [submitError, setSubmitError] = useState<string | null>(null);
 	const [curlInput, setCurlInput] = useState("");
-	const [curlFeedback, setCurlFeedback] = useState<{
-		kind: "ok" | "err";
-		text: string;
-	} | null>(null);
 
 	const form = useForm<ConnectionInput>({
 		resolver: zodResolver(connectionInputSchema),
@@ -75,21 +72,20 @@ export function ConnectionDialog({
 			setSubmitError(null);
 			setRevealKey(false);
 			setCurlInput("");
-			setCurlFeedback(null);
 		}
 	}, [open, connection, initialValues, form]);
 
 	const onParseCurl = () => {
 		const trimmed = curlInput.trim();
 		if (!trimmed) {
-			setCurlFeedback({ kind: "err", text: t("dialog.curl.empty") });
+			toast.error(t("dialog.curl.empty"));
 			return;
 		}
 		const parsed = parseCurlCommand(trimmed);
 		const { patch, filledKeys } = applyCurlToEndpoint(parsed);
 
 		if (filledKeys.length === 0) {
-			setCurlFeedback({ kind: "err", text: t("dialog.curl.invalid") });
+			toast.error(t("dialog.curl.invalid"));
 			return;
 		}
 
@@ -105,10 +101,7 @@ export function ConnectionDialog({
 		}
 
 		const localized = filledKeys.map((k) => t(`dialog.fields.${k}`));
-		setCurlFeedback({
-			kind: "ok",
-			text: t("dialog.curl.filled", { fields: localized.join(", ") }),
-		});
+		toast.success(t("dialog.curl.filled", { fields: localized.join(", ") }));
 	};
 
 	const onSubmit = form.handleSubmit((values) => {
@@ -144,27 +137,14 @@ export function ConnectionDialog({
 								placeholder={t("dialog.curl.placeholder")}
 								className="font-mono text-xs"
 							/>
-							<div className="flex items-center gap-2">
-								<Button
-									type="button"
-									size="sm"
-									variant="outline"
-									onClick={onParseCurl}
-								>
-									{t("dialog.curl.parse")}
-								</Button>
-								{curlFeedback ? (
-									<span
-										className={
-											curlFeedback.kind === "ok"
-												? "text-xs text-success"
-												: "text-xs text-destructive"
-										}
-									>
-										{curlFeedback.text}
-									</span>
-								) : null}
-							</div>
+							<Button
+								type="button"
+								size="sm"
+								variant="outline"
+								onClick={onParseCurl}
+							>
+								{t("dialog.curl.parse")}
+							</Button>
 						</div>
 					</details>
 

--- a/web/src/features/connections/ConnectionDialog.tsx
+++ b/web/src/features/connections/ConnectionDialog.tsx
@@ -9,6 +9,10 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+	type EndpointKey,
+	applyCurlToEndpoint,
+} from "@/lib/apply-curl-to-endpoint";
 import { parseCurlCommand } from "@/lib/curl-parser";
 import { useConnectionsStore } from "@/stores/connections-store";
 import type { Connection } from "@/types/connection";
@@ -75,50 +79,28 @@ export function ConnectionDialog({
 			return;
 		}
 		const parsed = parseCurlCommand(trimmed);
-		const filled: string[] = [];
+		const { patch, filledKeys } = applyCurlToEndpoint(parsed);
 
-		if (parsed.url) {
-			form.setValue("apiUrl", parsed.url, { shouldValidate: true });
-			filled.push(t("dialog.fields.apiUrl"));
-		}
-		if (parsed.queryParams) {
-			form.setValue("queryParams", parsed.queryParams);
-			filled.push(t("dialog.fields.queryParams"));
-		}
-		const auth = parsed.headers.authorization;
-		if (auth) {
-			const key = auth.value.replace(/^Bearer\s+/i, "").trim();
-			if (key) {
-				form.setValue("apiKey", key, { shouldValidate: true });
-				filled.push(t("dialog.fields.apiKey"));
-			}
-		}
-		const customLines: string[] = [];
-		for (const [lower, entry] of Object.entries(parsed.headers)) {
-			if (lower === "authorization" || lower === "content-type") continue;
-			customLines.push(`${entry.originalKey}: ${entry.value}`);
-		}
-		if (customLines.length) {
-			form.setValue("customHeaders", customLines.join("\n"));
-			filled.push(t("dialog.fields.customHeaders"));
-		}
-		const bodyModel =
-			parsed.body &&
-			typeof (parsed.body as { model?: unknown }).model === "string"
-				? (parsed.body as { model: string }).model
-				: "";
-		if (bodyModel) {
-			form.setValue("model", bodyModel, { shouldValidate: true });
-			filled.push(t("dialog.fields.model"));
-		}
-
-		if (filled.length === 0) {
+		if (filledKeys.length === 0) {
 			setCurlFeedback({ kind: "err", text: t("dialog.curl.invalid") });
 			return;
 		}
+
+		const validatedKeys: ReadonlySet<EndpointKey> = new Set([
+			"apiUrl",
+			"apiKey",
+			"model",
+		]);
+		for (const key of filledKeys) {
+			const value = patch[key];
+			if (value === undefined) continue;
+			form.setValue(key, value, { shouldValidate: validatedKeys.has(key) });
+		}
+
+		const localized = filledKeys.map((k) => t(`dialog.fields.${k}`));
 		setCurlFeedback({
 			kind: "ok",
-			text: t("dialog.curl.filled", { fields: filled.join(", ") }),
+			text: t("dialog.curl.filled", { fields: localized.join(", ") }),
 		});
 	};
 

--- a/web/src/features/e2e-smoke/E2ESmokePage.test.tsx
+++ b/web/src/features/e2e-smoke/E2ESmokePage.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@/lib/i18n";
+import { E2ESmokePage } from "./E2ESmokePage";
+import { useE2EStore } from "./store";
+import type { E2ETestResponse } from "./types";
+
+vi.mock("@/lib/api-client", () => {
+	class ApiError extends Error {
+		status: number;
+		constructor(status: number, message: string) {
+			super(message);
+			this.status = status;
+		}
+	}
+	return {
+		ApiError,
+		api: { get: vi.fn(), post: vi.fn() },
+	};
+});
+
+import { api } from "@/lib/api-client";
+
+describe("E2ESmokePage (happy path)", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		useE2EStore.getState().reset();
+		vi.mocked(api.post).mockReset();
+	});
+
+	it("Run All is disabled until endpoint fields are filled", async () => {
+		render(<E2ESmokePage />);
+		const runAll = screen.getByRole("button", { name: /run all/i });
+		expect(runAll).toBeDisabled();
+
+		const user = userEvent.setup();
+		await user.type(
+			screen.getByLabelText(/api url/i),
+			"http://host/v1/chat/completions",
+		);
+		await user.type(screen.getByLabelText(/api key/i), "sk-test");
+		await user.type(screen.getByLabelText(/^model$/i), "test-model");
+
+		expect(runAll).toBeEnabled();
+	});
+
+	it("Run All posts to /api/e2e-test and renders three Pass cards", async () => {
+		const response: E2ETestResponse = {
+			success: true,
+			results: [
+				{
+					probe: "text",
+					pass: true,
+					latencyMs: 12,
+					checks: [{ name: "HTTP status 200", pass: true, info: "200" }],
+					details: { content: "OK-TEXT-123" },
+				},
+				{
+					probe: "image",
+					pass: true,
+					latencyMs: 34,
+					checks: [{ name: "Reply mentions 'cat'", pass: true }],
+					details: { content: "Cat" },
+				},
+				{
+					probe: "audio",
+					pass: true,
+					latencyMs: 56,
+					checks: [{ name: "Valid WAV header", pass: true }],
+					details: { numChoices: 1 },
+				},
+			],
+		};
+		vi.mocked(api.post).mockResolvedValue(response);
+
+		const user = userEvent.setup();
+		render(<E2ESmokePage />);
+		await user.type(
+			screen.getByLabelText(/api url/i),
+			"http://host/v1/chat/completions",
+		);
+		await user.type(screen.getByLabelText(/api key/i), "sk-test");
+		await user.type(screen.getByLabelText(/^model$/i), "test-model");
+
+		await user.click(screen.getByRole("button", { name: /run all/i }));
+
+		await waitFor(() => {
+			const badges = screen.getAllByText(/^(pass|通过)$/i);
+			expect(badges).toHaveLength(3);
+		});
+
+		expect(api.post).toHaveBeenCalledWith(
+			"/api/e2e-test",
+			expect.objectContaining({
+				apiUrl: "http://host/v1/chat/completions",
+				apiKey: "sk-test",
+				model: "test-model",
+				probes: ["text", "image", "audio"],
+			}),
+		);
+	});
+
+	it("renders Fail badges when probes return pass=false", async () => {
+		vi.mocked(api.post).mockResolvedValue({
+			success: true,
+			results: [
+				{
+					probe: "text",
+					pass: false,
+					latencyMs: 10,
+					checks: [{ name: "HTTP status 200", pass: false, info: "500" }],
+					details: {},
+				},
+				{
+					probe: "image",
+					pass: false,
+					latencyMs: 10,
+					checks: [],
+					details: {},
+				},
+				{
+					probe: "audio",
+					pass: false,
+					latencyMs: 10,
+					checks: [],
+					details: {},
+				},
+			],
+		});
+
+		const user = userEvent.setup();
+		render(<E2ESmokePage />);
+		await user.type(
+			screen.getByLabelText(/api url/i),
+			"http://host/v1/chat/completions",
+		);
+		await user.type(screen.getByLabelText(/api key/i), "sk-test");
+		await user.type(screen.getByLabelText(/^model$/i), "test-model");
+		await user.click(screen.getByRole("button", { name: /run all/i }));
+
+		await waitFor(() => {
+			const fails = screen.getAllByText(/^(fail|失败)$/i);
+			expect(fails).toHaveLength(3);
+		});
+	});
+});
+
+// Silence: helper unused in this file but kept for when we expand
+void within;

--- a/web/src/features/e2e-smoke/E2ESmokePage.tsx
+++ b/web/src/features/e2e-smoke/E2ESmokePage.tsx
@@ -5,13 +5,7 @@ import { ApiError, api } from "@/lib/api-client";
 import { useTranslation } from "react-i18next";
 import { ProbeCard } from "./ProbeCard";
 import { useE2EStore } from "./store";
-import type { ProbeName, ProbeResult } from "./types";
-
-interface E2EApiResponse {
-	success: boolean;
-	results: Array<{ probe: ProbeName } & ProbeResult>;
-	error?: string;
-}
+import type { E2ETestResponse, ProbeName } from "./types";
 
 export function E2ESmokePage() {
 	const { t } = useTranslation("e2e");
@@ -29,7 +23,7 @@ export function E2ESmokePage() {
 		if (!canRun) return;
 		for (const p of probes) slice.setRunning(p, true);
 		try {
-			const data = await api.post<E2EApiResponse>("/api/e2e-test", {
+			const data = await api.post<E2ETestResponse>("/api/e2e-test", {
 				apiUrl: endpoint.apiUrl,
 				apiKey: endpoint.apiKey,
 				model: endpoint.model,

--- a/web/src/features/e2e-smoke/E2ESmokePage.tsx
+++ b/web/src/features/e2e-smoke/E2ESmokePage.tsx
@@ -69,7 +69,10 @@ export function E2ESmokePage() {
 				<EndpointPicker
 					endpoint={endpoint}
 					selectedConnectionId={slice.selectedConnectionId}
-					onSelect={slice.setSelected}
+					onSelect={(id) => {
+						slice.setSelected(id);
+						slice.resetResults();
+					}}
 					onEndpointChange={slice.setManualEndpoint}
 				/>
 
@@ -88,7 +91,7 @@ export function E2ESmokePage() {
 					<Button onClick={() => runProbes(["text", "image", "audio"])}>
 						{t("actions.runAll")}
 					</Button>
-					<Button variant="ghost" onClick={() => slice.clearAll()}>
+					<Button variant="ghost" onClick={() => slice.resetResults()}>
 						{t("actions.clear")}
 					</Button>
 				</div>

--- a/web/src/features/e2e-smoke/E2ESmokePage.tsx
+++ b/web/src/features/e2e-smoke/E2ESmokePage.tsx
@@ -19,11 +19,14 @@ export function E2ESmokePage() {
 	const slice = useE2EStore();
 	const endpoint = slice.manualEndpoint;
 
+	const canRun =
+		endpoint.apiUrl.trim().length > 0 &&
+		endpoint.apiKey.trim().length > 0 &&
+		endpoint.model.trim().length > 0;
+	const disabledReason = canRun ? undefined : tc("errors.required");
+
 	const runProbes = async (probes: ProbeName[]) => {
-		if (!endpoint.apiUrl || !endpoint.apiKey || !endpoint.model) {
-			alert(tc("errors.required"));
-			return;
-		}
+		if (!canRun) return;
 		for (const p of probes) slice.setRunning(p, true);
 		try {
 			const data = await api.post<E2EApiResponse>("/api/e2e-test", {
@@ -84,11 +87,16 @@ export function E2ESmokePage() {
 							result={slice.results[p]}
 							running={slice.running[p]}
 							onRun={() => runProbes([p])}
+							disabledReason={disabledReason}
 						/>
 					))}
 				</div>
 				<div className="flex gap-2">
-					<Button onClick={() => runProbes(["text", "image", "audio"])}>
+					<Button
+						onClick={() => runProbes(["text", "image", "audio"])}
+						disabled={!canRun}
+						title={disabledReason}
+					>
 						{t("actions.runAll")}
 					</Button>
 					<Button variant="ghost" onClick={() => slice.resetResults()}>

--- a/web/src/features/e2e-smoke/ProbeCard.tsx
+++ b/web/src/features/e2e-smoke/ProbeCard.tsx
@@ -10,9 +10,17 @@ interface Props {
 	result: ProbeResult | null;
 	running: boolean;
 	onRun: () => void;
+	/** When set, the Run button is disabled and this string is shown as tooltip. */
+	disabledReason?: string;
 }
 
-export function ProbeCard({ name, result, running, onRun }: Props) {
+export function ProbeCard({
+	name,
+	result,
+	running,
+	onRun,
+	disabledReason,
+}: Props) {
 	const { t } = useTranslation("e2e");
 	const { t: tc } = useTranslation("common");
 	const variant: "default" | "warning" | "success" | "destructive" = running
@@ -50,7 +58,13 @@ export function ProbeCard({ name, result, running, onRun }: Props) {
 				<Badge variant={variant}>{status}</Badge>
 			</div>
 
-			<Button variant="outline" size="sm" onClick={onRun} disabled={running}>
+			<Button
+				variant="outline"
+				size="sm"
+				onClick={onRun}
+				disabled={running || !!disabledReason}
+				title={disabledReason}
+			>
 				{tc("actions.run")}
 			</Button>
 

--- a/web/src/features/e2e-smoke/store.test.ts
+++ b/web/src/features/e2e-smoke/store.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useE2EStore } from "./store";
+
+const PERSIST_KEY = "md.e2e.v1";
+
+function storedState(): Record<string, unknown> | null {
+	const raw = localStorage.getItem(PERSIST_KEY);
+	if (!raw) return null;
+	return (JSON.parse(raw) as { state: Record<string, unknown> }).state;
+}
+
+describe("useE2EStore", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		useE2EStore.getState().reset();
+	});
+
+	it("starts with empty endpoint, no selection, no results", () => {
+		const s = useE2EStore.getState();
+		expect(s.selectedConnectionId).toBeNull();
+		expect(s.manualEndpoint).toEqual({
+			apiUrl: "",
+			apiKey: "",
+			model: "",
+			customHeaders: "",
+			queryParams: "",
+		});
+		expect(s.results).toEqual({ text: null, image: null, audio: null });
+		expect(s.running).toEqual({ text: false, image: false, audio: false });
+	});
+
+	it("setResult / setRunning update the specific probe only", () => {
+		useE2EStore.getState().setRunning("text", true);
+		useE2EStore.getState().setResult("image", {
+			pass: true,
+			latencyMs: 42,
+			checks: [],
+			details: {},
+		});
+		const s = useE2EStore.getState();
+		expect(s.running).toEqual({ text: true, image: false, audio: false });
+		expect(s.results.image?.pass).toBe(true);
+		expect(s.results.text).toBeNull();
+		expect(s.results.audio).toBeNull();
+	});
+
+	it("resetResults clears outputs but preserves endpoint + selection", () => {
+		const store = useE2EStore.getState();
+		store.setSelected("conn-1");
+		store.setManualEndpoint({
+			apiUrl: "http://a",
+			apiKey: "k",
+			model: "m",
+			customHeaders: "",
+			queryParams: "",
+		});
+		store.setResult("text", {
+			pass: false,
+			latencyMs: 5,
+			checks: [],
+			details: {},
+		});
+		store.setRunning("audio", true);
+
+		useE2EStore.getState().resetResults();
+		const s = useE2EStore.getState();
+		expect(s.selectedConnectionId).toBe("conn-1");
+		expect(s.manualEndpoint.apiUrl).toBe("http://a");
+		expect(s.results).toEqual({ text: null, image: null, audio: null });
+		expect(s.running).toEqual({ text: false, image: false, audio: false });
+	});
+
+	it("reset clears everything including endpoint and selection", () => {
+		const store = useE2EStore.getState();
+		store.setSelected("conn-1");
+		store.setManualEndpoint({
+			apiUrl: "http://a",
+			apiKey: "k",
+			model: "m",
+			customHeaders: "",
+			queryParams: "",
+		});
+		store.setResult("text", {
+			pass: true,
+			latencyMs: 1,
+			checks: [],
+			details: {},
+		});
+
+		useE2EStore.getState().reset();
+		const s = useE2EStore.getState();
+		expect(s.selectedConnectionId).toBeNull();
+		expect(s.manualEndpoint.apiUrl).toBe("");
+		expect(s.results.text).toBeNull();
+	});
+
+	it("persists only selection + endpoint, not transient results/running", () => {
+		const store = useE2EStore.getState();
+		store.setSelected("conn-1");
+		store.setManualEndpoint({
+			apiUrl: "http://x",
+			apiKey: "k",
+			model: "m",
+			customHeaders: "",
+			queryParams: "",
+		});
+		store.setResult("text", {
+			pass: true,
+			latencyMs: 10,
+			checks: [],
+			details: {},
+		});
+		store.setRunning("image", true);
+
+		const persisted = storedState();
+		expect(persisted).not.toBeNull();
+		expect(Object.keys(persisted as object).sort()).toEqual([
+			"manualEndpoint",
+			"selectedConnectionId",
+		]);
+	});
+});

--- a/web/src/features/e2e-smoke/store.ts
+++ b/web/src/features/e2e-smoke/store.ts
@@ -12,28 +12,49 @@ interface E2EState {
 	setManualEndpoint: (values: EndpointValues) => void;
 	setRunning: (name: ProbeName, running: boolean) => void;
 	setResult: (name: ProbeName, r: ProbeResult | null) => void;
-	clearAll: () => void;
+	/** Clear probe outputs only (results + running). Preserves endpoint & selection. */
+	resetResults: () => void;
+	/** Full reset to factory defaults, including endpoint and selection. */
+	reset: () => void;
 }
+
+const INITIAL_RESULTS: E2EState["results"] = {
+	text: null,
+	image: null,
+	audio: null,
+};
+const INITIAL_RUNNING: E2EState["running"] = {
+	text: false,
+	image: false,
+	audio: false,
+};
+const INITIAL = {
+	selectedConnectionId: null as string | null,
+	manualEndpoint: emptyEndpointValues,
+	results: INITIAL_RESULTS,
+	running: INITIAL_RUNNING,
+};
 
 export const useE2EStore = create<E2EState>()(
 	persist(
 		(set) => ({
-			selectedConnectionId: null,
-			manualEndpoint: emptyEndpointValues,
-			results: { text: null, image: null, audio: null },
-			running: { text: false, image: false, audio: false },
+			...INITIAL,
 			setSelected: (id) => set({ selectedConnectionId: id }),
 			setManualEndpoint: (values) => set({ manualEndpoint: values }),
 			setRunning: (name, running) =>
 				set((s) => ({ running: { ...s.running, [name]: running } })),
 			setResult: (name, r) =>
 				set((s) => ({ results: { ...s.results, [name]: r } })),
-			clearAll: () =>
-				set({
-					results: { text: null, image: null, audio: null },
-					running: { text: false, image: false, audio: false },
-				}),
+			resetResults: () =>
+				set({ results: INITIAL_RESULTS, running: INITIAL_RUNNING }),
+			reset: () => set(INITIAL),
 		}),
-		{ name: "md.e2e.v1" },
+		{
+			name: "md.e2e.v1",
+			partialize: (s) => ({
+				selectedConnectionId: s.selectedConnectionId,
+				manualEndpoint: s.manualEndpoint,
+			}),
+		},
 	),
 );

--- a/web/src/features/e2e-smoke/types.ts
+++ b/web/src/features/e2e-smoke/types.ts
@@ -22,3 +22,10 @@ export interface ProbeResult {
 		error?: string;
 	};
 }
+
+/** Wire format returned by `POST /api/e2e-test`. */
+export interface E2ETestResponse {
+	success: boolean;
+	results: Array<{ probe: ProbeName } & ProbeResult>;
+	error?: string;
+}

--- a/web/src/features/load-test/LoadTestPage.test.tsx
+++ b/web/src/features/load-test/LoadTestPage.test.tsx
@@ -1,0 +1,104 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@/lib/i18n";
+import { LoadTestPage } from "./LoadTestPage";
+import { useLoadTestStore } from "./store";
+import type { LoadTestResult } from "./types";
+
+vi.mock("@/lib/api-client", () => {
+	class ApiError extends Error {
+		status: number;
+		constructor(status: number, message: string) {
+			super(message);
+			this.status = status;
+		}
+	}
+	return {
+		ApiError,
+		api: { get: vi.fn(), post: vi.fn() },
+	};
+});
+
+import { api } from "@/lib/api-client";
+
+function Wrapper({ children }: { children: ReactNode }) {
+	const qc = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+const FAKE_RESULT: LoadTestResult = {
+	report:
+		"Requests      [total, rate, throughput]  120, 2.00, 2.00\nLatencies     [mean, 50, 95, 99, max]  5ms, 5ms, 6ms, 7ms, 9ms",
+	parsed: {
+		requests: 120,
+		success: 120,
+		throughput: 2,
+		latencies: { mean: "5ms", p50: "5ms", p95: "6ms", p99: "7ms", max: "9ms" },
+	},
+	config: { apiUrl: "http://host/v1/chat/completions", rate: 2, duration: 60 },
+};
+
+describe("LoadTestPage (happy path)", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		useLoadTestStore.getState().reset();
+		vi.mocked(api.post).mockReset();
+	});
+
+	it("Start posts to /api/load-test and renders metrics", async () => {
+		vi.mocked(api.post).mockResolvedValue(FAKE_RESULT);
+		const user = userEvent.setup();
+		render(
+			<Wrapper>
+				<LoadTestPage />
+			</Wrapper>,
+		);
+
+		await user.type(
+			screen.getByLabelText(/api url/i),
+			"http://host/v1/chat/completions",
+		);
+		await user.type(screen.getByLabelText(/api key/i), "sk-test");
+		await user.type(screen.getByLabelText(/^model$/i), "test-model");
+
+		await user.click(screen.getByRole("button", { name: /^(start|开始)$/i }));
+
+		await waitFor(() => {
+			// "总请求数" / "Total" label appears once the result renders
+			expect(screen.getAllByText(/120/).length).toBeGreaterThan(0);
+		});
+
+		expect(api.post).toHaveBeenCalledWith(
+			"/api/load-test",
+			expect.objectContaining({
+				apiType: "chat",
+				apiUrl: "http://host/v1/chat/completions",
+				apiKey: "sk-test",
+				model: "test-model",
+			}),
+		);
+	});
+
+	it("Reset clears the last result from view", async () => {
+		useLoadTestStore.getState().setLastResult(FAKE_RESULT);
+		const user = userEvent.setup();
+		render(
+			<Wrapper>
+				<LoadTestPage />
+			</Wrapper>,
+		);
+
+		expect(screen.getAllByText(/120/).length).toBeGreaterThan(0);
+		await user.click(screen.getByRole("button", { name: /^(reset|重置)$/i }));
+
+		await waitFor(() => {
+			expect(screen.queryAllByText(/120/).length).toBe(0);
+		});
+		expect(useLoadTestStore.getState().lastResult).toBeNull();
+	});
+});

--- a/web/src/features/load-test/LoadTestPage.tsx
+++ b/web/src/features/load-test/LoadTestPage.tsx
@@ -15,7 +15,6 @@ import { ApiError, api } from "@/lib/api-client";
 import { type ParsedCurl, detectApiType } from "@/lib/curl-parser";
 import type { EndpointValues } from "@/types/connection";
 import { useMutation } from "@tanstack/react-query";
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LoadTestResults } from "./Results";
 import { ChatForm } from "./forms/chat";
@@ -82,8 +81,6 @@ export function LoadTestPage() {
 	const { t: tc } = useTranslation("common");
 	const slice = useLoadTestStore();
 
-	const [error, setError] = useState<string | null>(null);
-	const [progress, setProgress] = useState(0);
 	const ActiveForm = formByType[slice.apiType];
 
 	const endpoint = slice.manualEndpoint;
@@ -171,20 +168,18 @@ export function LoadTestPage() {
 		},
 		onSuccess: (data) => {
 			slice.setLastResult(data);
-			setProgress(100);
+			slice.setProgress(100);
 		},
-		onError: (e) => setError(e.message),
+		onError: (e) => slice.setError(e.message),
 	});
 
 	const onStart = () => {
-		setError(null);
-		setProgress(0);
-		slice.setLastResult(null);
+		slice.resetResults();
 		const totalMs = slice.attack.duration * 1000;
 		const startedAt = Date.now();
 		const tick = setInterval(() => {
 			const pct = Math.min(99, ((Date.now() - startedAt) / totalMs) * 100);
-			setProgress(pct);
+			slice.setProgress(pct);
 			if (mutation.isIdle === false && !mutation.isPending) clearInterval(tick);
 		}, 250);
 		mutation.mutate(undefined, { onSettled: () => clearInterval(tick) });
@@ -197,7 +192,10 @@ export function LoadTestPage() {
 				<EndpointPicker
 					endpoint={endpoint}
 					selectedConnectionId={slice.selectedConnectionId}
-					onSelect={slice.setSelected}
+					onSelect={(id) => {
+						slice.setSelected(id);
+						slice.resetResults();
+					}}
 					onEndpointChange={onEndpointChange}
 					onCurlParsed={onCurlParsed}
 				/>
@@ -262,23 +260,16 @@ export function LoadTestPage() {
 					<Button onClick={onStart} disabled={mutation.isPending}>
 						{mutation.isPending ? t("attack.running") : t("attack.start")}
 					</Button>
-					<Button
-						variant="ghost"
-						onClick={() => {
-							slice.setLastResult(null);
-							setError(null);
-							setProgress(0);
-						}}
-					>
+					<Button variant="ghost" onClick={() => slice.resetResults()}>
 						{tc("actions.reset")}
 					</Button>
 				</div>
 
 				{mutation.isPending ? (
-					<Progress value={progress} className="h-1" />
+					<Progress value={slice.progress} className="h-1" />
 				) : null}
 
-				<LoadTestResults result={slice.lastResult} error={error} />
+				<LoadTestResults result={slice.lastResult} error={slice.error} />
 			</div>
 		</>
 	);

--- a/web/src/features/load-test/store.test.ts
+++ b/web/src/features/load-test/store.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useLoadTestStore } from "./store";
+import type { LoadTestResult } from "./types";
+
+const PERSIST_KEY = "md.load-test.v1";
+
+const FAKE_RESULT: LoadTestResult = {
+	report: "Requests [total] 120",
+	parsed: {
+		requests: 120,
+		success: 120,
+		throughput: 2,
+		latencies: { mean: "5ms", p50: "5ms", p95: "6ms", p99: "7ms", max: "9ms" },
+	},
+	config: { apiUrl: "http://a" },
+};
+
+function storedState(): Record<string, unknown> | null {
+	const raw = localStorage.getItem(PERSIST_KEY);
+	if (!raw) return null;
+	return (JSON.parse(raw) as { state: Record<string, unknown> }).state;
+}
+
+describe("useLoadTestStore", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		useLoadTestStore.getState().reset();
+	});
+
+	it("starts with factory defaults", () => {
+		const s = useLoadTestStore.getState();
+		expect(s.selectedConnectionId).toBeNull();
+		expect(s.apiType).toBe("chat");
+		expect(s.lastResult).toBeNull();
+		expect(s.error).toBeNull();
+		expect(s.progress).toBe(0);
+		expect(s.chat.prompt).toBe("What is the meaning of life?");
+	});
+
+	it("resetResults clears runtime output, preserves form config", () => {
+		const s = useLoadTestStore.getState();
+		s.patch("chat", { ...s.chat, prompt: "custom prompt" });
+		s.patch("attack", { rate: 10, duration: 30 });
+		s.setLastResult(FAKE_RESULT);
+		s.setError("boom");
+		s.setProgress(50);
+
+		useLoadTestStore.getState().resetResults();
+		const after = useLoadTestStore.getState();
+		expect(after.lastResult).toBeNull();
+		expect(after.error).toBeNull();
+		expect(after.progress).toBe(0);
+		// Form config untouched.
+		expect(after.chat.prompt).toBe("custom prompt");
+		expect(after.attack).toEqual({ rate: 10, duration: 30 });
+	});
+
+	it("reset reverts everything including form config", () => {
+		const s = useLoadTestStore.getState();
+		s.patch("chat", { ...s.chat, prompt: "changed" });
+		s.setLastResult(FAKE_RESULT);
+
+		useLoadTestStore.getState().reset();
+		const after = useLoadTestStore.getState();
+		expect(after.chat.prompt).toBe("What is the meaning of life?");
+		expect(after.lastResult).toBeNull();
+	});
+
+	it("does not persist lastResult / error / progress", () => {
+		const s = useLoadTestStore.getState();
+		s.patch("chat", { ...s.chat, prompt: "persisted prompt" });
+		s.setLastResult(FAKE_RESULT);
+		s.setError("should-not-persist");
+		s.setProgress(77);
+
+		const persisted = storedState();
+		expect(persisted).not.toBeNull();
+		expect(persisted).not.toHaveProperty("lastResult");
+		expect(persisted).not.toHaveProperty("error");
+		expect(persisted).not.toHaveProperty("progress");
+		// User input IS persisted.
+		expect((persisted as { chat: { prompt: string } }).chat.prompt).toBe(
+			"persisted prompt",
+		);
+	});
+});

--- a/web/src/features/load-test/store.ts
+++ b/web/src/features/load-test/store.ts
@@ -3,13 +3,9 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { ApiType, LoadTestResult } from "./types";
 
-/** @deprecated Use EndpointValues from @/types/connection instead. */
-export type ManualEndpoint = EndpointValues;
-
 export interface LoadTestSlice {
 	selectedConnectionId: string | null;
 	manualEndpoint: EndpointValues;
-	modified: boolean;
 	apiType: ApiType;
 	chat: {
 		prompt: string;
@@ -29,7 +25,6 @@ export interface LoadTestSlice {
 	};
 	chatAudio: { prompt: string; systemPrompt: string };
 	attack: { rate: number; duration: number };
-	curlExpanded: boolean;
 	curlInput: string;
 	/** Last successful attack result. Transient — not persisted. */
 	lastResult: LoadTestResult | null;
@@ -38,7 +33,6 @@ export interface LoadTestSlice {
 	/** Attack progress 0–100. Transient — not persisted. */
 	progress: number;
 	setSelected: (id: string | null) => void;
-	setModified: (m: boolean) => void;
 	setApiType: (t: ApiType) => void;
 	patch: <K extends keyof LoadTestSlice>(
 		key: K,
@@ -64,7 +58,6 @@ const emptyManualEndpoint: EndpointValues = {
 const INITIAL = {
 	selectedConnectionId: null as string | null,
 	manualEndpoint: emptyManualEndpoint,
-	modified: false,
 	apiType: "chat" as ApiType,
 	chat: {
 		prompt: "What is the meaning of life?",
@@ -93,7 +86,6 @@ const INITIAL = {
 			"You are Qwen, a virtual human capable of generating text and speech.",
 	},
 	attack: { rate: 2, duration: 60 },
-	curlExpanded: false,
 	curlInput: "",
 	lastResult: null as LoadTestResult | null,
 	error: null as string | null,
@@ -104,8 +96,7 @@ export const useLoadTestStore = create<LoadTestSlice>()(
 	persist(
 		(set) => ({
 			...INITIAL,
-			setSelected: (id) => set({ selectedConnectionId: id, modified: false }),
-			setModified: (m) => set({ modified: m }),
+			setSelected: (id) => set({ selectedConnectionId: id }),
 			setApiType: (t) => set({ apiType: t }),
 			patch: (key, value) => set({ [key]: value } as Partial<LoadTestSlice>),
 			setLastResult: (r) => set({ lastResult: r }),
@@ -119,7 +110,6 @@ export const useLoadTestStore = create<LoadTestSlice>()(
 			partialize: (s) => ({
 				selectedConnectionId: s.selectedConnectionId,
 				manualEndpoint: s.manualEndpoint,
-				modified: s.modified,
 				apiType: s.apiType,
 				chat: s.chat,
 				embeddings: s.embeddings,
@@ -128,7 +118,6 @@ export const useLoadTestStore = create<LoadTestSlice>()(
 				chatVision: s.chatVision,
 				chatAudio: s.chatAudio,
 				attack: s.attack,
-				curlExpanded: s.curlExpanded,
 				curlInput: s.curlInput,
 				// lastResult / error / progress are transient — not persisted
 			}),

--- a/web/src/features/load-test/store.ts
+++ b/web/src/features/load-test/store.ts
@@ -31,7 +31,12 @@ export interface LoadTestSlice {
 	attack: { rate: number; duration: number };
 	curlExpanded: boolean;
 	curlInput: string;
+	/** Last successful attack result. Transient — not persisted. */
 	lastResult: LoadTestResult | null;
+	/** Last attack error message. Transient — not persisted. */
+	error: string | null;
+	/** Attack progress 0–100. Transient — not persisted. */
+	progress: number;
 	setSelected: (id: string | null) => void;
 	setModified: (m: boolean) => void;
 	setApiType: (t: ApiType) => void;
@@ -40,6 +45,12 @@ export interface LoadTestSlice {
 		value: LoadTestSlice[K],
 	) => void;
 	setLastResult: (r: LoadTestResult | null) => void;
+	setError: (e: string | null) => void;
+	setProgress: (p: number) => void;
+	/** Clear attack outputs only (result + error + progress). Preserves form config. */
+	resetResults: () => void;
+	/** Full reset to factory defaults, including form config and selection. */
+	reset: () => void;
 }
 
 const emptyManualEndpoint: EndpointValues = {
@@ -50,8 +61,8 @@ const emptyManualEndpoint: EndpointValues = {
 	queryParams: "",
 };
 
-const defaults = {
-	selectedConnectionId: null,
+const INITIAL = {
+	selectedConnectionId: null as string | null,
 	manualEndpoint: emptyManualEndpoint,
 	modified: false,
 	apiType: "chat" as ApiType,
@@ -85,18 +96,42 @@ const defaults = {
 	curlExpanded: false,
 	curlInput: "",
 	lastResult: null as LoadTestResult | null,
+	error: null as string | null,
+	progress: 0,
 };
 
 export const useLoadTestStore = create<LoadTestSlice>()(
 	persist(
 		(set) => ({
-			...defaults,
+			...INITIAL,
 			setSelected: (id) => set({ selectedConnectionId: id, modified: false }),
 			setModified: (m) => set({ modified: m }),
 			setApiType: (t) => set({ apiType: t }),
 			patch: (key, value) => set({ [key]: value } as Partial<LoadTestSlice>),
 			setLastResult: (r) => set({ lastResult: r }),
+			setError: (e) => set({ error: e }),
+			setProgress: (p) => set({ progress: p }),
+			resetResults: () => set({ lastResult: null, error: null, progress: 0 }),
+			reset: () => set(INITIAL),
 		}),
-		{ name: "md.load-test.v1" },
+		{
+			name: "md.load-test.v1",
+			partialize: (s) => ({
+				selectedConnectionId: s.selectedConnectionId,
+				manualEndpoint: s.manualEndpoint,
+				modified: s.modified,
+				apiType: s.apiType,
+				chat: s.chat,
+				embeddings: s.embeddings,
+				rerank: s.rerank,
+				images: s.images,
+				chatVision: s.chatVision,
+				chatAudio: s.chatAudio,
+				attack: s.attack,
+				curlExpanded: s.curlExpanded,
+				curlInput: s.curlInput,
+				// lastResult / error / progress are transient — not persisted
+			}),
+		},
 	),
 );

--- a/web/src/features/request-debug/RequestDebugPage.test.tsx
+++ b/web/src/features/request-debug/RequestDebugPage.test.tsx
@@ -1,0 +1,141 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@/lib/i18n";
+import { RequestDebugPage } from "./RequestDebugPage";
+import { useDebugStore } from "./store";
+import type { DebugProxyResponse } from "./types";
+
+vi.mock("@/lib/api-client", () => {
+	class ApiError extends Error {
+		status: number;
+		constructor(status: number, message: string) {
+			super(message);
+			this.status = status;
+		}
+	}
+	return {
+		ApiError,
+		api: { get: vi.fn(), post: vi.fn() },
+	};
+});
+
+import { api } from "@/lib/api-client";
+
+function Wrapper({ children }: { children: ReactNode }) {
+	const qc = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return (
+		<MemoryRouter>
+			<QueryClientProvider client={qc}>{children}</QueryClientProvider>
+		</MemoryRouter>
+	);
+}
+
+const PROXY_OK: DebugProxyResponse = {
+	success: true,
+	status: 200,
+	statusText: "OK",
+	headers: { "content-type": "application/json" },
+	body: '{"ok": true}',
+	bodyEncoding: "text",
+	timingMs: { ttfbMs: 12, totalMs: 34 },
+	sizeBytes: 12,
+};
+
+const PROXY_ERR: DebugProxyResponse = {
+	success: false,
+	error: "connection refused",
+};
+
+describe("RequestDebugPage (happy path)", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		useDebugStore.getState().reset();
+		vi.mocked(api.post).mockReset();
+	});
+
+	it("Send posts to /api/debug/proxy with the form contents", async () => {
+		vi.mocked(api.post).mockResolvedValue(PROXY_OK);
+		const user = userEvent.setup();
+		render(
+			<Wrapper>
+				<RequestDebugPage />
+			</Wrapper>,
+		);
+
+		await user.type(
+			screen.getByLabelText(/url/i),
+			"http://host/v1/chat/completions",
+		);
+
+		const sendButtons = screen.getAllByRole("button", { name: /send|发送/i });
+		await user.click(sendButtons[sendButtons.length - 1]);
+
+		await waitFor(() => {
+			expect(api.post).toHaveBeenCalledWith(
+				"/api/debug/proxy",
+				expect.objectContaining({
+					method: "POST",
+					url: "http://host/v1/chat/completions",
+				}),
+			);
+		});
+
+		await waitFor(() => {
+			expect(useDebugStore.getState().lastResponse?.status).toBe(200);
+		});
+	});
+
+	it("stores lastError when the proxy reports failure", async () => {
+		vi.mocked(api.post).mockResolvedValue(PROXY_ERR);
+		const user = userEvent.setup();
+		render(
+			<Wrapper>
+				<RequestDebugPage />
+			</Wrapper>,
+		);
+
+		await user.type(screen.getByLabelText(/url/i), "http://bad-host/");
+		const sendButtons = screen.getAllByRole("button", { name: /send|发送/i });
+		await user.click(sendButtons[sendButtons.length - 1]);
+
+		await waitFor(() => {
+			expect(useDebugStore.getState().lastError).toBe("connection refused");
+		});
+		expect(useDebugStore.getState().lastResponse).toBeNull();
+	});
+
+	it("Clear button calls resetResults", async () => {
+		useDebugStore.getState().setLastResponse({
+			status: 200,
+			statusText: "OK",
+			headers: {},
+			body: '{"seeded": true}',
+			bodyEncoding: "text",
+			timingMs: { ttfbMs: 1, totalMs: 1 },
+			sizeBytes: 16,
+		});
+		useDebugStore.getState().patch("url", "http://host/x");
+
+		const user = userEvent.setup();
+		render(
+			<Wrapper>
+				<RequestDebugPage />
+			</Wrapper>,
+		);
+
+		const clearButtons = screen.getAllByRole("button", { name: /clear|清空/i });
+		await user.click(clearButtons[0]);
+
+		await waitFor(() => {
+			expect(useDebugStore.getState().lastResponse).toBeNull();
+		});
+		// Form config untouched.
+		expect(useDebugStore.getState().url).toBe("http://host/x");
+	});
+});

--- a/web/src/features/request-debug/RequestDebugPage.tsx
+++ b/web/src/features/request-debug/RequestDebugPage.tsx
@@ -125,7 +125,6 @@ export function RequestDebugPage() {
 				rightSlot={
 					<EndpointSelector
 						selectedId={slice.selectedConnectionId}
-						modified={false}
 						onSelect={onSelect}
 					/>
 				}

--- a/web/src/features/request-debug/RequestDebugPage.tsx
+++ b/web/src/features/request-debug/RequestDebugPage.tsx
@@ -44,6 +44,7 @@ export function RequestDebugPage() {
 
 	const onSelect = (id: string | null) => {
 		slice.setSelected(id);
+		slice.resetResults();
 		if (id) {
 			const c = conns.get(id);
 			if (c) {
@@ -230,13 +231,7 @@ export function RequestDebugPage() {
 						>
 							{mutation.isPending ? "…" : t("actions.send")}
 						</Button>
-						<Button
-							variant="ghost"
-							onClick={() => {
-								slice.setLastResponse(null);
-								slice.setLastError(null);
-							}}
-						>
+						<Button variant="ghost" onClick={() => slice.resetResults()}>
 							{tc("actions.clear")}
 						</Button>
 					</div>

--- a/web/src/features/request-debug/RequestDebugPage.tsx
+++ b/web/src/features/request-debug/RequestDebugPage.tsx
@@ -16,6 +16,7 @@ import { ApiError, api } from "@/lib/api-client";
 import { parseCurlCommand } from "@/lib/curl-parser";
 import { useConnectionsStore } from "@/stores/connections-store";
 import { useMutation } from "@tanstack/react-query";
+import { useId } from "react";
 import { useTranslation } from "react-i18next";
 import { KeyValueTable } from "./KeyValueTable";
 import { ResponseViewer } from "./ResponseViewer";
@@ -29,6 +30,9 @@ export function RequestDebugPage() {
 	const { t: tc } = useTranslation("common");
 	const slice = useDebugStore();
 	const conns = useConnectionsStore();
+	const methodId = useId();
+	const urlId = useId();
+	const bodyId = useId();
 
 	const onSelect = (id: string | null) => {
 		slice.setSelected(id);
@@ -151,12 +155,12 @@ export function RequestDebugPage() {
 				<section className="space-y-3 rounded-lg border border-border bg-card p-4">
 					<div className="grid grid-cols-[120px,1fr] gap-3">
 						<div>
-							<Label>{t("fields.method")}</Label>
+							<Label htmlFor={methodId}>{t("fields.method")}</Label>
 							<Select
 								value={slice.method}
 								onValueChange={(v) => slice.patch("method", v as HttpMethod)}
 							>
-								<SelectTrigger>
+								<SelectTrigger id={methodId}>
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent>
@@ -169,8 +173,9 @@ export function RequestDebugPage() {
 							</Select>
 						</div>
 						<div>
-							<Label>{t("fields.url")}</Label>
+							<Label htmlFor={urlId}>{t("fields.url")}</Label>
 							<Input
+								id={urlId}
 								value={slice.url}
 								onChange={(e) => slice.patch("url", e.target.value)}
 								className="font-mono text-xs"
@@ -192,7 +197,11 @@ export function RequestDebugPage() {
 						</TabsContent>
 						<TabsContent value="body">
 							<div className="space-y-2">
+								<Label htmlFor={bodyId} className="sr-only">
+									{t("fields.body")}
+								</Label>
 								<Textarea
+									id={bodyId}
 									rows={10}
 									className="font-mono text-xs"
 									value={slice.body}

--- a/web/src/features/request-debug/RequestDebugPage.tsx
+++ b/web/src/features/request-debug/RequestDebugPage.tsx
@@ -20,21 +20,9 @@ import { useTranslation } from "react-i18next";
 import { KeyValueTable } from "./KeyValueTable";
 import { ResponseViewer } from "./ResponseViewer";
 import { useDebugStore } from "./store";
-import type { DebugResponse, HttpMethod } from "./types";
+import type { DebugProxyResponse, DebugResponse, HttpMethod } from "./types";
 
 const METHODS: HttpMethod[] = ["GET", "POST", "PUT", "DELETE", "PATCH"];
-
-interface ProxyResponse {
-	success: boolean;
-	status?: number;
-	statusText?: string;
-	headers?: Record<string, string>;
-	body?: string;
-	bodyEncoding?: "text" | "base64";
-	timingMs?: { ttfbMs: number; totalMs: number };
-	sizeBytes?: number;
-	error?: string;
-}
 
 export function RequestDebugPage() {
 	const { t } = useTranslation("debug");
@@ -106,7 +94,7 @@ export function RequestDebugPage() {
 				const qs = params.toString();
 				if (qs) url += (url.includes("?") ? "&" : "?") + qs;
 			}
-			const proxy = await api.post<ProxyResponse>("/api/debug/proxy", {
+			const proxy = await api.post<DebugProxyResponse>("/api/debug/proxy", {
 				method: slice.method,
 				url,
 				headers,

--- a/web/src/features/request-debug/store.test.ts
+++ b/web/src/features/request-debug/store.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useDebugStore } from "./store";
+import type { DebugResponse } from "./types";
+
+const PERSIST_KEY = "md.debug.v1";
+
+const FAKE_RESPONSE: DebugResponse = {
+	status: 200,
+	statusText: "OK",
+	headers: { "content-type": "application/json" },
+	body: "{}",
+	bodyEncoding: "text",
+	timingMs: { ttfbMs: 5, totalMs: 7 },
+	sizeBytes: 2,
+};
+
+function storedState(): Record<string, unknown> | null {
+	const raw = localStorage.getItem(PERSIST_KEY);
+	if (!raw) return null;
+	return (JSON.parse(raw) as { state: Record<string, unknown> }).state;
+}
+
+describe("useDebugStore", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		useDebugStore.getState().reset();
+	});
+
+	it("starts with POST + a single Content-Type header", () => {
+		const s = useDebugStore.getState();
+		expect(s.method).toBe("POST");
+		expect(s.url).toBe("");
+		expect(s.headers).toEqual([
+			{ key: "Content-Type", value: "application/json", enabled: true },
+		]);
+		expect(s.lastResponse).toBeNull();
+		expect(s.lastError).toBeNull();
+	});
+
+	it("setLastResponse clears lastError and vice versa", () => {
+		useDebugStore.getState().setLastError("boom");
+		expect(useDebugStore.getState().lastError).toBe("boom");
+		useDebugStore.getState().setLastResponse(FAKE_RESPONSE);
+		const s = useDebugStore.getState();
+		expect(s.lastResponse?.status).toBe(200);
+		expect(s.lastError).toBeNull();
+
+		useDebugStore.getState().setLastError("boom2");
+		expect(useDebugStore.getState().lastResponse).toBeNull();
+	});
+
+	it("resetResults clears response + error, preserves form config", () => {
+		const s = useDebugStore.getState();
+		s.patch("url", "http://a");
+		s.patch("body", '{"x": 1}');
+		s.setLastResponse(FAKE_RESPONSE);
+		s.setLastError("stale");
+
+		useDebugStore.getState().resetResults();
+		const after = useDebugStore.getState();
+		expect(after.lastResponse).toBeNull();
+		expect(after.lastError).toBeNull();
+		expect(after.url).toBe("http://a");
+		expect(after.body).toBe('{"x": 1}');
+	});
+
+	it("does not persist lastResponse / lastError", () => {
+		const s = useDebugStore.getState();
+		s.patch("url", "http://persisted");
+		s.setLastResponse(FAKE_RESPONSE);
+		s.setLastError("should-not-persist");
+
+		const persisted = storedState();
+		expect(persisted).not.toBeNull();
+		expect(persisted).not.toHaveProperty("lastResponse");
+		expect(persisted).not.toHaveProperty("lastError");
+		expect((persisted as { url: string }).url).toBe("http://persisted");
+	});
+});

--- a/web/src/features/request-debug/store.ts
+++ b/web/src/features/request-debug/store.ts
@@ -10,33 +10,57 @@ interface DebugState {
 	headers: KeyValueRow[];
 	query: KeyValueRow[];
 	body: string;
+	/** Last successful response. Transient — not persisted. */
 	lastResponse: DebugResponse | null;
+	/** Last error message. Transient — not persisted. */
 	lastError: string | null;
 	setSelected: (id: string | null) => void;
 	patch: <K extends keyof DebugState>(key: K, value: DebugState[K]) => void;
 	setLastResponse: (r: DebugResponse | null) => void;
 	setLastError: (e: string | null) => void;
+	/** Clear runtime output only (response + error). Preserves form config. */
+	resetResults: () => void;
+	/** Full reset to factory defaults. */
+	reset: () => void;
 }
+
+const INITIAL = {
+	selectedConnectionId: null as string | null,
+	curlInput: "",
+	method: "POST" as HttpMethod,
+	url: "",
+	headers: [
+		{ key: "Content-Type", value: "application/json", enabled: true },
+	] as KeyValueRow[],
+	query: [] as KeyValueRow[],
+	body: "",
+	lastResponse: null as DebugResponse | null,
+	lastError: null as string | null,
+};
 
 export const useDebugStore = create<DebugState>()(
 	persist(
 		(set) => ({
-			selectedConnectionId: null,
-			curlInput: "",
-			method: "POST",
-			url: "",
-			headers: [
-				{ key: "Content-Type", value: "application/json", enabled: true },
-			],
-			query: [],
-			body: "",
-			lastResponse: null,
-			lastError: null,
+			...INITIAL,
 			setSelected: (id) => set({ selectedConnectionId: id }),
 			patch: (key, value) => set({ [key]: value } as Partial<DebugState>),
 			setLastResponse: (r) => set({ lastResponse: r, lastError: null }),
 			setLastError: (e) => set({ lastError: e, lastResponse: null }),
+			resetResults: () => set({ lastResponse: null, lastError: null }),
+			reset: () => set(INITIAL),
 		}),
-		{ name: "md.debug.v1" },
+		{
+			name: "md.debug.v1",
+			partialize: (s) => ({
+				selectedConnectionId: s.selectedConnectionId,
+				curlInput: s.curlInput,
+				method: s.method,
+				url: s.url,
+				headers: s.headers,
+				query: s.query,
+				body: s.body,
+				// lastResponse / lastError are transient — not persisted
+			}),
+		},
 	),
 );

--- a/web/src/features/request-debug/types.ts
+++ b/web/src/features/request-debug/types.ts
@@ -15,3 +15,16 @@ export interface DebugResponse {
 	timingMs: { ttfbMs: number; totalMs: number };
 	sizeBytes: number;
 }
+
+/** Wire format returned by `POST /api/debug/proxy`. */
+export interface DebugProxyResponse {
+	success: boolean;
+	status?: number;
+	statusText?: string;
+	headers?: Record<string, string>;
+	body?: string;
+	bodyEncoding?: "text" | "base64";
+	timingMs?: { ttfbMs: number; totalMs: number };
+	sizeBytes?: number;
+	error?: string;
+}

--- a/web/src/features/settings/SettingsPage.tsx
+++ b/web/src/features/settings/SettingsPage.tsx
@@ -20,6 +20,9 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { ConnectionsImportDialog } from "@/features/connections/ConnectionsImportDialog";
+import { useE2EStore } from "@/features/e2e-smoke/store";
+import { useLoadTestStore } from "@/features/load-test/store";
+import { useDebugStore } from "@/features/request-debug/store";
 import { api } from "@/lib/api-client";
 import { useConnectionsStore } from "@/stores/connections-store";
 import { type Locale, useLocaleStore } from "@/stores/locale-store";
@@ -27,6 +30,7 @@ import { type ThemeMode, useThemeStore } from "@/stores/theme-store";
 import { format } from "date-fns";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 
 export function SettingsPage() {
 	const { t } = useTranslation("settings");
@@ -36,8 +40,12 @@ export function SettingsPage() {
 	const locale = useLocaleStore((s) => s.locale);
 	const setLocale = useLocaleStore((s) => s.setLocale);
 	const exportAll = useConnectionsStore((s) => s.exportAll);
+	const resetE2E = useE2EStore((s) => s.reset);
+	const resetLoadTest = useLoadTestStore((s) => s.reset);
+	const resetDebug = useDebugStore((s) => s.reset);
 	const [importOpen, setImportOpen] = useState(false);
 	const [resetOpen, setResetOpen] = useState(false);
+	const [clearOpen, setClearOpen] = useState(false);
 
 	const [vegeta, setVegeta] = useState<{
 		installed: boolean;
@@ -63,6 +71,14 @@ export function SettingsPage() {
 		} catch {
 			setVegeta({ installed: false });
 		}
+	};
+
+	const onClearTestData = () => {
+		resetE2E();
+		resetLoadTest();
+		resetDebug();
+		setClearOpen(false);
+		toast.success(t("data.clearTestDataSuccess"));
 	};
 
 	const onResetAll = () => {
@@ -162,6 +178,13 @@ export function SettingsPage() {
 							{t("data.importConnections")}
 						</Button>
 						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => setClearOpen(true)}
+						>
+							{t("data.clearTestData")}
+						</Button>
+						<Button
 							variant="destructive"
 							size="sm"
 							onClick={() => setResetOpen(true)}
@@ -173,6 +196,22 @@ export function SettingsPage() {
 			</div>
 
 			<ConnectionsImportDialog open={importOpen} onOpenChange={setImportOpen} />
+			<AlertDialog open={clearOpen} onOpenChange={setClearOpen}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>{t("data.clearTestData")}</AlertDialogTitle>
+						<AlertDialogDescription>
+							{t("data.clearTestDataWarning")}
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>{tc("actions.cancel")}</AlertDialogCancel>
+						<AlertDialogAction onClick={onClearTestData}>
+							{t("data.clearTestDataConfirm")}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 			<AlertDialog open={resetOpen} onOpenChange={setResetOpen}>
 				<AlertDialogContent>
 					<AlertDialogHeader>

--- a/web/src/features/settings/SettingsPage.tsx
+++ b/web/src/features/settings/SettingsPage.tsx
@@ -26,6 +26,7 @@ import { useDebugStore } from "@/features/request-debug/store";
 import { api } from "@/lib/api-client";
 import { useConnectionsStore } from "@/stores/connections-store";
 import { type Locale, useLocaleStore } from "@/stores/locale-store";
+import { useSidebarStore } from "@/stores/sidebar-store";
 import { type ThemeMode, useThemeStore } from "@/stores/theme-store";
 import { format } from "date-fns";
 import { useState } from "react";
@@ -40,9 +41,13 @@ export function SettingsPage() {
 	const locale = useLocaleStore((s) => s.locale);
 	const setLocale = useLocaleStore((s) => s.setLocale);
 	const exportAll = useConnectionsStore((s) => s.exportAll);
+	const resetConnections = useConnectionsStore((s) => s.reset);
 	const resetE2E = useE2EStore((s) => s.reset);
 	const resetLoadTest = useLoadTestStore((s) => s.reset);
 	const resetDebug = useDebugStore((s) => s.reset);
+	const resetTheme = useThemeStore((s) => s.reset);
+	const resetLocale = useLocaleStore((s) => s.reset);
+	const resetSidebar = useSidebarStore((s) => s.reset);
 	const [importOpen, setImportOpen] = useState(false);
 	const [resetOpen, setResetOpen] = useState(false);
 	const [clearOpen, setClearOpen] = useState(false);
@@ -82,11 +87,16 @@ export function SettingsPage() {
 	};
 
 	const onResetAll = () => {
-		for (const k of Object.keys(localStorage).filter((k) =>
-			k.startsWith("md."),
-		)) {
-			localStorage.removeItem(k);
-		}
+		// Call every persistent store's reset() so localStorage holds the new
+		// INITIAL state for each. Reload gives a fresh React tree and resets
+		// route + any non-store component-local state.
+		resetE2E();
+		resetLoadTest();
+		resetDebug();
+		resetConnections();
+		resetTheme();
+		resetLocale();
+		resetSidebar();
 		window.location.reload();
 	};
 

--- a/web/src/lib/apply-curl-to-endpoint.ts
+++ b/web/src/lib/apply-curl-to-endpoint.ts
@@ -1,0 +1,59 @@
+import type { EndpointValues } from "@/types/connection";
+import type { ParsedCurl } from "./curl-parser";
+
+export type EndpointKey = keyof EndpointValues;
+
+export interface CurlToEndpointResult {
+	/** Partial patch to apply to an EndpointValues. Empty if nothing matched. */
+	patch: Partial<EndpointValues>;
+	/** Which endpoint fields were populated, in detection order. */
+	filledKeys: EndpointKey[];
+}
+
+/**
+ * Derive an EndpointValues patch from a parsed cURL invocation.
+ *
+ * Pure function — callers decide how to apply the patch (react-hook-form
+ * setValue, controlled setState, or direct store patch) and how to surface
+ * the `filledKeys` summary to the user.
+ */
+export function applyCurlToEndpoint(parsed: ParsedCurl): CurlToEndpointResult {
+	const patch: Partial<EndpointValues> = {};
+	const filledKeys: EndpointKey[] = [];
+
+	if (parsed.url) {
+		patch.apiUrl = parsed.url;
+		filledKeys.push("apiUrl");
+	}
+	if (parsed.queryParams) {
+		patch.queryParams = parsed.queryParams;
+		filledKeys.push("queryParams");
+	}
+
+	const auth = parsed.headers.authorization;
+	if (auth) {
+		const key = auth.value.replace(/^Bearer\s+/i, "").trim();
+		if (key) {
+			patch.apiKey = key;
+			filledKeys.push("apiKey");
+		}
+	}
+
+	const customLines: string[] = [];
+	for (const [lower, entry] of Object.entries(parsed.headers)) {
+		if (lower === "authorization" || lower === "content-type") continue;
+		customLines.push(`${entry.originalKey}: ${entry.value}`);
+	}
+	if (customLines.length) {
+		patch.customHeaders = customLines.join("\n");
+		filledKeys.push("customHeaders");
+	}
+
+	const body = parsed.body as Record<string, unknown> | null;
+	if (body && typeof body.model === "string") {
+		patch.model = body.model;
+		filledKeys.push("model");
+	}
+
+	return { patch, filledKeys };
+}

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -37,7 +37,7 @@ void i18n.use(initReactI18next).init({
 			settings: zhSettings,
 		},
 	},
-	lng: "en-US",
+	// `lng` is set by main.tsx from the locale store before first render.
 	fallbackLng: "en-US",
 	defaultNS: "common",
 	ns: [

--- a/web/src/locales/en-US/common.json
+++ b/web/src/locales/en-US/common.json
@@ -34,6 +34,10 @@
 		"dark": "Dark",
 		"system": "System"
 	},
+	"sidebar": {
+		"collapse": "Collapse sidebar",
+		"expand": "Expand sidebar"
+	},
 	"endpoint": {
 		"label": "Endpoint",
 		"manual": "— Manual —",

--- a/web/src/locales/en-US/common.json
+++ b/web/src/locales/en-US/common.json
@@ -50,8 +50,11 @@
 		"advanced": "Advanced (custom headers, query params)",
 		"parseCurl": "Parse & fill",
 		"curlPlaceholder": "curl http://example/v1/chat/completions \\\n  -H \"Authorization: Bearer sk-…\" \\\n  -d '{…}'",
+		"curlInvalid": "Could not parse cURL — check the command and try again",
 		"filled": "Filled: {{fields}}",
-		"newConnection": "+ New connection"
+		"newConnection": "+ New connection",
+		"saved": "Saved to connection \"{{name}}\"",
+		"saveFailed": "Failed to save"
 	},
 	"comingSoon": {
 		"title": "Coming soon",

--- a/web/src/locales/en-US/common.json
+++ b/web/src/locales/en-US/common.json
@@ -17,7 +17,6 @@
 		"start": "Start",
 		"back": "Back",
 		"manageConnections": "Manage connections",
-		"saveAsNew": "Save as new…",
 		"copy": "Copy",
 		"copied": "Copied",
 		"format": "Format as JSON"
@@ -52,9 +51,6 @@
 		"parseCurl": "Parse & fill",
 		"curlPlaceholder": "curl http://example/v1/chat/completions \\\n  -H \"Authorization: Bearer sk-…\" \\\n  -d '{…}'",
 		"filled": "Filled: {{fields}}",
-		"nameConnection": "Connection name",
-		"nameExists": "A connection with this name already exists",
-		"nameRequired": "Name is required",
 		"newConnection": "+ New connection"
 	},
 	"comingSoon": {

--- a/web/src/locales/en-US/load-test.json
+++ b/web/src/locales/en-US/load-test.json
@@ -39,8 +39,7 @@
 		"pasteCurl": "Paste cURL",
 		"loadFromSaved": "Load from saved",
 		"manual": "— Manual —",
-		"modified": "Modified",
-		"nameConnection": "Connection name"
+		"modified": "Modified"
 	},
 	"curl": {
 		"import": "Import from cURL",

--- a/web/src/locales/en-US/settings.json
+++ b/web/src/locales/en-US/settings.json
@@ -21,6 +21,10 @@
 		"title": "Data",
 		"exportConnections": "Export connections",
 		"importConnections": "Import connections",
+		"clearTestData": "Clear test data",
+		"clearTestDataWarning": "This clears every page's form fields and test results across Load Test, E2E Smoke, and Request Debug. Your connection library and appearance settings are kept.",
+		"clearTestDataConfirm": "Clear test data",
+		"clearTestDataSuccess": "Test data cleared",
 		"resetState": "Reset app state",
 		"resetWarning": "This deletes every connection, every form value, theme, and locale preference. Are you sure?",
 		"resetConfirm": "Reset everything"

--- a/web/src/locales/zh-CN/common.json
+++ b/web/src/locales/zh-CN/common.json
@@ -17,7 +17,6 @@
 		"start": "开始",
 		"back": "返回",
 		"manageConnections": "管理连接",
-		"saveAsNew": "另存为…",
 		"copy": "复制",
 		"copied": "已复制",
 		"format": "格式化为 JSON"
@@ -52,9 +51,6 @@
 		"parseCurl": "解析填充",
 		"curlPlaceholder": "curl http://example/v1/chat/completions \\\n  -H \"Authorization: Bearer sk-…\" \\\n  -d '{…}'",
 		"filled": "已填充：{{fields}}",
-		"nameConnection": "连接名称",
-		"nameExists": "已存在同名连接",
-		"nameRequired": "请输入名称",
 		"newConnection": "+ 新建连接"
 	},
 	"comingSoon": {

--- a/web/src/locales/zh-CN/common.json
+++ b/web/src/locales/zh-CN/common.json
@@ -50,8 +50,11 @@
 		"advanced": "高级（自定义 Headers、查询参数）",
 		"parseCurl": "解析填充",
 		"curlPlaceholder": "curl http://example/v1/chat/completions \\\n  -H \"Authorization: Bearer sk-…\" \\\n  -d '{…}'",
+		"curlInvalid": "无法解析 cURL，请检查命令后重试",
 		"filled": "已填充：{{fields}}",
-		"newConnection": "+ 新建连接"
+		"newConnection": "+ 新建连接",
+		"saved": "已保存到连接「{{name}}」",
+		"saveFailed": "保存失败"
 	},
 	"comingSoon": {
 		"title": "敬请期待",

--- a/web/src/locales/zh-CN/common.json
+++ b/web/src/locales/zh-CN/common.json
@@ -34,6 +34,10 @@
 		"dark": "深色",
 		"system": "跟随系统"
 	},
+	"sidebar": {
+		"collapse": "收起侧边栏",
+		"expand": "展开侧边栏"
+	},
 	"endpoint": {
 		"label": "端点",
 		"manual": "— 手动 —",

--- a/web/src/locales/zh-CN/load-test.json
+++ b/web/src/locales/zh-CN/load-test.json
@@ -39,8 +39,7 @@
 		"pasteCurl": "\u7c98\u8d34 cURL",
 		"loadFromSaved": "\u4ece\u5df2\u4fdd\u5b58\u52a0\u8f7d",
 		"manual": "\u2014 \u624b\u52a8 \u2014",
-		"modified": "\u5df2\u4fee\u6539",
-		"nameConnection": "\u8fde\u63a5\u540d\u79f0"
+		"modified": "\u5df2\u4fee\u6539"
 	},
 	"curl": {
 		"import": "\u4ece cURL \u5bfc\u5165",

--- a/web/src/locales/zh-CN/settings.json
+++ b/web/src/locales/zh-CN/settings.json
@@ -21,6 +21,10 @@
 		"title": "数据",
 		"exportConnections": "导出连接",
 		"importConnections": "导入连接",
+		"clearTestData": "清除测试数据",
+		"clearTestDataWarning": "会清空压力测试、E2E Smoke、请求调试三个页面的表单字段与测试结果。连接库和外观偏好保持不变。",
+		"clearTestDataConfirm": "清除测试数据",
+		"clearTestDataSuccess": "已清除测试数据",
 		"resetState": "重置应用状态",
 		"resetWarning": "将删除所有连接、表单数据、主题和语言偏好。确定继续？",
 		"resetConfirm": "确认重置"

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,11 +2,13 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./styles/globals.css";
-import "./lib/i18n";
+import i18n from "./lib/i18n";
 import { useLocaleStore } from "./stores/locale-store";
 
-// Force the locale store to hydrate before render so i18n.language is correct.
-useLocaleStore.getState();
+// Sync i18n to the (hydrated or detected) store locale before first render.
+// Without this, first-time zh-browser visitors briefly see the en fallback
+// because i18n's own default runs before persist rehydration.
+void i18n.changeLanguage(useLocaleStore.getState().locale);
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
 	<React.StrictMode>

--- a/web/src/stores/connections-store.ts
+++ b/web/src/stores/connections-store.ts
@@ -22,6 +22,8 @@ export interface ConnectionsStore {
 		json: string,
 		mode: "merge" | "replace",
 	) => { added: number; skipped: number };
+	/** Wipe the library back to an empty state. */
+	reset: () => void;
 }
 
 function nowIso(): string {
@@ -95,6 +97,7 @@ export const useConnectionsStore = create<ConnectionsStore>()(
 				};
 				return JSON.stringify(env, null, 2);
 			},
+			reset: () => set({ connections: [] }),
 			importAll: (json, mode) => {
 				const parsed = JSON.parse(json) as ConnectionsExport;
 				if (parsed.version !== 1) {

--- a/web/src/stores/locale-store.ts
+++ b/web/src/stores/locale-store.ts
@@ -23,11 +23,6 @@ export const useLocaleStore = create<LocaleStore>()(
 				set({ locale });
 			},
 		}),
-		{
-			name: "md.locale.v1",
-			onRehydrateStorage: () => (state) => {
-				if (state) i18n.changeLanguage(state.locale);
-			},
-		},
+		{ name: "md.locale.v1" },
 	),
 );

--- a/web/src/stores/locale-store.ts
+++ b/web/src/stores/locale-store.ts
@@ -7,6 +7,8 @@ export type Locale = "en-US" | "zh-CN";
 interface LocaleStore {
 	locale: Locale;
 	setLocale: (locale: Locale) => void;
+	/** Revert to browser-detected locale and update i18next. */
+	reset: () => void;
 }
 
 function detectInitial(): Locale {
@@ -21,6 +23,11 @@ export const useLocaleStore = create<LocaleStore>()(
 			setLocale: (locale) => {
 				i18n.changeLanguage(locale);
 				set({ locale });
+			},
+			reset: () => {
+				const detected = detectInitial();
+				i18n.changeLanguage(detected);
+				set({ locale: detected });
 			},
 		}),
 		{ name: "md.locale.v1" },

--- a/web/src/stores/sidebar-store.test.ts
+++ b/web/src/stores/sidebar-store.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useSidebarStore } from "./sidebar-store";
+
+const PERSIST_KEY = "md.sidebar-groups-collapsed.v1";
+
+describe("useSidebarStore", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		useSidebarStore.getState().reset();
+	});
+
+	it("starts expanded with no groups collapsed", () => {
+		const s = useSidebarStore.getState();
+		expect(s.railCollapsed).toBe(false);
+		expect(s.collapsedGroups).toEqual({});
+	});
+
+	it("toggleRail flips the rail flag", () => {
+		useSidebarStore.getState().toggleRail();
+		expect(useSidebarStore.getState().railCollapsed).toBe(true);
+		useSidebarStore.getState().toggleRail();
+		expect(useSidebarStore.getState().railCollapsed).toBe(false);
+	});
+
+	it("toggleGroup toggles a single group independently", () => {
+		useSidebarStore.getState().toggleGroup("performance");
+		expect(useSidebarStore.getState().collapsedGroups).toEqual({
+			performance: true,
+		});
+		useSidebarStore.getState().toggleGroup("correctness");
+		expect(useSidebarStore.getState().collapsedGroups).toEqual({
+			performance: true,
+			correctness: true,
+		});
+		useSidebarStore.getState().toggleGroup("performance");
+		expect(useSidebarStore.getState().collapsedGroups).toEqual({
+			performance: false,
+			correctness: true,
+		});
+	});
+
+	it("reset clears both group state and rail state", () => {
+		useSidebarStore.getState().toggleRail();
+		useSidebarStore.getState().toggleGroup("performance");
+		useSidebarStore.getState().toggleGroup("debug");
+		useSidebarStore.getState().reset();
+		const s = useSidebarStore.getState();
+		expect(s.railCollapsed).toBe(false);
+		expect(s.collapsedGroups).toEqual({});
+	});
+
+	it("persists rail + groups to localStorage", () => {
+		useSidebarStore.getState().toggleRail();
+		useSidebarStore.getState().toggleGroup("correctness");
+		const raw = localStorage.getItem(PERSIST_KEY);
+		expect(raw).not.toBeNull();
+		const persisted = (JSON.parse(raw as string) as { state: unknown })
+			.state as { railCollapsed: boolean; collapsedGroups: object };
+		expect(persisted.railCollapsed).toBe(true);
+		expect(persisted.collapsedGroups).toEqual({ correctness: true });
+	});
+});

--- a/web/src/stores/sidebar-store.ts
+++ b/web/src/stores/sidebar-store.ts
@@ -8,6 +8,8 @@ interface SidebarStore {
 	railCollapsed: boolean;
 	toggleGroup: (id: string) => void;
 	toggleRail: () => void;
+	/** Forget group-collapse state and expand the rail. */
+	reset: () => void;
 }
 
 export const useSidebarStore = create<SidebarStore>()(
@@ -23,6 +25,7 @@ export const useSidebarStore = create<SidebarStore>()(
 					},
 				})),
 			toggleRail: () => set((s) => ({ railCollapsed: !s.railCollapsed })),
+			reset: () => set({ collapsedGroups: {}, railCollapsed: false }),
 		}),
 		{ name: "md.sidebar-groups-collapsed.v1" },
 	),

--- a/web/src/stores/sidebar-store.ts
+++ b/web/src/stores/sidebar-store.ts
@@ -2,14 +2,19 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 interface SidebarStore {
+	/** Per-group "collapse this section's items" flags. */
 	collapsedGroups: Record<string, boolean>;
+	/** Whole-sidebar rail mode: show icon-only column instead of full sidebar. */
+	railCollapsed: boolean;
 	toggleGroup: (id: string) => void;
+	toggleRail: () => void;
 }
 
 export const useSidebarStore = create<SidebarStore>()(
 	persist(
 		(set) => ({
 			collapsedGroups: {},
+			railCollapsed: false,
 			toggleGroup: (id) =>
 				set((s) => ({
 					collapsedGroups: {
@@ -17,6 +22,7 @@ export const useSidebarStore = create<SidebarStore>()(
 						[id]: !s.collapsedGroups[id],
 					},
 				})),
+			toggleRail: () => set((s) => ({ railCollapsed: !s.railCollapsed })),
 		}),
 		{ name: "md.sidebar-groups-collapsed.v1" },
 	),

--- a/web/src/stores/theme-store.ts
+++ b/web/src/stores/theme-store.ts
@@ -6,6 +6,8 @@ export type ThemeMode = "light" | "dark" | "system";
 interface ThemeStore {
 	mode: ThemeMode;
 	setMode: (mode: ThemeMode) => void;
+	/** Revert to the "system" default and update the DOM. */
+	reset: () => void;
 }
 
 function applyMode(mode: ThemeMode): void {
@@ -23,6 +25,10 @@ export const useThemeStore = create<ThemeStore>()(
 			setMode: (mode) => {
 				applyMode(mode);
 				set({ mode });
+			},
+			reset: () => {
+				applyMode("system");
+				set({ mode: "system" });
 			},
 		}),
 		{

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -22,6 +22,12 @@ function stripThirdPartyEmoji(): Plugin {
   };
 }
 
+// Ports are overridable so multiple git worktrees can run `pnpm dev`
+// concurrently without colliding. Set VITE_PORT / API_PORT in the shell
+// (or a .env file; Vite loads .env automatically for `vite dev`).
+const VITE_PORT = Number(process.env.VITE_PORT) || 5173;
+const API_PORT = Number(process.env.API_PORT) || 3001;
+
 export default defineConfig({
   root: path.resolve(__dirname),
   css: {
@@ -36,11 +42,11 @@ export default defineConfig({
     },
   },
   server: {
-    port: 5173,
+    port: VITE_PORT,
     strictPort: true,
     proxy: {
       "/api": {
-        target: "http://localhost:3001",
+        target: `http://localhost:${API_PORT}`,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

- **E2E Smoke tab hardening** (19 commits): integration tests for all 3 implemented tabs, store unit tests, collapsible sidebar rail, sonner toast system, dev-port parametrization via `VITE_PORT` / `API_PORT`, per-feature "Clear test data" in Settings, internal refactors (store consolidation with `reset()`, `applyCurlToEndpoint` extraction, wire-format types moved out of page components).
- **NestJS backend refactor design spec** (`docs/superpowers/specs/2026-04-22-nestjs-backend-refactor-design.md`): full industrial rewrite plan — pnpm workspace (apps/web + apps/api + packages/contracts), NestJS 10 replacing Express, Prisma + Postgres, Passport + JWT auth, Pino logging, OpenAPI, Docker + CI, across 7 numbered phases with DoD per phase.
- **Phase 0 implementation plan** (`docs/superpowers/plans/2026-04-22-nestjs-refactor-phase-0-workspace-scaffold.md`): 16 bite-sized tasks to land the workspace skeleton + empty Nest scaffold while keeping the old Express backend runnable as `pnpm dev:legacy`. No runtime behavior changes in this plan; route porting and legacy deletion arrive in Phase 1.

## Test plan

- [x] `pnpm type-check` green
- [x] `pnpm lint` green
- [x] `pnpm test` green
- [ ] Manual smoke: `pnpm dev` → FE on 5173 + API on 3001; run a Load Test, E2E Smoke all-probes, and a Request Debug proxy call
- [ ] Spec and plan review — documents only, no runtime changes in the last 2 commits (0444273, 4508fc2)

## Note for reviewer

This PR covers two logical deliverables stacked on one branch: (1) E2E Smoke tab polish and (2) planning docs for the upcoming NestJS refactor. The docs commits (0444273, 4508fc2) are pure markdown additions under docs/superpowers/ and touch no code — they can be reviewed independently from the feature work above them.

Phase 0 of the NestJS refactor will land on a fresh feat/nestjs-phase-0 branch cut from main **after** this PR merges, so approving this PR unblocks that work without committing to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)