### PR TITLE
Phase 2: infrastructure (config / pino / OpenAPI / error envelope / static serving)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# apps/api — loaded by @nestjs/config in apps/api/src/main.ts
+
+NODE_ENV=development
+PORT=3001
+LOG_LEVEL=info
+CORS_ORIGINS=http://localhost:5173
+
+# Phase 4+ (uncomment when DB arrives)
+# DATABASE_URL=postgresql://modeldoctor:modeldoctor@localhost:5432/modeldoctor
+
+# Phase 5+ (uncomment when auth arrives; must be >= 32 chars random)
+# JWT_ACCESS_SECRET=
+# JWT_ACCESS_EXPIRES_IN=15m
+# JWT_REFRESH_EXPIRES_DAYS=7
+# DISABLE_FIRST_USER_ADMIN=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# ModelDoctor — Claude autonomous-operation policy
+
+**User authorization scope.** The user has authorized autonomous operation within this repo. In this project, do NOT stop to ask for confirmation before taking these actions:
+
+- All local, reversible edits (Read / Edit / Write under this repo)
+- Running `pnpm …`, `pnpm -r …`, `pnpm -F <pkg> …`, `pnpm dev/build/test/lint/format/type-check` (including starting and later killing the dev server the session itself launched)
+- Running `docker compose up/down/ps/logs` for the repo's own `docker-compose.yml` and `psql` against the local dev DB
+- Running `vegeta`, `curl`, and other read-only CLI tooling
+- `git add`, `git commit`, `git status/diff/log/show`, `git checkout <existing-branch>`, `git stash`, `git restore` of unstaged changes
+- Creating git branches whose name begins with `feat/`, `fix/`, `chore/`, `test/`, `refactor/`, `build/`, or `docs/`
+- `git worktree add/remove` under `/Users/fangyong/vllm/modeldoctor/*`
+- `git push -u origin <feat|fix|chore|test|refactor|build|docs>/*` — first push and subsequent fast-forward pushes to the same feature branch
+- `gh pr create`, `gh pr view`, `gh pr comment`, `gh pr checks`, `gh pr diff`, `gh issue view/list/comment`, `gh run list/view`
+- Dispatching subagents via the `Agent` tool; running skills
+
+**Still confirm with the user before:**
+
+- `gh pr merge` (or any merge to `main`/`master`)
+- `git push --force*` (anywhere, on any branch)
+- Any commit, push, rebase, or reset targeting `main` / `master` directly
+- `git reset --hard`, `git clean -fd`, `git branch -D` of branches that have ever been pushed, `git push origin --delete …`
+- `rm -rf` that touches anything outside this repo, or that targets `.git`, `node_modules` of another worktree, or anything the user didn't explicitly nominate
+- Installing a new top-level dependency the active plan did not specify, or changing `pnpm.onlyBuiltDependencies` / `packageManager` / lockfile-regeneration flags
+- Running `prisma migrate reset`, dropping tables, or any other destructive DB operation against shared data
+- Production deploys, uploading to registries, publishing packages, operating on cloud credentials
+
+**Plan discipline.** When executing an implementation plan from `docs/superpowers/plans/`, follow it literally. If reality forces a deviation (npm API changed, path doesn't exist, recommended config doesn't work), **report the deviation in the turn it's discovered**; do not silently rewrite the plan.
+
+**Commit / PR conventions.** Conventional-commit prefixes (`feat:`, `build:`, `refactor:`, `test:`, `fix:`, `docs:`, `chore:`), one logical change per commit, explicit `git add <files>` (never `git add -A`), commit bodies end with `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`. One phase of the NestJS refactor = one PR from a `feat/nestjs-phase-<N>` branch cut from `main`; do not mix commits across phases.
+
+**Project-specific constraints (do not violate):**
+
+- `apps/api/tsconfig.json` must not set `incremental: true` (conflicts with `nest-cli.json` `deleteOutDir`).
+- Vitest config files in `apps/api/` must stay `.mts`.
+- `apps/api` uses vitest@2, `apps/web` uses vitest@1 — do not unify.
+- `apps/api/tsconfig.json` `include` must stay narrow (`["src/**/*"]`).

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,6 +22,7 @@
     "@nestjs/config": "^3",
     "@nestjs/core": "^10",
     "@nestjs/platform-express": "^10",
+    "@nestjs/serve-static": "^4.0.2",
     "@nestjs/swagger": "^7",
     "nanoid": "^5.1.9",
     "nestjs-pino": "^4",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,8 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main.js",
     "type-check": "tsc -p tsconfig.json --noEmit",
+    "lint": "biome check src",
+    "format": "biome format --write src",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "vitest run --config vitest.e2e.config.mts"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,7 @@
     "@nestjs/core": "^10",
     "@nestjs/platform-express": "^10",
     "@nestjs/swagger": "^7",
+    "nanoid": "^5.1.9",
     "nestjs-pino": "^4",
     "nestjs-zod": "^3",
     "pino": "^9",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,7 +1,7 @@
 import { Module } from "@nestjs/common";
-import { HealthModule } from "./modules/health/health.module.js";
 import { DebugProxyModule } from "./modules/debug-proxy/debug-proxy.module.js";
 import { E2ETestModule } from "./modules/e2e-test/e2e-test.module.js";
+import { HealthModule } from "./modules/health/health.module.js";
 import { LoadTestModule } from "./modules/load-test/load-test.module.js";
 
 @Module({

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,13 +1,41 @@
 import { type MiddlewareConsumer, Module, type NestModule } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { LoggerModule } from "nestjs-pino";
 import { RequestIdMiddleware } from "./common/middleware/request-id.middleware.js";
 import { AppConfigModule } from "./config/config.module.js";
+import type { Env } from "./config/env.schema.js";
 import { DebugProxyModule } from "./modules/debug-proxy/debug-proxy.module.js";
 import { E2ETestModule } from "./modules/e2e-test/e2e-test.module.js";
 import { HealthModule } from "./modules/health/health.module.js";
 import { LoadTestModule } from "./modules/load-test/load-test.module.js";
 
 @Module({
-  imports: [AppConfigModule, HealthModule, DebugProxyModule, E2ETestModule, LoadTestModule],
+  imports: [
+    AppConfigModule,
+    LoggerModule.forRootAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService<Env, true>) => ({
+        pinoHttp: {
+          level: config.get("LOG_LEVEL", { infer: true }),
+          // Correlate with the RequestId middleware
+          genReqId: (req) => (req as { id?: string }).id ?? "",
+          customProps: (req) => ({ requestId: (req as { id?: string }).id }),
+          transport:
+            config.get("NODE_ENV", { infer: true }) === "development"
+              ? { target: "pino-pretty", options: { singleLine: true, colorize: true } }
+              : undefined,
+          // Suppress /api/health access logs — too noisy
+          autoLogging: {
+            ignore: (req: { url?: string }) => req.url === "/api/health",
+          },
+        },
+      }),
+    }),
+    HealthModule,
+    DebugProxyModule,
+    E2ETestModule,
+    LoadTestModule,
+  ],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer): void {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,4 +1,5 @@
-import { Module } from "@nestjs/common";
+import { type MiddlewareConsumer, Module, type NestModule } from "@nestjs/common";
+import { RequestIdMiddleware } from "./common/middleware/request-id.middleware.js";
 import { AppConfigModule } from "./config/config.module.js";
 import { DebugProxyModule } from "./modules/debug-proxy/debug-proxy.module.js";
 import { E2ETestModule } from "./modules/e2e-test/e2e-test.module.js";
@@ -8,4 +9,8 @@ import { LoadTestModule } from "./modules/load-test/load-test.module.js";
 @Module({
   imports: [AppConfigModule, HealthModule, DebugProxyModule, E2ETestModule, LoadTestModule],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer): void {
+    consumer.apply(RequestIdMiddleware).forRoutes("*");
+  }
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,10 +1,11 @@
 import { Module } from "@nestjs/common";
+import { AppConfigModule } from "./config/config.module.js";
 import { DebugProxyModule } from "./modules/debug-proxy/debug-proxy.module.js";
 import { E2ETestModule } from "./modules/e2e-test/e2e-test.module.js";
 import { HealthModule } from "./modules/health/health.module.js";
 import { LoadTestModule } from "./modules/load-test/load-test.module.js";
 
 @Module({
-  imports: [HealthModule, DebugProxyModule, E2ETestModule, LoadTestModule],
+  imports: [AppConfigModule, HealthModule, DebugProxyModule, E2ETestModule, LoadTestModule],
 })
 export class AppModule {}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,5 +1,7 @@
+import path from "node:path";
 import { type MiddlewareConsumer, Module, type NestModule } from "@nestjs/common";
-import { ConfigService } from "@nestjs/config";
+import { ConfigModule, ConfigService } from "@nestjs/config";
+import { ServeStaticModule } from "@nestjs/serve-static";
 import { LoggerModule } from "nestjs-pino";
 import { RequestIdMiddleware } from "./common/middleware/request-id.middleware.js";
 import { AppConfigModule } from "./config/config.module.js";
@@ -30,6 +32,23 @@ import { LoadTestModule } from "./modules/load-test/load-test.module.js";
           },
         },
       }),
