### PR TITLE
feat(benchmark): phase 1 — data model + contracts + crypto

### DIFF
--- a/apps/api/prisma/migrations/20260425112058_add_benchmark_runs/migration.sql
+++ b/apps/api/prisma/migrations/20260425112058_add_benchmark_runs/migration.sql
@@ -1,0 +1,39 @@
+-- CreateTable
+CREATE TABLE "benchmark_runs" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "profile" TEXT NOT NULL DEFAULT 'custom',
+    "api_type" TEXT NOT NULL,
+    "api_url" TEXT NOT NULL,
+    "api_key_cipher" TEXT NOT NULL,
+    "model" TEXT NOT NULL,
+    "dataset_name" TEXT NOT NULL DEFAULT 'random',
+    "dataset_input_tokens" INTEGER,
+    "dataset_output_tokens" INTEGER,
+    "dataset_seed" INTEGER,
+    "request_rate" INTEGER NOT NULL DEFAULT 0,
+    "total_requests" INTEGER NOT NULL DEFAULT 1000,
+    "state" TEXT NOT NULL DEFAULT 'pending',
+    "state_message" TEXT,
+    "progress" DOUBLE PRECISION,
+    "job_name" TEXT,
+    "metrics_summary" JSONB,
+    "raw_metrics" JSONB,
+    "logs" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "started_at" TIMESTAMP(3),
+    "completed_at" TIMESTAMP(3),
+
+    CONSTRAINT "benchmark_runs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "benchmark_runs_user_id_created_at_idx" ON "benchmark_runs"("user_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "benchmark_runs_state_idx" ON "benchmark_runs"("state");
+
+-- AddForeignKey
+ALTER TABLE "benchmark_runs" ADD CONSTRAINT "benchmark_runs_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
 
   refreshTokens RefreshToken[]
   loadTestRuns  LoadTestRun[]
+  benchmarkRuns BenchmarkRun[]
 
   @@index([email])
   @@map("users")
@@ -57,4 +58,49 @@ model LoadTestRun {
   @@index([userId, createdAt])
   @@index([createdAt])
   @@map("load_test_runs")
+}
+
+model BenchmarkRun {
+  id          String  @id @default(cuid())
+  userId      String? @map("user_id")
+
+  // Identification
+  name        String
+  description String? @db.Text
+  profile     String  @default("custom") // "throughput" | "latency" | "long_context" | "generation_heavy" | "sharegpt" | "custom"
+
+  // Target endpoint
+  apiType      String @map("api_type")        // "chat" | "completion"
+  apiUrl       String @map("api_url")
+  apiKeyCipher String @map("api_key_cipher") // AES-256-GCM ciphertext, see common/crypto
+  model        String
+
+  // Workload config
+  datasetName         String @default("random") @map("dataset_name") // "random" | "sharegpt"
+  datasetInputTokens  Int?   @map("dataset_input_tokens")
+  datasetOutputTokens Int?   @map("dataset_output_tokens")
+  datasetSeed         Int?   @map("dataset_seed")
+  requestRate         Int    @default(0)        @map("request_rate")    // 0 = unlimited
+  totalRequests       Int    @default(1000)     @map("total_requests")
+
+  // Lifecycle
+  state        String  @default("pending") // "pending" | "submitted" | "running" | "completed" | "failed" | "canceled"
+  stateMessage String? @db.Text             @map("state_message")
+  progress     Float?
+  jobName      String? @map("job_name")    // K8s Job metadata.name; null until submitted
+
+  // Metrics (denormalized summary for list views; full report in rawMetrics)
+  metricsSummary Json?  @map("metrics_summary")
+  rawMetrics     Json?  @map("raw_metrics")
+  logs           String? @db.Text
+
+  createdAt   DateTime  @default(now())  @map("created_at")
+  startedAt   DateTime?                  @map("started_at")
+  completedAt DateTime?                  @map("completed_at")
+
+  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  @@index([userId, createdAt])
+  @@index([state])
+  @@map("benchmark_runs")
 }

--- a/apps/api/src/common/crypto/aes-gcm.spec.ts
+++ b/apps/api/src/common/crypto/aes-gcm.spec.ts
@@ -1,0 +1,89 @@
+import { randomBytes } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { decodeKey, decrypt, encrypt } from "./aes-gcm.js";
+
+describe("aes-gcm", () => {
+  const key = randomBytes(32);
+
+  describe("decodeKey", () => {
+    it("decodes a valid 32-byte base64 key", () => {
+      const b64 = randomBytes(32).toString("base64");
+      const out = decodeKey(b64);
+      expect(out.length).toBe(32);
+      expect(out.equals(Buffer.from(b64, "base64"))).toBe(true);
+    });
+
+    it("throws when the decoded key is not 32 bytes", () => {
+      const tooShort = randomBytes(16).toString("base64");
+      expect(() => decodeKey(tooShort)).toThrow(/32 bytes/);
+    });
+  });
+
+  describe("encrypt + decrypt", () => {
+    it("round-trips a UTF-8 string", () => {
+      const ct = encrypt("hello, 世界", key);
+      expect(decrypt(ct, key)).toBe("hello, 世界");
+    });
+
+    it("emits the v1 prefix and four colon-separated parts", () => {
+      const ct = encrypt("anything", key);
+      const parts = ct.split(":");
+      expect(parts).toHaveLength(4);
+      expect(parts[0]).toBe("v1");
+    });
+
+    it("produces different ciphertexts for the same plaintext (random IV)", () => {
+      const a = encrypt("same input", key);
+      const b = encrypt("same input", key);
+      expect(a).not.toBe(b);
+    });
+
+    it("throws when decrypting with the wrong key", () => {
+      const ct = encrypt("secret", key);
+      const otherKey = randomBytes(32);
+      expect(() => decrypt(ct, otherKey)).toThrow();
+    });
+
+    it("throws when the ciphertext is tampered with", () => {
+      const ct = encrypt("secret", key);
+      // Flip a byte in the ciphertext segment (last colon-separated part)
+      const parts = ct.split(":");
+      const ctBytes = Buffer.from(parts[3], "base64");
+      ctBytes[0] = ctBytes[0] ^ 0x01;
+      parts[3] = ctBytes.toString("base64");
+      const tampered = parts.join(":");
+      expect(() => decrypt(tampered, key)).toThrow();
+    });
+
+    it("throws when the auth tag is tampered with", () => {
+      const ct = encrypt("secret", key);
+      const parts = ct.split(":");
+      const tagBytes = Buffer.from(parts[2], "base64");
+      tagBytes[0] = tagBytes[0] ^ 0x01;
+      parts[2] = tagBytes.toString("base64");
+      const tampered = parts.join(":");
+      expect(() => decrypt(tampered, key)).toThrow();
+    });
+
+    it("rejects an unknown version prefix", () => {
+      const ct = encrypt("secret", key);
+      const tampered = ct.replace(/^v1:/, "v2:");
+      expect(() => decrypt(tampered, key)).toThrow(/version/);
+    });
+
+    it("rejects malformed input (not 4 parts)", () => {
+      expect(() => decrypt("v1:not-enough-parts", key)).toThrow(/Malformed/);
+    });
+
+    it("encrypt rejects a wrong-length key", () => {
+      const badKey = randomBytes(16);
+      expect(() => encrypt("x", badKey)).toThrow(/32 bytes/);
+    });
+
+    it("decrypt rejects a wrong-length key", () => {
+      const ct = encrypt("x", key);
+      const badKey = randomBytes(16);
+      expect(() => decrypt(ct, badKey)).toThrow(/32 bytes/);
+    });
+  });
+});

