### PR TITLE
fix(api/e2e): inject BENCHMARK_CALLBACK_SECRET + apply apiBaseUrl rename

### DIFF
--- a/apps/api/test/e2e/auth.e2e-spec.ts
+++ b/apps/api/test/e2e/auth.e2e-spec.ts
@@ -190,7 +190,7 @@ describe("Auth (e2e)", () => {
       data: {
         userId: adminId,
         apiType: "chat",
-        apiUrl: "http://admin-run",
+        apiBaseUrl: "http://admin-run",
         model: "m",
         rate: 1,
         duration: 1,
@@ -203,7 +203,7 @@ describe("Auth (e2e)", () => {
       data: {
         userId: user2Id,
         apiType: "chat",
-        apiUrl: "http://user2-run",
+        apiBaseUrl: "http://user2-run",
         model: "m",
         rate: 1,
         duration: 1,
@@ -218,7 +218,7 @@ describe("Auth (e2e)", () => {
       .set("Authorization", `Bearer ${adminToken}`)
       .expect(200);
 
-    const urls = adminRunsRes.body.items.map((r: { apiUrl: string }) => r.apiUrl);
+    const urls = adminRunsRes.body.items.map((r: { apiBaseUrl: string }) => r.apiBaseUrl);
     expect(urls).toContain("http://admin-run");
     expect(urls).toContain("http://user2-run");
   });
@@ -239,7 +239,7 @@ describe("Auth (e2e)", () => {
       data: {
         userId,
         apiType: "chat",
-        apiUrl: "http://own-run",
+        apiBaseUrl: "http://own-run",
         model: "m",
         rate: 1,
         duration: 1,
@@ -256,7 +256,7 @@ describe("Auth (e2e)", () => {
 
     // All returned runs must belong to this user
     expect(runsRes.body.items.every((r: { userId: string }) => r.userId === userId)).toBe(true);
-    expect(runsRes.body.items.some((r: { apiUrl: string }) => r.apiUrl === "http://own-run")).toBe(
+    expect(runsRes.body.items.some((r: { apiBaseUrl: string }) => r.apiBaseUrl === "http://own-run")).toBe(
       true,
     );
   });

--- a/apps/api/test/e2e/e2e-test.e2e-spec.ts
+++ b/apps/api/test/e2e/e2e-test.e2e-spec.ts
@@ -16,14 +16,14 @@ describe("E2ETest (e2e)", () => {
     await ctx.teardown();
   });
 
-  it("rejects missing apiUrl", async () => {
+  it("rejects missing apiBaseUrl", async () => {
     const res = await request(ctx.app.getHttpServer())
       .post("/api/e2e-test")
       .set("Authorization", `Bearer ${accessToken}`)
       .send({ apiKey: "k", model: "m", probes: ["text"] })
       .expect(400);
     expect(res.body.error.code).toBe("VALIDATION_FAILED");
-    expect(res.body.error.message).toMatch(/apiUrl/);
+    expect(res.body.error.message).toMatch(/apiBaseUrl/);
     expect(res.body.error.requestId).toMatch(/^[A-Za-z0-9_-]+$/);
   });
 
@@ -31,7 +31,7 @@ describe("E2ETest (e2e)", () => {
     const res = await request(ctx.app.getHttpServer())
       .post("/api/e2e-test")
       .set("Authorization", `Bearer ${accessToken}`)
-      .send({ apiUrl: "x", apiKey: "k", model: "m", probes: [] })
+      .send({ apiBaseUrl: "x", apiKey: "k", model: "m", probes: [] })
       .expect(400);
     expect(res.body.error.code).toBe("VALIDATION_FAILED");
     expect(res.body.error.message).toMatch(/probes/);
@@ -42,7 +42,7 @@ describe("E2ETest (e2e)", () => {
     const res = await request(ctx.app.getHttpServer())
       .post("/api/e2e-test")
       .set("Authorization", `Bearer ${accessToken}`)
-      .send({ apiUrl: "x", apiKey: "k", model: "m", probes: ["bogus"] })
+      .send({ apiBaseUrl: "x", apiKey: "k", model: "m", probes: ["bogus"] })
       .expect(400);
     expect(res.body.error.code).toBe("VALIDATION_FAILED");
     expect(res.body.error.message).toMatch(/probes/);

--- a/apps/api/test/e2e/load-test-runs.e2e-spec.ts
+++ b/apps/api/test/e2e/load-test-runs.e2e-spec.ts
@@ -33,7 +33,7 @@ describe("LoadTestRuns (e2e)", () => {
     await prisma.loadTestRun.create({
       data: {
         apiType: "chat",
-        apiUrl: "http://x",
+        apiBaseUrl: "http://x",
         model: "m",
         rate: 1,
         duration: 1,
@@ -63,7 +63,7 @@ describe("LoadTestRuns (e2e)", () => {
       await prisma.loadTestRun.create({
         data: {
           apiType: "chat",
-          apiUrl: `http://x/${i}`,
+          apiBaseUrl: `http://x/${i}`,
           model: "m",
           rate: 1,
           duration: 1,
@@ -110,7 +110,7 @@ describe("LoadTestRuns (e2e)", () => {
       data: {
         userId: user2Id,
         apiType: "chat",
-        apiUrl: "http://user2-run",
+        apiBaseUrl: "http://user2-run",
         model: "m",
         rate: 1,
         duration: 1,
@@ -132,7 +132,7 @@ describe("LoadTestRuns (e2e)", () => {
       .get("/api/load-test/runs")
       .set("Authorization", `Bearer ${adminToken}`)
       .expect(200);
-    const adminRunIds = adminRuns.body.items.map((r: { apiUrl: string }) => r.apiUrl);
+    const adminRunIds = adminRuns.body.items.map((r: { apiBaseUrl: string }) => r.apiBaseUrl);
     expect(adminRunIds).toContain("http://user2-run");
     // admin sees more rows than user2 alone
     expect(adminRuns.body.items.length).toBeGreaterThan(user2Runs.body.items.length);
@@ -151,7 +151,7 @@ describe("LoadTestRuns (e2e)", () => {
       data: {
         userId: user3Id,
         apiType: "completions",
-        apiUrl: "http://user3-run",
+        apiBaseUrl: "http://user3-run",
         model: "m",
         rate: 1,
         duration: 1,
@@ -166,7 +166,7 @@ describe("LoadTestRuns (e2e)", () => {
       .get("/api/load-test/runs")
       .set("Authorization", `Bearer ${adminToken}`)
       .expect(200);
-    const adminUrls = adminRuns.body.items.map((r: { apiUrl: string }) => r.apiUrl);
+    const adminUrls = adminRuns.body.items.map((r: { apiBaseUrl: string }) => r.apiBaseUrl);
     expect(adminUrls).toContain("http://user3-run");
   });
 });

--- a/apps/api/test/e2e/load-test.e2e-spec.ts
+++ b/apps/api/test/e2e/load-test.e2e-spec.ts
@@ -16,7 +16,7 @@ describe("LoadTest (e2e)", () => {
     await ctx.teardown();
   });
 
-  it("rejects missing apiUrl", async () => {
+  it("rejects missing apiBaseUrl", async () => {
     const res = await request(ctx.app.getHttpServer())
       .post("/api/load-test")
       .set("Authorization", `Bearer ${accessToken}`)
@@ -30,7 +30,7 @@ describe("LoadTest (e2e)", () => {
     const res = await request(ctx.app.getHttpServer())
       .post("/api/load-test")
       .set("Authorization", `Bearer ${accessToken}`)
-      .send({ apiUrl: "x", apiKey: "k", model: "m", rate: 0, duration: 1 })
+      .send({ apiBaseUrl: "x", apiKey: "k", model: "m", rate: 0, duration: 1 })
       .expect(400);
     expect(res.body.error.code).toBe("VALIDATION_FAILED");
     expect(res.body.error.message).toMatch(/rate/i);
@@ -41,7 +41,7 @@ describe("LoadTest (e2e)", () => {
     const res = await request(ctx.app.getHttpServer())
       .post("/api/load-test")
       .set("Authorization", `Bearer ${accessToken}`)
-      .send({ apiUrl: "x", apiKey: "k", model: "m", rate: 1, duration: 99999 })
+      .send({ apiBaseUrl: "x", apiKey: "k", model: "m", rate: 1, duration: 99999 })
       .expect(400);
     expect(res.body.error.code).toBe("VALIDATION_FAILED");
     expect(res.body.error.message).toMatch(/duration/i);

--- a/apps/api/vitest.e2e.config.mts
+++ b/apps/api/vitest.e2e.config.mts
@@ -25,6 +25,12 @@ export default defineConfig({
       // passport-jwt validates secretOrKey at strategy-construction time,
       // so AppModule boot needs a non-empty JWT secret even in test mode.
       JWT_ACCESS_SECRET: "e2e-test-jwt-secret-not-for-production-use-only-32+chars",
+      // HmacCallbackGuard validates BENCHMARK_CALLBACK_SECRET at constructor
+      // time (same pattern as passport-jwt), so AppModule boot needs a
+      // non-empty value even when no benchmark e2e test cares about it.
+      // env.schema.ts treats it as optional under NODE_ENV=test; this
+      // injects a placeholder so the guard doesn't throw on construction.
+      BENCHMARK_CALLBACK_SECRET: "e2e-test-callback-secret-not-for-production-use-32+chars",
     },
   },
 });


### PR DESCRIPTION
## Summary

Two CI-only e2e failures surfaced when PR #20 (`feat/restructure → main`) tried to run the full test suite.

### 1. `HmacCallbackGuard` boot blocker

\`HmacCallbackGuard\` validates \`BENCHMARK_CALLBACK_SECRET\` at constructor time (same pattern as passport-jwt's \`secretOrKey\`). \`vitest.e2e.config.mts\` already injects \`JWT_ACCESS_SECRET\` as a placeholder so AppModule can boot under \`NODE_ENV=test\` — but the same treatment was missing for the benchmark callback secret. Result: every e2e spec failed before its first test ran (\`teardown of undefined\` cascade).

Fix: add the same placeholder pattern.

### 2. PR #19 didn't reach \`apps/api/test/e2e/\`

The Phase 6.2 \`apiUrl → apiBaseUrl\` rename updated the unit-test fixtures in \`apps/api/src/**/*.spec.ts\` but missed the e2e specs in \`apps/api/test/e2e/*.e2e-spec.ts\`. Four files affected:

- \`auth.e2e-spec.ts\`
- \`e2e-test.e2e-spec.ts\`
- \`load-test.e2e-spec.ts\`
- \`load-test-runs.e2e-spec.ts\`

Mechanical sed \`apiUrl → apiBaseUrl\` (and \`api_url → api_base_url\`).

## Verification

- [x] \`pnpm -F @modeldoctor/api test:e2e\` — **31/31 passing across 7 spec files** (was 18/31 before)
- [x] \`pnpm -F @modeldoctor/api type-check\` — clean
- [x] \`pnpm -F @modeldoctor/api exec biome check src test\` — clean

This unblocks PR #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)