+    }),
+    ServeStaticModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService<Env, true>) => {
+        if (config.get("NODE_ENV", { infer: true }) !== "production") {
+          return []; // empty → no static middleware registered in dev/test
+        }
+        return [
+          {
+            // apps/api/dist/main.js is invoked from repo root via `pnpm start`,
+            // so cwd === repo root → apps/web/dist is the correct target.
+            rootPath: path.resolve(process.cwd(), "apps/web/dist"),
+            exclude: ["/api/(.*)", "/api/docs", "/api/docs-json"],
+          },
+        ];
+      },
     }),
     HealthModule,
     DebugProxyModule,

--- a/apps/api/src/common/filters/all-exceptions.filter.ts
+++ b/apps/api/src/common/filters/all-exceptions.filter.ts
@@ -1,7 +1,7 @@
 import {
-  ArgumentsHost,
+  type ArgumentsHost,
   Catch,
-  ExceptionFilter,
+  type ExceptionFilter,
   HttpException,
   HttpStatus,
 } from "@nestjs/common";

--- a/apps/api/src/common/filters/all-exceptions.filter.ts
+++ b/apps/api/src/common/filters/all-exceptions.filter.ts
@@ -1,36 +1,85 @@
+import { type ErrorCode, ErrorCodes } from "@modeldoctor/contracts";
 import {
   type ArgumentsHost,
   Catch,
   type ExceptionFilter,
   HttpException,
   HttpStatus,
+  Logger,
 } from "@nestjs/common";
-import type { Response } from "express";
+import type { Request, Response } from "express";
+
+function httpStatusToCode(status: number): ErrorCode {
+  switch (status) {
+    case HttpStatus.BAD_REQUEST:
+      return ErrorCodes.BAD_REQUEST;
+    case HttpStatus.UNAUTHORIZED:
+      return ErrorCodes.UNAUTHORIZED;
+    case HttpStatus.FORBIDDEN:
+      return ErrorCodes.FORBIDDEN;
+    case HttpStatus.NOT_FOUND:
+      return ErrorCodes.NOT_FOUND;
+    case HttpStatus.CONFLICT:
+      return ErrorCodes.CONFLICT;
+    case HttpStatus.TOO_MANY_REQUESTS:
+      return ErrorCodes.TOO_MANY_REQUESTS;
+    default:
+      return ErrorCodes.INTERNAL_SERVER_ERROR;
+  }
+}
 
 @Catch()
 export class AllExceptionsFilter implements ExceptionFilter {
+  private readonly logger = new Logger(AllExceptionsFilter.name);
+
   catch(exception: unknown, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+    const requestId = request.id ?? "";
 
     let status = HttpStatus.INTERNAL_SERVER_ERROR;
+    let code: ErrorCode = ErrorCodes.INTERNAL_SERVER_ERROR;
     let message = "Internal server error";
+    let details: unknown;
 
     if (exception instanceof HttpException) {
       status = exception.getStatus();
+      code = httpStatusToCode(status);
       const body = exception.getResponse();
       if (typeof body === "string") {
         message = body;
-      } else if (body && typeof body === "object" && "message" in body) {
-        const m = (body as { message: unknown }).message;
-        message = Array.isArray(m) ? m.join("; ") : String(m);
+      } else if (body && typeof body === "object") {
+        const rec = body as Record<string, unknown>;
+        if (typeof rec.message === "string") {
+          message = rec.message;
+        } else if (Array.isArray(rec.message)) {
+          message = rec.message.join("; ");
+        } else {
+          message = exception.message;
+        }
+        if ("details" in rec) {
+          details = rec.details;
+        }
       } else {
         message = exception.message;
       }
+      // VALIDATION_FAILED refinement for 400s that carry structured details (ZodValidationPipe)
+      if (status === HttpStatus.BAD_REQUEST && details !== undefined) {
+        code = ErrorCodes.VALIDATION_FAILED;
+      }
     } else if (exception instanceof Error) {
       message = exception.message;
+      this.logger.error({ requestId, err: exception }, "Unhandled exception");
     }
 
-    response.status(status).json({ success: false, error: message });
+    response.status(status).json({
+      error: {
+        code,
+        message,
+        ...(details !== undefined ? { details } : {}),
+        requestId,
+      },
+    });
   }
 }

--- a/apps/api/src/common/middleware/request-id.middleware.spec.ts
+++ b/apps/api/src/common/middleware/request-id.middleware.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { RequestIdMiddleware } from "./request-id.middleware.js";
+
+describe("RequestIdMiddleware", () => {
+  const mw = new RequestIdMiddleware();
+
+  // biome-ignore lint/suspicious/noExplicitAny: Express Req/Res mocks are intentionally loose.
+  function makeReq(header?: string): { req: any; res: any; next: any } {
+    // biome-ignore lint/suspicious/noExplicitAny: see above.
+    const req: any = { header: vi.fn().mockReturnValue(header) };
+    // biome-ignore lint/suspicious/noExplicitAny: see above.
+    const res: any = { setHeader: vi.fn() };
+    const next = vi.fn();
+    return { req, res, next };
+  }
+
+  it("generates a 16-char id when header is absent", () => {
+    const { req, res, next } = makeReq(undefined);
+    mw.use(req, res, next);
+    expect(req.id).toMatch(/^[A-Za-z0-9_-]{16}$/);
+    expect(res.setHeader).toHaveBeenCalledWith("x-request-id", req.id);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("echoes a safe incoming id", () => {
+    const { req, res, next } = makeReq("trace-abc123xyz");
+    mw.use(req, res, next);
+    expect(req.id).toBe("trace-abc123xyz");
+    expect(res.setHeader).toHaveBeenCalledWith("x-request-id", "trace-abc123xyz");
+  });
+
+  it("rejects unsafe incoming id and generates new one", () => {
+    const { req, res, next } = makeReq("../etc/passwd");
+    mw.use(req, res, next);
+    expect(req.id).not.toBe("../etc/passwd");
+    expect(req.id).toMatch(/^[A-Za-z0-9_-]{16}$/);
+  });
+});

--- a/apps/api/src/common/middleware/request-id.middleware.ts
+++ b/apps/api/src/common/middleware/request-id.middleware.ts
@@ -1,0 +1,26 @@
+import { Injectable, type NestMiddleware } from "@nestjs/common";
+import type { NextFunction, Request, Response } from "express";
+import { nanoid } from "nanoid";
+
+const HEADER_NAME = "x-request-id";
+/** Accept client-provided request ids that look "safe" — alphanumeric + dashes, 8-64 chars. */
+const SAFE_ID = /^[A-Za-z0-9_-]{8,64}$/;
+
+declare global {
+  namespace Express {
+    interface Request {
+      id?: string;
+    }
+  }
+}
+
+@Injectable()
+export class RequestIdMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction): void {
+    const incoming = req.header(HEADER_NAME);
+    const id = incoming && SAFE_ID.test(incoming) ? incoming : nanoid(16);
+    req.id = id;
+    res.setHeader(HEADER_NAME, id);
+    next();
+  }
+}

--- a/apps/api/src/common/pipes/zod-validation.pipe.spec.ts
+++ b/apps/api/src/common/pipes/zod-validation.pipe.spec.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
 import { BadRequestException } from "@nestjs/common";
+import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { ZodValidationPipe } from "./zod-validation.pipe.js";
 

--- a/apps/api/src/common/pipes/zod-validation.pipe.ts
+++ b/apps/api/src/common/pipes/zod-validation.pipe.ts
@@ -17,6 +17,9 @@ export class ZodValidationPipe implements PipeTransform {
     const first = result.error.issues[0];
     const path = first?.path.join(".") || "body";
     const message = first?.message || "Validation failed";
-    throw new BadRequestException(`${path}: ${message}`);
+    throw new BadRequestException({
+      message: `${path}: ${message}`,
+      details: result.error.issues,
+    });
   }
 }

--- a/apps/api/src/common/pipes/zod-validation.pipe.ts
+++ b/apps/api/src/common/pipes/zod-validation.pipe.ts
@@ -1,8 +1,8 @@
 import {
-  ArgumentMetadata,
+  type ArgumentMetadata,
   BadRequestException,
   Injectable,
-  PipeTransform,
+  type PipeTransform,
 } from "@nestjs/common";
 import type { ZodSchema } from "zod";
 

