### PR TITLE
fix(benchmark-runner): API_KEY plumbing + URL slash + FD leak + README format step

### DIFF
--- a/apps/benchmark-runner/README.md
+++ b/apps/benchmark-runner/README.md
@@ -22,6 +22,7 @@ conda activate modeldoctor-benchmark-runner
 pip install -e ".[dev]"
 pytest
 ruff check .
+ruff format --check .   # CI runs this too — `ruff format .` to auto-apply
 ```
 
 (Non-conda contributors can substitute `python3.11 -m venv .venv && source .venv/bin/activate` —

--- a/apps/benchmark-runner/runner/argv.py
+++ b/apps/benchmark-runner/runner/argv.py
@@ -10,6 +10,7 @@ validation; this module assumes a well-typed ``EnvConfig``.
 
 from __future__ import annotations
 
+import json
 from typing import Literal, NamedTuple
 
 
@@ -47,12 +48,20 @@ def build_guidellm_argv(cfg: EnvConfig, *, output_path: str) -> list[str]:
             "the controller should have rejected this request",
         )
 
+    # The OpenAIHTTPBackend reads `api_key` from --backend-kwargs JSON and
+    # turns it into the Authorization Bearer header. We don't have a less
+    # leak-prone channel — guidellm doesn't read OPENAI_API_KEY from env —
+    # so the orchestrator (runner.main) must redact this argv element before
+    # logging it.
+    backend_kwargs = json.dumps({"api_key": cfg.api_key}, separators=(",", ":"))
+
     argv: list[str] = [
         "benchmark-runner",
         "benchmark",
         "run",
         # OpenAI-compatible HTTP backend covers vLLM and most other servers.
         "--backend=openai_http",
+        f"--backend-kwargs={backend_kwargs}",
         f"--target={cfg.target_url}",
         f"--model={cfg.model}",
         f"--max-requests={cfg.total_requests}",

--- a/apps/benchmark-runner/runner/callback.py
+++ b/apps/benchmark-runner/runner/callback.py
@@ -12,6 +12,16 @@ import requests
 _TIMEOUT_SECONDS = 10
 
 
+def _join(callback_url: str, path: str) -> str:
+    """Concatenate ``callback_url`` and ``path`` without double slashes.
+
+    Drivers may pass ``CALLBACK_URL=http://api/`` (trailing slash) or
+    ``http://api`` (none); both must produce a single ``/api/internal/...``
+    path component or NestJS strict routing returns 404.
+    """
+    return f"{callback_url.rstrip('/')}/{path.lstrip('/')}"
+
+
 def _post(url: str, token: str, body: dict[str, Any]) -> None:
     resp = requests.post(
         url,
@@ -38,7 +48,7 @@ def post_state(
         body["stateMessage"] = message
     if progress is not None:
         body["progress"] = progress
-    _post(f"{callback_url}/api/internal/benchmarks/{benchmark_id}/state", token, body)
+    _post(_join(callback_url, f"api/internal/benchmarks/{benchmark_id}/state"), token, body)
 
 
 def post_metrics(
@@ -54,4 +64,4 @@ def post_metrics(
     body: dict[str, Any] = {"metricsSummary": summary, "rawMetrics": raw}
     if logs is not None:
         body["logs"] = logs
-    _post(f"{callback_url}/api/internal/benchmarks/{benchmark_id}/metrics", token, body)
+    _post(_join(callback_url, f"api/internal/benchmarks/{benchmark_id}/metrics"), token, body)

--- a/apps/benchmark-runner/runner/main.py
+++ b/apps/benchmark-runner/runner/main.py
@@ -42,6 +42,24 @@ def _log_tail(buf: bytes, max_bytes: int) -> str:
         return repr(tail)
 
 
+def _redacted_argv(argv: list[str]) -> list[str]:
+    """Return ``argv`` with secret-bearing flags rewritten for safe logging.
+
+    The orchestrator logs the full benchmark-runner argv on startup and the
+    captured stdout/stderr later flow into the metrics callback's ``logs``
+    field — so the API + DB will end up with whatever appears here. Any flag
+    we know carries a secret must be redacted before that log line emits.
+    """
+    redacted: list[str] = []
+    for a in argv:
+        # --backend-kwargs JSON contains api_key (see runner.argv).
+        if a.startswith("--backend-kwargs="):
+            redacted.append("--backend-kwargs=***REDACTED***")
+        else:
+            redacted.append(a)
+    return redacted
+
+
 def main() -> int:
     """Run a single benchmark; return process exit code."""
     raw_env = dict(os.environ)
@@ -79,7 +97,7 @@ def main() -> int:
         log.error("running callback failed: %s — continuing anyway", e)
 
     argv = build_guidellm_argv(cfg, output_path=_OUTPUT_PATH)
-    log.info("running: %s", " ".join(argv))
+    log.info("running: %s", " ".join(_redacted_argv(argv)))
     proc = subprocess.run(argv, capture_output=True, check=False)  # noqa: S603
 
     if proc.returncode != 0:
@@ -99,7 +117,8 @@ def main() -> int:
 
     # Parse the report file produced by guidellm.
     try:
-        report = json.loads(open(_OUTPUT_PATH).read())  # noqa: SIM115
+        with open(_OUTPUT_PATH) as f:
+            report = json.load(f)
     except Exception as e:  # noqa: BLE001
         log.error("failed to read report at %s: %s", _OUTPUT_PATH, e)
         try:

--- a/apps/benchmark-runner/tests/test_argv.py
+++ b/apps/benchmark-runner/tests/test_argv.py
@@ -94,6 +94,18 @@ class TestBuildGuidellmArgv:
         argv = build_guidellm_argv(_config(), output_path="/tmp/r.json")
         assert "--disable-console" in argv
 
+    def test_api_key_is_passed_via_backend_kwargs(self) -> None:
+        # OpenAIHTTPBackend reads `api_key` from --backend-kwargs JSON and
+        # turns it into the Authorization header. Without this, every real
+        # vLLM/OpenAI target 401s.
+        import json as _json
+
+        argv = build_guidellm_argv(_config(api_key="sk-secret-123"), output_path="/tmp/r.json")
+        bk = next((a for a in argv if a.startswith("--backend-kwargs=")), None)
+        assert bk is not None, "argv must include --backend-kwargs"
+        payload = _json.loads(bk.split("=", 1)[1])
+        assert payload == {"api_key": "sk-secret-123"}
+
     def test_sharegpt_not_yet_supported(self) -> None:
         # ShareGPT is deferred to Phase 6 — the runner refuses now so a
         # mis-routed Phase-1 controller request fails loud.

--- a/apps/benchmark-runner/tests/test_callback.py
+++ b/apps/benchmark-runner/tests/test_callback.py
@@ -26,6 +26,18 @@ class TestPostState:
         url = fake_post.call_args.args[0]
         assert url == "http://api:3001/api/internal/benchmarks/ck-xyz/state"
 
+    def test_callback_url_trailing_slash_is_normalized(self, fake_post: MagicMock) -> None:
+        # NestJS strict routing 404s on `//api/internal/...` — drivers that
+        # accidentally pass a trailing slash must still hit the right route.
+        post_state(
+            callback_url="http://api:3001/",
+            token="t",
+            benchmark_id="ck",
+            state="running",
+        )
+        url = fake_post.call_args.args[0]
+        assert url == "http://api:3001/api/internal/benchmarks/ck/state"
+
     def test_authorization_header_is_bearer(self, fake_post: MagicMock) -> None:
         post_state(
             callback_url="http://api:3001",


### PR DESCRIPTION
## Summary

Follow-up to PR #12 (Phase 2). Addresses the four **Important** issues the final code-reviewer flagged before Phase 3 wires K8sJobDriver:

1. **API_KEY never reached the benchmark CLI** (`b746d15`). `EnvConfig.api_key` was required but never propagated to `benchmark-runner` — every real auth-bearing OpenAI/vLLM target would 401. Now passed via `--backend-kwargs={"api_key":...}` JSON. Smoke testing against an unauth localhost vLLM hid the gap.
2. **Secret leak via runner logs**: `runner.main` logs `" ".join(argv)` on startup, and that captured stdout flows into the metrics callback's `logs` field → API + DB. Added `_redacted_argv()` that rewrites `--backend-kwargs=...` to `--backend-kwargs=***REDACTED***` before logging.
3. **`CALLBACK_URL` trailing slash → 404** (`6b6a5c2`). `http://api/` would POST `http://api//api/internal/...` and NestJS strict routing 404s. Added a small `_join` helper that `rstrip`s.
4. **`open(...).read()` without `with`** (bundled in `b746d15` since same file as the redaction work). Switched to `with open(...) as f: json.load(f)` and dropped the `# noqa: SIM115` suppression.
5. **README local-dev recipe missing `ruff format --check .`** (`3a8977e`) — CI runs it; new contributors following the README would write code that lints but fails format on PR.

## Test plan

- [x] `pytest` — 50 tests pass (was 48; +1 for `test_api_key_is_passed_via_backend_kwargs`, +1 for `test_callback_url_trailing_slash_is_normalized`)
- [x] `ruff check .` and `ruff format --check .` — clean
- [x] `docker build` succeeds (gpustack base cached, ~instant)
- [x] `docker run --rm modeldoctor/benchmark-runner:dev` exits 1 with `MissingEnvError`
- [ ] CI green on this PR

## Commit-discipline note

`b746d15` bundles two fixes (API_KEY plumbing **and** the `with open` cleanup from Important #3) because both touch `runner/main.py` and ship together cleanly. The commit subject only mentions API_KEY for brevity — flagging here so reviewers don't think the FD-leak fix was missed.

## Out of scope (still tracked, deferred to Phase-3 prep)

- Mapper type-coercion hardening for non-numeric fields (Suggestion #5 from the final review)
- Wire-format Zod round-trip test (Suggestion #6)
- Extra orchestrator test for "guidellm exits 0 but writes malformed JSON" (Suggestion #7)
- `# TODO(phase-3):` comment near argv builder for the unused `--progress-url` opportunity (Suggestion #8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)