### PR TITLE
Feat/restructure

### DIFF
--- a/apps/api/src/config/config.module.ts
+++ b/apps/api/src/config/config.module.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import { Module } from "@nestjs/common";
 import { ConfigModule as NestConfigModule } from "@nestjs/config";
 import { validateEnv } from "./env.schema.js";
@@ -8,6 +9,7 @@ import { validateEnv } from "./env.schema.js";
       isGlobal: true,
       cache: true,
       validate: validateEnv,
+      envFilePath: resolve(__dirname, "../../../..", ".env"),
     }),
   ],
   exports: [NestConfigModule],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=20.0.0"
   },
   "scripts": {
-    "dev": "concurrently -k -n web,api -c cyan,magenta \"pnpm -F @modeldoctor/web dev\" \"pnpm -F @modeldoctor/api start:dev\"",
+    "dev": "pnpm -F @modeldoctor/contracts build && concurrently -k -n contracts,web,api -c yellow,cyan,magenta \"pnpm -F @modeldoctor/contracts dev\" \"pnpm -F @modeldoctor/web dev\" \"pnpm -F @modeldoctor/api start:dev\"",
     "build": "pnpm -F @modeldoctor/contracts build && pnpm -F @modeldoctor/web build && pnpm -F @modeldoctor/api build",
     "start": "node apps/api/dist/main.js",
     "lint": "pnpm -r --if-present lint",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -w -p tsconfig.build.json --preserveWatchOutput",
     "type-check": "tsc -p tsconfig.json --noEmit",
     "lint": "biome check src",
     "format": "biome format --write src",


### PR DESCRIPTION
Previously `pnpm dev` only ran web + api, so editing `packages/contracts/`
left `dist/` stale and the API's TS server collapsed shared types to `any`
(or, on a fresh worktree with no `dist/` at all, failed to resolve
`@modeldoctor/contracts` and emitted spurious cascade errors). The new
script does a one-time `contracts build` to seed `dist/`, then runs
`tsc -w` alongside the web and api dev servers so contract edits rebuild
incrementally.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>