--- a/apps/api/src/common/crypto/aes-gcm.ts
+++ b/apps/api/src/common/crypto/aes-gcm.ts
@@ -1,0 +1,52 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const KEY_BYTES = 32;
+const IV_BYTES = 12;
+const TAG_BYTES = 16;
+const VERSION = "v1";
+
+export function decodeKey(base64: string): Buffer {
+  const buf = Buffer.from(base64, "base64");
+  if (buf.length !== KEY_BYTES) {
+    throw new Error(`Encryption key must decode to ${KEY_BYTES} bytes, got ${buf.length}`);
+  }
+  return buf;
+}
+
+export function encrypt(plaintext: string, key: Buffer): string {
+  if (key.length !== KEY_BYTES) {
+    throw new Error(`Key must be ${KEY_BYTES} bytes`);
+  }
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${VERSION}:${iv.toString("base64")}:${tag.toString("base64")}:${ct.toString("base64")}`;
+}
+
+export function decrypt(payload: string, key: Buffer): string {
+  if (key.length !== KEY_BYTES) {
+    throw new Error(`Key must be ${KEY_BYTES} bytes`);
+  }
+  const parts = payload.split(":");
+  if (parts.length !== 4) {
+    throw new Error("Malformed ciphertext: expected 4 colon-separated parts");
+  }
+  const [version, ivB64, tagB64, ctB64] = parts;
+  if (version !== VERSION) {
+    throw new Error(`Unsupported ciphertext version: ${version}`);
+  }
+  const iv = Buffer.from(ivB64, "base64");
+  const tag = Buffer.from(tagB64, "base64");
+  const ct = Buffer.from(ctB64, "base64");
+  if (iv.length !== IV_BYTES) {
+    throw new Error(`Malformed IV: expected ${IV_BYTES} bytes, got ${iv.length}`);
+  }
+  if (tag.length !== TAG_BYTES) {
+    throw new Error(`Malformed auth tag: expected ${TAG_BYTES} bytes, got ${tag.length}`);
+  }
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ct), decipher.final()]).toString("utf8");
+}

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -38,6 +38,23 @@ export const EnvSchema = z
     JWT_ACCESS_SECRET: z.string().min(32).optional(),
     JWT_ACCESS_EXPIRES_IN: z.string().default("15m"),
     JWT_REFRESH_EXPIRES_DAYS: z.coerce.number().int().positive().default(7),
+    // 32-byte base64-encoded AES-256 key used to encrypt user-supplied API
+    // keys at rest. Optional in Phase 1 (the helper is added but no row uses
+    // it yet); Phase 4 tightens to required-when-not-test once the
+    // BenchmarkController persists encrypted rows.
+    BENCHMARK_API_KEY_ENCRYPTION_KEY: z
+      .string()
+      .optional()
+      .refine(
+        (v) => {
+          if (v === undefined) return true;
+          // Reject obviously non-base64 input. Buffer.from is permissive (it
+          // silently drops invalid chars) so we lint with a regex first.
+          if (!/^[A-Za-z0-9+/=]+$/.test(v)) return false;
+          return Buffer.from(v, "base64").length === 32;
+        },
+        { message: "must be a base64 string that decodes to exactly 32 bytes" },
+      ),
     DISABLE_FIRST_USER_ADMIN: envBoolean.default(false),
   })
   .superRefine((env, ctx) => {

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -7,10 +7,9 @@ import { z } from "zod";
 // (typos, "TRUE", "yes", "1", "") throws a ZodError at startup so a
 // misconfigured deployment fails loudly instead of silently flipping.
 const envBoolean = z
-  .union(
-    [z.boolean(), z.enum(["true", "false"])],
-    { errorMap: () => ({ message: 'must be true, false, "true", or "false"' }) },
-  )
+  .union([z.boolean(), z.enum(["true", "false"])], {
+    errorMap: () => ({ message: 'must be true, false, "true", or "false"' }),
+  })
   .transform((v) => (typeof v === "boolean" ? v : v === "true"));
 
 export const EnvSchema = z

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -55,6 +55,9 @@ export const EnvSchema = z
         },
         { message: "must be a base64 string that decodes to exactly 32 bytes" },
       ),
+    // Secret used to derive per-run HMAC callback tokens. Phase 3 enforces;
+    // Phase 1 only validates length when present.
+    BENCHMARK_CALLBACK_SECRET: z.string().min(32).optional(),
     DISABLE_FIRST_USER_ADMIN: envBoolean.default(false),
   })
   .superRefine((env, ctx) => {

--- a/apps/api/src/config/env.spec.ts
+++ b/apps/api/src/config/env.spec.ts
@@ -107,4 +107,30 @@ describe("validateEnv", () => {
       );
     }
   });
+
+  // BENCHMARK_API_KEY_ENCRYPTION_KEY: optional, but if provided must be a
+  // base64 string that decodes to exactly 32 bytes (AES-256 key length).
+  it("BENCHMARK_API_KEY_ENCRYPTION_KEY is optional", () => {
+    const env = validateEnv({ NODE_ENV: "test" });
+    expect(env.BENCHMARK_API_KEY_ENCRYPTION_KEY).toBeUndefined();
+  });
+
+  it("BENCHMARK_API_KEY_ENCRYPTION_KEY accepts a 32-byte base64 key", () => {
+    const key = Buffer.alloc(32, 0x42).toString("base64");
+    const env = validateEnv({ NODE_ENV: "test", BENCHMARK_API_KEY_ENCRYPTION_KEY: key });
+    expect(env.BENCHMARK_API_KEY_ENCRYPTION_KEY).toBe(key);
+  });
+
+  it("BENCHMARK_API_KEY_ENCRYPTION_KEY rejects a key that decodes to ≠ 32 bytes", () => {
+    const tooShort = Buffer.alloc(16, 0x42).toString("base64");
+    expect(() =>
+      validateEnv({ NODE_ENV: "test", BENCHMARK_API_KEY_ENCRYPTION_KEY: tooShort }),
+    ).toThrow(/BENCHMARK_API_KEY_ENCRYPTION_KEY/);
+  });
+
+  it("BENCHMARK_API_KEY_ENCRYPTION_KEY rejects non-base64 input", () => {
+    expect(() =>
+      validateEnv({ NODE_ENV: "test", BENCHMARK_API_KEY_ENCRYPTION_KEY: "not!base64!@#$" }),
+    ).toThrow(/BENCHMARK_API_KEY_ENCRYPTION_KEY/);
+  });
 });

--- a/apps/api/src/config/env.spec.ts
+++ b/apps/api/src/config/env.spec.ts
@@ -92,8 +92,12 @@ describe("validateEnv", () => {
   });
 
   it("DISABLE_FIRST_USER_ADMIN accepts native booleans", () => {
-    expect(validateEnv({ NODE_ENV: "test", DISABLE_FIRST_USER_ADMIN: true }).DISABLE_FIRST_USER_ADMIN).toBe(true);
-    expect(validateEnv({ NODE_ENV: "test", DISABLE_FIRST_USER_ADMIN: false }).DISABLE_FIRST_USER_ADMIN).toBe(false);
+    expect(
+      validateEnv({ NODE_ENV: "test", DISABLE_FIRST_USER_ADMIN: true }).DISABLE_FIRST_USER_ADMIN,
+    ).toBe(true);
+    expect(
+      validateEnv({ NODE_ENV: "test", DISABLE_FIRST_USER_ADMIN: false }).DISABLE_FIRST_USER_ADMIN,
+    ).toBe(false);
   });
 
   it("DISABLE_FIRST_USER_ADMIN rejects ambiguous strings (loud failure on typos)", () => {

--- a/apps/api/src/config/env.spec.ts
+++ b/apps/api/src/config/env.spec.ts
@@ -133,4 +133,21 @@ describe("validateEnv", () => {
       validateEnv({ NODE_ENV: "test", BENCHMARK_API_KEY_ENCRYPTION_KEY: "not!base64!@#$" }),
     ).toThrow(/BENCHMARK_API_KEY_ENCRYPTION_KEY/);
   });
+
+  // BENCHMARK_CALLBACK_SECRET: optional, but if provided must be ≥ 32 chars.
+  it("BENCHMARK_CALLBACK_SECRET is optional", () => {
+    const env = validateEnv({ NODE_ENV: "test" });
+    expect(env.BENCHMARK_CALLBACK_SECRET).toBeUndefined();
+  });
+
+  it("BENCHMARK_CALLBACK_SECRET accepts a 32-char string", () => {
+    const env = validateEnv({ NODE_ENV: "test", BENCHMARK_CALLBACK_SECRET: "x".repeat(32) });
+    expect(env.BENCHMARK_CALLBACK_SECRET).toBe("x".repeat(32));
+  });
+
+  it("BENCHMARK_CALLBACK_SECRET rejects a string shorter than 32 chars", () => {
+    expect(() =>
+      validateEnv({ NODE_ENV: "test", BENCHMARK_CALLBACK_SECRET: "x".repeat(31) }),
+    ).toThrow(/BENCHMARK_CALLBACK_SECRET/);
+  });
 });

--- a/apps/api/src/modules/benchmark/drivers/execution-driver.interface.spec.ts
+++ b/apps/api/src/modules/benchmark/drivers/execution-driver.interface.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type {
+  BenchmarkExecutionContext,
+  BenchmarkExecutionDriver,
+  BenchmarkExecutionHandle,
+} from "./execution-driver.interface.js";
+
+// Compile-time assertion that the interface shape is what consumers expect.
+// This file's primary value is the type-check: if a Phase 3 PR breaks the
+// interface, this spec stops compiling.
+class NoopDriver implements BenchmarkExecutionDriver {
+  async start(_ctx: BenchmarkExecutionContext): Promise<{ handle: BenchmarkExecutionHandle }> {
+    return { handle: "noop:0" };
+  }
+  async cancel(_handle: BenchmarkExecutionHandle): Promise<void> {
+    /* no-op */
+  }
+  async cleanup(_handle: BenchmarkExecutionHandle): Promise<void> {
+    /* no-op */
+  }
+}
+
+describe("BenchmarkExecutionDriver interface", () => {
+  it("is implementable by a noop driver", async () => {
+    const d: BenchmarkExecutionDriver = new NoopDriver();
+    const { handle } = await d.start({
+      benchmarkId: "ckxxx",
+      profile: "throughput",
+      apiType: "chat",
+      apiUrl: "http://target",
+      apiKey: "sk-test",
+      model: "facebook/opt-125m",
+      datasetName: "random",
+      datasetInputTokens: 1024,
+      datasetOutputTokens: 128,
+      requestRate: 0,
+      totalRequests: 1000,
+      maxDurationSeconds: 1800,
+      callbackUrl: "http://api:3001",
+      callbackToken: "hmac-token",
+    });
+    expect(handle).toBe("noop:0");
+    await expect(d.cancel(handle)).resolves.toBeUndefined();
+    await expect(d.cleanup(handle)).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/modules/benchmark/drivers/execution-driver.interface.spec.ts
+++ b/apps/api/src/modules/benchmark/drivers/execution-driver.interface.spec.ts
@@ -41,6 +41,8 @@ describe("BenchmarkExecutionDriver interface", () => {
     });
     expect(handle).toBe("noop:0");
     await expect(d.cancel(handle)).resolves.toBeUndefined();
+    await expect(d.cancel(handle)).resolves.toBeUndefined(); // idempotent
     await expect(d.cleanup(handle)).resolves.toBeUndefined();
+    await expect(d.cleanup(handle)).resolves.toBeUndefined(); // idempotent
   });
 });

--- a/apps/api/src/modules/benchmark/drivers/execution-driver.interface.ts
+++ b/apps/api/src/modules/benchmark/drivers/execution-driver.interface.ts
@@ -3,8 +3,18 @@ import type { BenchmarkApiType, BenchmarkDataset, BenchmarkProfile } from "@mode
 /**
  * Per-run input passed to a driver. Sensitive values (decrypted apiKey,
  * HMAC callback token) are passed by value; the driver is responsible for
- * propagating them to the runner via env or k8s Secret without leaking to
- * logs or process listings.
+ * propagating them safely to the runner without leaking to logs or process
+ * listings.
+ *
+ * Implementer guidance:
+ * - K8sJobDriver: sensitive values MUST be passed via
+ *   `env.valueFrom.secretKeyRef`. Create a per-run Secret (with
+ *   `ownerReferences` to the Job so it gets garbage-collected on Job
+ *   deletion) and reference it from the container's `env`. Plain
+ *   `env.value` strings leak via `kubectl describe`, `kubectl get -o yaml`,
+ *   the K8s API audit log, and any operator with `get jobs` RBAC.
+ * - SubprocessDriver: pass via the spawned process's `env`, never as argv
+ *   (argv shows up in `ps`).
  */
 export interface BenchmarkExecutionContext {
   benchmarkId: string;

--- a/apps/api/src/modules/benchmark/drivers/execution-driver.interface.ts
+++ b/apps/api/src/modules/benchmark/drivers/execution-driver.interface.ts
@@ -1,0 +1,57 @@
+import type { BenchmarkApiType, BenchmarkDataset, BenchmarkProfile } from "@modeldoctor/contracts";
+
+/**
+ * Per-run input passed to a driver. Sensitive values (decrypted apiKey,
+ * HMAC callback token) are passed by value; the driver is responsible for
+ * propagating them to the runner via env or k8s Secret without leaking to
+ * logs or process listings.
+ */
+export interface BenchmarkExecutionContext {
+  benchmarkId: string;
+  profile: BenchmarkProfile;
+
+  // Target endpoint
+  apiType: BenchmarkApiType;
+  apiUrl: string;
+  apiKey: string;
+  model: string;
+
+  // Workload
+  datasetName: BenchmarkDataset;
+  datasetInputTokens?: number;
+  datasetOutputTokens?: number;
+  datasetSeed?: number;
+  requestRate: number;
+  totalRequests: number;
+  maxDurationSeconds: number;
+
+  // Callback
+  callbackUrl: string;
+  callbackToken: string;
+}
+
+/**
+ * Opaque handle to an in-flight execution. SubprocessDriver uses
+ * "subprocess:<pid>"; K8sJobDriver uses "<namespace>/<jobName>".
+ * The service stores this on BenchmarkRun.jobName for cancel/cleanup.
+ */
+export type BenchmarkExecutionHandle = string;
+
+export interface BenchmarkExecutionDriver {
+  /**
+   * Start an execution. Resolves once the runner is launched (process spawned
+   * or Job created), NOT when the benchmark finishes. Lifecycle progression
+   * after start() is reported by the runner via HTTP callbacks.
+   */
+  start(ctx: BenchmarkExecutionContext): Promise<{ handle: BenchmarkExecutionHandle }>;
+
+  /** Stop an in-flight execution. Idempotent. */
+  cancel(handle: BenchmarkExecutionHandle): Promise<void>;
+
+  /**
+   * Release driver-side resources (subprocess wait, K8s Job delete) after
+   * a run reaches a terminal state. Idempotent — safe to call multiple
+   * times or on a handle whose underlying execution is already gone.
+   */
+  cleanup(handle: BenchmarkExecutionHandle): Promise<void>;
+}

--- a/docs/superpowers/plans/2026-04-25-benchmark-phase-1-data-contracts.md
+++ b/docs/superpowers/plans/2026-04-25-benchmark-phase-1-data-contracts.md
@@ -25,7 +25,7 @@ Every commit body ends with `Co-Authored-By: Claude Opus 4.7 (1M context) <norep
 
 **Environment assumptions:**
 - Working directory: the current ModelDoctor repo root (whichever worktree the user is on; commands are written repo-root-relative).
-- The local Postgres dev DB is up (`docker compose up -d postgres` — already configured per Spec 2). Without it `db:migrate:dev` will hang.
+- The local Postgres dev DB is brew-managed (`brew services list` shows `postgresql@18` started). `DATABASE_URL` in `.env` points at `localhost:5432`. Without a running Postgres, `db:migrate:dev` will hang.
 - Node ≥ 20, pnpm ≥ 9 — same as Phase 0 of the NestJS refactor.
 - `pnpm install` has been run on the current branch (Prisma 6 client is installed).
 
@@ -51,13 +51,10 @@ Expected: every workspace package green. **If anything is red, stop** — Phase 
 - [ ] **Step 0.3: Confirm the dev DB is reachable**
 
 ```bash
-docker compose ps postgres
+brew services list | grep postgres
+pg_isready -h localhost -p 5432
 ```
-Expected: a row with `STATUS` containing `Up` / `running`. If the container is not running:
-```bash
-docker compose up -d postgres
-```
-Wait ~5 seconds for it to accept connections, then re-run the `ps` check.
+Expected: a `postgresql@<version>` row with status `started`, and `pg_isready` returns `localhost:5432 - accepting connections`. If Postgres is stopped, start it with `brew services start postgresql@18` (adjust version as installed) and wait a couple of seconds.
 
 - [ ] **Step 0.4: Create the Phase 1 branch**
 

--- a/docs/superpowers/plans/2026-04-25-benchmark-phase-1-data-contracts.md
+++ b/docs/superpowers/plans/2026-04-25-benchmark-phase-1-data-contracts.md
@@ -1,0 +1,1314 @@
+# Benchmark Feature — Phase 1 Implementation Plan (Data + Contracts)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lay the typed foundation for the benchmark feature — the `BenchmarkRun` Prisma model, all shared Zod contracts, an AES-GCM helper for at-rest encryption of user-supplied API keys, the `BenchmarkExecutionDriver` interface, and two new optional env vars. Nothing observable from the outside; nothing is wired up. Phase 2 builds the runner image, Phase 3 implements the drivers and callback API.
+
+**Architecture:** Single PR from `feat/benchmark-phase-1` cut from `main`. One Prisma migration (additive only — no changes to existing tables). Contracts go in `packages/contracts/src/benchmark.ts` and are re-exported from the package barrel. The crypto helper lives at `apps/api/src/common/crypto/aes-gcm.ts` next to existing common utilities. The driver interface lives at `apps/api/src/modules/benchmark/drivers/execution-driver.interface.ts`, creating the module directory that Phase 3/4 fill in.
+
+**Tech Stack:** Prisma 6, PostgreSQL, Zod 3.23, Node `crypto` (AES-256-GCM), Vitest 2, TypeScript 5 strict. No new npm dependencies.
+
+**Source spec:** `docs/superpowers/specs/2026-04-25-benchmark-design.md` — §3 (Domain Model), §6 (Security), §1.2/§13 (env vars and driver overview).
+
+**Testing discipline:**
+- **TDD for code modules.** Every new function in `aes-gcm.ts` and every new branch added to `env.schema.ts` lands via *failing-test-first → minimal-impl → passing-test → commit*.
+- **Contracts tests are parser-driven.** For each Zod schema we add at least one accept-case and one reject-case. Type assertions alone are not enough — we need to verify the runtime behavior matches the type.
+- **Schema-only changes are verified, not TDD'd.** The Prisma migration (Task 1) and the driver interface (Task 6) ship with verification commands (migration applies cleanly, interface compiles + a noop implementation type-checks). They are not unit-tested in the traditional sense — there is nothing to assert beyond what the type system already enforces.
+
+**Commit cadence:** One commit per task (7 commits + the pre-flight branch creation). Conventional-commit prefixes per `CLAUDE.md`:
+- `feat:` runtime code (new functions, new schemas)
+- `test:` test-only changes (rare in this phase — tests usually land *with* their impl)
+- `chore:` Prisma migration scaffolding
+- `docs:` would only be used if we touched the spec, which we won't
+
+Every commit body ends with `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
+
+**Environment assumptions:**
+- Working directory: the current ModelDoctor repo root (whichever worktree the user is on; commands are written repo-root-relative).
+- The local Postgres dev DB is up (`docker compose up -d postgres` — already configured per Spec 2). Without it `db:migrate:dev` will hang.
+- Node ≥ 20, pnpm ≥ 9 — same as Phase 0 of the NestJS refactor.
+- `pnpm install` has been run on the current branch (Prisma 6 client is installed).
+
+---
+
+## Pre-flight
+
+- [ ] **Step 0.1: Confirm a clean working tree**
+
+```bash
+git status
+```
+Expected: `nothing to commit, working tree clean`. If dirty, commit or stash before proceeding.
+
+- [ ] **Step 0.2: Confirm baseline tests pass on the current branch**
+
+```bash
+pnpm -r type-check
+pnpm -r test
+```
+Expected: every workspace package green. **If anything is red, stop** — Phase 1 must start from a green baseline so any new failure clearly belongs to this plan.
+
+- [ ] **Step 0.3: Confirm the dev DB is reachable**
+
+```bash
+docker compose ps postgres
+```
+Expected: a row with `STATUS` containing `Up` / `running`. If the container is not running:
+```bash
+docker compose up -d postgres
+```
+Wait ~5 seconds for it to accept connections, then re-run the `ps` check.
+
+- [ ] **Step 0.4: Create the Phase 1 branch**
+
+This plan depends on the NestJS backend refactor (Spec 2) being present — specifically `apps/api/prisma/schema.prisma`, `apps/api/src/config/env.schema.ts`, `apps/api/src/common/`, and `packages/contracts/`. Branch from whichever integration branch carries that work: `main` if the refactor has been merged, otherwise the current refactor branch (e.g. `feat/restructure`).
+
+Verify prerequisites are present on the current branch:
+```bash
+test -f apps/api/prisma/schema.prisma && \
+  test -f apps/api/src/config/env.schema.ts && \
+  test -d packages/contracts/src && \
+  echo "OK: prerequisites present"
+```
+Expected: `OK: prerequisites present`. If this fails, switch to the correct base branch before continuing.
+
+Then create the Phase 1 branch:
+```bash
+git checkout -b feat/benchmark-phase-1
+```
+Expected: `Switched to a new branch 'feat/benchmark-phase-1'`. All Phase 1 commits land here. PR target is whichever branch you cut from (typically `main`).
+
+---
+
+## Phase 1 Tasks
+
+Phase goal (restated): one Prisma migration adds `benchmark_runs`; `packages/contracts/src/benchmark.ts` exports the full Zod surface; `apps/api/src/common/crypto/aes-gcm.ts` exports `encrypt` / `decrypt` / `decodeKey`; `apps/api/src/modules/benchmark/drivers/execution-driver.interface.ts` exports the driver interface; `env.schema.ts` accepts `BENCHMARK_API_KEY_ENCRYPTION_KEY` and `BENCHMARK_CALLBACK_SECRET` as optional, validated fields. After this phase merges nothing changes for end users — Phase 4 wires the contracts into a controller, Phase 3 wires the driver and crypto helper into a service.
+
+---
+
+### Task 1: Add `BenchmarkRun` Prisma model and migration
+
+**Files:**
+- Modify: `apps/api/prisma/schema.prisma`
+- Create (generated by `prisma migrate dev`): `apps/api/prisma/migrations/<timestamp>_add_benchmark_runs/migration.sql`
+
+This task is verified by inspection of the generated migration SQL plus a `db:generate` to confirm the Prisma client picks up the new types. There is no unit test — the Prisma migration toolchain is the verification.
+
+- [ ] **Step 1.1: Add the `BenchmarkRun` model to `schema.prisma`**
+
+Open `apps/api/prisma/schema.prisma`. Append the following model **after** the existing `LoadTestRun` model (i.e. at the end of the file):
+
+```prisma
+model BenchmarkRun {
+  id          String  @id @default(cuid())
+  userId      String? @map("user_id")
+
+  // Identification
+  name        String
+  description String? @db.Text
+  profile     String  @default("custom") // "throughput" | "latency" | "long_context" | "generation_heavy" | "sharegpt" | "custom"
+
+  // Target endpoint
+  apiType      String @map("api_type")        // "chat" | "completion"
+  apiUrl       String @map("api_url")
+  apiKeyCipher String @map("api_key_cipher") // AES-256-GCM ciphertext, see common/crypto
+  model        String
+
+  // Workload config
+  datasetName         String @default("random") @map("dataset_name") // "random" | "sharegpt"
+  datasetInputTokens  Int?   @map("dataset_input_tokens")
+  datasetOutputTokens Int?   @map("dataset_output_tokens")
+  datasetSeed         Int?   @map("dataset_seed")
+  requestRate         Int    @default(0)        @map("request_rate")    // 0 = unlimited
+  totalRequests       Int    @default(1000)     @map("total_requests")
+
+  // Lifecycle
+  state        String  @default("pending") // "pending" | "submitted" | "running" | "completed" | "failed" | "canceled"
+  stateMessage String? @db.Text             @map("state_message")
+  progress     Float?
+  jobName      String? @map("job_name")    // K8s Job metadata.name; null until submitted
+
+  // Metrics (denormalized summary for list views; full report in rawMetrics)
+  metricsSummary Json?  @map("metrics_summary")
+  rawMetrics     Json?  @map("raw_metrics")
+  logs           String? @db.Text
+
+  createdAt   DateTime  @default(now())  @map("created_at")
+  startedAt   DateTime?                  @map("started_at")
+  completedAt DateTime?                  @map("completed_at")
+
+  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  @@index([userId, createdAt])
+  @@index([state])
+  @@map("benchmark_runs")
+}
+```
+
+Now add the back-relation on the `User` model. Find the existing relations block on `User`:
+
+```prisma
+  refreshTokens RefreshToken[]
+  loadTestRuns  LoadTestRun[]
+```
+
+Append a third line so it reads:
+
+```prisma
+  refreshTokens RefreshToken[]
+  loadTestRuns  LoadTestRun[]
+  benchmarkRuns BenchmarkRun[]
+```
+
+- [ ] **Step 1.2: Generate the migration**
+
+```bash
+pnpm -F @modeldoctor/api db:migrate:dev --name add_benchmark_runs
+```
+Expected output: lines indicating Prisma applied migration `<timestamp>_add_benchmark_runs` and regenerated the client. A new directory `apps/api/prisma/migrations/<timestamp>_add_benchmark_runs/` exists with `migration.sql`.
+
+If the command prompts about resetting the dev DB or about drift, **stop** — Phase 1 is purely additive. The dev DB should already be on the prior `init` migration; if it isn't, investigate before proceeding.
+
+- [ ] **Step 1.3: Inspect the generated SQL**
+
+```bash
+cat apps/api/prisma/migrations/*_add_benchmark_runs/migration.sql
+```
+Verify it contains:
+- `CREATE TABLE "benchmark_runs"` with all the columns from the model (snake_case names)
+- `CREATE INDEX "benchmark_runs_user_id_created_at_idx"` on `(user_id, created_at)`
+- `CREATE INDEX "benchmark_runs_state_idx"` on `(state)`
+- `ALTER TABLE "benchmark_runs" ADD CONSTRAINT "benchmark_runs_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE`
+
+If any are missing or the SQL touches *other* tables, the model edit was wrong — fix `schema.prisma` and re-run `db:migrate:dev` (Prisma will roll the dev migration forward automatically).
+
+- [ ] **Step 1.4: Verify the Prisma client surfaces the new type**
+
+```bash
+pnpm -F @modeldoctor/api type-check
+```
+Expected: passes. The generated client now includes `prisma.benchmarkRun.create / findMany / …` overloads. If type-check fails it almost certainly means the schema edit has a typo — re-read it side-by-side with the spec §3.1.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add apps/api/prisma/schema.prisma apps/api/prisma/migrations/
+git commit -m "$(cat <<'EOF'
+feat(db): add benchmark_runs table
+
+Adds the BenchmarkRun Prisma model and an additive migration. Includes
+fields for target endpoint (apiKey stored as AES-GCM ciphertext, helper
+lands in a follow-up commit), workload config, lifecycle state, and
+metrics (summary denormalized for list views, raw blob for forensic
+re-analysis).
+
+Indexes: (user_id, created_at) for owner-scoped list queries; (state)
+for the reconciler sweep.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+Expected: one commit landed; `git log -1 --stat` shows `schema.prisma` + the new migration directory.
+
+---
+
+### Task 2: Add `BENCHMARK_API_KEY_ENCRYPTION_KEY` env var
+
+**Files:**
+- Modify: `apps/api/src/config/env.schema.ts`
+- Modify: `apps/api/src/config/env.spec.ts`
+
+The crypto helper in Task 4 will need a 32-byte key. We add the env field as **optional** in this phase — Phase 4 (which actually creates encrypted rows) tightens it to required-when-not-test. Adding it now lets the helper accept the key from config in Phase 3/4 without re-touching the schema.
+
+The validation we *do* enforce now: when the env var is set, it must base64-decode to exactly 32 bytes. That catches the most common misconfig (someone sets a 16-byte key by accident).
+
+- [ ] **Step 2.1: Write the failing test for accepting a valid key**
+
+Open `apps/api/src/config/env.spec.ts`. Append at the end of the `describe("validateEnv", () => { ... })` block, just before the closing `});`:
+
+```typescript
+  // BENCHMARK_API_KEY_ENCRYPTION_KEY: optional, but if provided must be a
+  // base64 string that decodes to exactly 32 bytes (AES-256 key length).
+  it("BENCHMARK_API_KEY_ENCRYPTION_KEY is optional", () => {
+    const env = validateEnv({ NODE_ENV: "test" });
+    expect(env.BENCHMARK_API_KEY_ENCRYPTION_KEY).toBeUndefined();
+  });
+
+  it("BENCHMARK_API_KEY_ENCRYPTION_KEY accepts a 32-byte base64 key", () => {
+    const key = Buffer.alloc(32, 0x42).toString("base64");
+    const env = validateEnv({ NODE_ENV: "test", BENCHMARK_API_KEY_ENCRYPTION_KEY: key });
+    expect(env.BENCHMARK_API_KEY_ENCRYPTION_KEY).toBe(key);
+  });
+
+  it("BENCHMARK_API_KEY_ENCRYPTION_KEY rejects a key that decodes to ≠ 32 bytes", () => {
+    const tooShort = Buffer.alloc(16, 0x42).toString("base64");
+    expect(() =>
+      validateEnv({ NODE_ENV: "test", BENCHMARK_API_KEY_ENCRYPTION_KEY: tooShort }),
+    ).toThrow(/BENCHMARK_API_KEY_ENCRYPTION_KEY/);
+  });
+
+  it("BENCHMARK_API_KEY_ENCRYPTION_KEY rejects non-base64 input", () => {
+    expect(() =>
+      validateEnv({ NODE_ENV: "test", BENCHMARK_API_KEY_ENCRYPTION_KEY: "not!base64!@#$" }),
+    ).toThrow(/BENCHMARK_API_KEY_ENCRYPTION_KEY/);
+  });
+```
+
+- [ ] **Step 2.2: Run the new tests and verify they fail**
+
+```bash
+pnpm -F @modeldoctor/api test -- env.spec
+```
+Expected: 4 new failures, all because `BENCHMARK_API_KEY_ENCRYPTION_KEY` is not in the schema. The pre-existing tests should still pass.
+
+- [ ] **Step 2.3: Add the field to the schema**
+
+Open `apps/api/src/config/env.schema.ts`. Inside the `EnvSchema = z.object({ ... })` block, just before the `DISABLE_FIRST_USER_ADMIN` line, add:
+
+```typescript
+    // 32-byte base64-encoded AES-256 key used to encrypt user-supplied API
+    // keys at rest. Optional in Phase 1 (the helper is added but no row uses
+    // it yet); Phase 4 tightens to required-when-not-test once the
+    // BenchmarkController persists encrypted rows.
+    BENCHMARK_API_KEY_ENCRYPTION_KEY: z
+      .string()
+      .optional()
+      .refine(
+        (v) => {
+          if (v === undefined) return true;
+          // Reject obviously non-base64 input. Buffer.from is permissive (it
+          // silently drops invalid chars) so we lint with a regex first.
+          if (!/^[A-Za-z0-9+/=]+$/.test(v)) return false;
+          return Buffer.from(v, "base64").length === 32;
+        },
+        { message: "must be a base64 string that decodes to exactly 32 bytes" },
+      ),
+```
+
+- [ ] **Step 2.4: Run the tests and verify they pass**
+
+```bash
+pnpm -F @modeldoctor/api test -- env.spec
+```
+Expected: all `validateEnv` tests pass, including the 4 new ones.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add apps/api/src/config/env.schema.ts apps/api/src/config/env.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(api/config): accept BENCHMARK_API_KEY_ENCRYPTION_KEY env var
+
+Optional in Phase 1 since no code path requires it yet; Phase 4 tightens
+to required-when-not-test once encrypted benchmark rows are persisted.
+Validates length-after-base64-decode = 32 bytes so a 16-byte key fails
+loudly at boot rather than silently producing a runtime crypto error.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Add `BENCHMARK_CALLBACK_SECRET` env var
+
+**Files:**
+- Modify: `apps/api/src/config/env.schema.ts`
+- Modify: `apps/api/src/config/env.spec.ts`
+
+Used in Phase 3 to sign the per-run HMAC token the runner pod presents on its callback. Like the encryption key, optional in Phase 1; Phase 3 tightens.
+
+- [ ] **Step 3.1: Write the failing tests**
+
+Append to `apps/api/src/config/env.spec.ts`, again just before the closing `});`:
+
+```typescript
+  // BENCHMARK_CALLBACK_SECRET: optional, but if provided must be ≥ 32 chars.
+  it("BENCHMARK_CALLBACK_SECRET is optional", () => {
+    const env = validateEnv({ NODE_ENV: "test" });
+    expect(env.BENCHMARK_CALLBACK_SECRET).toBeUndefined();
+  });
+
+  it("BENCHMARK_CALLBACK_SECRET accepts a 32-char string", () => {
+    const env = validateEnv({ NODE_ENV: "test", BENCHMARK_CALLBACK_SECRET: "x".repeat(32) });
+    expect(env.BENCHMARK_CALLBACK_SECRET).toBe("x".repeat(32));
+  });
+
+  it("BENCHMARK_CALLBACK_SECRET rejects a string shorter than 32 chars", () => {
+    expect(() =>
+      validateEnv({ NODE_ENV: "test", BENCHMARK_CALLBACK_SECRET: "x".repeat(31) }),
+    ).toThrow(/BENCHMARK_CALLBACK_SECRET/);
+  });
+```
+
+- [ ] **Step 3.2: Run the tests and verify they fail**
+
+```bash
+pnpm -F @modeldoctor/api test -- env.spec
+```
+Expected: 3 new failures.
+
+- [ ] **Step 3.3: Add the field to the schema**
+
+In `apps/api/src/config/env.schema.ts`, immediately after the `BENCHMARK_API_KEY_ENCRYPTION_KEY` field, add:
+
+```typescript
+    // Secret used to derive per-run HMAC callback tokens. Phase 3 enforces;
+    // Phase 1 only validates length when present.
+    BENCHMARK_CALLBACK_SECRET: z.string().min(32).optional(),
+```
+
+- [ ] **Step 3.4: Run the tests and verify they pass**
+
+```bash
+pnpm -F @modeldoctor/api test -- env.spec
+```
+Expected: all green, including the 3 new tests.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add apps/api/src/config/env.schema.ts apps/api/src/config/env.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(api/config): accept BENCHMARK_CALLBACK_SECRET env var
+
+Used in Phase 3 to derive per-run HMAC callback tokens the benchmark
+runner presents to /api/internal/benchmarks/:id/{state,metrics}. Same
+optional-in-Phase-1 pattern as BENCHMARK_API_KEY_ENCRYPTION_KEY.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: AES-GCM crypto helper
+
+**Files:**
+- Create: `apps/api/src/common/crypto/aes-gcm.ts`
+- Create: `apps/api/src/common/crypto/aes-gcm.spec.ts`
+
+The helper exports three pure functions:
+- `decodeKey(base64: string): Buffer` — decode and length-check a key.
+- `encrypt(plaintext: string, key: Buffer): string` — encrypt and emit a versioned `v1:iv:tag:ct` string.
+- `decrypt(payload: string, key: Buffer): string` — parse and decrypt; throws on tamper, wrong key, or unknown version.
+
+No NestJS — pure functions. Testable in isolation.
+
+- [ ] **Step 4.1: Write the failing test file**
+
+Create `apps/api/src/common/crypto/aes-gcm.spec.ts`:
+
+```typescript
+import { randomBytes } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { decodeKey, decrypt, encrypt } from "./aes-gcm.js";
+
+describe("aes-gcm", () => {
+  const key = randomBytes(32);
+
+  describe("decodeKey", () => {
+    it("decodes a valid 32-byte base64 key", () => {
+      const b64 = randomBytes(32).toString("base64");
+      const out = decodeKey(b64);
+      expect(out.length).toBe(32);
+      expect(out.equals(Buffer.from(b64, "base64"))).toBe(true);
+    });
+
+    it("throws when the decoded key is not 32 bytes", () => {
+      const tooShort = randomBytes(16).toString("base64");
+      expect(() => decodeKey(tooShort)).toThrow(/32 bytes/);
+    });
+  });
+
+  describe("encrypt + decrypt", () => {
+    it("round-trips a UTF-8 string", () => {
+      const ct = encrypt("hello, 世界", key);
+      expect(decrypt(ct, key)).toBe("hello, 世界");
+    });
+
+    it("emits the v1 prefix and four colon-separated parts", () => {
+      const ct = encrypt("anything", key);
+      const parts = ct.split(":");
+      expect(parts).toHaveLength(4);
+      expect(parts[0]).toBe("v1");
+    });
+
+    it("produces different ciphertexts for the same plaintext (random IV)", () => {
+      const a = encrypt("same input", key);
+      const b = encrypt("same input", key);
+      expect(a).not.toBe(b);
+    });
+
+    it("throws when decrypting with the wrong key", () => {
+      const ct = encrypt("secret", key);
+      const otherKey = randomBytes(32);
+      expect(() => decrypt(ct, otherKey)).toThrow();
+    });
+
+    it("throws when the ciphertext is tampered with", () => {
+      const ct = encrypt("secret", key);
+      // Flip a byte in the ciphertext segment (last colon-separated part)
+      const parts = ct.split(":");
+      const ctBytes = Buffer.from(parts[3], "base64");
+      ctBytes[0] = ctBytes[0] ^ 0x01;
+      parts[3] = ctBytes.toString("base64");
+      const tampered = parts.join(":");
+      expect(() => decrypt(tampered, key)).toThrow();
+    });
+
+    it("throws when the auth tag is tampered with", () => {
+      const ct = encrypt("secret", key);
+      const parts = ct.split(":");
+      const tagBytes = Buffer.from(parts[2], "base64");
+      tagBytes[0] = tagBytes[0] ^ 0x01;
+      parts[2] = tagBytes.toString("base64");
+      const tampered = parts.join(":");
+      expect(() => decrypt(tampered, key)).toThrow();
+    });
+
+    it("rejects an unknown version prefix", () => {
+      const ct = encrypt("secret", key);
+      const tampered = ct.replace(/^v1:/, "v2:");
+      expect(() => decrypt(tampered, key)).toThrow(/version/);
+    });
+
+    it("rejects malformed input (not 4 parts)", () => {
+      expect(() => decrypt("v1:not-enough-parts", key)).toThrow(/Malformed/);
+    });
+
+    it("encrypt rejects a wrong-length key", () => {
+      const badKey = randomBytes(16);
+      expect(() => encrypt("x", badKey)).toThrow(/32 bytes/);
+    });
+
+    it("decrypt rejects a wrong-length key", () => {
+      const ct = encrypt("x", key);
+      const badKey = randomBytes(16);
+      expect(() => decrypt(ct, badKey)).toThrow(/32 bytes/);
+    });
+  });
+});
+```
+
+- [ ] **Step 4.2: Run the test file and verify it fails**
+
+```bash
+pnpm -F @modeldoctor/api test -- aes-gcm.spec
+```
+Expected: every test fails with a module-not-found error pointing at `./aes-gcm.js`.
+
+- [ ] **Step 4.3: Implement the helper**
+
+Create `apps/api/src/common/crypto/aes-gcm.ts`:
+
+```typescript
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const KEY_BYTES = 32;
+const IV_BYTES = 12;
+const TAG_BYTES = 16;
+const VERSION = "v1";
+
+export function decodeKey(base64: string): Buffer {
+  const buf = Buffer.from(base64, "base64");
+  if (buf.length !== KEY_BYTES) {
+    throw new Error(`Encryption key must decode to ${KEY_BYTES} bytes, got ${buf.length}`);
+  }
+  return buf;
+}
+
+export function encrypt(plaintext: string, key: Buffer): string {
+  if (key.length !== KEY_BYTES) {
+    throw new Error(`Key must be ${KEY_BYTES} bytes`);
+  }
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${VERSION}:${iv.toString("base64")}:${tag.toString("base64")}:${ct.toString("base64")}`;
+}
+
+export function decrypt(payload: string, key: Buffer): string {
+  if (key.length !== KEY_BYTES) {
+    throw new Error(`Key must be ${KEY_BYTES} bytes`);
+  }
+  const parts = payload.split(":");
+  if (parts.length !== 4) {
+    throw new Error("Malformed ciphertext: expected 4 colon-separated parts");
+  }
+  const [version, ivB64, tagB64, ctB64] = parts;
+  if (version !== VERSION) {
+    throw new Error(`Unsupported ciphertext version: ${version}`);
+  }
+  const iv = Buffer.from(ivB64, "base64");
+  const tag = Buffer.from(tagB64, "base64");
+  const ct = Buffer.from(ctB64, "base64");
+  if (iv.length !== IV_BYTES) {
+    throw new Error(`Malformed IV: expected ${IV_BYTES} bytes, got ${iv.length}`);
+  }
+  if (tag.length !== TAG_BYTES) {
+    throw new Error(`Malformed auth tag: expected ${TAG_BYTES} bytes, got ${tag.length}`);
+  }
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ct), decipher.final()]).toString("utf8");
+}
+```
+
+- [ ] **Step 4.4: Run the tests and verify they pass**
+
+```bash
+pnpm -F @modeldoctor/api test -- aes-gcm.spec
+```
+Expected: all 12 tests pass. If a tamper test does NOT throw, the GCM auth-tag handling is wrong — re-read `decrypt` for a missing `setAuthTag` call.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add apps/api/src/common/crypto/
+git commit -m "$(cat <<'EOF'
+feat(api/crypto): add AES-256-GCM encrypt/decrypt helper
+
+Pure-function helper for encrypting user-supplied API keys at rest.
+Output format is "v1:<iv>:<tag>:<ct>" (all base64) so future key
+rotations or algorithm changes are detectable by prefix. decodeKey()
+validates length-after-base64-decode = 32 bytes so a misconfigured
+env var fails loudly at parse time, not at first encrypt() call.
+
+Used by Phase 4's BenchmarkService when persisting BenchmarkRun rows;
+not yet wired up.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Benchmark contracts (Zod schemas)
+
+**Files:**
+- Create: `packages/contracts/src/benchmark.ts`
+- Create: `packages/contracts/src/benchmark.spec.ts`
+- Modify: `packages/contracts/src/index.ts`
+
+This is the wire-format authority. Both API and web import these schemas. Schemas covered:
+- Enums: `BenchmarkApiTypeSchema`, `BenchmarkProfileSchema`, `BenchmarkDatasetSchema`, `BenchmarkStateSchema`
+- Metrics shapes: `LatencyDistributionSchema`, `BenchmarkMetricsSummarySchema`
+- Create request: `CreateBenchmarkRequestSchema` (with conditional `superRefine` for Random dataset)
+- Read responses: `BenchmarkRunSummarySchema`, `BenchmarkRunSchema`, `ListBenchmarksQuerySchema`, `ListBenchmarksResponseSchema`
+- Internal callbacks (used by Phase 3): `BenchmarkStateCallbackSchema`, `BenchmarkMetricsCallbackSchema`
+
+- [ ] **Step 5.1: Write the failing test file**
+
+Create `packages/contracts/src/benchmark.spec.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import {
+  BenchmarkApiTypeSchema,
+  BenchmarkDatasetSchema,
+  BenchmarkMetricsCallbackSchema,
+  BenchmarkMetricsSummarySchema,
+  BenchmarkProfileSchema,
+  BenchmarkRunSchema,
+  BenchmarkRunSummarySchema,
+  BenchmarkStateCallbackSchema,
+  BenchmarkStateSchema,
+  CreateBenchmarkRequestSchema,
+  ListBenchmarksQuerySchema,
+  ListBenchmarksResponseSchema,
+} from "./benchmark.js";
+
+describe("benchmark contracts", () => {
+  describe("enums", () => {
+    it("BenchmarkApiTypeSchema accepts only chat/completion", () => {
+      expect(BenchmarkApiTypeSchema.parse("chat")).toBe("chat");
+      expect(BenchmarkApiTypeSchema.parse("completion")).toBe("completion");
+      expect(() => BenchmarkApiTypeSchema.parse("embeddings")).toThrow();
+    });
+
+    it("BenchmarkProfileSchema includes all 5 named profiles plus custom", () => {
+      for (const p of ["throughput", "latency", "long_context", "generation_heavy", "sharegpt", "custom"]) {
+        expect(BenchmarkProfileSchema.parse(p)).toBe(p);
+      }
+      expect(() => BenchmarkProfileSchema.parse("unknown")).toThrow();
+    });
+
+    it("BenchmarkDatasetSchema accepts random and sharegpt", () => {
+      expect(BenchmarkDatasetSchema.parse("random")).toBe("random");
+      expect(BenchmarkDatasetSchema.parse("sharegpt")).toBe("sharegpt");
+      expect(() => BenchmarkDatasetSchema.parse("custom-set")).toThrow();
+    });
+
+    it("BenchmarkStateSchema includes the full lifecycle", () => {
+      for (const s of ["pending", "submitted", "running", "completed", "failed", "canceled"]) {
+        expect(BenchmarkStateSchema.parse(s)).toBe(s);
+      }
+      expect(() => BenchmarkStateSchema.parse("unknown")).toThrow();
+    });
+  });
+
+  describe("CreateBenchmarkRequestSchema", () => {
+    const valid = {
+      name: "throughput-baseline",
+      profile: "throughput" as const,
+      apiType: "chat" as const,
+      apiUrl: "http://vllm.local:8000/v1",
+      apiKey: "sk-test",
+      model: "facebook/opt-125m",
+      datasetName: "random" as const,
+      datasetInputTokens: 1024,
+      datasetOutputTokens: 128,
+      requestRate: 0,
+      totalRequests: 1000,
+    };
+
+    it("accepts a complete random-dataset request", () => {
+      expect(() => CreateBenchmarkRequestSchema.parse(valid)).not.toThrow();
+    });
+
+    it("requires datasetInputTokens when datasetName is 'random'", () => {
+      const { datasetInputTokens: _, ...rest } = valid;
+      const result = CreateBenchmarkRequestSchema.safeParse(rest);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.some((i) => i.path[0] === "datasetInputTokens")).toBe(true);
+      }
+    });
+
+    it("requires datasetOutputTokens when datasetName is 'random'", () => {
+      const { datasetOutputTokens: _, ...rest } = valid;
+      const result = CreateBenchmarkRequestSchema.safeParse(rest);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.some((i) => i.path[0] === "datasetOutputTokens")).toBe(true);
+      }
+    });
+
+    it("rejects empty name", () => {
+      expect(() => CreateBenchmarkRequestSchema.parse({ ...valid, name: "" })).toThrow();
+    });
+
+    it("rejects name longer than 128 chars", () => {
+      expect(() => CreateBenchmarkRequestSchema.parse({ ...valid, name: "x".repeat(129) })).toThrow();
+    });
+
+    it("rejects non-URL apiUrl", () => {
+      expect(() => CreateBenchmarkRequestSchema.parse({ ...valid, apiUrl: "not-a-url" })).toThrow();
+    });
+
+    it("rejects negative requestRate", () => {
+      expect(() => CreateBenchmarkRequestSchema.parse({ ...valid, requestRate: -1 })).toThrow();
+    });
+
+    it("rejects totalRequests > 100000", () => {
+      expect(() => CreateBenchmarkRequestSchema.parse({ ...valid, totalRequests: 100_001 })).toThrow();
+    });
+
+    it("allows requestRate=0 (unlimited)", () => {
+      expect(() => CreateBenchmarkRequestSchema.parse({ ...valid, requestRate: 0 })).not.toThrow();
+    });
+  });
+
+  describe("BenchmarkMetricsSummarySchema", () => {
+    const validMetrics = {
+      ttft: { mean: 120, p50: 110, p95: 200, p99: 320 },
+      itl: { mean: 25, p50: 22, p95: 50, p99: 80 },
+      e2eLatency: { mean: 1800, p50: 1700, p95: 2500, p99: 3200 },
+      requestsPerSecond: { mean: 12.4 },
+      outputTokensPerSecond: { mean: 1580 },
+      inputTokensPerSecond: { mean: 12700 },
+      totalTokensPerSecond: { mean: 14280 },
+      concurrency: { mean: 8.2, max: 12 },
+      requests: { total: 1000, success: 998, error: 1, incomplete: 1 },
+    };
+
+    it("accepts a fully-populated metrics summary", () => {
+      expect(() => BenchmarkMetricsSummarySchema.parse(validMetrics)).not.toThrow();
+    });
+
+    it("rejects a missing ttft.p99", () => {
+      const broken = { ...validMetrics, ttft: { mean: 120, p50: 110, p95: 200 } };
+      expect(() => BenchmarkMetricsSummarySchema.parse(broken)).toThrow();
+    });
+  });
+
+  describe("BenchmarkRunSummarySchema and BenchmarkRunSchema", () => {
+    const summary = {
+      id: "ckxxx",
+      userId: "uxxx",
+      name: "run-1",
+      profile: "throughput" as const,
+      apiType: "chat" as const,
+      apiUrl: "http://vllm:8000/v1",
+      model: "facebook/opt-125m",
+      datasetName: "random" as const,
+      state: "completed" as const,
+      progress: 1,
+      metricsSummary: null,
+      createdAt: "2026-04-25T00:00:00.000Z",
+      startedAt: "2026-04-25T00:00:01.000Z",
+      completedAt: "2026-04-25T00:05:00.000Z",
+    };
+
+    it("BenchmarkRunSummarySchema accepts a minimal completed summary", () => {
+      expect(() => BenchmarkRunSummarySchema.parse(summary)).not.toThrow();
+    });
+
+    it("BenchmarkRunSchema requires the full set of fields", () => {
+      const full = {
+        ...summary,
+        description: null,
+        datasetInputTokens: 1024,
+        datasetOutputTokens: 128,
+        datasetSeed: null,
+        requestRate: 0,
+        totalRequests: 1000,
+        stateMessage: null,
+        jobName: "benchmark-ckxxx",
+        rawMetrics: null,
+        logs: null,
+      };
+      expect(() => BenchmarkRunSchema.parse(full)).not.toThrow();
+    });
+  });
+
+  describe("ListBenchmarksQuerySchema", () => {
+    it("applies the default limit", () => {
+      const q = ListBenchmarksQuerySchema.parse({});
+      expect(q.limit).toBe(20);
+    });
+
+    it("coerces limit from a string", () => {
+      const q = ListBenchmarksQuerySchema.parse({ limit: "50" });
+      expect(q.limit).toBe(50);
+    });
+
+    it("rejects limit > 100", () => {
+      expect(() => ListBenchmarksQuerySchema.parse({ limit: 101 })).toThrow();
+    });
+
+    it("accepts a state filter", () => {
+      const q = ListBenchmarksQuerySchema.parse({ state: "running" });
+      expect(q.state).toBe("running");
+    });
+
+    it("rejects an unknown state filter", () => {
+      expect(() => ListBenchmarksQuerySchema.parse({ state: "weird" })).toThrow();
+    });
+  });
+
+  describe("ListBenchmarksResponseSchema", () => {
+    it("accepts an empty list with null cursor", () => {
+      expect(() => ListBenchmarksResponseSchema.parse({ items: [], nextCursor: null })).not.toThrow();
+    });
+  });
+
+  describe("internal callback schemas", () => {
+    it("BenchmarkStateCallbackSchema accepts running with no extras", () => {
+      const cb = BenchmarkStateCallbackSchema.parse({ state: "running" });
+      expect(cb.state).toBe("running");
+    });
+
+    it("BenchmarkStateCallbackSchema rejects progress > 1", () => {
+      expect(() => BenchmarkStateCallbackSchema.parse({ state: "running", progress: 1.5 })).toThrow();
+    });
+
+    it("BenchmarkMetricsCallbackSchema requires metricsSummary", () => {
+      expect(() => BenchmarkMetricsCallbackSchema.parse({ rawMetrics: {} })).toThrow();
+    });
+  });
+});
+```
+
+- [ ] **Step 5.2: Run the test file and verify it fails**
+
+```bash
+pnpm -F @modeldoctor/contracts test
+```
+Expected: every test fails with a module-not-found error pointing at `./benchmark.js`.
+
+- [ ] **Step 5.3: Implement the schemas**
+
+Create `packages/contracts/src/benchmark.ts`:
+
+```typescript
+import { z } from "zod";
+
+// ============================================================
+// Enums
+// ============================================================
+
+export const BenchmarkApiTypeSchema = z.enum(["chat", "completion"]);
+export type BenchmarkApiType = z.infer<typeof BenchmarkApiTypeSchema>;
+
+export const BenchmarkProfileSchema = z.enum([
+  "throughput",
+  "latency",
+  "long_context",
+  "generation_heavy",
+  "sharegpt",
+  "custom",
+]);
+export type BenchmarkProfile = z.infer<typeof BenchmarkProfileSchema>;
+
+export const BenchmarkDatasetSchema = z.enum(["random", "sharegpt"]);
+export type BenchmarkDataset = z.infer<typeof BenchmarkDatasetSchema>;
+
+export const BenchmarkStateSchema = z.enum([
+  "pending",
+  "submitted",
+  "running",
+  "completed",
+  "failed",
+  "canceled",
+]);
+export type BenchmarkState = z.infer<typeof BenchmarkStateSchema>;
+
+// ============================================================
+// Metrics
+// ============================================================
+
+export const LatencyDistributionSchema = z.object({
+  mean: z.number(),
+  p50: z.number(),
+  p95: z.number(),
+  p99: z.number(),
+});
+export type LatencyDistribution = z.infer<typeof LatencyDistributionSchema>;
+
+export const BenchmarkMetricsSummarySchema = z.object({
+  ttft: LatencyDistributionSchema,
+  itl: LatencyDistributionSchema,
+  e2eLatency: LatencyDistributionSchema,
+  requestsPerSecond: z.object({ mean: z.number() }),
+  outputTokensPerSecond: z.object({ mean: z.number() }),
+  inputTokensPerSecond: z.object({ mean: z.number() }),
+  totalTokensPerSecond: z.object({ mean: z.number() }),
+  concurrency: z.object({ mean: z.number(), max: z.number() }),
+  requests: z.object({
+    total: z.number().int(),
+    success: z.number().int(),
+    error: z.number().int(),
+    incomplete: z.number().int(),
+  }),
+});
+export type BenchmarkMetricsSummary = z.infer<typeof BenchmarkMetricsSummarySchema>;
+
+// ============================================================
+// Create request (POST /api/benchmarks body)
+// ============================================================
+
+export const CreateBenchmarkRequestSchema = z
+  .object({
+    name: z.string().min(1).max(128),
+    description: z.string().max(2048).optional(),
+    profile: BenchmarkProfileSchema,
+    apiType: BenchmarkApiTypeSchema,
+    apiUrl: z.string().url(),
+    apiKey: z.string().min(1),
+    model: z.string().min(1),
+    datasetName: BenchmarkDatasetSchema,
+    datasetInputTokens: z.number().int().min(1).optional(),
+    datasetOutputTokens: z.number().int().min(1).optional(),
+    datasetSeed: z.number().int().optional(),
+    requestRate: z.number().int().min(0).default(0),
+    totalRequests: z.number().int().min(1).max(100_000).default(1000),
+  })
+  .superRefine((data, ctx) => {
+    if (data.datasetName === "random") {
+      if (data.datasetInputTokens === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["datasetInputTokens"],
+          message: "Required when datasetName is 'random'",
+        });
+      }
+      if (data.datasetOutputTokens === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["datasetOutputTokens"],
+          message: "Required when datasetName is 'random'",
+        });
+      }
+    }
+  });
+export type CreateBenchmarkRequest = z.infer<typeof CreateBenchmarkRequestSchema>;
+
+// ============================================================
+// Read responses
+// ============================================================
+
+export const BenchmarkRunSummarySchema = z.object({
+  id: z.string(),
+  userId: z.string().nullable(),
+  name: z.string(),
+  profile: BenchmarkProfileSchema,
+  apiType: BenchmarkApiTypeSchema,
+  apiUrl: z.string(),
+  model: z.string(),
+  datasetName: BenchmarkDatasetSchema,
+  state: BenchmarkStateSchema,
+  progress: z.number().nullable(),
+  metricsSummary: BenchmarkMetricsSummarySchema.nullable(),
+  createdAt: z.string(), // ISO 8601
+  startedAt: z.string().nullable(),
+  completedAt: z.string().nullable(),
+});
+export type BenchmarkRunSummary = z.infer<typeof BenchmarkRunSummarySchema>;
+
+export const BenchmarkRunSchema = BenchmarkRunSummarySchema.extend({
+  description: z.string().nullable(),
+  datasetInputTokens: z.number().int().nullable(),
+  datasetOutputTokens: z.number().int().nullable(),
+  datasetSeed: z.number().int().nullable(),
+  requestRate: z.number().int(),
+  totalRequests: z.number().int(),
+  stateMessage: z.string().nullable(),
+  jobName: z.string().nullable(),
+  rawMetrics: z.unknown().nullable(),
+  logs: z.string().nullable(),
+});
+export type BenchmarkRun = z.infer<typeof BenchmarkRunSchema>;
+
+export const ListBenchmarksQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  cursor: z.string().optional(),
+  state: BenchmarkStateSchema.optional(),
+  profile: BenchmarkProfileSchema.optional(),
+  search: z.string().optional(),
+});
+export type ListBenchmarksQuery = z.infer<typeof ListBenchmarksQuerySchema>;
+
+export const ListBenchmarksResponseSchema = z.object({
+  items: z.array(BenchmarkRunSummarySchema),
+  nextCursor: z.string().nullable(),
+});
+export type ListBenchmarksResponse = z.infer<typeof ListBenchmarksResponseSchema>;
+
+// ============================================================
+// Internal callback schemas (runner pod → API)
+// ============================================================
+
+export const BenchmarkStateCallbackSchema = z.object({
+  state: BenchmarkStateSchema,
+  stateMessage: z.string().max(2048).optional(),
+  progress: z.number().min(0).max(1).optional(),
+});
+export type BenchmarkStateCallback = z.infer<typeof BenchmarkStateCallbackSchema>;
+
+export const BenchmarkMetricsCallbackSchema = z.object({
+  metricsSummary: BenchmarkMetricsSummarySchema,
+  rawMetrics: z.unknown(),
+  logs: z.string().optional(),
+});
+export type BenchmarkMetricsCallback = z.infer<typeof BenchmarkMetricsCallbackSchema>;
+```
+
+- [ ] **Step 5.4: Re-export from the package barrel**
+
+Open `packages/contracts/src/index.ts`. Append:
+
+```typescript
+export * from "./benchmark.js";
+```
+
+- [ ] **Step 5.5: Run the contracts tests and verify they pass**
+
+```bash
+pnpm -F @modeldoctor/contracts test
+```
+Expected: all tests in `benchmark.spec.ts` pass.
+
+- [ ] **Step 5.6: Run type-check across the workspace**
+
+```bash
+pnpm -r type-check
+```
+Expected: every package green. The barrel re-export is compile-checked here.
+
+- [ ] **Step 5.7: Commit**
+
+```bash
+git add packages/contracts/src/benchmark.ts packages/contracts/src/benchmark.spec.ts packages/contracts/src/index.ts
+git commit -m "$(cat <<'EOF'
+feat(contracts): add benchmark Zod schemas
+
+Wire-format authority for the upcoming benchmark feature: enums for
+api-type / profile / dataset / state, the metrics summary shape, the
+create-request body (with random-dataset conditional validation), the
+list/detail response shapes, and the two internal runner callback
+shapes used in Phase 3. Both API and web import from here.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: `BenchmarkExecutionDriver` interface
+
+**Files:**
+- Create: `apps/api/src/modules/benchmark/drivers/execution-driver.interface.ts`
+- Create: `apps/api/src/modules/benchmark/drivers/execution-driver.interface.spec.ts`
+
+The interface is pure TypeScript — there is no runtime to test. The "test" is a type-level assertion: a noop class implements the interface and the file compiles. Phase 3 supplies the real implementations.
+
+- [ ] **Step 6.1: Write the interface contract test**
+
+Create `apps/api/src/modules/benchmark/drivers/execution-driver.interface.spec.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import type {
+  BenchmarkExecutionContext,
+  BenchmarkExecutionDriver,
+  BenchmarkExecutionHandle,
+} from "./execution-driver.interface.js";
+
+// Compile-time assertion that the interface shape is what consumers expect.
+// This file's primary value is the type-check: if a Phase 3 PR breaks the
+// interface, this spec stops compiling.
+class NoopDriver implements BenchmarkExecutionDriver {
+  async start(_ctx: BenchmarkExecutionContext): Promise<{ handle: BenchmarkExecutionHandle }> {
+    return { handle: "noop:0" };
+  }
+  async cancel(_handle: BenchmarkExecutionHandle): Promise<void> {
+    /* no-op */
+  }
+  async cleanup(_handle: BenchmarkExecutionHandle): Promise<void> {
+    /* no-op */
+  }
+}
+
+describe("BenchmarkExecutionDriver interface", () => {
+  it("is implementable by a noop driver", async () => {
+    const d: BenchmarkExecutionDriver = new NoopDriver();
+    const { handle } = await d.start({
+      benchmarkId: "ckxxx",
+      profile: "throughput",
+      apiType: "chat",
+      apiUrl: "http://target",
+      apiKey: "sk-test",
+      model: "facebook/opt-125m",
+      datasetName: "random",
+      datasetInputTokens: 1024,
+      datasetOutputTokens: 128,
+      requestRate: 0,
+      totalRequests: 1000,
+      maxDurationSeconds: 1800,
+      callbackUrl: "http://api:3001",
+      callbackToken: "hmac-token",
+    });
+    expect(handle).toBe("noop:0");
+    await expect(d.cancel(handle)).resolves.toBeUndefined();
+    await expect(d.cleanup(handle)).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 6.2: Run the test and verify it fails**
+
+```bash
+pnpm -F @modeldoctor/api test -- execution-driver.interface.spec
+```
+Expected: failure on `module not found './execution-driver.interface.js'`.
+
+- [ ] **Step 6.3: Create the interface file**
+
+Create `apps/api/src/modules/benchmark/drivers/execution-driver.interface.ts`:
+
+```typescript
+import type { BenchmarkApiType, BenchmarkDataset, BenchmarkProfile } from "@modeldoctor/contracts";
+
+/**
+ * Per-run input passed to a driver. Sensitive values (decrypted apiKey,
+ * HMAC callback token) are passed by value; the driver is responsible for
+ * propagating them to the runner via env or k8s Secret without leaking to
+ * logs or process listings.
+ */
+export interface BenchmarkExecutionContext {
+  benchmarkId: string;
+  profile: BenchmarkProfile;
+
+  // Target endpoint
+  apiType: BenchmarkApiType;
+  apiUrl: string;
+  apiKey: string;
+  model: string;
+
+  // Workload
+  datasetName: BenchmarkDataset;
+  datasetInputTokens?: number;
+  datasetOutputTokens?: number;
+  datasetSeed?: number;
+  requestRate: number;
+  totalRequests: number;
+  maxDurationSeconds: number;
+
+  // Callback
+  callbackUrl: string;
+  callbackToken: string;
+}
+
+/**
+ * Opaque handle to an in-flight execution. SubprocessDriver uses
+ * "subprocess:<pid>"; K8sJobDriver uses "<namespace>/<jobName>".
+ * The service stores this on BenchmarkRun.jobName for cancel/cleanup.
+ */
+export type BenchmarkExecutionHandle = string;
+
+export interface BenchmarkExecutionDriver {
+  /**
+   * Start an execution. Resolves once the runner is launched (process spawned
+   * or Job created), NOT when the benchmark finishes. Lifecycle progression
+   * after start() is reported by the runner via HTTP callbacks.
+   */
+  start(ctx: BenchmarkExecutionContext): Promise<{ handle: BenchmarkExecutionHandle }>;
+
+  /** Stop an in-flight execution. Idempotent. */
+  cancel(handle: BenchmarkExecutionHandle): Promise<void>;
+
+  /**
+   * Release driver-side resources (subprocess wait, K8s Job delete) after
+   * a run reaches a terminal state. Idempotent — safe to call multiple
+   * times or on a handle whose underlying execution is already gone.
+   */
+  cleanup(handle: BenchmarkExecutionHandle): Promise<void>;
+}
+```
+
+- [ ] **Step 6.4: Run the test and verify it passes**
+
+```bash
+pnpm -F @modeldoctor/api test -- execution-driver.interface.spec
+```
+Expected: the test passes.
+
+- [ ] **Step 6.5: Run a workspace type-check**
+
+```bash
+pnpm -r type-check
+```
+Expected: green. The cross-package import (`@modeldoctor/contracts` → API) is exercised here.
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add apps/api/src/modules/benchmark/
+git commit -m "$(cat <<'EOF'
+feat(api/benchmark): define BenchmarkExecutionDriver interface
+
+Pluggable execution backend contract used by both K8sJobDriver
+(production) and SubprocessDriver (local dev). Driver is responsible
+for launching the runner and propagating sensitive context (decrypted
+apiKey, HMAC callback token); lifecycle progression after start() is
+reported back via HTTP callback, not polled by the driver.
+
+Phase 3 adds the two implementations.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Phase 1 final verification
+
+No new files; this task confirms the workspace is green and prepares the branch for PR.
+
+- [ ] **Step 7.1: Run all tests across the workspace**
+
+```bash
+pnpm -r test
+```
+Expected: every package green. The total test count should have grown by:
+- `apps/api`: ~7 (env) + ~12 (aes-gcm) + ~1 (driver interface) ≈ 20 new tests
+- `packages/contracts`: ~25 new tests
+
+If anything is red, fix it before opening the PR.
+
+- [ ] **Step 7.2: Run type-check across the workspace**
+
+```bash
+pnpm -r type-check
+```
+Expected: green.
+
+- [ ] **Step 7.3: Run lint across the workspace**
+
+```bash
+pnpm -r lint
+```
+Expected: green. If Biome flags formatting issues, run `pnpm -r format` and amend the relevant commit (or, if the changes touch multiple commits, follow up with one `style:` commit covering all auto-fixes).
+
+- [ ] **Step 7.4: Inspect the commit graph**
+
+```bash
+git log --oneline -6
+```
+Expected: the most recent 6 commits are the Phase 1 commits, in this order, all on `feat/benchmark-phase-1`:
+1. `feat(db): add benchmark_runs table`
+2. `feat(api/config): accept BENCHMARK_API_KEY_ENCRYPTION_KEY env var`
+3. `feat(api/config): accept BENCHMARK_CALLBACK_SECRET env var`
+4. `feat(api/crypto): add AES-256-GCM encrypt/decrypt helper`
+5. `feat(contracts): add benchmark Zod schemas`
+6. `feat(api/benchmark): define BenchmarkExecutionDriver interface`
+
+If the order is different or commits are missing, do **not** rewrite history — just verify nothing is broken and proceed. Commit ordering only matters for review readability.
+
+- [ ] **Step 7.5: Push the branch and open the PR**
+
+```bash
+git push -u origin feat/benchmark-phase-1
+```
+
+Then open the PR via `gh pr create`:
+
+Set the PR base to whatever branch you cut from in Step 0.4 (e.g. `--base main` if cut from main, `--base feat/restructure` if cut from there):
+
+```bash
+gh pr create --base <integration-branch> --title "feat(benchmark): phase 1 — data model + contracts + crypto" --body "$(cat <<'EOF'
+## Summary
+- New `benchmark_runs` Prisma table (additive migration; no changes to existing tables).
+- Full Zod contract surface in `packages/contracts/src/benchmark.ts` (enums, create request, list/detail responses, internal callbacks).
+- AES-256-GCM helper at `apps/api/src/common/crypto/aes-gcm.ts` for at-rest encryption of user-supplied API keys.
+- `BenchmarkExecutionDriver` interface (Phase 3 supplies impls).
+- Two new optional env vars: `BENCHMARK_API_KEY_ENCRYPTION_KEY`, `BENCHMARK_CALLBACK_SECRET`.
+
+Nothing is wired up — no controller, no service, no UI. Phase 4 imports the contracts; Phase 3 imports the crypto helper and the driver interface; Phase 5 imports the contracts on the web side.
+
+Spec: `docs/superpowers/specs/2026-04-25-benchmark-design.md`.
+
+## Test plan
+- [ ] `pnpm -r type-check` green
+- [ ] `pnpm -r test` green
+- [ ] `pnpm -r lint` green
+- [ ] `git log --oneline main..HEAD` shows 6 commits with `feat:` prefixes
+- [ ] Migration SQL hand-inspected for additive-only changes
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: the PR URL is returned. Wait for CI to finish before merging.
+
+---
+
+## Phase 1 Done When
+
+- Branch `feat/benchmark-phase-1` exists with 6 commits as above.
+- `pnpm -r test`, `pnpm -r type-check`, `pnpm -r lint` all green.
+- Prisma `db:migrate:dev` applied cleanly (no drift, no reset prompt).
+- A PR is open and CI is green.
+
+Phase 2 (`feat/benchmark-phase-2-runner`) builds the Python `apps/benchmark-runner/` image and is independent of this PR — it can be developed in parallel.

--- a/docs/superpowers/specs/2026-04-25-benchmark-design.md
+++ b/docs/superpowers/specs/2026-04-25-benchmark-design.md
@@ -24,7 +24,7 @@ A new `Benchmark` feature, end-to-end:
 - **API surface**: NestJS `BenchmarkModule` with create / list / detail / cancel / delete + an internal HMAC-authenticated callback endpoint for the runner pod to report state and metrics.
 - **Execution**: each benchmark run launches a one-shot Kubernetes Job in the same cluster the API runs in. The Job pulls `modeldoctor/benchmark-runner:<tag>`, executes guidellm against the user-supplied OpenAI-compatible endpoint, and POSTs results back to the API.
 - **Runner image**: a Python 3.11-slim image at `apps/benchmark-runner/`, ~50-line Python entrypoint that translates env vars into a guidellm CLI invocation and reports lifecycle + metrics back to the API.
-- **Driver abstraction**: a `BenchmarkExecutionDriver` interface with one production implementation (`K8sJobDriver`) and a concrete plan to add `SubprocessDriver` later if local-without-K8s dev becomes painful.
+- **Driver abstraction**: a `BenchmarkExecutionDriver` interface with two implementations — `K8sJobDriver` (production) and `SubprocessDriver` (local development without K8s). Selected at startup via `BENCHMARK_DRIVER=k8s|subprocess`.
 - **Web UI**: a `Benchmarks` page mirroring GPUStack's two-tab modal (基本信息 / 配置), a list view with status badges + filters, a detail page with the full metrics table and runtime logs, and 5 named profile presets (Throughput, Latency, Long Context, Generation Heavy, ShareGPT).
 - **K8s integration**: ServiceAccount, RBAC (Role + RoleBinding restricted to `batch/v1/jobs` in one namespace), `@kubernetes/client-node` wired into the API.
 
@@ -134,11 +134,11 @@ A throughput-tuned config has bad latency; a latency-tuned config has bad throug
 - **runner pod → api**: HMAC token, generated per run, embedded as env var, validated by `HmacCallbackGuard`. Token is a short HMAC-SHA256 of `(benchmark_id, exp)` signed with `BENCHMARK_CALLBACK_SECRET` (env var on the API). TTL = `max_duration + 15 min` slack.
 - **runner pod → user target endpoint**: standard HTTP. The user-supplied API key flows from the form → DB (encrypted at rest, see §6) → Job env var → guidellm `--api-key`. Secret never logged.
 
-### 2.3 Why K8s Job, Not Subprocess
+### 2.3 Why K8s Job in MVP (and SubprocessDriver alongside it)
 
-The end state is K8s. Building subprocess first would force ~30–40 % of the execution layer to be rewritten when migrating: Job creation API, lifecycle tracking (`pid` → `jobName`), cancellation (`SIGTERM` → `delete job`), result retrieval (file → HTTP callback), error handling (exit code → pod terminated state). The Prisma schema, contracts, controllers, and UI carry over but the interesting surface area churns. Driving the design from K8s Day 1 is cheaper.
+The end state is K8s. Building subprocess-only first would force ~30–40 % of the execution layer to be rewritten when migrating: Job creation API, lifecycle tracking (`pid` → `jobName`), cancellation (`SIGTERM` → `delete job`), result retrieval (file → HTTP callback), error handling (exit code → pod terminated state). The Prisma schema, contracts, controllers, and UI carry over but the interesting surface area churns. Driving the design from K8s Day 1 is cheaper than a subprocess-then-K8s migration.
 
-For local dev without K8s, a `SubprocessDriver` can be added behind the same interface in a follow-up. Anyone with `kubectl` access to 4pd (the user's setup) can develop directly against it.
+`SubprocessDriver` is *not* a transitional crutch — it ships in MVP and stays, because day-to-day development should not require a K8s cluster. The `BenchmarkExecutionDriver` interface forces both implementations to be honest: the same callback flow, the same env-var contract, the same lifecycle. K8s validation happens against a local k3d/kind cluster (fast iteration) or 4pd staging (final validation). See §13 for workflows.
 
 ## 3. Domain Model
 
@@ -426,13 +426,17 @@ Each phase is one PR from `feat/benchmark-phase-<N>` cut from `main`. Same conve
 - `docker run --rm -e ... modeldoctor/benchmark-runner:dev` smoke test against a tiny OpenAI stub.
 - **Output**: pushable runner image, callable manually.
 
-### Phase 3 — K8sJobDriver + callback API
-- `K8sJobDriver` using `@kubernetes/client-node`.
+### Phase 3 — Drivers + callback API
+- `BenchmarkExecutionDriver` interface (`apps/api/src/modules/benchmark/drivers/`).
+- `SubprocessDriver` — `child_process.spawn("guidellm", [...])`, mirrors LoadTest's vegeta pattern. Used for local dev (workflow A) and CI runner-integration tests.
+- `K8sJobDriver` using `@kubernetes/client-node` — Job manifest with env, labels, resource limits, `ttlSecondsAfterFinished`, ServiceAccount.
+- Driver selection via `BENCHMARK_DRIVER=k8s|subprocess` env var; default `subprocess` in dev, `k8s` in production.
 - `/api/internal/benchmarks/:id/{state,metrics}` controller + `HmacCallbackGuard`.
 - `BenchmarkReconciler` with `@nestjs/schedule`.
 - ServiceAccount + Role + RoleBinding YAML in `deploy/k8s/rbac.yaml` (only what the API needs to manage Jobs).
-- Local dev path: `kubectl apply` the RBAC, run API with `~/.kube/config`, run a benchmark, see the Job appear and finish, see metrics appear in the DB.
-- **Output**: end-to-end flow without a UI.
+- Subprocess dev path: `pip install guidellm` on the dev machine, `BENCHMARK_DRIVER=subprocess pnpm dev`, run a benchmark, see metrics in the DB.
+- K8s dev path: `k3d cluster create modeldoctor`, `k3d image import modeldoctor/benchmark-runner:dev`, `kubectl apply -f deploy/k8s/rbac.yaml`, `BENCHMARK_DRIVER=k8s pnpm dev`, run a benchmark, see the Job appear and finish.
+- **Output**: end-to-end flow on both drivers without a UI.
 
 ### Phase 4 — User-facing CRUD API
 - `BenchmarkController`, `BenchmarkService`.
@@ -452,8 +456,8 @@ Each phase is one PR from `feat/benchmark-phase-<N>` cut from `main`. Same conve
 ### Phase 6 — Hardening (optional follow-up)
 - E2E test in CI hitting 4pd.
 - ShareGPT support: download dataset on Job startup with init container, runner wires `--data /data/sharegpt.json`.
-- `SubprocessDriver` fallback for local-without-K8s dev.
 - Live-tail logs (SSE).
+- Application-level concurrent-job cap.
 
 Phases 1–5 are MVP. Phase 6 is post-MVP.
 
@@ -475,5 +479,86 @@ Phases 1–5 are MVP. Phase 6 is post-MVP.
 - **Decode** — the inference phase that emits output tokens; bounded by memory bandwidth.
 - **guidellm** — Neural Magic / vLLM-team OSS LLM benchmarking CLI; the execution engine here.
 - **Profile** — a named workload preset (Throughput / Latency / etc.).
-- **Driver** — pluggable execution backend (`K8sJobDriver`, future `SubprocessDriver`).
+- **Driver** — pluggable execution backend; `K8sJobDriver` (production) and `SubprocessDriver` (local dev) both ship in MVP.
 - **HMAC token** — per-run callback credential; `HMAC_SHA256(secret, "<id>.<exp>")`.
+
+## 13. Development Workflows
+
+Three modes, chosen by what you're working on. Day-to-day dev never touches K8s.
+
+### 13.1 Workflow A — Local subprocess (default, ~90% of dev)
+
+Use for: UI, contracts, controllers, services, runner image (when iterating without K8s), unit tests.
+
+One-time setup:
+```bash
+pipx install guidellm    # or: pip install --user guidellm
+```
+
+Run:
+```bash
+# .env.local
+BENCHMARK_DRIVER=subprocess
+BENCHMARK_CALLBACK_URL=http://localhost:3001
+BENCHMARK_CALLBACK_SECRET=<32-bytes-base64>
+BENCHMARK_API_KEY_ENCRYPTION_KEY=<32-bytes-base64>
+
+pnpm dev   # web on :5173, api on :3001
+```
+
+Submit a benchmark from the UI → `BenchmarkService` calls `SubprocessDriver.start()` → `child_process.spawn("guidellm", [...])` → guidellm runs against the user-supplied target → runner posts callback to `http://localhost:3001/api/internal/...` → metrics in DB.
+
+No K8s, no Docker, no tunnel. Logs go to the same terminal as the API.
+
+### 13.2 Workflow B — Local k3d / kind (K8s-driver iteration)
+
+Use for: changing `K8sJobDriver`, Job manifest, RBAC, runner image's K8s integration. Faster than deploying to 4pd.
+
+One-time setup:
+```bash
+brew install k3d                                              # or: brew install kind
+k3d cluster create modeldoctor                                # or: kind create cluster --name modeldoctor
+kubectl apply -f deploy/k8s/rbac.yaml
+kubectl create namespace modeldoctor-benchmarks
+```
+
+Per-iteration:
+```bash
+docker build -t modeldoctor/benchmark-runner:dev apps/benchmark-runner/
+k3d image import modeldoctor/benchmark-runner:dev -c modeldoctor
+# (or for kind: kind load docker-image modeldoctor/benchmark-runner:dev --name modeldoctor)
+```
+
+Run:
+```bash
+# .env.local
+BENCHMARK_DRIVER=k8s
+BENCHMARK_K8S_NAMESPACE=modeldoctor-benchmarks
+BENCHMARK_RUNNER_IMAGE=modeldoctor/benchmark-runner:dev
+BENCHMARK_CALLBACK_URL=http://host.k3d.internal:3001          # k3d
+# BENCHMARK_CALLBACK_URL=http://host.docker.internal:3001     # kind on Docker Desktop
+KUBECONFIG=~/.kube/config                                     # current-context = k3d-modeldoctor
+
+pnpm dev
+```
+
+`host.k3d.internal` / `host.docker.internal` is how a pod inside the local cluster reaches the dev machine's `localhost:3001`. No tunnel needed.
+
+### 13.3 Workflow C — 4pd staging namespace (final validation)
+
+Use for: pre-PR validation of K8s code, validating real RBAC against 4pd's API server, validating image pull from the company registry, occasional smoke tests.
+
+One-time setup (per dev): a dedicated staging namespace and the API deployed there. Out of scope for this spec — plain `kubectl apply` of standard Deployment / Service / Secret manifests.
+
+Per-iteration: build → push → `kubectl rollout restart deployment/modeldoctor-api -n modeldoctor-staging`. Slower (~2–3 min per cycle), so reserved for final validation, not active iteration.
+
+### 13.4 Mode selection cheat sheet
+
+| What you're doing | Use |
+|---|---|
+| Writing UI components / contracts | A |
+| Adding a controller, service, validation | A |
+| Editing `runner.py` | A |
+| Editing `K8sJobDriver`, Job manifest, RBAC YAML | B |
+| Final pre-PR check on K8s code | C |
+| CI E2E (post-Phase 6) | C |

--- a/docs/superpowers/specs/2026-04-25-benchmark-design.md
+++ b/docs/superpowers/specs/2026-04-25-benchmark-design.md
@@ -1,0 +1,479 @@
+# Model Benchmark — guidellm Runner on K8s
+
+**Status:** Draft — pending user approval
+**Date:** 2026-04-25
+**Predecessors:**
+- Spec 1 (`2026-04-20-modeldoctor-restructure-design.md`) — frontend rewrite to Vite + React + TypeScript.
+- Spec 2 (`2026-04-22-nestjs-backend-refactor-design.md`) — NestJS + Prisma + auth + RBAC.
+
+This spec extends Spec 2's NestJS infrastructure with a new `Benchmark` feature module, a Python container image, and a Kubernetes-Job-based execution layer.
+
+## 1. Purpose and Scope
+
+### 1.1 Problem Statement
+
+ModelDoctor today ships **load testing** (Vegeta — pure HTTP) and **end-to-end smoke tests** (correctness). It does not measure **inference-layer performance**: token-level latencies (TTFT, ITL), token throughput, prefill vs decode behavior, or LLM-shaped metrics that buyers, capacity planners, and inference-engine tuners actually care about.
+
+Reference benchmark UX comes from GPUStack (`gpustack/benchmark-runner:v0.0.3`), which is itself a thin wrapper over **guidellm** — Neural Magic / vLLM team's de-facto-standard inference benchmarking CLI. Industry-standard metric definitions, profile semantics, and dataset conventions are guidellm's.
+
+### 1.2 What This Spec Delivers
+
+A new `Benchmark` feature, end-to-end:
+
+- **Domain model**: a single `BenchmarkRun` Prisma entity with full LLM-benchmark metric coverage (TTFT, ITL, output tokens/s, request throughput, success/error counts, percentiles).
+- **API surface**: NestJS `BenchmarkModule` with create / list / detail / cancel / delete + an internal HMAC-authenticated callback endpoint for the runner pod to report state and metrics.
+- **Execution**: each benchmark run launches a one-shot Kubernetes Job in the same cluster the API runs in. The Job pulls `modeldoctor/benchmark-runner:<tag>`, executes guidellm against the user-supplied OpenAI-compatible endpoint, and POSTs results back to the API.
+- **Runner image**: a Python 3.11-slim image at `apps/benchmark-runner/`, ~50-line Python entrypoint that translates env vars into a guidellm CLI invocation and reports lifecycle + metrics back to the API.
+- **Driver abstraction**: a `BenchmarkExecutionDriver` interface with one production implementation (`K8sJobDriver`) and a concrete plan to add `SubprocessDriver` later if local-without-K8s dev becomes painful.
+- **Web UI**: a `Benchmarks` page mirroring GPUStack's two-tab modal (基本信息 / 配置), a list view with status badges + filters, a detail page with the full metrics table and runtime logs, and 5 named profile presets (Throughput, Latency, Long Context, Generation Heavy, ShareGPT).
+- **K8s integration**: ServiceAccount, RBAC (Role + RoleBinding restricted to `batch/v1/jobs` in one namespace), `@kubernetes/client-node` wired into the API.
+
+### 1.3 Explicit Non-Goals
+
+- **No `Cluster` or `ModelInstance` Prisma entities.** GPUStack's benchmark form references a cluster + model-instance because GPUStack itself manages model deployments. ModelDoctor does not. Users supply `apiUrl + apiKey + model` directly, the same way LoadTest accepts them today. The "集群 / 模型实例" fields from the GPUStack screenshot are collapsed into a single endpoint section.
+- **No K8s deployment manifests for ModelDoctor itself.** The user already runs ModelDoctor in their 4pd cluster. This spec only ships the manifests *the API needs to create benchmark Jobs* (ServiceAccount + Role + RoleBinding for `batch/v1/jobs`); how the API/web/db pods themselves get deployed is out of scope.
+- **No ShareGPT bundled in the runner image.** The `ShareGPT` profile and `dataset=sharegpt` option in the schema are placeholders — the form lets the user pick them, but Phase 1 returns a validation error ("ShareGPT not yet supported"). Backfilled in a follow-up. This keeps the runner image small (~600 MB Python + guidellm vs ~1.2 GB with ShareGPT JSON).
+- **No SSE / WebSocket streaming.** Progress is polled by the web UI every 2s on the detail page. Real-time push deferred.
+- **No multi-cluster.** API uses in-cluster config and creates Jobs in its own cluster only.
+- **No `LoadTestRun` deprecation.** Load test (HTTP-layer) and benchmark (model-layer) coexist permanently. They answer different questions.
+- **No GPU access for runner pods.** Runner is a pure HTTP client; it does *not* request `nvidia.com/gpu`. All GPU work happens at the user-supplied target endpoint, which ModelDoctor doesn't manage.
+- **No live log streaming from the K8s pod.** stderr/stdout are captured by the runner wrapper, posted back in chunks via the callback API, and stored in the DB. The detail page polls these. Live `kubectl logs -f` style is out of scope.
+
+### 1.4 Background — What Is Being Measured
+
+LLM serving has two distinct phases that affect benchmark design:
+- **Prefill**: processing the input prompt; bounded by GPU compute and KV-cache memory; dominates Time-To-First-Token.
+- **Decode**: emitting output tokens one at a time; bounded by memory bandwidth; dominates Inter-Token Latency.
+
+Standard metrics:
+
+| Metric | What it measures | Why it matters |
+|---|---|---|
+| **TTFT** (Time To First Token) | ms from request sent → first token returned | "How long until the answer starts appearing?" |
+| **ITL** (Inter-Token Latency) | ms between consecutive output tokens | Streaming "typing speed" |
+| **TPOT** (Time Per Output Token) | mean per-token cost across the request | Same idea as ITL, mean form |
+| **E2E Latency** | full request duration | Total wait |
+| **Requests/sec** | completed requests per wall-clock second | Throughput in service-level units |
+| **Output tokens/sec** | output tokens emitted per second | Throughput in model-effort units |
+| **Concurrency mean / max** | in-flight request count | How parallel the load actually was |
+| **Success / Error / Incomplete** | completion buckets | Reliability under load |
+
+The five profiles each isolate a different concern:
+
+| Profile | Input tokens | Output tokens | Rate | Total req | What it stresses |
+|---|---|---|---|---|---|
+| **Throughput** | 1024 | 128 | unlimited | 1000 | Peak server capacity, batch behavior |
+| **Latency** | 128 | 128 | 1 req/s | 100 | Single-user response speed; SLA |
+| **Long Context** | 32 000 | 100 | 1 req/s | 100 | Prefill compute + KV-cache memory; RAG / long-document |
+| **Generation Heavy** | 1000 | 2000 | 1 req/s | 200 | Decode speed; code/long-form generation |
+| **ShareGPT** | (mixed real data) | (mixed) | (mixed) | 1000 | Realistic mixed traffic |
+
+A throughput-tuned config has bad latency; a latency-tuned config has bad throughput. Long Context tests prefill; Generation Heavy tests decode. Running multiple profiles is the point.
+
+## 2. Architecture
+
+### 2.1 Component Diagram
+
+```
+4pd Kubernetes cluster
+┌────────────────────────────────────────────────────────────────────┐
+│ namespace: modeldoctor                                             │
+│                                                                    │
+│   ┌────────────────────┐          ┌──────────────────────────┐     │
+│   │ modeldoctor-web    │  HTTP    │  modeldoctor-api          │    │
+│   │ (Vite SPA in nginx)│ ───────► │  (NestJS)                 │    │
+│   └────────────────────┘          │  ┌────────────────────┐  │    │
+│                                   │  │ BenchmarkController│  │    │
+│                                   │  │ BenchmarkService   │  │    │
+│                                   │  │ ┌───────────────┐  │  │    │
+│                                   │  │ │ K8sJobDriver  │──┼──┼──┐ │
+│                                   │  │ └───────────────┘  │  │  │ │
+│                                   │  │ HmacCallbackGuard  │  │  │ │
+│                                   │  └────────────────────┘  │  │ │
+│                                   │  uses ServiceAccount     │  │ │
+│                                   │  modeldoctor-api-sa      │  │ │
+│                                   └──────────┬───────────────┘  │ │
+│                                              │ Postgres          │ │
+│                                              ▼                   │ │
+│                                   ┌──────────────────────────┐   │ │
+│                                   │ Prisma → modeldoctor DB  │   │ │
+│                                   └──────────────────────────┘   │ │
+│                                                                  │ │
+│ namespace: modeldoctor-benchmarks                                │ │
+│   ┌──────────────────────────────────────────────────────────┐   │ │
+│   │ Job: benchmark-<runId>     (created by K8sJobDriver) ◄───┼───┘ │
+│   │  ┌────────────────────────────────────────────────────┐  │     │
+│   │  │ Pod: modeldoctor/benchmark-runner:<tag>           │  │     │
+│   │  │  - reads env: TARGET_URL, API_KEY, MODEL,          │  │     │
+│   │  │    PROFILE, PROMPT_TOKENS, OUTPUT_TOKENS, RATE,    │  │     │
+│   │  │    TOTAL_REQUESTS, CALLBACK_URL, CALLBACK_TOKEN,   │  │     │
+│   │  │    BENCHMARK_ID                                    │  │     │
+│   │  │  - python /app/runner.py                           │  │     │
+│   │  │  - spawns guidellm CLI                             │  │     │
+│   │  │  - POSTs progress + final metrics to               │  │     │
+│   │  │    http://modeldoctor-api.modeldoctor.svc:3001/    │  │     │
+│   │  │      api/internal/benchmarks/<id>/{state,metrics}  │──┼──┐  │
+│   │  └─────────────────────┬──────────────────────────────┘  │  │  │
+│   │  ttlSecondsAfterFinished: 3600                            │  │  │
+│   └────────────────────────┼─────────────────────────────────┘  │  │
+│                            │ HTTP (OpenAI compatible)            │  │
+│                            ▼                                     │  │
+│   ┌─────────────────────────────────────────────────────────┐    │  │
+│   │ User-supplied target endpoint                           │    │  │
+│   │ vLLM / SGLang / TGI / OpenAI / Anthropic / ...          │    │  │
+│   │ (in-cluster Service OR external URL)                    │    │  │
+│   └─────────────────────────────────────────────────────────┘    │  │
+│                                                                  │  │
+│   callback flow ◄─────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 Trust Boundaries
+
+- **api → K8s API server**: in-cluster ServiceAccount + RBAC. Permission: `create / get / list / watch / delete` on `batch/v1/jobs` and `get / list` on `core/v1/pods` (for failure debugging) restricted to namespace `modeldoctor-benchmarks`. No cluster-wide permissions.
+- **runner pod → api**: HMAC token, generated per run, embedded as env var, validated by `HmacCallbackGuard`. Token is a short HMAC-SHA256 of `(benchmark_id, exp)` signed with `BENCHMARK_CALLBACK_SECRET` (env var on the API). TTL = `max_duration + 15 min` slack.
+- **runner pod → user target endpoint**: standard HTTP. The user-supplied API key flows from the form → DB (encrypted at rest, see §6) → Job env var → guidellm `--api-key`. Secret never logged.
+
+### 2.3 Why K8s Job, Not Subprocess
+
+The end state is K8s. Building subprocess first would force ~30–40 % of the execution layer to be rewritten when migrating: Job creation API, lifecycle tracking (`pid` → `jobName`), cancellation (`SIGTERM` → `delete job`), result retrieval (file → HTTP callback), error handling (exit code → pod terminated state). The Prisma schema, contracts, controllers, and UI carry over but the interesting surface area churns. Driving the design from K8s Day 1 is cheaper.
+
+For local dev without K8s, a `SubprocessDriver` can be added behind the same interface in a follow-up. Anyone with `kubectl` access to 4pd (the user's setup) can develop directly against it.
+
+## 3. Domain Model
+
+### 3.1 Prisma Schema Addition
+
+```prisma
+model BenchmarkRun {
+  id           String    @id @default(cuid())
+  userId       String?   @map("user_id")
+
+  // Identification
+  name         String
+  description  String?   @db.Text
+  profile      String    @default("custom")        // "throughput" | "latency" | "long_context" | "generation_heavy" | "sharegpt" | "custom"
+
+  // Target
+  apiType      String    @map("api_type")          // BenchmarkApiType: "chat" | "completion" — narrower than LoadTest's ApiType
+  apiUrl       String    @map("api_url")
+  apiKeyCipher String    @map("api_key_cipher")    // AES-GCM ciphertext; see §6
+  model        String
+
+  // Workload config
+  datasetName        String  @default("random")    @map("dataset_name")  // "random" | "sharegpt"
+  datasetInputTokens Int?    @map("dataset_input_tokens")
+  datasetOutputTokens Int?   @map("dataset_output_tokens")
+  datasetSeed        Int?    @map("dataset_seed")
+  requestRate        Int     @default(0)           @map("request_rate")  // 0 = unlimited
+  totalRequests      Int     @default(1000)        @map("total_requests")
+
+  // Lifecycle
+  state        String    @default("pending")       // "pending" | "submitted" | "running" | "completed" | "failed" | "canceled"
+  stateMessage String?   @db.Text                  @map("state_message")
+  progress     Float?
+  jobName      String?   @map("job_name")          // K8s Job metadata.name; null until submitted
+
+  // Metrics (denormalized for list views; full report in rawMetrics)
+  metricsSummary Json?   @map("metrics_summary")
+  rawMetrics     Json?   @map("raw_metrics")
+  logs           String? @db.Text
+
+  createdAt    DateTime  @default(now())           @map("created_at")
+  startedAt    DateTime?                           @map("started_at")
+  completedAt  DateTime?                           @map("completed_at")
+
+  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  @@index([userId, createdAt])
+  @@index([state])
+  @@map("benchmark_runs")
+}
+```
+
+`metricsSummary` shape (also exposed as Zod schema in contracts):
+
+```ts
+{
+  ttft: { mean: number; p50: number; p95: number; p99: number };       // ms
+  itl:  { mean: number; p50: number; p95: number; p99: number };       // ms
+  e2eLatency: { mean: number; p50: number; p95: number; p99: number }; // ms
+  requestsPerSecond: { mean: number };
+  outputTokensPerSecond: { mean: number };
+  inputTokensPerSecond: { mean: number };
+  totalTokensPerSecond: { mean: number };
+  concurrency: { mean: number; max: number };
+  requests: { total: number; success: number; error: number; incomplete: number };
+}
+```
+
+`rawMetrics` is whatever JSON guidellm emits, stored verbatim for forensic / re-analysis use. List-view queries select `metricsSummary` only.
+
+### 3.2 User Scoping
+
+Same pattern as `LoadTestRun`: queries filter by `userId = currentUser.sub` unless `currentUser.roles.includes("admin")`. Anyone can create. Admins see all; users see their own. `delete` requires owner-or-admin.
+
+## 4. API Surface
+
+All routes are under `/api`, JWT-protected, and follow the contracts in `packages/contracts/src/benchmark.ts`. The benchmark domain defines its own `BenchmarkApiTypeSchema = z.enum(["chat", "completion"])` — a strict subset of LoadTest's `ApiTypeSchema`. Embeddings / rerank / image / vision / audio APIs do not have meaningful TTFT/ITL semantics and are not supported.
+
+### 4.1 User-Facing
+
+| Method | Route | Body / Query | Returns |
+|---|---|---|---|
+| `POST` | `/api/benchmarks` | `CreateBenchmarkRequest` (name, description, profile, target endpoint, dataset config, request rate, total requests) | `BenchmarkRun` (state=`pending`) — Job creation kicks off async |
+| `GET` | `/api/benchmarks` | `?limit&cursor&state&profile` | `{ items: BenchmarkRunSummary[], nextCursor }` |
+| `GET` | `/api/benchmarks/:id` | — | `BenchmarkRun` (full, including `rawMetrics` and `logs`) |
+| `POST` | `/api/benchmarks/:id/cancel` | — | `BenchmarkRun` (state=`canceled` if successful) |
+| `DELETE` | `/api/benchmarks/:id` | — | `204` |
+
+Profile presets are **client-side**: when the user picks "Throughput" in the modal, the form auto-fills `datasetInputTokens=1024, datasetOutputTokens=128, requestRate=0, totalRequests=1000`. Server stores whatever the user submitted (with the `profile` label as metadata for filtering). The user can still tweak fields after picking a profile — picking a profile is "load preset", not "lock to preset".
+
+### 4.2 Internal (Runner Callback)
+
+| Method | Route | Auth | Body |
+|---|---|---|---|
+| `POST` | `/api/internal/benchmarks/:id/state` | HMAC | `{ state: "running"|"completed"|"failed", stateMessage?, progress? }` |
+| `POST` | `/api/internal/benchmarks/:id/metrics` | HMAC | `{ metricsSummary, rawMetrics, logs }` |
+
+`HmacCallbackGuard` validates the `Authorization: Bearer <hmac-token>` header against the per-run secret derived as `HMAC_SHA256(BENCHMARK_CALLBACK_SECRET, "${id}.${exp}")`, with a constant-time compare and `exp` check. JWT global guard is bypassed via `@Public()` for these routes (the HMAC is the auth).
+
+### 4.3 Validation
+
+- `profile` must be one of the 5 known presets or `"custom"`.
+- For `datasetName=random`: both `datasetInputTokens` and `datasetOutputTokens` required, both ≥ 1.
+- For `datasetName=sharegpt`: returns 400 in Phase 1 with `code=BENCHMARK_DATASET_UNSUPPORTED`.
+- `requestRate` ≥ 0 (0 = unlimited).
+- `totalRequests` between 1 and 100 000.
+- `apiUrl` must be a valid URL; `model` non-empty; `apiKey` non-empty.
+- `name` 1–128 chars, unique per user (soft enforced at controller — DB `@@unique([userId, name])` is too strict for re-runs; we only block within active state in service).
+
+## 5. Runner Image
+
+### 5.1 Layout
+
+```
+apps/benchmark-runner/
+├── Dockerfile
+├── pyproject.toml          # guidellm pin, requests, pydantic
+├── runner.py               # entrypoint
+└── tests/
+    └── test_runner.py      # unit tests, mocks guidellm subprocess and callback HTTP
+```
+
+### 5.2 `runner.py` Behavior
+
+```
+1. Read env: BENCHMARK_ID, CALLBACK_URL, CALLBACK_TOKEN,
+             TARGET_URL, API_KEY, MODEL, API_TYPE,
+             DATASET_NAME, PROMPT_TOKENS, OUTPUT_TOKENS, SEED,
+             REQUEST_RATE, TOTAL_REQUESTS, MAX_DURATION_SECONDS
+2. POST {state: "running"} to CALLBACK_URL/state
+3. Build guidellm CLI:
+   - If $REQUEST_RATE > 0: --rate-type=constant --rate=$REQUEST_RATE
+   - If $REQUEST_RATE == 0: --rate-type=throughput  (guidellm pushes as fast as possible; --rate omitted)
+
+   guidellm benchmark \
+     --target $TARGET_URL \
+     --model $MODEL \
+     <rate flags as above> \
+     --max-requests $TOTAL_REQUESTS \
+     --max-seconds $MAX_DURATION_SECONDS \
+     --data prompt_tokens=$PROMPT_TOKENS,output_tokens=$OUTPUT_TOKENS \
+     --output-path /tmp/report.json
+4. Spawn guidellm subprocess; tee stdout/stderr to memory buffer.
+5. Wait for exit. On non-zero exit:
+   - POST {state: "failed", stateMessage: "<last 1024 chars of stderr>"}
+   - POST /metrics with empty summary + logs
+   - exit 1
+6. Parse /tmp/report.json → metricsSummary (mapping in §5.3).
+7. POST /metrics with metricsSummary + rawMetrics + logs.
+8. POST {state: "completed", progress: 1.0}
+9. exit 0
+```
+
+### 5.3 guidellm JSON → metricsSummary Mapping
+
+guidellm's output schema (per its 0.4.x docs) provides:
+- `time_to_first_token_ms` (mean / median / p95 / p99) → `ttft.{mean,p50,p95,p99}`
+- `inter_token_latency_ms` → `itl.*`
+- `request_latency_ms` → `e2eLatency.*`
+- `requests_per_second` → `requestsPerSecond.mean`
+- `output_tokens_per_second`, `prompt_tokens_per_second`, `tokens_per_second` → respective fields
+- `request_concurrency.{mean,max}` → `concurrency.{mean,max}`
+- `summary.{requests, errors, incomplete}` → `requests.*`
+
+If guidellm releases a breaking schema change, the runner image is the only place to fix it (the API stores `rawMetrics` verbatim and reads only `metricsSummary`).
+
+### 5.4 Image Build
+
+- Base: `python:3.11-slim`
+- `pip install guidellm` (pin a specific version, e.g. `0.4.x`).
+- `COPY runner.py /app/runner.py`
+- `ENTRYPOINT ["python", "/app/runner.py"]`
+- Built by CI when `apps/benchmark-runner/**` changes. Tagged `modeldoctor/benchmark-runner:<git-sha>` and `:latest`.
+
+## 6. Security
+
+- **API key encryption**: stored as `apiKeyCipher` (AES-256-GCM, key from `BENCHMARK_API_KEY_ENCRYPTION_KEY` env var, 32 bytes base64). Never returned in any API response (controller-level filter). Decrypted only when materializing the K8s Job env. Added as a Secret on the Job pod (not as plain env in the Job manifest text).
+- **HMAC callback**: §2.2 / §4.2.
+- **Network policy** (out of MVP scope but documented): runner pods need egress to (a) the API service (callback), (b) the user-supplied target URL. Cluster-default-deny + targeted egress is recommended but not enforced by this spec.
+- **Resource quotas**: each Job sets `cpu: 500m, memory: 512Mi` requests and `cpu: 2, memory: 2Gi` limits. Configurable via API env vars `BENCHMARK_RUNNER_CPU_*`, `BENCHMARK_RUNNER_MEMORY_*`.
+- **Job TTL**: `ttlSecondsAfterFinished: 3600` so K8s GCs completed Jobs after 1 hour. Logs and metrics are already in our DB.
+
+## 7. State Machine and Reconciliation
+
+```
+       create                          first runner callback
+pending ─────────► submitted ─────────────────────────────► running
+   │                  │                                       │
+   │                  │ Job creation API call fails           │ runner POSTs state=completed
+   │                  ▼                                       ▼
+   └──────────► failed                                    completed
+                                                              │
+       cancel (any time)                                       │
+   ────────────────────────────────► canceled                  │
+                                                              │
+       reconciler: running > max_duration       ──────────► failed
+       reconciler: pod terminated nonzero       ──────────► failed
+       reconciler: Job missing & not completed  ──────────► failed
+```
+
+A `BenchmarkReconciler` (`@Cron("*/30 * * * * *")` — every 30s) sweeps `running` and `submitted` runs and:
+- if `running` for > `maxDurationSeconds`, calls `driver.cancel()` then sets `failed`;
+- if the K8s Job no longer exists and the run is not in a terminal state, sets `failed` with `stateMessage="job vanished"`;
+- if the underlying pod is in `Failed` phase but no metrics callback arrived, sets `failed` with the pod's termination reason.
+
+This makes the design tolerant of dropped callbacks. The callback is the happy path; the reconciler is the safety net.
+
+## 8. Web UI
+
+### 8.1 Routes
+
+- `/benchmarks` — list page
+- `/benchmarks/:id` — detail page
+
+Sidebar entry "基准测试" (i18n key `sidebar.benchmark`) added between "压力测试" and other items.
+
+### 8.2 List Page
+
+- TanStack Query for `GET /api/benchmarks` with cursor pagination.
+- Table columns: name, model, profile (badge), state (badge with color: pending=gray, running=blue+spinner, completed=green, failed=red, canceled=gray), throughput (output tokens/s), TTFT mean, created at, actions (cancel if running, delete).
+- Filter row: state select, profile select, name search.
+- "Add benchmark" button opens the create modal.
+
+### 8.3 Create Modal
+
+Two tabs (mirrors GPUStack screenshot):
+
+**基本信息 tab**:
+- Name (required)
+- Description (textarea, optional)
+- Endpoint section: API type (chat / completion), API URL, API key, model — laid out same as LoadTest's endpoint picker so the components can be reused.
+
+**配置 tab**:
+- Profile (radio chips: Throughput / Latency / Long Context / Generation Heavy / ShareGPT / Custom). Picking a non-Custom profile fills the fields below; switching to Custom unlocks them for editing. The ShareGPT chip is disabled in Phase 1 with a "(coming soon)" tooltip — consistent with §1.3 deferring the ShareGPT dataset.
+- Dataset (select: Random / ShareGPT — ShareGPT option is disabled in Phase 1 with a "(coming soon)" badge).
+- Input token length (number, default per profile).
+- Output token length (number, default per profile).
+- Request rate (number, 0 = unlimited).
+- Total requests (number).
+
+Submit → `POST /api/benchmarks` → close modal → invalidate list query → navigate to detail page of the new run.
+
+### 8.4 Detail Page
+
+- Header: name, state badge, cancel/delete buttons.
+- Config card: target endpoint, profile, dataset config.
+- Metrics grid: 12 tiles in a 4×3 layout — TTFT mean/p95/p99, ITL mean/p95/p99, output tok/s, RPS, concurrency mean/max, success/error counts.
+- Polling: every 2s while `state ∈ {pending, submitted, running}`; stops on terminal state.
+- Logs panel: collapsible `<pre>`, scrollable, monospace. Logs are posted by the runner in a single chunk on the final `/metrics` callback (after guidellm exits — success or failure). While the run is `pending`/`submitted`/`running` the panel shows "Logs available after run completes". Live tailing is Phase 6.
+- (Out of scope: charts. Just numbers in MVP.)
+
+### 8.5 i18n
+
+New namespace `benchmark` with: page titles, all field labels, profile names, state labels, error messages. Mirrors the existing `load-test` namespace structure.
+
+## 9. Testing Strategy
+
+| Layer | Test type | What's covered |
+|---|---|---|
+| `runner.py` | pytest, mocks `subprocess.Popen` and `requests.post` | argv construction, JSON→summary mapping, error propagation, HMAC token usage |
+| Runner image | integration test in CI: build image, run against a stub OpenAI server (Python `aiohttp`), assert callback HTTP calls match expected sequence | end-to-end runner behavior |
+| `BenchmarkService` | vitest, mocks Prisma + Driver | state transitions, ownership scoping, validation, callback handling |
+| `K8sJobDriver` | vitest, mocks `@kubernetes/client-node` | Job manifest correctness (env, labels, RBAC SA, TTL, resource limits) |
+| `BenchmarkController` | vitest with NestJS testing module + supertest | route registration, JWT/HMAC guards, Zod validation, error shape |
+| `HmacCallbackGuard` | vitest | valid token accepted, expired rejected, wrong signature rejected, constant-time compare |
+| `BenchmarkReconciler` | vitest | runaway timeout, missing job, pod failure → failed transitions |
+| Web | vitest + RTL | profile picker fills fields, modal submit, list filter, detail polling |
+| E2E (deferred) | playwright in 4pd dev cluster, real guidellm against a tiny `vllm serve facebook/opt-125m` | full happy path, runs in a CI gate before each release |
+
+## 10. Phase Decomposition
+
+Each phase is one PR from `feat/benchmark-phase-<N>` cut from `main`. Same convention as the NestJS refactor.
+
+### Phase 1 — Data + contracts
+- Prisma migration adding `benchmark_runs`.
+- `packages/contracts/src/benchmark.ts` (request, response, summary, list-query schemas).
+- AES-GCM helper (`apps/api/src/common/crypto/`).
+- `BenchmarkExecutionDriver` interface (no impls yet).
+- Unit tests for crypto helper.
+- **Output**: schema and contracts approved; nothing externally observable.
+
+### Phase 2 — Runner image
+- `apps/benchmark-runner/` Python project + Dockerfile + tests.
+- Image build job in CI on changes under that path.
+- `docker run --rm -e ... modeldoctor/benchmark-runner:dev` smoke test against a tiny OpenAI stub.
+- **Output**: pushable runner image, callable manually.
+
+### Phase 3 — K8sJobDriver + callback API
+- `K8sJobDriver` using `@kubernetes/client-node`.
+- `/api/internal/benchmarks/:id/{state,metrics}` controller + `HmacCallbackGuard`.
+- `BenchmarkReconciler` with `@nestjs/schedule`.
+- ServiceAccount + Role + RoleBinding YAML in `deploy/k8s/rbac.yaml` (only what the API needs to manage Jobs).
+- Local dev path: `kubectl apply` the RBAC, run API with `~/.kube/config`, run a benchmark, see the Job appear and finish, see metrics appear in the DB.
+- **Output**: end-to-end flow without a UI.
+
+### Phase 4 — User-facing CRUD API
+- `BenchmarkController`, `BenchmarkService`.
+- `Create`, `List` (cursor + filters), `Detail`, `Cancel`, `Delete`.
+- User scoping (admin sees all).
+- API key encryption at rest.
+- **Output**: feature usable via curl.
+
+### Phase 5 — Web UI
+- `apps/web/src/features/benchmark/` with list page, detail page, create modal.
+- Profile presets + form auto-fill.
+- Polling on detail page.
+- i18n namespace `benchmark` (zh + en).
+- Sidebar entry.
+- **Output**: full feature visible.
+
+### Phase 6 — Hardening (optional follow-up)
+- E2E test in CI hitting 4pd.
+- ShareGPT support: download dataset on Job startup with init container, runner wires `--data /data/sharegpt.json`.
+- `SubprocessDriver` fallback for local-without-K8s dev.
+- Live-tail logs (SSE).
+
+Phases 1–5 are MVP. Phase 6 is post-MVP.
+
+## 11. Open Risks
+
+1. **guidellm CLI / output schema churn.** Mitigation: pin a specific version in `apps/benchmark-runner/pyproject.toml`. Bumping is a deliberate PR with new fixture-based tests.
+2. **In-cluster networking from runner → API service.** Assumes `modeldoctor-api` is reachable as `modeldoctor-api.<ns>.svc:3001` from the `modeldoctor-benchmarks` namespace. If the user uses NetworkPolicies, an explicit allow rule is needed. Documented in Phase 3 README; not generated.
+3. **K8s API rate limits / quota.** A flood of benchmark creations could create a flood of Jobs. MVP relies on the existing throttler for `/api/benchmarks` POST (100 req/min already configured globally) and on K8s namespace quotas for runtime. No application-level concurrent-job cap in MVP — flagged for Phase 6 if needed.
+4. **Runner image size.** ~600 MB. First pull on a fresh node can take 30–60s. ImagePullPolicy `IfNotPresent` (default) plus tagged releases should keep this rare.
+5. **HMAC secret rotation.** Rotating `BENCHMARK_CALLBACK_SECRET` invalidates in-flight runs. Acceptable: callers can re-create. Documented in deploy README.
+6. **Token-counter mismatch.** guidellm uses HuggingFace tokenizers. If the user's target is a model whose tokenizer guidellm doesn't auto-detect, prompt-token / output-token accounting can drift. Phase 1 leaves this as user error; Phase 6 may add an explicit `tokenizer` field.
+
+## 12. Glossary
+
+- **TTFT** — Time To First Token; ms from POST sent to first SSE chunk received.
+- **ITL** — Inter-Token Latency; ms between consecutive output tokens within a single response.
+- **TPOT** — Time Per Output Token; mean per-token cost across a request (≈ ITL mean ignoring first).
+- **Prefill** — the inference phase that processes the input prompt; bounded by GPU compute.
+- **Decode** — the inference phase that emits output tokens; bounded by memory bandwidth.
+- **guidellm** — Neural Magic / vLLM-team OSS LLM benchmarking CLI; the execution engine here.
+- **Profile** — a named workload preset (Throughput / Latency / etc.).
+- **Driver** — pluggable execution backend (`K8sJobDriver`, future `SubprocessDriver`).
+- **HMAC token** — per-run callback credential; `HMAC_SHA256(secret, "<id>.<exp>")`.

--- a/packages/contracts/src/benchmark.spec.ts
+++ b/packages/contracts/src/benchmark.spec.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import {
+  BenchmarkApiTypeSchema,
+  BenchmarkDatasetSchema,
+  BenchmarkMetricsCallbackSchema,
+  BenchmarkMetricsSummarySchema,
+  BenchmarkProfileSchema,
+  BenchmarkRunSchema,
+  BenchmarkRunSummarySchema,
+  BenchmarkStateCallbackSchema,
+  BenchmarkStateSchema,
+  CreateBenchmarkRequestSchema,
+  ListBenchmarksQuerySchema,
+  ListBenchmarksResponseSchema,
+} from "./benchmark.js";
+
+describe("benchmark contracts", () => {
+  describe("enums", () => {
+    it("BenchmarkApiTypeSchema accepts only chat/completion", () => {
+      expect(BenchmarkApiTypeSchema.parse("chat")).toBe("chat");
+      expect(BenchmarkApiTypeSchema.parse("completion")).toBe("completion");
+      expect(() => BenchmarkApiTypeSchema.parse("embeddings")).toThrow();
+    });
+
+    it("BenchmarkProfileSchema includes all 5 named profiles plus custom", () => {
+      for (const p of ["throughput", "latency", "long_context", "generation_heavy", "sharegpt", "custom"]) {
+        expect(BenchmarkProfileSchema.parse(p)).toBe(p);
+      }
+      expect(() => BenchmarkProfileSchema.parse("unknown")).toThrow();
+    });
+
+    it("BenchmarkDatasetSchema accepts random and sharegpt", () => {
+      expect(BenchmarkDatasetSchema.parse("random")).toBe("random");
+      expect(BenchmarkDatasetSchema.parse("sharegpt")).toBe("sharegpt");
+      expect(() => BenchmarkDatasetSchema.parse("custom-set")).toThrow();
+    });
+
+    it("BenchmarkStateSchema includes the full lifecycle", () => {
+      for (const s of ["pending", "submitted", "running", "completed", "failed", "canceled"]) {
+        expect(BenchmarkStateSchema.parse(s)).toBe(s);
+      }
+      expect(() => BenchmarkStateSchema.parse("unknown")).toThrow();
+    });
+  });
+
+  describe("CreateBenchmarkRequestSchema", () => {
+    const valid = {
+      name: "throughput-baseline",
+      profile: "throughput" as const,
+      apiType: "chat" as const,
+      apiUrl: "http://vllm.local:8000/v1",
+      apiKey: "sk-test",
+      model: "facebook/opt-125m",
+      datasetName: "random" as const,
+      datasetInputTokens: 1024,
+      datasetOutputTokens: 128,
+      requestRate: 0,
+      totalRequests: 1000,
+    };
+
+    it("accepts a complete random-dataset request", () => {
+      expect(() => CreateBenchmarkRequestSchema.parse(valid)).not.toThrow();
+    });
+
+    it("requires datasetInputTokens when datasetName is 'random'", () => {
+      const { datasetInputTokens: _, ...rest } = valid;
+      const result = CreateBenchmarkRequestSchema.safeParse(rest);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.some((i) => i.path[0] === "datasetInputTokens")).toBe(true);
+      }
+    });
+
+    it("requires datasetOutputTokens when datasetName is 'random'", () => {
+      const { datasetOutputTokens: _, ...rest } = valid;
+      const result = CreateBenchmarkRequestSchema.safeParse(rest);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.some((i) => i.path[0] === "datasetOutputTokens")).toBe(true);
+      }
+    });
+
+    it("rejects empty name", () => {
+      expect(() => CreateBenchmarkRequestSchema.parse({ ...valid, name: "" })).toThrow();
+    });
+
+    it("rejects name longer than 128 chars", () => {
+      expect(() => CreateBenchmarkRequestSchema.parse({ ...valid, name: "x".repeat(129) })).toThrow();
+    });
+
+    it("rejects non-URL apiUrl", () => {
+      expect(() => CreateBenchmarkRequestSchema.parse({ ...valid, apiUrl: "not-a-url" })).toThrow();
+    });
+
+    it("rejects negative requestRate", () => {
+      expect(() => CreateBenchmarkRequestSchema.parse({ ...valid, requestRate: -1 })).toThrow();
+    });
+
+    it("rejects totalRequests > 100000", () => {
+      expect(() => CreateBenchmarkRequestSchema.parse({ ...valid, totalRequests: 100_001 })).toThrow();
+    });
+
+    it("allows requestRate=0 (unlimited)", () => {
+      expect(() => CreateBenchmarkRequestSchema.parse({ ...valid, requestRate: 0 })).not.toThrow();
+    });
+  });
+
+  describe("BenchmarkMetricsSummarySchema", () => {
+    const validMetrics = {
+      ttft: { mean: 120, p50: 110, p95: 200, p99: 320 },
+      itl: { mean: 25, p50: 22, p95: 50, p99: 80 },
+      e2eLatency: { mean: 1800, p50: 1700, p95: 2500, p99: 3200 },
+      requestsPerSecond: { mean: 12.4 },
+      outputTokensPerSecond: { mean: 1580 },
+      inputTokensPerSecond: { mean: 12700 },
+      totalTokensPerSecond: { mean: 14280 },
+      concurrency: { mean: 8.2, max: 12 },
+      requests: { total: 1000, success: 998, error: 1, incomplete: 1 },
+    };
+
+    it("accepts a fully-populated metrics summary", () => {
+      expect(() => BenchmarkMetricsSummarySchema.parse(validMetrics)).not.toThrow();
+    });
+
+    it("rejects a missing ttft.p99", () => {
+      const broken = { ...validMetrics, ttft: { mean: 120, p50: 110, p95: 200 } };
+      expect(() => BenchmarkMetricsSummarySchema.parse(broken)).toThrow();
+    });
+  });
+
+  describe("BenchmarkRunSummarySchema and BenchmarkRunSchema", () => {
+    const summary = {
+      id: "ckxxx",
+      userId: "uxxx",
+      name: "run-1",
+      profile: "throughput" as const,
+      apiType: "chat" as const,
+      apiUrl: "http://vllm:8000/v1",
+      model: "facebook/opt-125m",
+      datasetName: "random" as const,
+      state: "completed" as const,
+      progress: 1,
+      metricsSummary: null,
+      createdAt: "2026-04-25T00:00:00.000Z",
+      startedAt: "2026-04-25T00:00:01.000Z",
+      completedAt: "2026-04-25T00:05:00.000Z",
+    };
+
+    it("BenchmarkRunSummarySchema accepts a minimal completed summary", () => {
+      expect(() => BenchmarkRunSummarySchema.parse(summary)).not.toThrow();
+    });
+
+    it("BenchmarkRunSchema requires the full set of fields", () => {
+      const full = {
+        ...summary,
+        description: null,
+        datasetInputTokens: 1024,
+        datasetOutputTokens: 128,
+        datasetSeed: null,
+        requestRate: 0,
+        totalRequests: 1000,
+        stateMessage: null,
+        jobName: "benchmark-ckxxx",
+        rawMetrics: null,
+        logs: null,
+      };
+      expect(() => BenchmarkRunSchema.parse(full)).not.toThrow();
+    });
+  });
+
+  describe("ListBenchmarksQuerySchema", () => {
+    it("applies the default limit", () => {
+      const q = ListBenchmarksQuerySchema.parse({});
+      expect(q.limit).toBe(20);
+    });
+
+    it("coerces limit from a string", () => {
+      const q = ListBenchmarksQuerySchema.parse({ limit: "50" });
+      expect(q.limit).toBe(50);
+    });
+
+    it("rejects limit > 100", () => {
+      expect(() => ListBenchmarksQuerySchema.parse({ limit: 101 })).toThrow();
+    });
+
+    it("accepts a state filter", () => {
+      const q = ListBenchmarksQuerySchema.parse({ state: "running" });
+      expect(q.state).toBe("running");
+    });
+
+    it("rejects an unknown state filter", () => {
+      expect(() => ListBenchmarksQuerySchema.parse({ state: "weird" })).toThrow();
+    });
+  });
+
+  describe("ListBenchmarksResponseSchema", () => {
+    it("accepts an empty list with null cursor", () => {
+      expect(() => ListBenchmarksResponseSchema.parse({ items: [], nextCursor: null })).not.toThrow();
+    });
+  });
+
+  describe("internal callback schemas", () => {
+    it("BenchmarkStateCallbackSchema accepts running with no extras", () => {
+      const cb = BenchmarkStateCallbackSchema.parse({ state: "running" });
+      expect(cb.state).toBe("running");
+    });
+
+    it("BenchmarkStateCallbackSchema rejects progress > 1", () => {
+      expect(() => BenchmarkStateCallbackSchema.parse({ state: "running", progress: 1.5 })).toThrow();
+    });
+
+    it("BenchmarkMetricsCallbackSchema requires metricsSummary", () => {
+      expect(() => BenchmarkMetricsCallbackSchema.parse({ rawMetrics: {} })).toThrow();
+    });
+  });
+});

