### PR TITLE
chore(web): biome lint fixes from Phase 5

### DIFF
--- a/apps/web/src/features/benchmark/BenchmarkActionsCell.tsx
+++ b/apps/web/src/features/benchmark/BenchmarkActionsCell.tsx
@@ -1,15 +1,15 @@
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Button } from "@/components/ui/button";
+import type { BenchmarkRunSummary } from "@modeldoctor/contracts";
 import { MoreHorizontal } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { TERMINAL_STATES } from "./queries";
-import type { BenchmarkRunSummary } from "@modeldoctor/contracts";
 
 interface Props {
   run: BenchmarkRunSummary;
@@ -24,11 +24,7 @@ export function BenchmarkActionsCell({ run, onCancel, onDelete }: Props) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label={`Actions for ${run.name}`}
-        >
+        <Button variant="ghost" size="icon" aria-label={`Actions for ${run.name}`}>
           <MoreHorizontal className="size-4" />
         </Button>
       </DropdownMenuTrigger>
@@ -36,9 +32,7 @@ export function BenchmarkActionsCell({ run, onCancel, onDelete }: Props) {
         <DropdownMenuItem onClick={() => navigate(`/benchmarks/${run.id}`)}>
           {t("actions.openDetail")}
         </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => navigate(`/benchmarks?duplicate=${run.id}`)}
-        >
+        <DropdownMenuItem onClick={() => navigate(`/benchmarks?duplicate=${run.id}`)}>
           {t("actions.duplicate")}
         </DropdownMenuItem>
         {!isTerminal && (

--- a/apps/web/src/features/benchmark/BenchmarkCreateModal.tsx
+++ b/apps/web/src/features/benchmark/BenchmarkCreateModal.tsx
@@ -1,23 +1,15 @@
-import { useEffect, useId, useRef } from "react";
-import { useTranslation } from "react-i18next";
-import { useNavigate, useSearchParams } from "react-router-dom";
-import { useForm, FormProvider } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { toast } from "sonner";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogDescription,
 } from "@/components/ui/dialog";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
-import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   Select,
   SelectContent,
@@ -25,14 +17,22 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect, useId, useRef } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { toast } from "sonner";
 import { BenchmarkEndpointFields } from "./BenchmarkEndpointFields";
 import { BenchmarkProfilePicker } from "./BenchmarkProfilePicker";
 import { profileLabelKey } from "./profiles";
-import { useCreateBenchmark, useBenchmarkDetail } from "./queries";
+import { useBenchmarkDetail, useCreateBenchmark } from "./queries";
 import {
-  CreateBenchmarkRequestSchema,
   type BenchmarkRun,
   type CreateBenchmarkRequest,
+  CreateBenchmarkRequestSchema,
 } from "./schemas";
 
 function mapDuplicateToDefaults(run: BenchmarkRun): CreateBenchmarkRequest {
@@ -190,14 +190,8 @@ export function BenchmarkCreateModal() {
                   <Input id={nameId} {...form.register("name")} />
                 </div>
                 <div>
-                  <Label htmlFor={descId}>
-                    {t("create.fields.description")}
-                  </Label>
-                  <Textarea
-                    id={descId}
-                    rows={2}
-                    {...form.register("description")}
-                  />
+                  <Label htmlFor={descId}>{t("create.fields.description")}</Label>
+                  <Textarea id={descId} rows={2} {...form.register("description")} />
                 </div>
                 <BenchmarkEndpointFields requireApiKeyHighlight={!!duplicateId} />
               </TabsContent>
@@ -220,22 +214,16 @@ export function BenchmarkCreateModal() {
                     <Select
                       value={datasetName}
                       onValueChange={(v) =>
-                        form.setValue(
-                          "datasetName",
-                          v as "random" | "sharegpt",
-                          {
-                            shouldValidate: true,
-                          },
-                        )
+                        form.setValue("datasetName", v as "random" | "sharegpt", {
+                          shouldValidate: true,
+                        })
                       }
                     >
                       <SelectTrigger>
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="random">
-                          {t("datasets.random")}
-                        </SelectItem>
+                        <SelectItem value="random">{t("datasets.random")}</SelectItem>
                         <SelectItem value="sharegpt" disabled>
                           {t("datasets.sharegpt")} {t("comingSoon")}
                         </SelectItem>
@@ -247,8 +235,7 @@ export function BenchmarkCreateModal() {
                     <Input
                       type="number"
                       {...form.register("datasetSeed", {
-                        setValueAs: (v) =>
-                          v === "" ? undefined : Number(v),
+                        setValueAs: (v) => (v === "" ? undefined : Number(v)),
                       })}
                     />
                   </div>
@@ -300,10 +287,7 @@ export function BenchmarkCreateModal() {
               <Button type="button" variant="outline" onClick={close}>
                 {t("actions.cancel")}
               </Button>
-              <Button
-                type="submit"
-                disabled={!form.formState.isValid || createMut.isPending}
-              >
+              <Button type="submit" disabled={!form.formState.isValid || createMut.isPending}>
                 {createMut.isPending ? "…" : t("create.submit")}
               </Button>
             </DialogFooter>

--- a/apps/web/src/features/benchmark/BenchmarkDetailPage.tsx
+++ b/apps/web/src/features/benchmark/BenchmarkDetailPage.tsx
@@ -1,15 +1,6 @@
-import { useEffect, useRef, useState } from "react";
-import { toast } from "sonner";
-import { useTranslation } from "react-i18next";
-import { useQueryClient } from "@tanstack/react-query";
-import { useNavigate, useParams, Link } from "react-router-dom";
-import { format, formatDistanceStrict } from "date-fns";
-import { ArrowLeft, SearchX } from "lucide-react";
-import { PageHeader } from "@/components/common/page-header";
 import { EmptyState } from "@/components/common/empty-state";
+import { PageHeader } from "@/components/common/page-header";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Button } from "@/components/ui/button";
-import { Progress } from "@/components/ui/progress";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -20,9 +11,19 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { BenchmarkStateBadge } from "./BenchmarkStateBadge";
-import { BenchmarkMetricsGrid } from "./BenchmarkMetricsGrid";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { useQueryClient } from "@tanstack/react-query";
+import { format, formatDistanceStrict } from "date-fns";
+import { ArrowLeft, SearchX } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { toast } from "sonner";
 import { BenchmarkLogsPanel } from "./BenchmarkLogsPanel";
+import { BenchmarkMetricsGrid } from "./BenchmarkMetricsGrid";
+import { BenchmarkStateBadge } from "./BenchmarkStateBadge";
+import { profileLabelKey } from "./profiles";
 import {
   TERMINAL_STATES,
   benchmarkKeys,
@@ -30,15 +31,12 @@ import {
   useCancelBenchmark,
   useDeleteBenchmark,
 } from "./queries";
-import { profileLabelKey } from "./profiles";
 
 export function BenchmarkDetailPage() {
   const { t } = useTranslation("benchmark");
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { data, isLoading, isError, error, refetch } = useBenchmarkDetail(
-    id ?? "",
-  );
+  const { data, isLoading, isError, error, refetch } = useBenchmarkDetail(id ?? "");
   const cancelMut = useCancelBenchmark();
   const deleteMut = useDeleteBenchmark();
   const [confirmCancel, setConfirmCancel] = useState(false);
@@ -143,14 +141,9 @@ export function BenchmarkDetailPage() {
     );
   }
 
-  const isTerminal = (TERMINAL_STATES as readonly string[]).includes(
-    data.state,
-  );
+  const isTerminal = (TERMINAL_STATES as readonly string[]).includes(data.state);
   const duration = data.startedAt
-    ? formatDistanceStrict(
-        new Date(data.startedAt),
-        new Date(data.completedAt ?? Date.now()),
-      )
+    ? formatDistanceStrict(new Date(data.startedAt), new Date(data.completedAt ?? Date.now()))
     : null;
 
   return (
@@ -160,20 +153,12 @@ export function BenchmarkDetailPage() {
         subtitle={`${t(`profiles.${profileLabelKey(data.profile)}`)}`}
         rightSlot={
           <div className="flex items-center gap-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => navigate("/benchmarks")}
-            >
+            <Button variant="ghost" size="sm" onClick={() => navigate("/benchmarks")}>
               <ArrowLeft className="mr-1 size-4" />
               List
             </Button>
             {!isTerminal && (
-              <Button
-                variant="destructive"
-                size="sm"
-                onClick={() => setConfirmCancel(true)}
-              >
+              <Button variant="destructive" size="sm" onClick={() => setConfirmCancel(true)}>
                 {t("actions.cancel")}
               </Button>
             )}
@@ -182,17 +167,11 @@ export function BenchmarkDetailPage() {
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() =>
-                    navigate(`/benchmarks?duplicate=${data.id}`)
-                  }
+                  onClick={() => navigate(`/benchmarks?duplicate=${data.id}`)}
                 >
                   {t("actions.duplicate")}
                 </Button>
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  onClick={() => setConfirmDelete(true)}
-                >
+                <Button variant="destructive" size="sm" onClick={() => setConfirmDelete(true)}>
                   {t("actions.delete")}
                 </Button>
               </>
@@ -204,15 +183,11 @@ export function BenchmarkDetailPage() {
       <div className="space-y-4 px-8 py-6">
         <div className="flex items-center gap-3">
           <BenchmarkStateBadge state={data.state} />
-          {duration && (
-            <span className="text-xs text-muted-foreground">{duration}</span>
-          )}
+          {duration && <span className="text-xs text-muted-foreground">{duration}</span>}
           {data.startedAt && (
             <span className="text-xs text-muted-foreground">
               {format(new Date(data.startedAt), "yyyy-MM-dd HH:mm")}
-              {data.completedAt
-                ? ` → ${format(new Date(data.completedAt), "HH:mm")}`
-                : ""}
+              {data.completedAt ? ` → ${format(new Date(data.completedAt), "HH:mm")}` : ""}
             </span>
           )}
         </div>
@@ -252,14 +227,9 @@ export function BenchmarkDetailPage() {
           />
           <KV
             label={t("detail.config.rate")}
-            value={
-              data.requestRate === 0 ? "unlimited" : `${data.requestRate}/s`
-            }
+            value={data.requestRate === 0 ? "unlimited" : `${data.requestRate}/s`}
           />
-          <KV
-            label={t("detail.config.totalRequests")}
-            value={String(data.totalRequests)}
-          />
+          <KV label={t("detail.config.totalRequests")} value={String(data.totalRequests)} />
           <KV
             label={t("detail.config.success")}
             value={
@@ -270,11 +240,7 @@ export function BenchmarkDetailPage() {
           />
           <KV
             label={t("detail.config.errors")}
-            value={
-              data.metricsSummary
-                ? String(data.metricsSummary.requests.error)
-                : "—"
-            }
+            value={data.metricsSummary ? String(data.metricsSummary.requests.error) : "—"}
           />
         </div>
 
@@ -287,9 +253,7 @@ export function BenchmarkDetailPage() {
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>{t("actions.cancel")}?</AlertDialogTitle>
-            <AlertDialogDescription>
-              In-flight requests will be terminated.
-            </AlertDialogDescription>
+            <AlertDialogDescription>In-flight requests will be terminated.</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Back</AlertDialogCancel>
@@ -336,9 +300,7 @@ export function BenchmarkDetailPage() {
 function KV({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-        {label}
-      </div>
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">{label}</div>
       <div className="text-sm font-medium text-foreground">{value}</div>
     </div>
   );

--- a/apps/web/src/features/benchmark/BenchmarkEndpointFields.tsx
+++ b/apps/web/src/features/benchmark/BenchmarkEndpointFields.tsx
@@ -1,6 +1,3 @@
-import { useId } from "react";
-import { useFormContext, Controller } from "react-hook-form";
-import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -11,6 +8,9 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useConnectionsStore } from "@/stores/connections-store";
+import { useId } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import type { CreateBenchmarkRequest } from "./schemas";
 
 export function BenchmarkEndpointFields({
@@ -91,21 +91,13 @@ export function BenchmarkEndpointFields({
         </div>
         <div className="col-span-2">
           <Label htmlFor={modelId}>{t("create.fields.model")}</Label>
-          <Input
-            id={modelId}
-            {...register("model")}
-            aria-invalid={!!errors.model}
-          />
+          <Input id={modelId} {...register("model")} aria-invalid={!!errors.model} />
         </div>
       </div>
 
       <div>
         <Label htmlFor={apiUrlId}>{t("create.fields.apiUrl")}</Label>
-        <Input
-          id={apiUrlId}
-          {...register("apiUrl")}
-          aria-invalid={!!errors.apiUrl}
-        />
+        <Input id={apiUrlId} {...register("apiUrl")} aria-invalid={!!errors.apiUrl} />
       </div>
       <div>
         <Label htmlFor={apiKeyId}>{t("create.fields.apiKey")}</Label>

--- a/apps/web/src/features/benchmark/BenchmarkListPage.tsx
+++ b/apps/web/src/features/benchmark/BenchmarkListPage.tsx
@@ -1,11 +1,16 @@
-import { useState, useMemo } from "react";
-import { useTranslation } from "react-i18next";
-import { Link, useSearchParams } from "react-router-dom";
-import { useQueryClient } from "@tanstack/react-query";
-import { formatDistanceToNow } from "date-fns";
-import { PageHeader } from "@/components/common/page-header";
 import { EmptyState } from "@/components/common/empty-state";
+import { PageHeader } from "@/components/common/page-header";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -24,30 +29,17 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import { BenchmarkStateBadge } from "./BenchmarkStateBadge";
+import type { BenchmarkProfile, BenchmarkState } from "@modeldoctor/contracts";
+import { useQueryClient } from "@tanstack/react-query";
+import { formatDistanceToNow } from "date-fns";
+import { Activity } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link, useSearchParams } from "react-router-dom";
 import { BenchmarkActionsCell } from "./BenchmarkActionsCell";
 import { BenchmarkCreateModal } from "./BenchmarkCreateModal";
-import {
-  benchmarkKeys,
-  useBenchmarkList,
-  useCancelBenchmark,
-  useDeleteBenchmark,
-} from "./queries";
-import type {
-  BenchmarkProfile,
-  BenchmarkState,
-} from "@modeldoctor/contracts";
-import { Activity } from "lucide-react";
+import { BenchmarkStateBadge } from "./BenchmarkStateBadge";
+import { benchmarkKeys, useBenchmarkList, useCancelBenchmark, useDeleteBenchmark } from "./queries";
 
 const PROFILES: BenchmarkProfile[] = [
   "throughput",
@@ -90,8 +82,7 @@ export function BenchmarkListPage() {
   const qc = useQueryClient();
 
   const [stateFilter, setStateFilter] = useState<BenchmarkState | undefined>();
-  const [profileFilter, setProfileFilter] =
-    useState<BenchmarkProfile | undefined>();
+  const [profileFilter, setProfileFilter] = useState<BenchmarkProfile | undefined>();
   const [search, setSearch] = useState("");
   const [pendingCancel, setPendingCancel] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState<string | null>(null);
@@ -111,9 +102,7 @@ export function BenchmarkListPage() {
   const deleteMut = useDeleteBenchmark();
 
   const isFiltered =
-    stateFilter !== undefined ||
-    profileFilter !== undefined ||
-    search.trim() !== "";
+    stateFilter !== undefined || profileFilter !== undefined || search.trim() !== "";
 
   return (
     <>
@@ -125,16 +114,11 @@ export function BenchmarkListPage() {
             <Button
               variant="outline"
               size="sm"
-              onClick={() =>
-                qc.invalidateQueries({ queryKey: benchmarkKeys.lists() })
-              }
+              onClick={() => qc.invalidateQueries({ queryKey: benchmarkKeys.lists() })}
             >
               {t("actions.refresh")}
             </Button>
-            <Button
-              size="sm"
-              onClick={() => setSearchParams({ create: "1" })}
-            >
+            <Button size="sm" onClick={() => setSearchParams({ create: "1" })}>
               {t("actions.create")}
             </Button>
           </div>
@@ -145,14 +129,9 @@ export function BenchmarkListPage() {
         <div className="flex flex-wrap gap-2">
           <Select
             value={stateFilter ?? ALL}
-            onValueChange={(v) =>
-              setStateFilter(v === ALL ? undefined : (v as BenchmarkState))
-            }
+            onValueChange={(v) => setStateFilter(v === ALL ? undefined : (v as BenchmarkState))}
           >
-            <SelectTrigger
-              className="w-[180px]"
-              aria-label={t("list.filters.state")}
-            >
+            <SelectTrigger className="w-[180px]" aria-label={t("list.filters.state")}>
               <SelectValue placeholder={t("list.filters.state")} />
             </SelectTrigger>
             <SelectContent>
@@ -167,14 +146,9 @@ export function BenchmarkListPage() {
 
           <Select
             value={profileFilter ?? ALL}
-            onValueChange={(v) =>
-              setProfileFilter(v === ALL ? undefined : (v as BenchmarkProfile))
-            }
+            onValueChange={(v) => setProfileFilter(v === ALL ? undefined : (v as BenchmarkProfile))}
           >
-            <SelectTrigger
-              className="w-[180px]"
-              aria-label={t("list.filters.profile")}
-            >
+            <SelectTrigger className="w-[180px]" aria-label={t("list.filters.profile")}>
               <SelectValue placeholder={t("list.filters.profile")} />
             </SelectTrigger>
             <SelectContent>
@@ -246,12 +220,8 @@ export function BenchmarkListPage() {
                     <TableHead>{t("list.columns.model")}</TableHead>
                     <TableHead>{t("list.columns.profile")}</TableHead>
                     <TableHead>{t("list.columns.state")}</TableHead>
-                    <TableHead className="text-right">
-                      {t("list.columns.outputTps")}
-                    </TableHead>
-                    <TableHead className="text-right">
-                      {t("list.columns.ttftMean")}
-                    </TableHead>
+                    <TableHead className="text-right">{t("list.columns.outputTps")}</TableHead>
+                    <TableHead className="text-right">{t("list.columns.ttftMean")}</TableHead>
                     <TableHead>{t("list.columns.createdAt")}</TableHead>
                     <TableHead className="w-10" />
                   </TableRow>
@@ -328,9 +298,7 @@ export function BenchmarkListPage() {
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>{t("actions.cancel")}?</AlertDialogTitle>
-            <AlertDialogDescription>
-              In-flight requests will be terminated.
-            </AlertDialogDescription>
+            <AlertDialogDescription>In-flight requests will be terminated.</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Back</AlertDialogCancel>

--- a/apps/web/src/features/benchmark/BenchmarkLogsPanel.tsx
+++ b/apps/web/src/features/benchmark/BenchmarkLogsPanel.tsx
@@ -1,6 +1,6 @@
+import type { BenchmarkState } from "@modeldoctor/contracts";
 import { useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import type { BenchmarkState } from "@modeldoctor/contracts";
 import { TERMINAL_STATES } from "./queries";
 
 function formatSize(bytes: number): string {
@@ -19,10 +19,7 @@ export function BenchmarkLogsPanel({
   const preRef = useRef<HTMLPreElement>(null);
   const isTerminal = (TERMINAL_STATES as readonly string[]).includes(state);
 
-  const size = useMemo(
-    () => (logs ? new TextEncoder().encode(logs).length : 0),
-    [logs],
-  );
+  const size = useMemo(() => (logs ? new TextEncoder().encode(logs).length : 0), [logs]);
 
   useEffect(() => {
     if (preRef.current) {
@@ -39,22 +36,18 @@ export function BenchmarkLogsPanel({
   }
 
   return (
-    <details
-      className="rounded-md border border-border"
-      open={isTerminal}
-      role="region"
-      aria-label={t("detail.logs.title")}
-    >
-      <summary className="cursor-pointer px-3 py-2 text-xs text-muted-foreground select-none">
-        ▾ {t("detail.logs.title")}{" "}
-        <span className="ml-1">({formatSize(size)})</span>
-      </summary>
-      <pre
-        ref={preRef}
-        className="m-0 max-h-[300px] overflow-auto rounded-b-md bg-zinc-900 p-3 text-[11px] text-zinc-200"
-      >
-        {logs}
-      </pre>
-    </details>
+    <section aria-label={t("detail.logs.title")}>
+      <details className="rounded-md border border-border" open={isTerminal}>
+        <summary className="cursor-pointer px-3 py-2 text-xs text-muted-foreground select-none">
+          ▾ {t("detail.logs.title")} <span className="ml-1">({formatSize(size)})</span>
+        </summary>
+        <pre
+          ref={preRef}
+          className="m-0 max-h-[300px] overflow-auto rounded-b-md bg-zinc-900 p-3 text-[11px] text-zinc-200"
+        >
+          {logs}
+        </pre>
+      </details>
+    </section>
   );
 }

--- a/apps/web/src/features/benchmark/BenchmarkMetricsGrid.tsx
+++ b/apps/web/src/features/benchmark/BenchmarkMetricsGrid.tsx
@@ -1,5 +1,5 @@
-import { useTranslation } from "react-i18next";
 import type { BenchmarkMetricsSummary } from "@modeldoctor/contracts";
+import { useTranslation } from "react-i18next";
 
 interface TileProps {
   label: string;
@@ -11,37 +11,20 @@ interface TileProps {
 
 function Tile({ label, value, unit, subtitle, tone = "default" }: TileProps) {
   const valueColor =
-    tone === "success"
-      ? "text-green-600"
-      : tone === "danger"
-        ? "text-red-600"
-        : "text-foreground";
+    tone === "success" ? "text-green-600" : tone === "danger" ? "text-red-600" : "text-foreground";
   return (
     <div className="rounded-md border border-border p-3">
-      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-        {label}
-      </div>
-      <div
-        className={`mt-1 text-2xl font-semibold tabular-nums ${valueColor}`}
-      >
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className={`mt-1 text-2xl font-semibold tabular-nums ${valueColor}`}>
         {value}
-        {unit && (
-          <span className="ml-1 text-sm font-normal text-muted-foreground">
-            {unit}
-          </span>
-        )}
+        {unit && <span className="ml-1 text-sm font-normal text-muted-foreground">{unit}</span>}
       </div>
-      {subtitle && (
-        <div className="mt-0.5 text-[11px] text-muted-foreground">
-          {subtitle}
-        </div>
-      )}
+      {subtitle && <div className="mt-0.5 text-[11px] text-muted-foreground">{subtitle}</div>}
     </div>
   );
 }
 
-const fmt = (n: number | undefined) =>
-  n === undefined ? "—" : n.toFixed(1);
+const fmt = (n: number | undefined) => (n === undefined ? "—" : n.toFixed(1));
 
 export function BenchmarkMetricsGrid({
   summary,
@@ -94,30 +77,17 @@ export function BenchmarkMetricsGrid({
         value={fmt(m?.itl.p99)}
         unit={m ? "ms" : undefined}
       />
-      <Tile
-        label={t("detail.metrics.outputTps")}
-        value={fmt(m?.outputTokensPerSecond.mean)}
-      />
-      <Tile
-        label={t("detail.metrics.rps")}
-        value={fmt(m?.requestsPerSecond.mean)}
-      />
+      <Tile label={t("detail.metrics.outputTps")} value={fmt(m?.outputTokensPerSecond.mean)} />
+      <Tile label={t("detail.metrics.rps")} value={fmt(m?.requestsPerSecond.mean)} />
 
-      <Tile
-        label={t("detail.metrics.concurrencyMean")}
-        value={fmt(m?.concurrency.mean)}
-      />
+      <Tile label={t("detail.metrics.concurrencyMean")} value={fmt(m?.concurrency.mean)} />
       <Tile
         label={t("detail.metrics.concurrencyMax")}
-        value={
-          m?.concurrency.max === undefined ? "—" : String(m.concurrency.max)
-        }
+        value={m?.concurrency.max === undefined ? "—" : String(m.concurrency.max)}
       />
       <Tile
         label={t("detail.metrics.successCount")}
-        value={
-          m?.requests.success === undefined ? "—" : String(m.requests.success)
-        }
+        value={m?.requests.success === undefined ? "—" : String(m.requests.success)}
         tone="success"
       />
       <Tile

--- a/apps/web/src/features/benchmark/BenchmarkProfilePicker.tsx
+++ b/apps/web/src/features/benchmark/BenchmarkProfilePicker.tsx
@@ -1,19 +1,10 @@
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import type { BenchmarkProfile } from "@modeldoctor/contracts";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { Button } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { cn } from "@/lib/utils";
-import {
-  PROFILE_DEFAULTS,
-  PROFILE_ORDER,
-  profileLabelKey,
-  type LivePreset,
-} from "./profiles";
-import type { BenchmarkProfile } from "@modeldoctor/contracts";
+import { type LivePreset, PROFILE_DEFAULTS, PROFILE_ORDER, profileLabelKey } from "./profiles";
 import type { CreateBenchmarkRequest } from "./schemas";
 
 export function BenchmarkProfilePicker() {
@@ -62,9 +53,7 @@ export function BenchmarkProfilePicker() {
           >
             {label}
             {disabled && (
-              <span className="ml-1 text-[10px] text-muted-foreground">
-                {t("comingSoon")}
-              </span>
+              <span className="ml-1 text-[10px] text-muted-foreground">{t("comingSoon")}</span>
             )}
           </Button>
         );

--- a/apps/web/src/features/benchmark/BenchmarkStateBadge.tsx
+++ b/apps/web/src/features/benchmark/BenchmarkStateBadge.tsx
@@ -1,6 +1,6 @@
 import { Badge } from "@/components/ui/badge";
-import { useTranslation } from "react-i18next";
 import type { BenchmarkState } from "@modeldoctor/contracts";
+import { useTranslation } from "react-i18next";
 
 const VARIANT: Record<BenchmarkState, string> = {
   pending: "bg-zinc-100 text-zinc-700 border-zinc-200",

--- a/apps/web/src/features/benchmark/__tests__/BenchmarkCreateModal.test.tsx
+++ b/apps/web/src/features/benchmark/__tests__/BenchmarkCreateModal.test.tsx
@@ -2,13 +2,16 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@/lib/i18n";
 
 vi.mock("@/lib/api-client", () => {
   class ApiError extends Error {
-    constructor(public status: number, message: string) {
+    constructor(
+      public status: number,
+      message: string,
+    ) {
       super(message);
     }
   }
@@ -16,8 +19,8 @@ vi.mock("@/lib/api-client", () => {
 });
 
 import { api } from "@/lib/api-client";
-import { BenchmarkCreateModal } from "../BenchmarkCreateModal";
 import type { BenchmarkRun } from "@modeldoctor/contracts";
+import { BenchmarkCreateModal } from "../BenchmarkCreateModal";
 
 const SOURCE_RUN: BenchmarkRun = {
   id: "src1",
@@ -88,10 +91,7 @@ function Wrapper({
       <MemoryRouter initialEntries={initialEntries}>
         <Routes>
           <Route path="/benchmarks" element={children} />
-          <Route
-            path="/benchmarks/:id"
-            element={<div>detail page for navigation target</div>}
-          />
+          <Route path="/benchmarks/:id" element={<div>detail page for navigation target</div>} />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>
@@ -126,9 +126,7 @@ describe("BenchmarkCreateModal — basic tab", () => {
       ),
     });
     expect(screen.getByRole("tab", { name: /basic info/i })).toBeInTheDocument();
-    expect(
-      screen.getByRole("tab", { name: /configuration/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /configuration/i })).toBeInTheDocument();
   });
 
   it("closes when Cancel is clicked and clears the URL search param", async () => {
@@ -151,10 +149,7 @@ describe("BenchmarkCreateModal — basic tab", () => {
     });
 
     await userEvent.type(screen.getByLabelText(/^name$/i), "smoke");
-    await userEvent.type(
-      screen.getByLabelText(/api url/i),
-      "https://api.test/v1",
-    );
+    await userEvent.type(screen.getByLabelText(/api url/i), "https://api.test/v1");
     await userEvent.type(screen.getByLabelText(/api key/i), "k");
     await userEvent.type(screen.getByLabelText(/^model$/i), "m");
 
@@ -173,9 +168,7 @@ describe("BenchmarkCreateModal — basic tab", () => {
         }),
       ),
     );
-    expect(
-      await screen.findByText(/detail page for navigation target/i),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/detail page for navigation target/i)).toBeInTheDocument();
   });
 
   it("?duplicate=src1 prefills form with source values and blanks apiKey", async () => {
@@ -183,25 +176,15 @@ describe("BenchmarkCreateModal — basic tab", () => {
 
     render(<BenchmarkCreateModal />, {
       wrapper: ({ children }) => (
-        <Wrapper initialEntries={["/benchmarks?duplicate=src1"]}>
-          {children}
-        </Wrapper>
+        <Wrapper initialEntries={["/benchmarks?duplicate=src1"]}>{children}</Wrapper>
       ),
     });
 
-    expect(
-      await screen.findByText(/duplicating from/i),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/duplicating from/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/^name$/i)).toHaveValue("vllm-llama3-tput-2");
-    expect(screen.getByLabelText(/api url/i)).toHaveValue(
-      "https://api.test/v1",
-    );
+    expect(screen.getByLabelText(/api url/i)).toHaveValue("https://api.test/v1");
     expect(screen.getByLabelText(/^model$/i)).toHaveValue("llama-3-8b");
     expect(screen.getByLabelText(/api key/i)).toHaveValue("");
-    expect(screen.getByLabelText(/api key/i)).toHaveAttribute(
-      "aria-invalid",
-      "true",
-    );
+    expect(screen.getByLabelText(/api key/i)).toHaveAttribute("aria-invalid", "true");
   });
-
 });

--- a/apps/web/src/features/benchmark/__tests__/BenchmarkDetailPage.test.tsx
+++ b/apps/web/src/features/benchmark/__tests__/BenchmarkDetailPage.test.tsx
@@ -1,13 +1,16 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@/lib/i18n";
 
 vi.mock("@/lib/api-client", () => {
   class ApiError extends Error {
-    constructor(public status: number, message: string) {
+    constructor(
+      public status: number,
+      message: string,
+    ) {
       super(message);
     }
   }
@@ -15,8 +18,8 @@ vi.mock("@/lib/api-client", () => {
 });
 
 import { api } from "@/lib/api-client";
-import { BenchmarkDetailPage } from "../BenchmarkDetailPage";
 import type { BenchmarkRun } from "@modeldoctor/contracts";
+import { BenchmarkDetailPage } from "../BenchmarkDetailPage";
 
 function Wrapper({ children }: { children: ReactNode }) {
   const qc = new QueryClient({
@@ -84,12 +87,8 @@ describe("BenchmarkDetailPage", () => {
     render(<BenchmarkDetailPage />, { wrapper: Wrapper });
     expect(await screen.findByText("smoke")).toBeInTheDocument();
     expect(screen.getByText(/Completed/i)).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /duplicate/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /^delete$/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /duplicate/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^delete$/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /^cancel$/i })).toBeNull();
     expect(screen.getAllByText(/142/).length).toBeGreaterThan(0); // some metric number
   });
@@ -104,13 +103,9 @@ describe("BenchmarkDetailPage", () => {
     });
     render(<BenchmarkDetailPage />, { wrapper: Wrapper });
     expect(await screen.findByText(/Running/i)).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /^cancel$/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^cancel$/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /^delete$/i })).toBeNull();
-    expect(
-      screen.getByText(/logs available after run completes/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/logs available after run completes/i)).toBeInTheDocument();
   });
 
   it("renders failed run with red Alert and stateMessage", async () => {
@@ -127,9 +122,7 @@ describe("BenchmarkDetailPage", () => {
   });
 
   it("renders 404 EmptyState on ApiError 404", async () => {
-    vi.mocked(api.get).mockRejectedValue(
-      Object.assign(new Error("not found"), { status: 404 }),
-    );
+    vi.mocked(api.get).mockRejectedValue(Object.assign(new Error("not found"), { status: 404 }));
     render(<BenchmarkDetailPage />, { wrapper: Wrapper });
     const matches = await screen.findAllByText(/not found/i);
     expect(matches.length).toBeGreaterThan(0);

--- a/apps/web/src/features/benchmark/__tests__/BenchmarkEndpointFields.test.tsx
+++ b/apps/web/src/features/benchmark/__tests__/BenchmarkEndpointFields.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useForm, FormProvider } from "react-hook-form";
-import { describe, it, expect } from "vitest";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
 import "@/lib/i18n";
 import { BenchmarkEndpointFields } from "../BenchmarkEndpointFields";
 import type { CreateBenchmarkRequest } from "../schemas";
@@ -45,20 +45,13 @@ describe("BenchmarkEndpointFields", () => {
     render(<Harness />);
     await userEvent.click(screen.getByLabelText(/api type/i));
     expect(screen.getByRole("option", { name: /chat/i })).toBeInTheDocument();
-    expect(
-      screen.getByRole("option", { name: /completion/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /completion/i })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: /embedding/i })).toBeNull();
   });
 
   it("typing in apiUrl updates the form value", async () => {
     render(<Harness />);
-    await userEvent.type(
-      screen.getByLabelText(/api url/i),
-      "https://api.test/v1",
-    );
-    expect(screen.getByLabelText(/api url/i)).toHaveValue(
-      "https://api.test/v1",
-    );
+    await userEvent.type(screen.getByLabelText(/api url/i), "https://api.test/v1");
+    expect(screen.getByLabelText(/api url/i)).toHaveValue("https://api.test/v1");
   });
 });

--- a/apps/web/src/features/benchmark/__tests__/BenchmarkListPage.test.tsx
+++ b/apps/web/src/features/benchmark/__tests__/BenchmarkListPage.test.tsx
@@ -1,16 +1,19 @@
+import type { ListBenchmarksResponse } from "@modeldoctor/contracts";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
-import type { ListBenchmarksResponse } from "@modeldoctor/contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@/lib/i18n";
 import { BenchmarkListPage } from "../BenchmarkListPage";
 
 vi.mock("@/lib/api-client", () => {
   class ApiError extends Error {
-    constructor(public status: number, message: string) {
+    constructor(
+      public status: number,
+      message: string,
+    ) {
       super(message);
     }
   }

--- a/apps/web/src/features/benchmark/__tests__/BenchmarkLogsPanel.test.tsx
+++ b/apps/web/src/features/benchmark/__tests__/BenchmarkLogsPanel.test.tsx
@@ -6,9 +6,7 @@ import { BenchmarkLogsPanel } from "../BenchmarkLogsPanel";
 describe("BenchmarkLogsPanel", () => {
   it("shows pending message when run is non-terminal and logs are null", () => {
     render(<BenchmarkLogsPanel logs={null} state="running" />);
-    expect(
-      screen.getByText(/logs available after run completes/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/logs available after run completes/i)).toBeInTheDocument();
   });
 
   it("renders logs in a <pre> when present", () => {
@@ -25,12 +23,8 @@ describe("BenchmarkLogsPanel", () => {
   });
 
   it("survives transition from null logs to present logs without hook-order error", () => {
-    const { rerender } = render(
-      <BenchmarkLogsPanel logs={null} state="running" />,
-    );
-    expect(
-      screen.getByText(/logs available after run completes/i),
-    ).toBeInTheDocument();
+    const { rerender } = render(<BenchmarkLogsPanel logs={null} state="running" />);
+    expect(screen.getByText(/logs available after run completes/i)).toBeInTheDocument();
     rerender(<BenchmarkLogsPanel logs="hello world" state="completed" />);
     expect(screen.getByText(/hello world/i)).toBeInTheDocument();
   });

--- a/apps/web/src/features/benchmark/__tests__/BenchmarkMetricsGrid.test.tsx
+++ b/apps/web/src/features/benchmark/__tests__/BenchmarkMetricsGrid.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import "@/lib/i18n";
-import { BenchmarkMetricsGrid } from "../BenchmarkMetricsGrid";
 import type { BenchmarkMetricsSummary } from "@modeldoctor/contracts";
+import { BenchmarkMetricsGrid } from "../BenchmarkMetricsGrid";
 
 const SUMMARY: BenchmarkMetricsSummary = {
   ttft: { mean: 142, p50: 137, p95: 198, p99: 240 },

--- a/apps/web/src/features/benchmark/__tests__/BenchmarkProfilePicker.test.tsx
+++ b/apps/web/src/features/benchmark/__tests__/BenchmarkProfilePicker.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useForm, FormProvider } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 import { describe, expect, it } from "vitest";
 import "@/lib/i18n";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -32,9 +32,7 @@ function Harness({
     <TooltipProvider>
       <FormProvider {...form}>
         <BenchmarkProfilePicker />
-        <output data-testid="snapshot">
-          {JSON.stringify(form.watch())}
-        </output>
+        <output data-testid="snapshot">{JSON.stringify(form.watch())}</output>
       </FormProvider>
     </TooltipProvider>
   );

--- a/apps/web/src/features/benchmark/__tests__/queries.test.tsx
+++ b/apps/web/src/features/benchmark/__tests__/queries.test.tsx
@@ -5,7 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/api-client", () => {
   class ApiError extends Error {
-    constructor(public status: number, message: string) {
+    constructor(
+      public status: number,
+      message: string,
+    ) {
       super(message);
     }
   }
@@ -13,8 +16,8 @@ vi.mock("@/lib/api-client", () => {
 });
 
 import { api } from "@/lib/api-client";
-import { useBenchmarkDetail } from "../queries";
 import type { BenchmarkRun } from "@modeldoctor/contracts";
+import { useBenchmarkDetail } from "../queries";
 
 function makeRun(overrides: Partial<BenchmarkRun> = {}): BenchmarkRun {
   return {

--- a/apps/web/src/features/benchmark/api.ts
+++ b/apps/web/src/features/benchmark/api.ts
@@ -21,9 +21,7 @@ export const benchmarkApi = {
   list: (q: Partial<ListBenchmarksQuery>) =>
     api.get<ListBenchmarksResponse>(`/api/benchmarks${buildListQuery(q)}`),
   get: (id: string) => api.get<BenchmarkRun>(`/api/benchmarks/${id}`),
-  create: (body: CreateBenchmarkRequest) =>
-    api.post<BenchmarkRun>("/api/benchmarks", body),
-  cancel: (id: string) =>
-    api.post<BenchmarkRun>(`/api/benchmarks/${id}/cancel`, {}),
+  create: (body: CreateBenchmarkRequest) => api.post<BenchmarkRun>("/api/benchmarks", body),
+  cancel: (id: string) => api.post<BenchmarkRun>(`/api/benchmarks/${id}/cancel`, {}),
   delete: (id: string) => api.del<void>(`/api/benchmarks/${id}`),
 };

--- a/apps/web/src/features/benchmark/profiles.ts
+++ b/apps/web/src/features/benchmark/profiles.ts
@@ -1,7 +1,4 @@
-import type {
-  BenchmarkDataset,
-  BenchmarkProfile,
-} from "@modeldoctor/contracts";
+import type { BenchmarkDataset, BenchmarkProfile } from "@modeldoctor/contracts";
 
 export type LivePreset = Exclude<BenchmarkProfile, "custom" | "sharegpt">;
 

--- a/apps/web/src/features/benchmark/queries.ts
+++ b/apps/web/src/features/benchmark/queries.ts
@@ -1,21 +1,16 @@
-import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
-import { toast } from "sonner";
 import type {
   BenchmarkRun,
   CreateBenchmarkRequest,
   ListBenchmarksQuery,
 } from "@modeldoctor/contracts";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { benchmarkApi } from "./api";
 
 export const benchmarkKeys = {
   all: ["benchmarks"] as const,
   lists: () => [...benchmarkKeys.all, "list"] as const,
-  list: (q: Partial<ListBenchmarksQuery>) =>
-    [...benchmarkKeys.lists(), q] as const,
+  list: (q: Partial<ListBenchmarksQuery>) => [...benchmarkKeys.lists(), q] as const,
   details: () => [...benchmarkKeys.all, "detail"] as const,
   detail: (id: string) => [...benchmarkKeys.details(), id] as const,
 };
@@ -83,7 +78,7 @@ export function useDeleteBenchmark() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => benchmarkApi.delete(id),
-    onSuccess: (_: void, id: string) => {
+    onSuccess: (_data, id: string) => {
       qc.invalidateQueries({ queryKey: benchmarkKeys.lists() });
       qc.removeQueries({ queryKey: benchmarkKeys.detail(id) });
     },

--- a/apps/web/src/features/benchmark/schemas.ts
+++ b/apps/web/src/features/benchmark/schemas.ts
@@ -1,7 +1,7 @@
 import {
-  CreateBenchmarkRequestSchema,
   type BenchmarkRun,
   type CreateBenchmarkRequest,
+  CreateBenchmarkRequestSchema,
 } from "@modeldoctor/contracts";
 
 export { CreateBenchmarkRequestSchema };


### PR DESCRIPTION
## Summary

CI on the just-merged PR #15 (Phase 5 web UI) failed on `pnpm -F @modeldoctor/web lint` (biome) with 38 errors. Plan §11 only gated on type-check + tests, not lint, so the lint surface accumulated. This is a no-functional-change cleanup commit.

## What changed

- **36 `organizeImports` diagnostics** across the 21 benchmark files — biome wants strict alphabetical import order; we had logical groupings. Applied via `biome check --fix`.
- **`queries.ts` `useDeleteBenchmark`** — `onSuccess: (_: void, id)` triggered `noConfusingVoidType`; renamed to `(_data, id)` (TS still infers the right type from `useMutation`).
- **`BenchmarkLogsPanel` `<details role="region">`** — `useSemanticElements` rule wants `<section>` for `role="region"`. Wrapped the `<details>` in `<section aria-label={…}>` so the collapsible widget keeps its UX and the accessibility tree gets a real `region` landmark.

## Verification

- [x] `pnpm -F @modeldoctor/web lint` — 0 errors (4 non-blocking warnings remain; tracked separately)
- [x] `pnpm -F @modeldoctor/web type-check` — 0 errors
- [x] `pnpm -F @modeldoctor/web test -- --run` — 118 / 118 still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)