### PR TITLE
Phase 6: Productionization (Docker + Terminus + CI + docs)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+**/node_modules
+**/dist
+**/.turbo
+**/.next
+.git
+.github
+.vscode
+tmp
+*.log
+.env
+.env.local
+.env.*.local
+.DS_Store
+docs
+ai-docs

--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,29 @@
-# apps/api — loaded by @nestjs/config in apps/api/src/main.ts
+# ModelDoctor API — loaded by @nestjs/config in apps/api/src/main.ts.
+# See the README "Environment variables" section for what each one does.
+# Copy this file to `.env` (gitignored) and fill in the JWT secret.
 
 NODE_ENV=development
 PORT=3001
 LOG_LEVEL=info
+
+# Comma-separated origin allowlist for the browser SPA.
 CORS_ORIGINS=http://localhost:5173
 
+# Required (except NODE_ENV=test). See the README for guidance on provisioning
+# the role + database the first time.
 DATABASE_URL=postgresql://modeldoctor:modeldoctor@localhost:5432/modeldoctor
 
-# Phase 5+ (auth — all required in non-test environments)
-JWT_ACCESS_SECRET=<generate 32+ random chars via: openssl rand -base64 48>
+# Required (except NODE_ENV=test). Minimum 32 characters; generate via:
+#   openssl rand -base64 48
+# Rotating this invalidates every outstanding access token on next restart.
+JWT_ACCESS_SECRET=<replace with: openssl rand -base64 48>
+
+# Access token TTL (jsonwebtoken-style). Kept short; refresh cookie handles session lifetime.
 JWT_ACCESS_EXPIRES_IN=15m
+
+# Refresh cookie (md_refresh) lifetime in days.
 JWT_REFRESH_EXPIRES_DAYS=7
+
+# Set to true to disable the first-registered-user-becomes-admin shortcut
+# (useful when you want to pre-seed an admin via SQL instead).
 DISABLE_FIRST_USER_ADMIN=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-type-test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: modeldoctor
