### PR TITLE
fix(api/benchmark): respect KUBECONFIG from .env + correct runner image default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,7 +49,15 @@ BENCHMARK_CALLBACK_SECRET=<replace with: openssl rand -base64 48>
 
 # Only used when BENCHMARK_DRIVER=k8s.
 BENCHMARK_K8S_NAMESPACE=modeldoctor-benchmarks
-BENCHMARK_RUNNER_IMAGE=gpustack/benchmark-runner:v0.0.4
+# v0.0.3 is the latest tag actually published to Docker Hub; matches
+# apps/benchmark-runner/Dockerfile FROM. Bumping is a deliberate PR with
+# new fixture-based metrics-mapper tests.
+BENCHMARK_RUNNER_IMAGE=gpustack/benchmark-runner:v0.0.3
+
+# Optional kubeconfig override for out-of-cluster local dev. Leave unset in
+# production (the API runs as a pod and uses its in-cluster ServiceAccount).
+# Example for k3d: KUBECONFIG=/Users/you/.kube/k3d-modeldoctor.config
+# KUBECONFIG=
 
 # Default --max-seconds applied to runs when not otherwise capped.
 BENCHMARK_DEFAULT_MAX_DURATION_SECONDS=1800

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -63,6 +63,13 @@ export const EnvSchema = z
     BENCHMARK_K8S_NAMESPACE: z.string().min(1).default("modeldoctor-benchmarks"),
     BENCHMARK_RUNNER_IMAGE: z.string().min(1).optional(),
     BENCHMARK_DEFAULT_MAX_DURATION_SECONDS: z.coerce.number().int().positive().default(1800),