--- a/apps/api/src/config/config.module.ts
+++ b/apps/api/src/config/config.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule as NestConfigModule } from "@nestjs/config";
+import { validateEnv } from "./env.schema.js";
+
+@Module({
+  imports: [
+    NestConfigModule.forRoot({
+      isGlobal: true,
+      cache: true,
+      validate: validateEnv,
+    }),
+  ],
+  exports: [NestConfigModule],
+})
+export class AppConfigModule {}

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+export const EnvSchema = z.object({
+  NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+  PORT: z.coerce.number().int().positive().default(3001),
+  LOG_LEVEL: z.enum(["trace", "debug", "info", "warn", "error", "fatal", "silent"]).default("info"),
+
+  // CORS in non-production — comma-separated origin list
+  CORS_ORIGINS: z
+    .string()
+    .default("http://localhost:5173")
+    .transform((s) =>
+      s
+        .split(",")
+        .map((o) => o.trim())
+        .filter(Boolean),
+    ),
+
+  // Placeholders for later phases — required fields land in their respective phase tasks.
+  // Keep optional here so Phase 2 doesn't force operators to set them prematurely.
+  DATABASE_URL: z.string().url().optional(),
+  JWT_ACCESS_SECRET: z.string().min(32).optional(),
+  JWT_ACCESS_EXPIRES_IN: z.string().default("15m"),
+  JWT_REFRESH_EXPIRES_DAYS: z.coerce.number().int().positive().default(7),
+  DISABLE_FIRST_USER_ADMIN: z.coerce.boolean().default(false),
+});
+
+export type Env = z.infer<typeof EnvSchema>;
+
+export function validateEnv(raw: Record<string, unknown>): Env {
+  const result = EnvSchema.safeParse(raw);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `  - ${i.path.join(".")}: ${i.message}`)
+      .join("\n");
+    throw new Error(`Invalid environment:\n${issues}`);
+  }
+  return result.data;
+}

--- a/apps/api/src/config/env.spec.ts
+++ b/apps/api/src/config/env.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { validateEnv } from "./env.schema.js";
+
+describe("validateEnv", () => {
+  it("accepts minimal env", () => {
+    const env = validateEnv({});
+    expect(env.NODE_ENV).toBe("development");
+    expect(env.PORT).toBe(3001);
+    expect(env.LOG_LEVEL).toBe("info");
+    expect(env.CORS_ORIGINS).toEqual(["http://localhost:5173"]);
+  });
+
+  it("coerces PORT string to number", () => {
+    const env = validateEnv({ PORT: "8080" });
+    expect(env.PORT).toBe(8080);
+  });
+
+  it("rejects bad LOG_LEVEL", () => {
+    expect(() => validateEnv({ LOG_LEVEL: "chatty" })).toThrow(/LOG_LEVEL/);
+  });
+
+  it("splits CORS_ORIGINS on comma", () => {
+    const env = validateEnv({ CORS_ORIGINS: "http://a,http://b" });
+    expect(env.CORS_ORIGINS).toEqual(["http://a", "http://b"]);
+  });
+
+  it("rejects JWT_ACCESS_SECRET shorter than 32 chars when provided", () => {
+    expect(() => validateEnv({ JWT_ACCESS_SECRET: "short" })).toThrow(/JWT_ACCESS_SECRET/);
+  });
+});