--- a/packages/contracts/src/benchmark.spec.ts
+++ b/packages/contracts/src/benchmark.spec.ts
@@ -23,7 +23,14 @@ describe("benchmark contracts", () => {
     });
 
     it("BenchmarkProfileSchema includes all 5 named profiles plus custom", () => {
-      for (const p of ["throughput", "latency", "long_context", "generation_heavy", "sharegpt", "custom"]) {
+      for (const p of [
+        "throughput",
+        "latency",
+        "long_context",
+        "generation_heavy",
+        "sharegpt",
+        "custom",
+      ]) {
         expect(BenchmarkProfileSchema.parse(p)).toBe(p);
       }
       expect(() => BenchmarkProfileSchema.parse("unknown")).toThrow();
@@ -85,7 +92,9 @@ describe("benchmark contracts", () => {
     });
 
     it("rejects name longer than 128 chars", () => {
-      expect(() => CreateBenchmarkRequestSchema.parse({ ...valid, name: "x".repeat(129) })).toThrow();
+      expect(() =>
+        CreateBenchmarkRequestSchema.parse({ ...valid, name: "x".repeat(129) }),
+      ).toThrow();
     });
 
     it("rejects non-URL apiUrl", () => {
@@ -97,7 +106,9 @@ describe("benchmark contracts", () => {
     });
 
     it("rejects totalRequests > 100000", () => {
-      expect(() => CreateBenchmarkRequestSchema.parse({ ...valid, totalRequests: 100_001 })).toThrow();
+      expect(() =>
+        CreateBenchmarkRequestSchema.parse({ ...valid, totalRequests: 100_001 }),
+      ).toThrow();
     });
 
     it("allows requestRate=0 (unlimited)", () => {
@@ -195,7 +206,9 @@ describe("benchmark contracts", () => {
 
   describe("ListBenchmarksResponseSchema", () => {
     it("accepts an empty list with null cursor", () => {
-      expect(() => ListBenchmarksResponseSchema.parse({ items: [], nextCursor: null })).not.toThrow();
+      expect(() =>
+        ListBenchmarksResponseSchema.parse({ items: [], nextCursor: null }),
+      ).not.toThrow();
     });
   });
 
@@ -206,7 +219,9 @@ describe("benchmark contracts", () => {
     });
 
     it("BenchmarkStateCallbackSchema rejects progress > 1", () => {
-      expect(() => BenchmarkStateCallbackSchema.parse({ state: "running", progress: 1.5 })).toThrow();
+      expect(() =>
+        BenchmarkStateCallbackSchema.parse({ state: "running", progress: 1.5 }),
+      ).toThrow();
     });
 
     it("BenchmarkMetricsCallbackSchema requires metricsSummary", () => {

--- a/packages/contracts/src/benchmark.ts
+++ b/packages/contracts/src/benchmark.ts
@@ -1,0 +1,170 @@
+import { z } from "zod";
+
+// ============================================================
+// Enums
+// ============================================================
+
+export const BenchmarkApiTypeSchema = z.enum(["chat", "completion"]);
+export type BenchmarkApiType = z.infer<typeof BenchmarkApiTypeSchema>;
+
+export const BenchmarkProfileSchema = z.enum([
+  "throughput",
+  "latency",
+  "long_context",
+  "generation_heavy",
+  "sharegpt",
+  "custom",
+]);
+export type BenchmarkProfile = z.infer<typeof BenchmarkProfileSchema>;
+
+export const BenchmarkDatasetSchema = z.enum(["random", "sharegpt"]);
+export type BenchmarkDataset = z.infer<typeof BenchmarkDatasetSchema>;
+
+export const BenchmarkStateSchema = z.enum([
+  "pending",
+  "submitted",
+  "running",
+  "completed",
+  "failed",
+  "canceled",
+]);
+export type BenchmarkState = z.infer<typeof BenchmarkStateSchema>;
+
+// ============================================================
+// Metrics
+// ============================================================
+
+export const LatencyDistributionSchema = z.object({
+  mean: z.number(),
+  p50: z.number(),
+  p95: z.number(),
+  p99: z.number(),
+});
+export type LatencyDistribution = z.infer<typeof LatencyDistributionSchema>;
+
+export const BenchmarkMetricsSummarySchema = z.object({
+  ttft: LatencyDistributionSchema,
+  itl: LatencyDistributionSchema,
+  e2eLatency: LatencyDistributionSchema,
+  requestsPerSecond: z.object({ mean: z.number() }),
+  outputTokensPerSecond: z.object({ mean: z.number() }),
+  inputTokensPerSecond: z.object({ mean: z.number() }),
+  totalTokensPerSecond: z.object({ mean: z.number() }),
+  concurrency: z.object({ mean: z.number(), max: z.number() }),
+  requests: z.object({
+    total: z.number().int(),
+    success: z.number().int(),
+    error: z.number().int(),
+    incomplete: z.number().int(),
+  }),
+});
+export type BenchmarkMetricsSummary = z.infer<typeof BenchmarkMetricsSummarySchema>;
+
+// ============================================================
+// Create request (POST /api/benchmarks body)
+// ============================================================
+
+export const CreateBenchmarkRequestSchema = z
+  .object({
+    name: z.string().min(1).max(128),
+    description: z.string().max(2048).optional(),
+    profile: BenchmarkProfileSchema,
+    apiType: BenchmarkApiTypeSchema,
+    apiUrl: z.string().url(),
+    apiKey: z.string().min(1),
+    model: z.string().min(1),
+    datasetName: BenchmarkDatasetSchema,
+    datasetInputTokens: z.number().int().min(1).optional(),
+    datasetOutputTokens: z.number().int().min(1).optional(),
+    datasetSeed: z.number().int().optional(),
+    requestRate: z.number().int().min(0).default(0),
+    totalRequests: z.number().int().min(1).max(100_000).default(1000),
+  })
+  .superRefine((data, ctx) => {
+    if (data.datasetName === "random") {
+      if (data.datasetInputTokens === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["datasetInputTokens"],
+          message: "Required when datasetName is 'random'",
+        });
+      }
+      if (data.datasetOutputTokens === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["datasetOutputTokens"],
+          message: "Required when datasetName is 'random'",
+        });
+      }
+    }
+  });
+export type CreateBenchmarkRequest = z.infer<typeof CreateBenchmarkRequestSchema>;
+
+// ============================================================
+// Read responses
+// ============================================================
+
+export const BenchmarkRunSummarySchema = z.object({
+  id: z.string(),
+  userId: z.string().nullable(),
+  name: z.string(),
+  profile: BenchmarkProfileSchema,
+  apiType: BenchmarkApiTypeSchema,
+  apiUrl: z.string(),
+  model: z.string(),
+  datasetName: BenchmarkDatasetSchema,
+  state: BenchmarkStateSchema,
+  progress: z.number().nullable(),
+  metricsSummary: BenchmarkMetricsSummarySchema.nullable(),
+  createdAt: z.string(), // ISO 8601
+  startedAt: z.string().nullable(),
+  completedAt: z.string().nullable(),
+});
+export type BenchmarkRunSummary = z.infer<typeof BenchmarkRunSummarySchema>;
+
+export const BenchmarkRunSchema = BenchmarkRunSummarySchema.extend({
+  description: z.string().nullable(),
+  datasetInputTokens: z.number().int().nullable(),
+  datasetOutputTokens: z.number().int().nullable(),
+  datasetSeed: z.number().int().nullable(),
+  requestRate: z.number().int(),
+  totalRequests: z.number().int(),
+  stateMessage: z.string().nullable(),
+  jobName: z.string().nullable(),
+  rawMetrics: z.unknown().nullable(),
+  logs: z.string().nullable(),
+});
+export type BenchmarkRun = z.infer<typeof BenchmarkRunSchema>;
+
+export const ListBenchmarksQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  cursor: z.string().optional(),
+  state: BenchmarkStateSchema.optional(),
+  profile: BenchmarkProfileSchema.optional(),
+  search: z.string().optional(),
+});
+export type ListBenchmarksQuery = z.infer<typeof ListBenchmarksQuerySchema>;
+
+export const ListBenchmarksResponseSchema = z.object({
+  items: z.array(BenchmarkRunSummarySchema),
+  nextCursor: z.string().nullable(),
+});
+export type ListBenchmarksResponse = z.infer<typeof ListBenchmarksResponseSchema>;
+
+// ============================================================
+// Internal callback schemas (runner pod → API)
+// ============================================================
+
+export const BenchmarkStateCallbackSchema = z.object({
+  state: BenchmarkStateSchema,
+  stateMessage: z.string().max(2048).optional(),
+  progress: z.number().min(0).max(1).optional(),
+});
+export type BenchmarkStateCallback = z.infer<typeof BenchmarkStateCallbackSchema>;
+
+export const BenchmarkMetricsCallbackSchema = z.object({
+  metricsSummary: BenchmarkMetricsSummarySchema,
+  rawMetrics: z.unknown(),
+  logs: z.string().optional(),
+});
+export type BenchmarkMetricsCallback = z.infer<typeof BenchmarkMetricsCallbackSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -15,3 +15,4 @@ export * from "./debug-proxy.js";
 export * from "./e2e-test.js";
 export * from "./load-test.js";
 export * from "./auth.js";
+export * from "./benchmark.js";


### PR DESCRIPTION
## Summary

Foundation for the new model-inference benchmark feature. Nothing wired up — pure typed surface that Phases 2-5 build on.

- **Prisma `benchmark_runs` table** — additive migration; no changes to existing tables
- **Zod contracts** at `packages/contracts/src/benchmark.ts` (enums, metrics, create request with conditional refine for random dataset, list/detail responses, internal runner→API callbacks)
- **AES-256-GCM helper** at `apps/api/src/common/crypto/aes-gcm.ts` with versioned `v1:iv:tag:ct` envelope; pure functions, `node:crypto` only
- **`BenchmarkExecutionDriver` interface** at `apps/api/src/modules/benchmark/drivers/` for Phase 3 (K8sJobDriver + SubprocessDriver)
- **2 new optional env vars** — `BENCHMARK_API_KEY_ENCRYPTION_KEY` (32-byte base64), `BENCHMARK_CALLBACK_SECRET` (≥32 chars). Phase 4 tightens to required-when-not-test.

Spec: `docs/superpowers/specs/2026-04-25-benchmark-design.md`. Plan: `docs/superpowers/plans/2026-04-25-benchmark-phase-1-data-contracts.md`.

## Test plan

- [x] `pnpm -r type-check` green (3 packages)
- [x] `pnpm -r test` green — 86 web + 47 api + 26 contracts = 159 passing, 0 failing
- [x] `pnpm -r lint` green
- [x] `prisma migrate dev` applied cleanly; migration is single-table additive (`CREATE TABLE benchmark_runs` + 2 indexes + 1 FK; no ALTER on existing tables)
- [x] AES-GCM helper covers tamper detection (ciphertext + auth tag), wrong-key, version prefix, malformed input, length validation (12 tests)
- [x] Driver-interface JSDoc explicitly requires K8s `secretKeyRef` for sensitive values (no naive `env.value` plaintext); idempotency of `cancel`/`cleanup` exercised in spec

## Watch out for in Phase 3 (forward-looking, surfaced by code review)

- `metricsSummary: Json?` Prisma column needs `BenchmarkMetricsSummarySchema.parse()` round-trip on read in the controller layer
- `BENCHMARK_DRIVER=k8s|subprocess` env var still to be added (intentionally deferred to Phase 3 where it's first needed)
- Consider renaming `jobName` → `executionHandle` if the K8s handle ends up being `<namespace>/<jobName>`
- `nestjs-zod` Swagger generation drops `superRefine` clauses — runtime validation still works, OpenAPI docs may understate field requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)