+          POSTGRES_PASSWORD: modeldoctor
+          POSTGRES_DB: modeldoctor_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://modeldoctor:modeldoctor@localhost:5432/modeldoctor_test
+      JWT_ACCESS_SECRET: ci-test-secret-with-at-least-32-characters-long-xyz
+      CORS_ORIGINS: http://localhost:5173
+      LOG_LEVEL: warn
+      NODE_ENV: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.5.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm -F @modeldoctor/api exec prisma generate
+      - run: pnpm -F @modeldoctor/api exec prisma migrate deploy
+      - run: pnpm -r type-check
+      - run: pnpm lint
+      - run: pnpm -r test
+      - run: pnpm -F @modeldoctor/api test:e2e
+      - run: pnpm build
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: lint-type-test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build (no push)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: modeldoctor:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1.7
+
+# ---------- Stage 1: install all deps ----------
+FROM node:20-alpine AS deps
+WORKDIR /repo
+
+RUN corepack enable && corepack prepare pnpm@10.5.2 --activate
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json biome.json ./
+COPY apps/web/package.json ./apps/web/
+COPY apps/api/package.json ./apps/api/
+COPY packages/contracts/package.json ./packages/contracts/
+
+RUN pnpm install --frozen-lockfile
+
+# ---------- Stage 2: build ----------
+FROM node:20-alpine AS build
+WORKDIR /repo
+RUN corepack enable && corepack prepare pnpm@10.5.2 --activate
+
+COPY --from=deps /repo/node_modules ./node_modules
+COPY --from=deps /repo/apps/web/node_modules ./apps/web/node_modules
+COPY --from=deps /repo/apps/api/node_modules ./apps/api/node_modules
+COPY --from=deps /repo/packages/contracts/node_modules ./packages/contracts/node_modules
+COPY . .
+
+# Generate Prisma client + build everything
+RUN pnpm -F @modeldoctor/api exec prisma generate
+RUN pnpm build
+
+# ---------- Stage 3: runtime ----------
+FROM node:20-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+
+RUN corepack enable && corepack prepare pnpm@10.5.2 --activate && \
+    addgroup -S app && adduser -S app -G app
+
+# Copy manifests + build outputs
+COPY --from=build /repo/package.json ./
+COPY --from=build /repo/pnpm-lock.yaml ./
+COPY --from=build /repo/pnpm-workspace.yaml ./
+COPY --from=build /repo/apps/api/package.json ./apps/api/
+COPY --from=build /repo/apps/api/dist ./apps/api/dist
+COPY --from=build /repo/apps/api/prisma ./apps/api/prisma
+COPY --from=build /repo/apps/web/package.json ./apps/web/
+COPY --from=build /repo/apps/web/dist ./apps/web/dist
+COPY --from=build /repo/packages/contracts/package.json ./packages/contracts/
+COPY --from=build /repo/packages/contracts/dist ./packages/contracts/dist
+
+# Install production deps + regenerate Prisma client.
+# - argon2 postinstall needs a C toolchain on musl; install/uninstall in one RUN to keep image lean.
+# - `prisma` is a prod dep (so the CLI is installed by --prod), and `prisma generate` must run here
+#   because the just-installed @prisma/client ships without generated output.
+RUN apk add --no-cache python3 make g++ && \
+    pnpm install --prod --frozen-lockfile && \
+    pnpm -F @modeldoctor/api exec prisma generate && \
+    apk del python3 make g++ && \
+    rm -rf /var/cache/apk/*
+
+USER app
+EXPOSE 3001
+ENV PORT=3001
+
+# Run migrations then start the API. Fail-fast on migration error.
+CMD ["sh", "-c", "pnpm -F @modeldoctor/api exec prisma migrate deploy && node apps/api/dist/main.js"]

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 Troubleshooting toolkit for model-serving APIs.
 
-**Current state:** Spec 1 — frontend skeleton with three working tabs (Load Test, E2E Smoke, Request Debug). Five additional tabs (Soak / Stability, Streaming TTFT, Regression, Health Monitor, History) are visible in the sidebar as placeholders and arrive in later specs. Connection credentials are persisted to browser `localStorage` in plaintext; Spec 2 will move them to an encrypted backend store. Do **not** deploy Spec 1 on an untrusted network.
+**Current state:** The NestJS refactor is complete (Phases 0-6). The API is a NestJS 10 app with Prisma-backed Postgres, JWT + refresh-cookie auth, RBAC scaffolding, rate limiting, Terminus health probes, and a Vite-built React SPA served from the same container in production. Frontend tabs: Load Test, E2E Smoke, Request Debug, Connections, Settings; the sidebar's remaining tabs (Soak, Streaming TTFT, Regression, Health Monitor, History) are placeholders for later specs. Connection credentials (API keys the user tests against their own upstreams) are still browser-local `localStorage`; moving them to an encrypted backend store is tracked as a separate spec.
 
 ## Prerequisites
 
-- Node.js **≥ 20** (upgraded from 18 in Phase 0 of the NestJS refactor)
-- pnpm 9 (`npm install -g pnpm@9`)
+- Node.js **≥ 20**
+- pnpm **10** (`corepack enable && corepack prepare pnpm@10 --activate`, or `npm install -g pnpm@10`)
+- Docker (for the e2e test suite, which uses testcontainers, and for the production container build)
+- Postgres 16 locally (Homebrew `postgresql@18` works; any ≥14 is fine) — see [Start Postgres](#start-postgres-local-dev)
 - Vegeta for Load Test (`brew install vegeta` on macOS, or releases at <https://github.com/tsenart/vegeta/releases>)
 
 ## Install
@@ -68,7 +70,45 @@ pnpm build
 pnpm start
 ```
 
-`pnpm build` compiles `@modeldoctor/contracts` (type-check only), then `apps/web` (Vite → `apps/web/dist/`), then `apps/api` (Nest → `apps/api/dist/`). `pnpm start` runs the compiled API (`node apps/api/dist/main.js`). Static web serving from Nest arrives in Phase 2 — for now, `pnpm start` serves API only.
+`pnpm build` compiles `@modeldoctor/contracts` (`tsc`), then `apps/web` (Vite → `apps/web/dist/`), then `apps/api` (Nest → `apps/api/dist/`). `pnpm start` runs the compiled API (`node apps/api/dist/main.js`); in production (`NODE_ENV=production`) it also serves `apps/web/dist` as an SPA fallback via `ServeStaticModule`, so the single process covers both `/api/*` and the web UI.
+
+## Deploy
+
+Single-container deploy:
+
+```bash
+docker build -t modeldoctor .
+docker run -d \
+  -e DATABASE_URL=postgresql://user:pass@host:5432/modeldoctor \
+  -e JWT_ACCESS_SECRET=$(openssl rand -base64 48) \
+  -e CORS_ORIGINS=https://your.domain \
+  -e NODE_ENV=production \
+  -p 3001:3001 \
+  --name modeldoctor modeldoctor
+```
+
+The container runs `prisma migrate deploy` on boot, then serves:
+
+- `/api/*` from NestJS
+- everything else from the Vite-built `apps/web/dist` (SPA fallback)
+
+Health check: `GET /api/health` returns 200 with `{"status":"ok","info":{"database":{"status":"up"}},...}` if Postgres is reachable, 503 otherwise (Terminus + Prisma liveness probe).
+
+## Environment variables
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `NODE_ENV` | No | `development` | Logging format, CORS strictness, cookie `secure`/`sameSite` flags |
+| `PORT` | No | `3001` | API listener |
+| `LOG_LEVEL` | No | `info` | pino log level |
+| `CORS_ORIGINS` | No | `http://localhost:5173` | Comma-separated allowlist |
+| `DATABASE_URL` | **Yes** (non-test) | — | Postgres connection string |
+| `JWT_ACCESS_SECRET` | **Yes** (non-test) | — | Min 32 chars; rotate by restart (invalidates all active access tokens) |
+| `JWT_ACCESS_EXPIRES_IN` | No | `15m` | jsonwebtoken-style duration for access tokens |
+| `JWT_REFRESH_EXPIRES_DAYS` | No | `7` | Refresh-token TTL (also the `md_refresh` cookie's Max-Age) |
+| `DISABLE_FIRST_USER_ADMIN` | No | `false` | When `true`, the first user registered is NOT auto-promoted to the `admin` role |
+
+In `NODE_ENV=test`, both `DATABASE_URL` and `JWT_ACCESS_SECRET` become optional so unit tests can boot `AppModule` without a real database. The e2e suite sets both itself via `vitest.e2e.config.mts` + testcontainers.
 
 ## Repo layout
 
@@ -76,11 +116,14 @@ pnpm start
 modeldoctor/
 ├── apps/
 │   ├── web/                # React + Vite + TS frontend (@modeldoctor/web)
-│   └── api/                # NestJS 10 backend (@modeldoctor/api) — scaffold only, routes arrive in Phase 1
+│   └── api/                # NestJS 10 backend (@modeldoctor/api): auth, load-test, debug-proxy, e2e-test, health
 ├── packages/
-│   └── contracts/          # Shared Zod schemas (@modeldoctor/contracts) — empty in Phase 0
+│   └── contracts/          # Shared Zod schemas (@modeldoctor/contracts): auth, health, load-test, debug-proxy, errors, ...
+├── .github/workflows/      # CI: type-check, lint, test, e2e (with postgres service), docker build
 ├── docs/superpowers/       # Specs and implementation plans
 ├── tmp/                    # Runtime artifacts (Vegeta request.txt)
+├── Dockerfile              # Multi-stage (deps → build → runtime, node:20-alpine, pnpm@10)
+├── .dockerignore
 ├── pnpm-workspace.yaml
 ├── tsconfig.base.json
 └── package.json            # Workspace coordinator
@@ -97,7 +140,7 @@ modeldoctor/
 | `pnpm format` | Biome format across all packages |
 | `pnpm type-check` | `tsc --noEmit` across all packages |
 | `pnpm test` | Vitest across all packages |
-| `pnpm test:e2e` | Nest e2e tests (supertest, empty until Phase 1) |
+| `pnpm test:e2e` | NestJS e2e suite (supertest + testcontainers Postgres; needs Docker running) |
 
 Before a PR lands, all three must pass:
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -41,6 +41,7 @@
     "passport-jwt": "^4.0.1",
     "pino": "^9",
     "pino-http": "^10",
+    "prisma": "^6.19.3",
     "reflect-metadata": "^0.2",
     "rxjs": "^7",
     "zod": "^3.23"
@@ -56,7 +57,6 @@
     "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6",
     "pino-pretty": "^11",
-    "prisma": "^6.19.3",
     "supertest": "^7",
     "testcontainers": "^11.14.0",
     "unplugin-swc": "^1",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -30,6 +30,7 @@
     "@nestjs/platform-express": "^10",
     "@nestjs/serve-static": "^4.0.2",
     "@nestjs/swagger": "^7",
+    "@nestjs/terminus": "^11.1.1",
     "@nestjs/throttler": "^6.5.0",
     "@prisma/client": "^6.19.3",
     "argon2": "^0.44.0",

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -4,7 +4,9 @@ export const EnvSchema = z
   .object({
     NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
     PORT: z.coerce.number().int().positive().default(3001),
-    LOG_LEVEL: z.enum(["trace", "debug", "info", "warn", "error", "fatal", "silent"]).default("info"),
+    LOG_LEVEL: z
+      .enum(["trace", "debug", "info", "warn", "error", "fatal", "silent"])
+      .default("info"),
 
     // CORS in non-production — comma-separated origin list
     CORS_ORIGINS: z

--- a/apps/api/src/config/env.spec.ts
+++ b/apps/api/src/config/env.spec.ts
@@ -25,9 +25,9 @@ describe("validateEnv", () => {
   });
 
   it("rejects JWT_ACCESS_SECRET shorter than 32 chars when provided", () => {
-    expect(() =>
-      validateEnv({ NODE_ENV: "test", JWT_ACCESS_SECRET: "short" }),
-    ).toThrow(/JWT_ACCESS_SECRET/);
+    expect(() => validateEnv({ NODE_ENV: "test", JWT_ACCESS_SECRET: "short" })).toThrow(
+      /JWT_ACCESS_SECRET/,
+    );
   });
 
   // DATABASE_URL enforcement tests
@@ -49,9 +49,9 @@ describe("validateEnv", () => {
   });
 
   it("rejects non-URL DATABASE_URL in production", () => {
-    expect(() =>
-      validateEnv({ NODE_ENV: "production", DATABASE_URL: "not-a-url" }),
-    ).toThrow(/DATABASE_URL/);
+    expect(() => validateEnv({ NODE_ENV: "production", DATABASE_URL: "not-a-url" })).toThrow(
+      /DATABASE_URL/,
+    );
   });
 
   // JWT_ACCESS_SECRET enforcement tests

--- a/apps/api/src/integrations/parsers/vegeta-report.ts
+++ b/apps/api/src/integrations/parsers/vegeta-report.ts
@@ -63,7 +63,7 @@ export function parseVegetaReport(report: string): VegetaParsed {
 
   const lines = report.split("\n");
 
-  lines.forEach((line) => {
+  for (const line of lines) {
     if (line.includes("Requests") && line.includes("[total")) {
       const match = line.match(/Requests\s+\[.*?\]\s+([\d.]+)/);
       if (match && match[1] !== undefined) parsed.requests = Number.parseInt(match[1]);
@@ -120,15 +120,15 @@ export function parseVegetaReport(report: string): VegetaParsed {
       const match = line.match(/\[code:count\]\s+(.*)/);
       if (match && match[1] !== undefined) {
         const codes = match[1].trim().split(/\s+/);
-        codes.forEach((code) => {
+        for (const code of codes) {
           const [status, count] = code.split(":");
           if (status && count) {
             parsed.statusCodes[status] = Number.parseInt(count);
           }
-        });
+        }
       }
     }
-  });
+  }
 
   return parsed;
 }

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import type { AuthTokenResponse } from "@modeldoctor/contracts";
+import type { AuthTokenResponse, PublicUser } from "@modeldoctor/contracts";
 import {
   type LoginRequest,
   LoginRequestSchema,
@@ -21,6 +21,7 @@ import type { Request, Response } from "express";
 import { Public } from "../../common/decorators/public.decorator.js";
 import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
 import type { Env } from "../../config/env.schema.js";
+import { UsersService } from "../users/users.service.js";
 import { AuthService } from "./auth.service.js";
 import { JwtAuthGuard } from "./jwt-auth.guard.js";
 import type { JwtPayload } from "./jwt.strategy.js";
@@ -41,6 +42,7 @@ function setRefreshCookie(res: Response, token: string, maxAgeDays: number, isPr
 export class AuthController {
   constructor(
     private readonly auth: AuthService,
+    private readonly users: UsersService,
     private readonly config: ConfigService<Env, true>,
   ) {}
 
@@ -109,7 +111,8 @@ export class AuthController {
 
   @UseGuards(JwtAuthGuard)
   @Get("me")
-  me(@Req() req: Request & { user: JwtPayload }): JwtPayload {
-    return req.user;
+  async me(@Req() req: Request & { user: JwtPayload }): Promise<PublicUser> {
+    const user = await this.users.findById(req.user.sub);
+    return this.users.toPublic(user);
   }
 }

--- a/apps/api/src/modules/health/health.controller.ts
+++ b/apps/api/src/modules/health/health.controller.ts
@@ -1,13 +1,19 @@
 import {
   type CheckVegetaResponse,
   CheckVegetaResponseSchema,
-  type HealthResponse,
   HealthResponseSchema,
 } from "@modeldoctor/contracts";
 import { Controller, Get } from "@nestjs/common";
 import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
+import {
+  HealthCheck,
+  type HealthCheckResult,
+  HealthCheckService,
+  PrismaHealthIndicator,
+} from "@nestjs/terminus";
 import { createZodDto } from "nestjs-zod";
 import { Public } from "../../common/decorators/public.decorator.js";
+import { PrismaService } from "../../database/prisma.service.js";
 import { HealthService } from "./health.service.js";
 
 class HealthResponseDto extends createZodDto(HealthResponseSchema) {}
@@ -16,14 +22,22 @@ class CheckVegetaResponseDto extends createZodDto(CheckVegetaResponseSchema) {}
 @ApiTags("health")
 @Controller()
 export class HealthController {
-  constructor(private readonly health: HealthService) {}
+  constructor(
+    private readonly health: HealthCheckService,
+    private readonly prismaProbe: PrismaHealthIndicator,
+    private readonly prisma: PrismaService,
+    private readonly legacy: HealthService,
+  ) {}
 
   @Public()
-  @ApiOperation({ summary: "Liveness probe" })
+  @ApiOperation({ summary: "Liveness probe with DB check" })
   @ApiOkResponse({ type: HealthResponseDto })
   @Get("health")
-  getHealth(): HealthResponse {
-    return this.health.getHealth();
+  @HealthCheck()
+  check(): Promise<HealthCheckResult> {
+    return this.health.check([
+      () => this.prismaProbe.pingCheck("database", this.prisma, { timeout: 500 }),
+    ]);
   }
 
   @Public()
@@ -31,6 +45,6 @@ export class HealthController {
   @ApiOkResponse({ type: CheckVegetaResponseDto })
   @Get("check-vegeta")
   checkVegeta(): Promise<CheckVegetaResponse> {
-    return this.health.checkVegeta();
+    return this.legacy.checkVegeta();
   }
 }

--- a/apps/api/src/modules/health/health.module.ts
+++ b/apps/api/src/modules/health/health.module.ts
@@ -1,8 +1,10 @@
 import { Module } from "@nestjs/common";
+import { TerminusModule } from "@nestjs/terminus";
 import { HealthController } from "./health.controller.js";
 import { HealthService } from "./health.service.js";
 
 @Module({
+  imports: [TerminusModule],
   controllers: [HealthController],
   providers: [HealthService],
 })

--- a/apps/api/src/modules/health/health.service.ts
+++ b/apps/api/src/modules/health/health.service.ts
@@ -1,16 +1,12 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import type { CheckVegetaResponse, HealthResponse } from "@modeldoctor/contracts";
+import type { CheckVegetaResponse } from "@modeldoctor/contracts";
 import { Injectable } from "@nestjs/common";
 
 const execP = promisify(exec);
 
 @Injectable()
 export class HealthService {
-  getHealth(): HealthResponse {
-    return { status: "ok", timestamp: new Date().toISOString() };
-  }
-
   async checkVegeta(): Promise<CheckVegetaResponse> {
     try {
       const { stdout } = await execP("which vegeta");

--- a/apps/api/test/e2e/auth.e2e-spec.ts
+++ b/apps/api/test/e2e/auth.e2e-spec.ts
@@ -75,22 +75,25 @@ describe("Auth (e2e)", () => {
     expect(refreshCookie).toBeTruthy();
   });
 
-  // ── 6. GET /api/auth/me with bearer → payload shape ──────────────────────
-  it("GET /api/auth/me with bearer → { sub, email, roles }", async () => {
+  // ── 6. GET /api/auth/me with bearer → PublicUser shape ───────────────────
+  it("GET /api/auth/me with bearer → { id, email, roles, createdAt }", async () => {
     const loginRes = await request(ctx.app.getHttpServer())
       .post("/api/auth/login")
       .send({ email: "admin@example.com", password: "Password1!" })
       .expect(201);
     const token = loginRes.body.accessToken as string;
+    const registeredId = loginRes.body.user.id as string;
 
     const meRes = await request(ctx.app.getHttpServer())
       .get("/api/auth/me")
       .set("Authorization", `Bearer ${token}`)
       .expect(200);
 
-    expect(meRes.body.sub).toBeTruthy();
+    expect(meRes.body.id).toBeTruthy();
+    expect(meRes.body.id).toBe(registeredId);
     expect(meRes.body.email).toBe("admin@example.com");
     expect(Array.isArray(meRes.body.roles)).toBe(true);
+    expect(meRes.body.createdAt).toBeTruthy();
   });
 
   // ── 7. GET /api/auth/me WITHOUT bearer → 401 ─────────────────────────────

--- a/apps/api/test/e2e/health.e2e-spec.ts
+++ b/apps/api/test/e2e/health.e2e-spec.ts
@@ -1,35 +1,28 @@
 import { CheckVegetaResponseSchema, HealthResponseSchema } from "@modeldoctor/contracts";
-import type { INestApplication } from "@nestjs/common";
-import { Test } from "@nestjs/testing";
 import request from "supertest";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { AppModule } from "../../src/app.module.js";
-import { AllExceptionsFilter } from "../../src/common/filters/all-exceptions.filter.js";
+import { type E2EContext, bootE2E } from "../helpers/app.js";
 
 describe("Health (e2e)", () => {
-  let app: INestApplication;
+  let ctx: E2EContext;
 
   beforeAll(async () => {
-    const moduleRef = await Test.createTestingModule({ imports: [AppModule] }).compile();
-    app = moduleRef.createNestApplication();
-    app.setGlobalPrefix("api");
-    app.useGlobalFilters(new AllExceptionsFilter());
-    await app.init();
-  });
+    ctx = await bootE2E();
+  }, 120_000);
 
   afterAll(async () => {
-    await app.close();
+    await ctx.teardown();
   });
 
-  it("GET /api/health → 200 with legacy-compatible shape", async () => {
-    const res = await request(app.getHttpServer()).get("/api/health").expect(200);
+  it("GET /api/health → 200 with terminus shape", async () => {
+    const res = await request(ctx.app.getHttpServer()).get("/api/health").expect(200);
     const parsed = HealthResponseSchema.parse(res.body);
     expect(parsed.status).toBe("ok");
-    expect(new Date(parsed.timestamp).toString()).not.toBe("Invalid Date");
+    expect(res.body.info?.database?.status).toBe("up");
   });
 
   it("GET /api/check-vegeta → 200 with legacy-compatible shape", async () => {
-    const res = await request(app.getHttpServer()).get("/api/check-vegeta").expect(200);
+    const res = await request(ctx.app.getHttpServer()).get("/api/check-vegeta").expect(200);
     const parsed = CheckVegetaResponseSchema.parse(res.body);
     expect(typeof parsed.installed).toBe("boolean");
     if (parsed.installed) {

--- a/apps/api/test/helpers/postgres-container.ts
+++ b/apps/api/test/helpers/postgres-container.ts
@@ -1,5 +1,5 @@
-import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 import { execSync } from "node:child_process";
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 
 export interface TestDatabase {
   container: StartedPostgreSqlContainer;

--- a/packages/contracts/src/health.ts
+++ b/packages/contracts/src/health.ts
@@ -4,9 +4,7 @@ import { z } from "zod";
 export const HealthResponseSchema = z.object({
   status: z.enum(["ok", "error", "shutting_down"]),
   info: z.record(z.object({ status: z.string() })).optional(),
-  error: z
-    .record(z.object({ status: z.string(), message: z.string().optional() }))
-    .optional(),
+  error: z.record(z.object({ status: z.string(), message: z.string().optional() })).optional(),
   details: z.record(z.object({ status: z.string() })).optional(),
 });
 export type HealthResponse = z.infer<typeof HealthResponseSchema>;

--- a/packages/contracts/src/health.ts
+++ b/packages/contracts/src/health.ts
@@ -1,8 +1,13 @@
 import { z } from "zod";
 
+// Terminus HealthCheckResult: { status, info?, error?, details }.
 export const HealthResponseSchema = z.object({
-  status: z.literal("ok"),
-  timestamp: z.string(),
+  status: z.enum(["ok", "error", "shutting_down"]),
+  info: z.record(z.object({ status: z.string() })).optional(),
+  error: z
+    .record(z.object({ status: z.string(), message: z.string().optional() }))
+    .optional(),
+  details: z.record(z.object({ status: z.string() })).optional(),
 });
 export type HealthResponse = z.infer<typeof HealthResponseSchema>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@nestjs/swagger':
         specifier: ^7
         version: 7.4.2(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(reflect-metadata@0.2.2)
+      '@nestjs/terminus':
+        specifier: ^11.1.1
+        version: 11.1.1(@grpc/grpc-js@1.14.3)(@grpc/proto-loader@0.8.0)(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@prisma/client@6.19.3(prisma@6.19.3(typescript@5.7.2))(typescript@5.7.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/throttler':
         specifier: ^6.5.0
         version: 6.5.0(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(reflect-metadata@0.2.2)
@@ -146,7 +149,7 @@ importers:
         version: 5.1.4(typescript@5.7.2)(vite@5.4.21(@types/node@20.19.39)(terser@5.46.1))
       vitest:
         specifier: ^2
-        version: 2.1.9(@types/node@20.19.39)(@vitest/ui@1.6.1(vitest@1.6.1))(jsdom@24.1.3)(terser@5.46.1)
+        version: 2.1.9(@types/node@20.19.39)(@vitest/ui@1.6.1)(jsdom@24.1.3)(terser@5.46.1)
 
   apps/web:
     dependencies:
@@ -832,6 +835,54 @@ packages:
       class-transformer:
         optional: true
       class-validator:
+        optional: true
+
+  '@nestjs/terminus@11.1.1':
+    resolution: {integrity: sha512-Ssql79H+EQY/Wg108eJqN4NiNsO/tLrj+qbzOWSQUf2JE4vJQ2RG3WTqUOrYjfjWmVHD3+Ys0+azed7LSMKScw==}
+    peerDependencies:
+      '@grpc/grpc-js': '*'
+      '@grpc/proto-loader': '*'
+      '@mikro-orm/core': '*'
+      '@mikro-orm/nestjs': '*'
+      '@nestjs/axios': ^2.0.0 || ^3.0.0 || ^4.0.0
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+      '@nestjs/microservices': ^10.0.0 || ^11.0.0
+      '@nestjs/mongoose': ^11.0.0
+      '@nestjs/sequelize': ^10.0.0 || ^11.0.0
+      '@nestjs/typeorm': ^10.0.0 || ^11.0.0
+      '@prisma/client': '*'
+      mongoose: '*'
+      reflect-metadata: 0.1.x || 0.2.x
+      rxjs: 7.x
+      sequelize: '*'
+      typeorm: '*'
+    peerDependenciesMeta:
+      '@grpc/grpc-js':
+        optional: true
+      '@grpc/proto-loader':
+        optional: true
+      '@mikro-orm/core':
+        optional: true
+      '@mikro-orm/nestjs':
+        optional: true
+      '@nestjs/axios':
+        optional: true
+      '@nestjs/microservices':
+        optional: true
+      '@nestjs/mongoose':
+        optional: true
+      '@nestjs/sequelize':
+        optional: true
+      '@nestjs/typeorm':
+        optional: true
+      '@prisma/client':
+        optional: true
+      mongoose:
+        optional: true
+      sequelize:
+        optional: true
+      typeorm:
         optional: true
 
   '@nestjs/testing@10.4.22':
@@ -1972,6 +2023,9 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  ansi-align@3.0.1:
+    resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -2156,6 +2210,10 @@ packages:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  boxen@5.1.2:
+    resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
+    engines: {node: '>=10'}
+
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -2235,6 +2293,10 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
 
@@ -2256,6 +2318,10 @@ packages:
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  check-disk-space@3.4.0:
+    resolution: {integrity: sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==}
+    engines: {node: '>=16'}
 
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
@@ -2287,6 +2353,10 @@ packages:
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  cli-boxes@2.2.1:
+    resolution: {integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==}
+    engines: {node: '>=6'}
 
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -4381,6 +4451,10 @@ packages:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
 
+  type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
@@ -4663,6 +4737,10 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  widest-line@3.1.0:
+    resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
+    engines: {node: '>=8'}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -5255,6 +5333,19 @@ snapshots:
       path-to-regexp: 3.3.0
       reflect-metadata: 0.2.2
       swagger-ui-dist: 5.17.14
+
+  '@nestjs/terminus@11.1.1(@grpc/grpc-js@1.14.3)(@grpc/proto-loader@0.8.0)(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@prisma/client@6.19.3(prisma@6.19.3(typescript@5.7.2))(typescript@5.7.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      boxen: 5.1.2
+      check-disk-space: 3.4.0
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+    optionalDependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.8.0
+      '@prisma/client': 6.19.3(prisma@6.19.3(typescript@5.7.2))(typescript@5.7.2)
 
   '@nestjs/testing@10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-express@10.4.22)':
     dependencies:
@@ -6424,6 +6515,10 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-align@3.0.1:
+    dependencies:
+      string-width: 4.2.3
+
   ansi-colors@4.1.3: {}
 
   ansi-escapes@4.3.2:
@@ -6598,6 +6693,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  boxen@5.1.2:
+    dependencies:
+      ansi-align: 3.0.1
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      cli-boxes: 2.2.1
+      string-width: 4.2.3
+      type-fest: 0.20.2
+      widest-line: 3.1.0
+      wrap-ansi: 7.0.0
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -6684,6 +6790,8 @@ snapshots:
 
   camelcase-css@2.0.1: {}
 
+  camelcase@6.3.0: {}
+
   caniuse-lite@1.0.30001788: {}
 
   chai@4.5.0:
@@ -6712,6 +6820,8 @@ snapshots:
   chalk@5.6.2: {}
 
   chardet@0.7.0: {}
+
+  check-disk-space@3.4.0: {}
 
   check-error@1.0.3:
     dependencies:
@@ -6748,6 +6858,8 @@ snapshots:
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
+
+  cli-boxes@2.2.1: {}
 
   cli-cursor@3.1.0:
     dependencies:
@@ -8922,6 +9034,8 @@ snapshots:
 
   type-detect@4.1.0: {}
 
+  type-fest@0.20.2: {}
+
   type-fest@0.21.3: {}
 
   type-is@1.6.18:
@@ -9106,7 +9220,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@20.19.39)(@vitest/ui@1.6.1(vitest@1.6.1))(jsdom@24.1.3)(terser@5.46.1):
+  vitest@2.1.9(@types/node@20.19.39)(@vitest/ui@1.6.1)(jsdom@24.1.3)(terser@5.46.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.39)(terser@5.46.1))
@@ -9222,6 +9336,10 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  widest-line@3.1.0:
+    dependencies:
+      string-width: 4.2.3
 
   wrap-ansi@6.2.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       pino-http:
         specifier: ^10
         version: 10.5.0
+      prisma:
+        specifier: ^6.19.3
+        version: 6.19.3(typescript@5.7.2)
       reflect-metadata:
         specifier: ^0.2
         version: 0.2.2
@@ -129,9 +132,6 @@ importers:
       pino-pretty:
         specifier: ^11
         version: 11.3.0
-      prisma:
-        specifier: ^6.19.3
-        version: 6.19.3(typescript@5.7.2)
       supertest:
         specifier: ^7
         version: 7.2.2
@@ -146,7 +146,7 @@ importers:
         version: 5.1.4(typescript@5.7.2)(vite@5.4.21(@types/node@20.19.39)(terser@5.46.1))
       vitest:
         specifier: ^2
-        version: 2.1.9(@types/node@20.19.39)(@vitest/ui@1.6.1)(jsdom@24.1.3)(terser@5.46.1)
+        version: 2.1.9(@types/node@20.19.39)(@vitest/ui@1.6.1(vitest@1.6.1))(jsdom@24.1.3)(terser@5.46.1)
 
   apps/web:
     dependencies:
@@ -9106,7 +9106,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@20.19.39)(@vitest/ui@1.6.1)(jsdom@24.1.3)(terser@5.46.1):
+  vitest@2.1.9(@types/node@20.19.39)(@vitest/ui@1.6.1(vitest@1.6.1))(jsdom@24.1.3)(terser@5.46.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.39)(terser@5.46.1))


### PR DESCRIPTION
## Summary

Final phase of the NestJS refactor — turns the app into a single-container deployable with CI, live health probes, and proper deploy docs.

- **Multi-stage `Dockerfile`** (node:20-alpine, pnpm@10.5.2): deps → build → runtime. Entrypoint runs `prisma migrate deploy` then boots `node apps/api/dist/main.js`. Non-root user, `NODE_ENV=production`, `PORT=3001` default, argon2 built with an ephemeral toolchain that's removed in the same RUN layer. Final image ~706MB (Prisma engines dominate).
- **`@nestjs/terminus` `/api/health`** with `PrismaHealthIndicator.pingCheck("database", prisma, { timeout: 500 })`. Returns `{status:"ok",info:{database:{status:"up"}}…}` when DB is reachable, 503 otherwise. k8s/ECS readiness-probe-ready.
- **`GET /api/auth/me` returns a real `PublicUser`** (`{id, email, roles, createdAt}`) via `UsersService.findById → toPublic` — reconciles the Phase 5 mismatch where `/me` returned the raw JwtPayload.
- **GitHub Actions CI** (`.github/workflows/ci.yml`): two jobs. `lint-type-test` runs type-check + lint + unit + e2e (with a Postgres service container for `prisma migrate deploy`; testcontainers handles the e2e DB itself) + build. `docker-build` (needs: lint-type-test) builds the image with buildx + GHA cache (no push).
- **Phase 4 biome debt cleared** (env.schema format, env.spec format, postgres-container import order, two `forEach → for...of` in vegeta-report) so `pnpm lint` is green across all three packages.
- **README deploy + env vars section**, **.env.example** fleshed out with inline guidance for each var. "Current state" paragraph updated to reflect the completed refactor.

One commit per task:

| # | Commit | Task |
|---|--------|------|
| 6.1 | 82cdc90 | `build: multi-stage Dockerfile …` |
| 6.2 | c9b5316 | `feat(api): @nestjs/terminus /api/health with DB liveness probe + /me returns PublicUser` |
| 6.3a | 4d0f4b3 | `chore: clear carryover Phase 4 biome debt …` |
| 6.3b | 1998221 | `ci: GitHub Actions …` |
| 6.4 | 1ed3e38 | `docs: deploy section + env variable reference + current-state refresh` |

## Phase 6 DoD

- [x] `docker build -t modeldoctor .` succeeds on a fresh clone (706MB image).
- [x] `docker run …` with DB/secret env boots; `/api/health` returns 200 with DB up, 503 with DB down.
- [x] CI workflow covers type-check + lint + unit + e2e (with Postgres service) + build + docker-build (no push). Local dry-run of every step is green.
- [x] README documents deploy + all 9 env vars (cross-checked against `env.schema.ts`).

## Project-wide DoD (now complete after this merges)

- [x] `pnpm install && pnpm dev` works on a clean clone.
- [x] `docker build . && docker run -p 3001:3001 -e DATABASE_URL=… …` produces a single-container deployment.
- [x] All Phase 0/1 FE features work against Nest (Load Test / E2E Smoke / Request Debug / Connections / Settings).
- [x] Login gate enforced via global `JwtAuthGuard` + `RolesGuard` + `ThrottlerGuard`.
- [ ] CI green on main (will be, once this PR lands and a follow-up PR exercises it).
- [x] README has dev + prod + env + auth sections.
- [x] `pnpm -r type-check` covers web/api/contracts.
- [x] `grep -R "require(" apps/api/src packages/contracts/src` → 0 matches.
- [x] OWASP ASVS L2 spot-check: no critical gaps (auth cookies, guards, rate limits all in place). Minor items (password complexity rules, PII log scrubbing) tracked as follow-up.

## Deviations from plan

- **pnpm@9 → pnpm@10.5.2** in Dockerfile and CI. Repo lockfile is `lockfileVersion: 9.0` produced by pnpm 10; `--frozen-lockfile` requires matching pnpm.
- **`prisma` promoted from devDep to prod dep** to eliminate a hard-coded `node_modules/.pnpm/@prisma+client@<VER>_…` path in the Dockerfile's runtime stage (would break silently on any prisma/TS bump). Saves ~36MB on image size too.
- **`pnpm/action-setup@v3` → `@v4`** in CI — v3 is deprecated; no breaking changes for our use case.
- **`health.e2e-spec.ts` migrated to `bootE2E()` helper** (testcontainer Postgres). The Phase 5 version booted AppModule without a DB; with Terminus that returns 503 on no-DB, the test needs a real Postgres. Now uses the same scaffolding as all other e2e specs.
- **`docker compose up -d postgres` step in Task 6.2 smoke (from plan)** doesn't apply — no docker-compose.yml; use brew postgres or `host.docker.internal`.

## Known follow-ups

- Docker image smoke test step in CI (`docker run + curl /api/health` after the build). Considered low priority because `docker-build` job already catches build breaks.
- Image size (706MB) is dominated by Prisma engine binaries for all architectures. Pruning to `linux-musl-*` only via `PRISMA_CLI_BINARY_TARGETS` at install time is a ~250MB saving — future optimization.
- Password complexity rules (OWASP ASVS V2.1) and PII log scrubbing (V7.1) — backlog items, not blockers.
- Token revocation list for access tokens (current only mechanism is rotating `JWT_ACCESS_SECRET`) — separate spec if needed.
- Vitest version split (web@1 vs api@2) — unify when either side next upgrades (pre-existing debt).

## Test plan

- [x] `pnpm -r type-check` — all 3 packages clean
- [x] `pnpm -r lint` — 165 files, 0 issues
- [x] `pnpm -r test` — 86/86 web + contracts + api unit tests pass
- [x] `pnpm -F @modeldoctor/api test:e2e` — 31/31 across 7 files pass
- [x] `pnpm build` — contracts + web + api dist all produced
- [x] `docker build` — 706MB image, clean buildx check
- [x] `docker run` smoke — `/api/health` → 200 (with DB up), SPA `/` → 200
- [ ] CI green on this PR (will verify in the PR checks tab)