--- a/apps/api/src/integrations/builders/builders.spec.ts
+++ b/apps/api/src/integrations/builders/builders.spec.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { buildRequestBody, VALID_API_TYPES } from "./index";
+import { describe, expect, it } from "vitest";
+import { VALID_API_TYPES, buildRequestBody } from "./index";
 
 describe("buildRequestBody", () => {
   it("accepts every declared api type without throwing", () => {
@@ -25,8 +25,6 @@ describe("buildRequestBody", () => {
   });
 
   it("rejects an unknown apiType at the type level (runtime throw)", () => {
-    expect(() => buildRequestBody("bogus" as never, {})).toThrow(
-      /Unknown apiType/,
-    );
+    expect(() => buildRequestBody("bogus" as never, {})).toThrow(/Unknown apiType/);
   });
 });

--- a/apps/api/src/integrations/builders/chat.ts
+++ b/apps/api/src/integrations/builders/chat.ts
@@ -29,8 +29,8 @@ export function buildChatBody({
   return {
     model,
     messages: [{ role: "user", content: prompt }],
-    max_tokens: parseInt(maxTokens as string) || 1000,
-    temperature: parseFloat(temperature as string) || 0.7,
+    max_tokens: Number.parseInt(maxTokens as string) || 1000,
+    temperature: Number.parseFloat(temperature as string) || 0.7,
     stream: !!stream,
   };
 }

--- a/apps/api/src/integrations/builders/embeddings.ts
+++ b/apps/api/src/integrations/builders/embeddings.ts
@@ -13,7 +13,6 @@ export function buildEmbeddingsBody({
   model,
   embeddingInput,
 }: EmbeddingsBodyConfig): Record<string, unknown> {
-  if (!embeddingInput)
-    throw new Error("Missing required parameter: embeddingInput");
+  if (!embeddingInput) throw new Error("Missing required parameter: embeddingInput");
   return { model, input: embeddingInput };
 }

--- a/apps/api/src/integrations/builders/images.ts
+++ b/apps/api/src/integrations/builders/images.ts
@@ -19,10 +19,9 @@ export function buildImagesBody({
   imageSize,
   imageN,
 }: ImagesBodyConfig): Record<string, unknown> {
-  if (!imagePrompt)
-    throw new Error("Missing required parameter: imagePrompt");
+  if (!imagePrompt) throw new Error("Missing required parameter: imagePrompt");
   const body: Record<string, unknown> = { model, prompt: imagePrompt };
   if (imageSize) body.size = imageSize;
-  if (imageN) body.n = parseInt(imageN as string) || 1;
+  if (imageN) body.n = Number.parseInt(imageN as string) || 1;
   return body;
 }

--- a/apps/api/src/integrations/builders/index.ts
+++ b/apps/api/src/integrations/builders/index.ts
@@ -8,9 +8,9 @@
 
 import { buildChatBody } from "./chat.js";
 import { buildEmbeddingsBody } from "./embeddings.js";
-import { buildRerankBody } from "./rerank.js";
 import { buildImagesBody } from "./images.js";
-import { buildChatVisionBody, buildChatAudioBody } from "./multimodal.js";
+import { buildChatAudioBody, buildChatVisionBody } from "./multimodal.js";
+import { buildRerankBody } from "./rerank.js";
 
 export { buildChatBody } from "./chat.js";
 export { buildEmbeddingsBody } from "./embeddings.js";
@@ -46,25 +46,15 @@ export function buildRequestBody(
     case "chat":
       return buildChatBody(cfg as unknown as Parameters<typeof buildChatBody>[0]);
     case "embeddings":
-      return buildEmbeddingsBody(
-        cfg as unknown as Parameters<typeof buildEmbeddingsBody>[0],
-      );
+      return buildEmbeddingsBody(cfg as unknown as Parameters<typeof buildEmbeddingsBody>[0]);
     case "rerank":
-      return buildRerankBody(
-        cfg as unknown as Parameters<typeof buildRerankBody>[0],
-      );
+      return buildRerankBody(cfg as unknown as Parameters<typeof buildRerankBody>[0]);
     case "images":
-      return buildImagesBody(
-        cfg as unknown as Parameters<typeof buildImagesBody>[0],
-      );
+      return buildImagesBody(cfg as unknown as Parameters<typeof buildImagesBody>[0]);
     case "chat-vision":
-      return buildChatVisionBody(
-        cfg as unknown as Parameters<typeof buildChatVisionBody>[0],
-      );
+      return buildChatVisionBody(cfg as unknown as Parameters<typeof buildChatVisionBody>[0]);
     case "chat-audio":
-      return buildChatAudioBody(
-        cfg as unknown as Parameters<typeof buildChatAudioBody>[0],
-      );
+      return buildChatAudioBody(cfg as unknown as Parameters<typeof buildChatAudioBody>[0]);
     default: {
       const exhaustive: never = apiType;
       throw new Error(`Unknown apiType: ${String(exhaustive)}`);

--- a/apps/api/src/integrations/builders/multimodal.ts
+++ b/apps/api/src/integrations/builders/multimodal.ts
@@ -26,8 +26,7 @@ export interface ChatAudioBodyConfig {
 type ChatMessage = {
   role: "system" | "user";
   content: Array<
-    | { type: "text"; text: string }
-    | { type: "image_url"; image_url: { url: string } }
+    { type: "text"; text: string } | { type: "image_url"; image_url: { url: string } }
   >;
 };
 
@@ -62,8 +61,8 @@ export function buildChatVisionBody({
   return {
     model,
     messages,
-    max_tokens: parseInt(maxTokens as string) || 256,
-    temperature: parseFloat(temperature as string) || 0.0,
+    max_tokens: Number.parseInt(maxTokens as string) || 256,
+    temperature: Number.parseFloat(temperature as string) || 0.0,
   };
 }
 

--- a/apps/api/src/integrations/parsers/vegeta-report.spec.ts
+++ b/apps/api/src/integrations/parsers/vegeta-report.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { parseVegetaReport } from "./vegeta-report.js";
 
 // Realistic Vegeta stdout (captured format). The parser was ported verbatim

--- a/apps/api/src/integrations/parsers/vegeta-report.ts
+++ b/apps/api/src/integrations/parsers/vegeta-report.ts
@@ -66,7 +66,7 @@ export function parseVegetaReport(report: string): VegetaParsed {
   lines.forEach((line) => {
     if (line.includes("Requests") && line.includes("[total")) {
       const match = line.match(/Requests\s+\[.*?\]\s+([\d.]+)/);
-      if (match && match[1] !== undefined) parsed.requests = parseInt(match[1]);
+      if (match && match[1] !== undefined) parsed.requests = Number.parseInt(match[1]);
 
       const valuesMatch = line.match(/\]\s+([\d.]+),\s+([\d.]+),\s+([\d.]+)/);
       if (
@@ -75,9 +75,9 @@ export function parseVegetaReport(report: string): VegetaParsed {
         valuesMatch[2] !== undefined &&
         valuesMatch[3] !== undefined
       ) {
-        parsed.requests = parseInt(valuesMatch[1]);
-        parsed.rate = parseFloat(valuesMatch[2]);
-        parsed.throughput = parseFloat(valuesMatch[3]);
+        parsed.requests = Number.parseInt(valuesMatch[1]);
+        parsed.rate = Number.parseFloat(valuesMatch[2]);
+        parsed.throughput = Number.parseFloat(valuesMatch[3]);
       }
     }
 
@@ -103,17 +103,17 @@ export function parseVegetaReport(report: string): VegetaParsed {
 
     if (line.includes("Bytes In") && line.includes("[total")) {
       const match = line.match(/\]\s+([\d.]+)/);
-      if (match && match[1] !== undefined) parsed.bytesIn = parseInt(match[1]);
+      if (match && match[1] !== undefined) parsed.bytesIn = Number.parseInt(match[1]);
     }
 
     if (line.includes("Bytes Out") && line.includes("[total")) {
       const match = line.match(/\]\s+([\d.]+)/);
-      if (match && match[1] !== undefined) parsed.bytesOut = parseInt(match[1]);
+      if (match && match[1] !== undefined) parsed.bytesOut = Number.parseInt(match[1]);
     }
 
     if (line.includes("Success") && line.includes("[ratio]")) {
       const match = line.match(/\]\s+([\d.]+)%/);
-      if (match && match[1] !== undefined) parsed.success = parseFloat(match[1]);
+      if (match && match[1] !== undefined) parsed.success = Number.parseFloat(match[1]);
     }
 
     if (line.includes("Status Codes") && line.includes("[code:count]")) {
@@ -123,7 +123,7 @@ export function parseVegetaReport(report: string): VegetaParsed {
         codes.forEach((code) => {
           const [status, count] = code.split(":");
           if (status && count) {
-            parsed.statusCodes[status] = parseInt(count);
+            parsed.statusCodes[status] = Number.parseInt(count);
           }
         });
       }

--- a/apps/api/src/integrations/probes/audio.ts
+++ b/apps/api/src/integrations/probes/audio.ts
@@ -29,8 +29,7 @@ export async function runAudioProbe({
   const body = buildChatAudioBody({
     model,
     prompt: "Say the word hello.",
-    systemPrompt:
-      "You are Qwen, a virtual human capable of generating text and speech.",
+    systemPrompt: "You are Qwen, a virtual human capable of generating text and speech.",
   });
 
   const t0 = Date.now();

--- a/apps/api/src/integrations/probes/image.ts
+++ b/apps/api/src/integrations/probes/image.ts
@@ -13,8 +13,8 @@
  * are one dir down from `assets/`. Switch to `import.meta.url` only if
  * tsconfig moves to ESM later.
  */
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import { buildChatVisionBody } from "../builders/multimodal.js";
 import type { ProbeCtx, ProbeResult } from "./index.js";
 

--- a/apps/api/src/integrations/probes/index.ts
+++ b/apps/api/src/integrations/probes/index.ts
@@ -1,3 +1,5 @@
+import { runAudioProbe } from "./audio.js";
+import { runImageProbe } from "./image.js";
 /**
  * Probe dispatcher + shared types.
  *
@@ -6,8 +8,6 @@
  * apps/web/src/features/e2e-smoke/types.ts byte-for-byte.
  */
 import { runTextProbe } from "./text.js";
-import { runImageProbe } from "./image.js";
-import { runAudioProbe } from "./audio.js";
 
 export { runTextProbe } from "./text.js";
 export { runImageProbe } from "./image.js";

--- a/apps/api/src/integrations/utils/tiny-png.ts
+++ b/apps/api/src/integrations/utils/tiny-png.ts
@@ -5,7 +5,7 @@
  * The CRC-32 table, chunk layout, and IHDR/IDAT/IEND ordering are preserved.
  */
 
-import zlib from "zlib";
+import zlib from "node:zlib";
 
 // Precomputed CRC-32 table (IEEE polynomial 0xedb88320) — PNG uses this.
 const CRC_TABLE: Uint32Array = (() => {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,5 +1,5 @@
-import { NestFactory } from "@nestjs/core";
 import type { INestApplication } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
 import { AllExceptionsFilter } from "./common/filters/all-exceptions.filter.js";
 

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,7 +1,9 @@
 import type { INestApplication } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { NestFactory } from "@nestjs/core";
+import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { Logger } from "nestjs-pino";
+import { patchNestJsSwagger } from "nestjs-zod";
 import { AppModule } from "./app.module";
 import { AllExceptionsFilter } from "./common/filters/all-exceptions.filter.js";
 import type { Env } from "./config/env.schema.js";
@@ -19,6 +21,18 @@ async function bootstrap(): Promise<void> {
   app.enableCors({
     origin: origins,
     credentials: true,
+  });
+
+  patchNestJsSwagger();
+  const swaggerConfig = new DocumentBuilder()
+    .setTitle("ModelDoctor API")
+    .setDescription("Troubleshooting toolkit for model-serving APIs")
+    .setVersion("0.1.0")
+    .addBearerAuth() // used starting Phase 5
+    .build();
+  const document = SwaggerModule.createDocument(app, swaggerConfig);
+  SwaggerModule.setup("api/docs", app, document, {
+    jsonDocumentUrl: "api/docs-json",
   });
 
   const port = config.get("PORT", { infer: true });

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,8 +1,10 @@
 import type { INestApplication } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
 import { NestFactory } from "@nestjs/core";
 import { Logger } from "nestjs-pino";
 import { AppModule } from "./app.module";
 import { AllExceptionsFilter } from "./common/filters/all-exceptions.filter.js";
+import type { Env } from "./config/env.schema.js";
 
 async function bootstrap(): Promise<void> {
   const app: INestApplication = await NestFactory.create(AppModule, { bufferLogs: true });
@@ -12,19 +14,14 @@ async function bootstrap(): Promise<void> {
 
   app.useGlobalFilters(new AllExceptionsFilter());
 
-  // Dev-time CORS: Vite dev server runs on 5173; browser calls here hit the
-  // Vite proxy server-to-server, so CORS is not strictly needed for the FE
-  // dev loop. But developers occasionally curl/fetch the API from other
-  // origins (notebooks, Postman browser), and permissive dev CORS is harmless.
-  // Production CORS policy is revisited in Phase 2 with @nestjs/config.
-  if (process.env.NODE_ENV !== "production") {
-    app.enableCors({
-      origin: ["http://localhost:5173"],
-      credentials: true,
-    });
-  }
+  const config = app.get<ConfigService<Env, true>>(ConfigService);
+  const origins = config.get("CORS_ORIGINS", { infer: true });
+  app.enableCors({
+    origin: origins,
+    credentials: true,
+  });
 
-  const port = Number(process.env.PORT ?? 3001);
+  const port = config.get("PORT", { infer: true });
   await app.listen(port);
   console.log(`[api] listening on http://localhost:${port}`);
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,10 +1,12 @@
 import type { INestApplication } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
+import { Logger } from "nestjs-pino";
 import { AppModule } from "./app.module";
 import { AllExceptionsFilter } from "./common/filters/all-exceptions.filter.js";
 
 async function bootstrap(): Promise<void> {
-  const app: INestApplication = await NestFactory.create(AppModule);
+  const app: INestApplication = await NestFactory.create(AppModule, { bufferLogs: true });
+  app.useLogger(app.get(Logger));
 
   app.setGlobalPrefix("api");
 

--- a/apps/api/src/modules/debug-proxy/debug-proxy.controller.ts
+++ b/apps/api/src/modules/debug-proxy/debug-proxy.controller.ts
@@ -2,15 +2,30 @@ import {
   type DebugProxyRequest,
   DebugProxyRequestSchema,
   type DebugProxyResponse,
+  DebugProxyResponseSchema,
 } from "@modeldoctor/contracts";
 import { Body, Controller, HttpCode, HttpStatus, Post, UsePipes } from "@nestjs/common";
+import { ApiBody, ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { createZodDto } from "nestjs-zod";
 import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
 import { DebugProxyService } from "./debug-proxy.service.js";
 
+class DebugProxyRequestDto extends createZodDto(DebugProxyRequestSchema) {}
+// DebugProxyResponseSchema is a z.discriminatedUnion, whose inferred TOutput is
+// a union type — TS can't extend a class whose base-constructor return type is a
+// union. Assign the factory result directly and rename the class so Swagger
+// emits a stable `DebugProxyResponseDto` component (default: `AugmentedZodDto`).
+const DebugProxyResponseDto = createZodDto(DebugProxyResponseSchema);
+Object.defineProperty(DebugProxyResponseDto, "name", { value: "DebugProxyResponseDto" });
+
+@ApiTags("debug-proxy")
 @Controller("debug")
 export class DebugProxyController {
   constructor(private readonly proxy: DebugProxyService) {}
 
+  @ApiOperation({ summary: "Proxy an upstream HTTP request and return the decoded response" })
+  @ApiBody({ type: DebugProxyRequestDto })
+  @ApiOkResponse({ type: DebugProxyResponseDto })
   @Post("proxy")
   @HttpCode(HttpStatus.OK)
   @UsePipes(new ZodValidationPipe(DebugProxyRequestSchema))

--- a/apps/api/src/modules/debug-proxy/debug-proxy.controller.ts
+++ b/apps/api/src/modules/debug-proxy/debug-proxy.controller.ts
@@ -1,18 +1,11 @@
 import {
-  Body,
-  Controller,
-  HttpCode,
-  HttpStatus,
-  Post,
-  UsePipes,
-} from "@nestjs/common";
-import { DebugProxyService } from "./debug-proxy.service.js";
-import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
-import {
-  DebugProxyRequestSchema,
   type DebugProxyRequest,
+  DebugProxyRequestSchema,
   type DebugProxyResponse,
 } from "@modeldoctor/contracts";
+import { Body, Controller, HttpCode, HttpStatus, Post, UsePipes } from "@nestjs/common";
+import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
+import { DebugProxyService } from "./debug-proxy.service.js";
 
 @Controller("debug")
 export class DebugProxyController {

--- a/apps/api/src/modules/debug-proxy/debug-proxy.service.ts
+++ b/apps/api/src/modules/debug-proxy/debug-proxy.service.ts
@@ -1,8 +1,5 @@
+import type { DebugProxyRequest, DebugProxyResponse } from "@modeldoctor/contracts";
 import { Injectable } from "@nestjs/common";
-import type {
-  DebugProxyRequest,
-  DebugProxyResponse,
-} from "@modeldoctor/contracts";
 
 const MAX_BODY_BYTES = 20 * 1024 * 1024;
 
@@ -51,9 +48,7 @@ export class DebugProxyService {
       }
 
       const binary = looksBinary(contentType);
-      const body = binary
-        ? buffer.toString("base64")
-        : buffer.toString("utf-8");
+      const body = binary ? buffer.toString("base64") : buffer.toString("utf-8");
       const headers: Record<string, string> = {};
       response.headers.forEach((v, k) => {
         headers[k] = v;

--- a/apps/api/src/modules/e2e-test/e2e-test.controller.ts
+++ b/apps/api/src/modules/e2e-test/e2e-test.controller.ts
@@ -2,15 +2,25 @@ import {
   type E2ETestRequest,
   E2ETestRequestSchema,
   type E2ETestResponse,
+  E2ETestResponseSchema,
 } from "@modeldoctor/contracts";
 import { Body, Controller, HttpCode, HttpStatus, Post, UsePipes } from "@nestjs/common";
+import { ApiBody, ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { createZodDto } from "nestjs-zod";
 import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
 import { E2ETestService } from "./e2e-test.service.js";
 
+class E2ETestRequestDto extends createZodDto(E2ETestRequestSchema) {}
+class E2ETestResponseDto extends createZodDto(E2ETestResponseSchema) {}
+
+@ApiTags("e2e-test")
 @Controller()
 export class E2ETestController {
   constructor(private readonly svc: E2ETestService) {}
 
+  @ApiOperation({ summary: "Run selected probes against a model endpoint" })
+  @ApiBody({ type: E2ETestRequestDto })
+  @ApiOkResponse({ type: E2ETestResponseDto })
   @Post("e2e-test")
   @HttpCode(HttpStatus.OK)
   @UsePipes(new ZodValidationPipe(E2ETestRequestSchema))

--- a/apps/api/src/modules/e2e-test/e2e-test.controller.ts
+++ b/apps/api/src/modules/e2e-test/e2e-test.controller.ts
@@ -1,18 +1,11 @@
 import {
-  Body,
-  Controller,
-  HttpCode,
-  HttpStatus,
-  Post,
-  UsePipes,
-} from "@nestjs/common";
-import { E2ETestService } from "./e2e-test.service.js";
-import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
-import {
-  E2ETestRequestSchema,
   type E2ETestRequest,
+  E2ETestRequestSchema,
   type E2ETestResponse,
 } from "@modeldoctor/contracts";
+import { Body, Controller, HttpCode, HttpStatus, Post, UsePipes } from "@nestjs/common";
+import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
+import { E2ETestService } from "./e2e-test.service.js";
 
 @Controller()
 export class E2ETestController {

--- a/apps/api/src/modules/e2e-test/e2e-test.service.ts
+++ b/apps/api/src/modules/e2e-test/e2e-test.service.ts
@@ -1,13 +1,6 @@
+import type { E2ETestRequest, E2ETestResponse } from "@modeldoctor/contracts";
 import { Injectable } from "@nestjs/common";
-import type {
-  E2ETestRequest,
-  E2ETestResponse,
-} from "@modeldoctor/contracts";
-import {
-  PROBES,
-  type ProbeCtx,
-  type ProbeName,
-} from "../../integrations/probes/index.js";
+import { PROBES, type ProbeCtx, type ProbeName } from "../../integrations/probes/index.js";
 
 function parseHeaderLines(s: string | undefined): Record<string, string> {
   const out: Record<string, string> = {};

--- a/apps/api/src/modules/health/health.controller.ts
+++ b/apps/api/src/modules/health/health.controller.ts
@@ -1,6 +1,6 @@
+import type { CheckVegetaResponse, HealthResponse } from "@modeldoctor/contracts";
 import { Controller, Get } from "@nestjs/common";
 import { HealthService } from "./health.service.js";
-import type { HealthResponse, CheckVegetaResponse } from "@modeldoctor/contracts";
 
 @Controller()
 export class HealthController {

--- a/apps/api/src/modules/health/health.controller.ts
+++ b/apps/api/src/modules/health/health.controller.ts
@@ -1,16 +1,31 @@
-import type { CheckVegetaResponse, HealthResponse } from "@modeldoctor/contracts";
+import {
+  type CheckVegetaResponse,
+  CheckVegetaResponseSchema,
+  type HealthResponse,
+  HealthResponseSchema,
+} from "@modeldoctor/contracts";
 import { Controller, Get } from "@nestjs/common";
+import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { createZodDto } from "nestjs-zod";
 import { HealthService } from "./health.service.js";
 
+class HealthResponseDto extends createZodDto(HealthResponseSchema) {}
+class CheckVegetaResponseDto extends createZodDto(CheckVegetaResponseSchema) {}
+
+@ApiTags("health")
 @Controller()
 export class HealthController {
   constructor(private readonly health: HealthService) {}
 
+  @ApiOperation({ summary: "Liveness probe" })
+  @ApiOkResponse({ type: HealthResponseDto })
   @Get("health")
   getHealth(): HealthResponse {
     return this.health.getHealth();
   }
 
+  @ApiOperation({ summary: "Check if Vegeta CLI is installed on the host" })
+  @ApiOkResponse({ type: CheckVegetaResponseDto })
   @Get("check-vegeta")
   checkVegeta(): Promise<CheckVegetaResponse> {
     return this.health.checkVegeta();

--- a/apps/api/src/modules/health/health.service.ts
+++ b/apps/api/src/modules/health/health.service.ts
@@ -1,7 +1,7 @@
-import { Injectable } from "@nestjs/common";
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import type { HealthResponse, CheckVegetaResponse } from "@modeldoctor/contracts";
+import type { CheckVegetaResponse, HealthResponse } from "@modeldoctor/contracts";
+import { Injectable } from "@nestjs/common";
 
 const execP = promisify(exec);
 
@@ -16,11 +16,19 @@ export class HealthService {
       const { stdout } = await execP("which vegeta");
       const path = stdout.trim();
       if (!path) {
-        return { installed: false, message: "Vegeta is not installed. Please install it first.", path: null };
+        return {
+          installed: false,
+          message: "Vegeta is not installed. Please install it first.",
+          path: null,
+        };
       }
       return { installed: true, message: "Vegeta is installed", path };
     } catch {
-      return { installed: false, message: "Vegeta is not installed. Please install it first.", path: null };
+      return {
+        installed: false,
+        message: "Vegeta is not installed. Please install it first.",
+        path: null,
+      };
     }
   }
 }

--- a/apps/api/src/modules/load-test/load-test.controller.ts
+++ b/apps/api/src/modules/load-test/load-test.controller.ts
@@ -1,18 +1,11 @@
 import {
-  Body,
-  Controller,
-  HttpCode,
-  HttpStatus,
-  Post,
-  UsePipes,
-} from "@nestjs/common";
-import { LoadTestService } from "./load-test.service.js";
-import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
-import {
-  LoadTestRequestSchema,
   type LoadTestRequest,
+  LoadTestRequestSchema,
   type LoadTestResponse,
 } from "@modeldoctor/contracts";
+import { Body, Controller, HttpCode, HttpStatus, Post, UsePipes } from "@nestjs/common";
+import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
+import { LoadTestService } from "./load-test.service.js";
 
 @Controller()
 export class LoadTestController {

--- a/apps/api/src/modules/load-test/load-test.controller.ts
+++ b/apps/api/src/modules/load-test/load-test.controller.ts
@@ -2,15 +2,25 @@ import {
   type LoadTestRequest,
   LoadTestRequestSchema,
   type LoadTestResponse,
+  LoadTestResponseSchema,
 } from "@modeldoctor/contracts";
 import { Body, Controller, HttpCode, HttpStatus, Post, UsePipes } from "@nestjs/common";
+import { ApiBody, ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { createZodDto } from "nestjs-zod";
 import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
 import { LoadTestService } from "./load-test.service.js";
 
+class LoadTestRequestDto extends createZodDto(LoadTestRequestSchema) {}
+class LoadTestResponseDto extends createZodDto(LoadTestResponseSchema) {}
+
+@ApiTags("load-test")
 @Controller()
 export class LoadTestController {
   constructor(private readonly svc: LoadTestService) {}
 
+  @ApiOperation({ summary: "Run a vegeta load test" })
+  @ApiBody({ type: LoadTestRequestDto })
+  @ApiOkResponse({ type: LoadTestResponseDto })
   @Post("load-test")
   @HttpCode(HttpStatus.OK)
   @UsePipes(new ZodValidationPipe(LoadTestRequestSchema))

--- a/apps/api/src/modules/load-test/load-test.service.ts
+++ b/apps/api/src/modules/load-test/load-test.service.ts
@@ -1,21 +1,14 @@
-import { Injectable, InternalServerErrorException } from "@nestjs/common";
 import { spawn } from "node:child_process";
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import type {
-  LoadTestRequest,
-  LoadTestResponse,
-  LoadTestParsed,
-} from "@modeldoctor/contracts";
+import type { LoadTestParsed, LoadTestRequest, LoadTestResponse } from "@modeldoctor/contracts";
+import { Injectable, InternalServerErrorException } from "@nestjs/common";
 import {
-  buildRequestBody,
-  VALID_API_TYPES,
   type ApiType,
+  VALID_API_TYPES,
+  buildRequestBody,
 } from "../../integrations/builders/index.js";
-import {
-  parseVegetaReport,
-  type VegetaParsed,
-} from "../../integrations/parsers/vegeta-report.js";
+import { type VegetaParsed, parseVegetaReport } from "../../integrations/parsers/vegeta-report.js";
 
 const TMP_DIR = path.resolve(process.cwd(), "tmp");
 
@@ -37,9 +30,7 @@ function narrowParsed(v: VegetaParsed): LoadTestParsed {
 @Injectable()
 export class LoadTestService {
   async run(req: LoadTestRequest): Promise<LoadTestResponse> {
-    const apiType = (VALID_API_TYPES as readonly string[]).includes(
-      req.apiType ?? "",
-    )
+    const apiType = (VALID_API_TYPES as readonly string[]).includes(req.apiType ?? "")
       ? (req.apiType as ApiType)
       : "chat";
 
@@ -47,9 +38,7 @@ export class LoadTestService {
     try {
       requestBody = buildRequestBody(apiType, { ...req, model: req.model });
     } catch (e) {
-      throw new InternalServerErrorException(
-        e instanceof Error ? e.message : String(e),
-      );
+      throw new InternalServerErrorException(e instanceof Error ? e.message : String(e));
     }
 
     await fs.mkdir(TMP_DIR, { recursive: true });
@@ -58,7 +47,7 @@ export class LoadTestService {
     await fs.writeFile(jsonPath, JSON.stringify(requestBody, null, 2));
 
     let finalUrl = req.apiUrl;
-    if (req.queryParams && req.queryParams.trim()) {
+    if (req.queryParams?.trim()) {
       const params = req.queryParams
         .split("\n")
         .map((p) => p.trim())
@@ -70,7 +59,7 @@ export class LoadTestService {
     }
 
     let extraHeaders = "";
-    if (req.customHeaders && req.customHeaders.trim()) {
+    if (req.customHeaders?.trim()) {
       const lines = req.customHeaders
         .split("\n")
         .map((h) => h.trim())

--- a/apps/api/test/e2e/debug-proxy.e2e-spec.ts
+++ b/apps/api/test/e2e/debug-proxy.e2e-spec.ts
@@ -59,15 +59,15 @@ describe("DebugProxy (e2e)", () => {
     await new Promise<void>((r) => upstream.close(() => r()));
   });
 
-  it("rejects missing url with 400 and legacy error shape", async () => {
+  it("rejects missing url with 400 and standard error envelope", async () => {
     const res = await request(app.getHttpServer())
       .post("/api/debug/proxy")
       .send({})
       .expect(400);
-    expect(res.body).toEqual({
-      success: false,
-      error: expect.stringContaining("url"),
-    });
+    expect(res.body.error.code).toBe("VALIDATION_FAILED");
+    expect(res.body.error.message).toMatch(/url/);
+    expect(res.body.error.requestId).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(Array.isArray(res.body.error.details)).toBe(true);
   });
 
   it("forwards GET and returns decoded text body", async () => {

--- a/apps/api/test/e2e/e2e-test.e2e-spec.ts
+++ b/apps/api/test/e2e/e2e-test.e2e-spec.ts
@@ -27,8 +27,9 @@ describe("E2ETest (e2e)", () => {
       .post("/api/e2e-test")
       .send({ apiKey: "k", model: "m", probes: ["text"] })
       .expect(400);
-    expect(res.body.success).toBe(false);
-    expect(res.body.error).toMatch(/apiUrl/);
+    expect(res.body.error.code).toBe("VALIDATION_FAILED");
+    expect(res.body.error.message).toMatch(/apiUrl/);
+    expect(res.body.error.requestId).toMatch(/^[A-Za-z0-9_-]+$/);
   });
 
   it("rejects empty probes array", async () => {
@@ -36,8 +37,9 @@ describe("E2ETest (e2e)", () => {
       .post("/api/e2e-test")
       .send({ apiUrl: "x", apiKey: "k", model: "m", probes: [] })
       .expect(400);
-    expect(res.body.success).toBe(false);
-    expect(res.body.error).toMatch(/probes/);
+    expect(res.body.error.code).toBe("VALIDATION_FAILED");
+    expect(res.body.error.message).toMatch(/probes/);
+    expect(res.body.error.requestId).toMatch(/^[A-Za-z0-9_-]+$/);
   });
 
   it("rejects unknown probe name", async () => {
@@ -45,7 +47,8 @@ describe("E2ETest (e2e)", () => {
       .post("/api/e2e-test")
       .send({ apiUrl: "x", apiKey: "k", model: "m", probes: ["bogus"] })
       .expect(400);
-    expect(res.body.success).toBe(false);
-    expect(res.body.error).toMatch(/probes/);
+    expect(res.body.error.code).toBe("VALIDATION_FAILED");
+    expect(res.body.error.message).toMatch(/probes/);
+    expect(res.body.error.requestId).toMatch(/^[A-Za-z0-9_-]+$/);
   });
 });

--- a/apps/api/test/e2e/load-test.e2e-spec.ts
+++ b/apps/api/test/e2e/load-test.e2e-spec.ts
@@ -27,7 +27,8 @@ describe("LoadTest (e2e)", () => {
       .post("/api/load-test")
       .send({ apiKey: "k", model: "m", rate: 1, duration: 1 })
       .expect(400);
-    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe("VALIDATION_FAILED");
+    expect(res.body.error.requestId).toMatch(/^[A-Za-z0-9_-]+$/);
   });
 
   it("rejects rate=0", async () => {
@@ -35,8 +36,9 @@ describe("LoadTest (e2e)", () => {
       .post("/api/load-test")
       .send({ apiUrl: "x", apiKey: "k", model: "m", rate: 0, duration: 1 })
       .expect(400);
-    expect(res.body.success).toBe(false);
-    expect(res.body.error).toMatch(/rate/i);
+    expect(res.body.error.code).toBe("VALIDATION_FAILED");
+    expect(res.body.error.message).toMatch(/rate/i);
+    expect(res.body.error.requestId).toMatch(/^[A-Za-z0-9_-]+$/);
   });
 
   it("rejects duration>3600", async () => {
@@ -44,7 +46,8 @@ describe("LoadTest (e2e)", () => {
       .post("/api/load-test")
       .send({ apiUrl: "x", apiKey: "k", model: "m", rate: 1, duration: 99999 })
       .expect(400);
-    expect(res.body.success).toBe(false);
-    expect(res.body.error).toMatch(/duration/i);
+    expect(res.body.error.code).toBe("VALIDATION_FAILED");
+    expect(res.body.error.message).toMatch(/duration/i);
+    expect(res.body.error.requestId).toMatch(/^[A-Za-z0-9_-]+$/);
   });
 });

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiError, api } from "./api-client";
+
+describe("api-client", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns parsed JSON on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(JSON.stringify({ ok: true })),
+      }),
+    );
+    const data = await api.get<{ ok: boolean }>("/api/health");
+    expect(data).toEqual({ ok: true });
+  });
+
+  it("parses standard error envelope", async () => {
+    const envelope = {
+      error: {
+        code: "VALIDATION_FAILED",
+        message: "body: url is required",
+        details: [{ path: ["url"], message: "Required" }],
+        requestId: "abc123xyz_",
+      },
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve(JSON.stringify(envelope)),
+      }),
+    );
+    await expect(api.post("/api/debug/proxy", {})).rejects.toMatchObject({
+      status: 400,
+      message: "body: url is required",
+      code: "VALIDATION_FAILED",
+      requestId: "abc123xyz_",
+    });
+  });
+
+  it("falls back for non-conforming error bodies", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 502,
+        text: () => Promise.resolve("<html>Bad Gateway</html>"),
+      }),
+    );
+    let caught: unknown;
+    try {
+      await api.get("/api/upstream");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ApiError);
+    expect((caught as ApiError).status).toBe(502);
+    expect((caught as ApiError).code).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,7 +1,12 @@
+import { StandardErrorResponseSchema } from "@modeldoctor/contracts";
+
 export class ApiError extends Error {
   constructor(
     public status: number,
     message: string,
+    public code?: string,
+    public requestId?: string,
+    public details?: unknown,
   ) {
     super(message);
   }
@@ -25,14 +30,17 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     }
   }
   if (!res.ok) {
-    const message =
-      (data &&
-      typeof data === "object" &&
-      "error" in data &&
-      typeof (data as { error: unknown }).error === "string"
-        ? (data as { error: string }).error
-        : null) ?? `HTTP ${res.status}`;
-    throw new ApiError(res.status, message);
+    const parsed = StandardErrorResponseSchema.safeParse(data);
+    if (parsed.success) {
+      throw new ApiError(
+        res.status,
+        parsed.data.error.message,
+        parsed.data.error.code,
+        parsed.data.error.requestId,
+        parsed.data.error.details,
+      );
+    }
+    throw new ApiError(res.status, `HTTP ${res.status}`);
   }
   return data as T;
 }

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "files": {
-    "ignore": ["dist", "node_modules", "coverage"]
+    "ignore": ["**/dist", "**/node_modules", "**/coverage", "**/.vite"]
   },
   "organizeImports": { "enabled": true },
   "formatter": {
@@ -12,6 +12,9 @@
     "lineEnding": "lf"
   },
   "javascript": {
+    "parser": {
+      "unsafeParameterDecoratorsEnabled": true
+    },
     "formatter": {
       "quoteStyle": "double",
       "jsxQuoteStyle": "double",
@@ -23,17 +26,10 @@
     "enabled": true,
     "rules": {
       "recommended": true,
-      "style": {
-        "noUselessElse": "warn",
-        "useConst": "warn"
-      },
-      "suspicious": {
-        "noExplicitAny": "warn",
-        "noArrayIndexKey": "warn"
-      },
-      "correctness": {
-        "useExhaustiveDependencies": "warn"
-      }
+      "style": { "noUselessElse": "warn", "useConst": "warn", "useImportType": "off" },
+      "suspicious": { "noExplicitAny": "warn", "noArrayIndexKey": "warn" },
+      "correctness": { "useExhaustiveDependencies": "warn" },
+      "complexity": { "noForEach": "warn" }
     }
   }
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -16,6 +16,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "type-check": "tsc -p tsconfig.json --noEmit",
+    "lint": "biome check src",
+    "format": "biome format --write src",
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {

--- a/packages/contracts/src/debug-proxy.ts
+++ b/packages/contracts/src/debug-proxy.ts
@@ -1,9 +1,7 @@
 import { z } from "zod";
 
 export const DebugProxyRequestSchema = z.object({
-  method: z
-    .enum(["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"])
-    .default("GET"),
+  method: z.enum(["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]).default("GET"),
   url: z.string().min(1, "url is required"),
   headers: z.record(z.string()).default({}),
   body: z.union([z.string(), z.null()]).optional(),

--- a/packages/contracts/src/e2e-test.ts
+++ b/packages/contracts/src/e2e-test.ts
@@ -16,9 +16,7 @@ export const ProbeResultSchema = z.object({
   checks: z.array(ProbeCheckSchema),
   details: z.object({
     content: z.string().optional(),
-    usage: z
-      .object({ prompt_tokens: z.number(), completion_tokens: z.number() })
-      .optional(),
+    usage: z.object({ prompt_tokens: z.number(), completion_tokens: z.number() }).optional(),
     imagePreviewB64: z.string().optional(),
     imageMime: z.string().optional(),
     audioB64: z.string().optional(),

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -1,9 +1,31 @@
 import { z } from "zod";
 
-/** Legacy-compatible error shape. Every non-2xx response from apps/api matches this. */
+/** @deprecated Phase-1 error shape. Kept for clients that haven't migrated yet. */
 export const ApiErrorResponseSchema = z.object({
   success: z.literal(false),
   error: z.string(),
 });
-
 export type ApiErrorResponse = z.infer<typeof ApiErrorResponseSchema>;
+
+export const StandardErrorResponseSchema = z.object({
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+    details: z.unknown().optional(),
+    requestId: z.string(),
+  }),
+});
+export type StandardErrorResponse = z.infer<typeof StandardErrorResponseSchema>;
+
+/** Stable error codes. Append-only — never change the string of an existing code. */
+export const ErrorCodes = {
+  VALIDATION_FAILED: "VALIDATION_FAILED",
+  BAD_REQUEST: "BAD_REQUEST",
+  UNAUTHORIZED: "UNAUTHORIZED",
+  FORBIDDEN: "FORBIDDEN",
+  NOT_FOUND: "NOT_FOUND",
+  CONFLICT: "CONFLICT",
+  TOO_MANY_REQUESTS: "TOO_MANY_REQUESTS",
+  INTERNAL_SERVER_ERROR: "INTERNAL_SERVER_ERROR",
+} as const;
+export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@nestjs/swagger':
         specifier: ^7
         version: 7.4.2(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(reflect-metadata@0.2.2)
+      nanoid:
+        specifier: ^5.1.9
+        version: 5.1.9
       nestjs-pino:
         specifier: ^4
         version: 4.6.1(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(pino-http@10.5.0)(pino@9.14.0)(rxjs@7.8.2)
@@ -2910,6 +2913,11 @@ packages:
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.9:
+    resolution: {integrity: sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   negotiator@0.6.3:
@@ -6747,6 +6755,8 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
+
+  nanoid@5.1.9: {}
 
   negotiator@0.6.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^10
         version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
+      '@nestjs/serve-static':
+        specifier: ^4.0.2
+        version: 4.0.2(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(express@4.22.1)
       '@nestjs/swagger':
         specifier: ^7
         version: 7.4.2(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(reflect-metadata@0.2.2)
@@ -721,6 +724,22 @@ packages:
     resolution: {integrity: sha512-4e8gxaCk7DhBxVUly2PjYL4xC2ifDFexCqq1/u4TtivLGXotVk0wHdYuPYe1tHTHuR1lsOkRbfOCpkdTnigLVg==}
     peerDependencies:
       typescript: '>=4.8.2'
+
+  '@nestjs/serve-static@4.0.2':
+    resolution: {integrity: sha512-cT0vdWN5ar7jDI2NKbhf4LcwJzU4vS5sVpMkVrHuyLcltbrz6JdGi1TfIMMatP2pNiq5Ie/uUdPSFDVaZX/URQ==}
+    peerDependencies:
+      '@fastify/static': ^6.5.0 || ^7.0.0
+      '@nestjs/common': ^9.0.0 || ^10.0.0
+      '@nestjs/core': ^9.0.0 || ^10.0.0
+      express: ^4.18.1
+      fastify: ^4.7.0
+    peerDependenciesMeta:
+      '@fastify/static':
+        optional: true
+      express:
+        optional: true
+      fastify:
+        optional: true
 
   '@nestjs/swagger@7.4.2':
     resolution: {integrity: sha512-Mu6TEn1M/owIvAx2B4DUQObQXqo2028R2s9rSZ/hJEgBK95+doTwS0DjmVA2wTeZTyVtXOoN7CsoM5pONBzvKQ==}
@@ -3059,6 +3078,9 @@ packages:
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
+  path-to-regexp@0.2.5:
+    resolution: {integrity: sha512-l6qtdDPIkmAmzEO6egquYDfqQGPMRNGjYtrU13HAXb3YSRrt7HSb1sJY0pKp6o2bAa86tSB6iwaW2JbthPKr7Q==}
+
   path-to-regexp@3.3.0:
     resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
 
@@ -4553,6 +4575,14 @@ snapshots:
       typescript: 5.7.2
     transitivePeerDependencies:
       - chokidar
+
+  '@nestjs/serve-static@4.0.2(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(express@4.22.1)':
+    dependencies:
+      '@nestjs/common': 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      path-to-regexp: 0.2.5
+    optionalDependencies:
+      express: 4.22.1
 
   '@nestjs/swagger@7.4.2(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(reflect-metadata@0.2.2)':
     dependencies:
@@ -6871,6 +6901,8 @@ snapshots:
       minipass: 7.1.3
 
   path-to-regexp@0.1.13: {}
+
+  path-to-regexp@0.2.5: {}
 
   path-to-regexp@3.3.0: {}
 


### PR DESCRIPTION
## Summary

Infrastructure pass on the NestJS API: typed config, structured logging, OpenAPI docs, upgraded error envelope, env-driven CORS, and production static serving. All 8 tasks from the Phase 2 plan, one PR per phase. Breaking wire-format change on errors (atomic BE + contracts + FE).

9 commits:
- `docs: add CLAUDE.md policy` — autonomous-operation scope + project constraints for this repo
- `build: shared Biome config at repo root` — hoisted from apps/web; apps/api + packages/contracts now lint/format against the same rules
- `feat(api): typed env schema + @nestjs/config with fail-fast validation` — `EnvSchema` (zod) validated on boot; invalid env prints a readable error and refuses to start
- `feat(api): RequestId middleware` — generates/propagates `X-Request-Id`; safe-id regex echoes client ids, otherwise `nanoid(16)`
- `feat(api): nestjs-pino logger with requestId correlation and dev pretty print` — replaces Nest's default logger; `requestId` threaded into every access log; pino-pretty in dev, JSON in prod/test; `/api/health` suppressed
- **`feat: upgrade error response to {error:{code,message,requestId,details?}} (breaking wire change)`** — atomic across `AllExceptionsFilter`, `ZodValidationPipe`, `@modeldoctor/contracts` (adds `StandardErrorResponseSchema` + `ErrorCodes`; legacy shape kept `@deprecated`), `apps/web/src/lib/api-client.ts` (parses envelope), all e2e assertions, new `api-client.test.ts`
- `refactor(api): drive CORS origins + port from typed ConfigService` — `CORS_ORIGINS` + `PORT` now come from `ConfigService<Env, true>`
- `feat(api): OpenAPI at /api/docs via @nestjs/swagger + nestjs-zod schema patcher` — `patchNestJsSwagger()` + 4 annotated controllers; 8 DTO schemas registered; `/api/docs` + `/api/docs-json` serve all 5 endpoints
- `feat(api): serve apps/web/dist in production via ServeStaticModule (SPA fallback)` — single-process prod deploy; SPA fallback for non-`/api/*` paths; dev remains Vite-only

## Phase 2 DoD (all passing)

- [x] `pnpm -r type-check` green
- [x] `pnpm -r test` green — 80 tests (65 web incl. 3 new api-client, 15 api incl. 5 env + 3 requestId middleware)
- [x] `pnpm -F @modeldoctor/api test:e2e` green — 13/13 with updated error-shape assertions (7 sites)
- [x] `pnpm build` green (contracts → web → api topological)
- [x] `NODE_ENV=production pnpm start` serves API on `/api/*` and FE on everything else, single process (verified: `/api/health` 200, `/` 200, `/some/spa/path` 200, `/api/docs` 200)
- [x] `/api/docs` renders all 5 endpoints with Zod-derived schemas (discriminated union in `DebugProxyResponse` emits proper `oneOf`)
- [x] Missing/invalid env vars fail boot with a readable error (verified: `LOG_LEVEL=chatty` → `Invalid environment: - LOG_LEVEL: Invalid enum value …`)
- [x] Every error response includes a `requestId` matching the `X-Request-Id` response header (verified via curl: header and body both `U6bD-qu0wa8Eun7p`)
- [x] `pnpm lint` green across all 3 packages (root biome config picked up everywhere)

## Plan deviations (documented)

Phase 2 followed the plan literally except for these execution-time fixes, each surfaced in the implementer's commit/report and spec-review approved:

1. **Task 2.0 — Biome config tuning.** The plan's root `biome.json` turns out to conflict with Nest's reflection-based DI (auto `import type` breaks param decorators) and with Nest's `@Body()` decorator parser. Root `biome.json` therefore sets `style.useImportType: "off"`, adds `javascript.parser.unsafeParameterDecoratorsEnabled: true`, and downgrades `complexity.noForEach` to `"warn"` (two pre-existing call sites in `apps/api/src/integrations/parsers/vegeta-report.ts`). Running `biome check --write --unsafe` also swept 26 api + 2 contracts source files with behavior-preserving fixes (`organizeImports`, `useOptionalChain`, `useNodejsImportProtocol`).
2. **Task 2.2 — Express Request augmentation.** Plan's `declare module "express-serve-static-core" { … }` does NOT type-check here because `@types/express-serve-static-core` is present only inside pnpm's isolated store (not hoisted to `node_modules/@types/`). Replaced with the canonical `declare global { namespace Express { interface Request { id?: string } } }`. Behaviour identical; no new devDep.
3. **Task 2.6 — discriminated-union DTO.** `class extends createZodDto(DebugProxyResponseSchema) {}` fails with TS2509 because `z.discriminatedUnion` makes the base a union type. Used `const DebugProxyResponseDto = createZodDto(…)` + `Object.defineProperty` to preserve the Swagger component name. Runtime + OpenAPI output identical to the other DTOs.
4. **Task 2.7 — ServeStaticModule version.** `pnpm add @nestjs/serve-static` resolved to 5.0.5 which requires `@nestjs/core@^11`; pinned to `^4.0.2` (peer range covers Nest 9 & 10).

## Test plan

- [x] `pnpm -r type-check`
- [x] `pnpm -r test`
- [x] `pnpm -F @modeldoctor/api test:e2e`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] Manual: `NODE_ENV=production pnpm start` + curl smoke of `/api/health`, `/`, `/some/spa/path`, `/api/docs`
- [x] Manual: `LOG_LEVEL=chatty pnpm -F @modeldoctor/api start` fails with readable env error
- [x] Manual: curl `POST /api/debug/proxy {}` returns `{error:{code:"VALIDATION_FAILED", message, details:[…Zod issues…], requestId}}` with `requestId === X-Request-Id` response header

🤖 Generated with [Claude Code](https://claude.com/claude-code)