+    // Optional override for the kubeconfig file used by the K8s driver.
+    // Out-of-cluster local dev: set this to a specific kubeconfig (e.g. an
+    // isolated k3d config) so the driver doesn't pick up your default
+    // ~/.kube/config (which may point at a real cluster).
+    // In-cluster production: leave unset; @kubernetes/client-node falls back
+    // to the in-cluster ServiceAccount automatically.
+    KUBECONFIG: z.string().optional(),
     DISABLE_FIRST_USER_ADMIN: envBoolean.default(false),
   })
   .superRefine((env, ctx) => {

--- a/apps/api/src/modules/benchmark/drivers/driver.factory.spec.ts
+++ b/apps/api/src/modules/benchmark/drivers/driver.factory.spec.ts
@@ -28,6 +28,7 @@ describe("createBenchmarkDriver", () => {
     vi.stubGlobal("__test_kc_loader__", () => ({
       KubeConfig: class {
         loadFromDefault() {}
+        loadFromFile(_path: string) {}
         makeApiClient() {
           return {};
         }
@@ -43,6 +44,46 @@ describe("createBenchmarkDriver", () => {
       }),
     );
     expect(drv).toBeInstanceOf(K8sJobDriver);
+  });
+
+  it("uses KUBECONFIG path via loadFromFile when set, otherwise loadFromDefault", async () => {
+    // Track which loader was called per-instantiation.
+    const calls: string[] = [];
+    vi.stubGlobal("__test_kc_loader__", () => ({
+      KubeConfig: class {
+        loadFromDefault() {
+          calls.push("default");
+        }
+        loadFromFile(path: string) {
+          calls.push(`file:${path}`);
+        }
+        makeApiClient() {
+          return {};
+        }
+      },
+      BatchV1Api: class {},
+      CoreV1Api: class {},
+    }));
+
+    await createBenchmarkDriver(
+      buildConfig({
+        BENCHMARK_DRIVER: "k8s",
+        BENCHMARK_K8S_NAMESPACE: "ns",
+        BENCHMARK_RUNNER_IMAGE: "img:tag",
+        KUBECONFIG: "/custom/kubeconfig",
+      }),
+    );
+    expect(calls).toEqual(["file:/custom/kubeconfig"]);
+
+    calls.length = 0;
+    await createBenchmarkDriver(
+      buildConfig({
+        BENCHMARK_DRIVER: "k8s",
+        BENCHMARK_K8S_NAMESPACE: "ns",
+        BENCHMARK_RUNNER_IMAGE: "img:tag",
+      }),
+    );
+    expect(calls).toEqual(["default"]);
   });
 
   it("rejects unknown driver names", async () => {

--- a/apps/api/src/modules/benchmark/drivers/driver.factory.ts
+++ b/apps/api/src/modules/benchmark/drivers/driver.factory.ts
@@ -30,7 +30,18 @@ export async function createBenchmarkDriver(
     }
     const k8s = await loadK8sClient();
     const kc = new k8s.KubeConfig();
-    kc.loadFromDefault();
+    // Prefer an explicit KUBECONFIG from .env / process.env over loadFromDefault().
+    // @nestjs/config does not always populate process.env, so loadFromDefault()
+    // would silently fall through to ~/.kube/config — easy to mis-target a real
+    // cluster from local dev. ConfigService sees the validated .env value
+    // either way. In-cluster mode leaves KUBECONFIG unset and loadFromDefault()
+    // detects the ServiceAccount mount automatically.
+    const explicitKubeconfig = config.get("KUBECONFIG", { infer: true }) as string | undefined;
+    if (explicitKubeconfig) {
+      kc.loadFromFile(explicitKubeconfig);
+    } else {
+      kc.loadFromDefault();
+    }
     return new K8sJobDriver({
       namespace: ns,
       image,

--- a/apps/api/src/modules/benchmark/drivers/k8s-reader.factory.ts
+++ b/apps/api/src/modules/benchmark/drivers/k8s-reader.factory.ts
@@ -15,7 +15,16 @@ export async function createBenchmarkK8sReader(
   if (driver !== "k8s") return null;
   const k8s = await loadK8sClient();
   const kc = new k8s.KubeConfig();
-  kc.loadFromDefault();
+  // Mirror driver.factory.ts: prefer an explicit KUBECONFIG so out-of-cluster
+  // dev doesn't fall through to ~/.kube/config and accidentally read a real
+  // cluster's context. In-cluster mode (KUBECONFIG unset) is handled by
+  // loadFromDefault()'s ServiceAccount fallback.
+  const explicitKubeconfig = config.get("KUBECONFIG", { infer: true }) as string | undefined;
+  if (explicitKubeconfig) {
+    kc.loadFromFile(explicitKubeconfig);
+  } else {
+    kc.loadFromDefault();
+  }
   const batch = kc.makeApiClient(k8s.BatchV1Api);
   const core = kc.makeApiClient(k8s.CoreV1Api);
   return {


### PR DESCRIPTION
## Summary

Two real bugs surfaced during the local k3d smoke test of Phase 5.

### 1. KUBECONFIG from `.env` was being silently ignored

`K8sReaderFactory` and `createBenchmarkDriver` both called `kc.loadFromDefault()`, which reads `process.env.KUBECONFIG`. But `@nestjs/config` doesn't reliably populate `process.env` from `.env` files (values land in the internal `ConfigService` store; mirroring to `process.env` is conditional). Result: out-of-cluster local dev with `KUBECONFIG=/path/to/k3d/config` in `.env` silently fell through to `~/.kube/config` — easy to mis-target a real cluster from a local API.

**Concretely observed:** during smoke test the API tried to create a Job at `https://10.100.121.67:6443/api/v1/namespaces/modeldoctor-benchmarks/secrets` (the user's 4pd cluster, sourced from `~/.kube/config`'s default context), instead of the local k3d cluster `~/.kube/k3d-modeldoctor.config` had been pointed to.

**Fix:** read `KUBECONFIG` via `ConfigService.get` (which sees the validated `.env`) and call `loadFromFile(path)` explicitly when set; otherwise `loadFromDefault()`, which still detects the in-cluster ServiceAccount mount automatically in production. **In-cluster deployments leave `KUBECONFIG` unset and behave exactly as before** — the change is additive for the out-of-cluster case.

### 2. `.env.example` pinned a non-existent image tag

`BENCHMARK_RUNNER_IMAGE=gpustack/benchmark-runner:v0.0.4` doesn't exist on Docker Hub. `apps/benchmark-runner/Dockerfile` \`FROM gpustack/benchmark-runner:v0.0.3\` is the actual latest published tag, matches the existing \`llm-endpoint-benchmark\` skill, and is what the k3d smoke run actually pulled.

## Changes

- \`apps/api/src/config/env.schema.ts\` — adds \`KUBECONFIG: z.string().optional()\`
- \`apps/api/src/modules/benchmark/drivers/driver.factory.ts\` — reads explicit kubeconfig path; \`loadFromFile\` if set, \`loadFromDefault\` otherwise
- \`apps/api/src/modules/benchmark/drivers/k8s-reader.factory.ts\` — same pattern (mirror change)
- \`apps/api/src/modules/benchmark/drivers/driver.factory.spec.ts\` — adds \`loadFromFile\` to the test stub, plus a new test asserting branch selection (6 tests total, was 5)
- \`.env.example\` — fixes runner image tag, adds inline \`KUBECONFIG=\` example for k3d

## Verification

- [x] \`pnpm -F @modeldoctor/api type-check\` — 0 errors
- [x] \`pnpm -F @modeldoctor/api test\` — **159 / 159** passing (1 new)
- [x] \`pnpm -F @modeldoctor/api exec biome check src\` — 0 errors
- [x] Manual: Phase 5 smoke worked with \`KUBECONFIG\` exported in shell. After this fix, same behavior should work with \`KUBECONFIG=\` set only in \`.env\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)