### PR TITLE
fix(api/e2e): inject BENCHMARK_API_KEY_ENCRYPTION_KEY for AppModule boot

### DIFF
--- a/apps/api/vitest.e2e.config.mts
+++ b/apps/api/vitest.e2e.config.mts
@@ -31,6 +31,11 @@ export default defineConfig({
       // env.schema.ts treats it as optional under NODE_ENV=test; this
       // injects a placeholder so the guard doesn't throw on construction.
       BENCHMARK_CALLBACK_SECRET: "e2e-test-callback-secret-not-for-production-use-32+chars",
+      // BenchmarkService.constructor → decodeKey() runs at module init time,
+      // same constructor-validation pattern. env.schema.ts treats this as
+      // optional in test mode; inject a 32-byte base64 placeholder so the
+      // service can boot. (32 zero bytes; never used to encrypt real data.)
+      BENCHMARK_API_KEY_ENCRYPTION_KEY: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
     },
   },
 });


### PR DESCRIPTION
## Summary

PR #21 unblocked the first CI boot blocker (`HmacCallbackGuard` reading `BENCHMARK_CALLBACK_SECRET`), but a second one surfaced behind it: `BenchmarkService.constructor` calls `decodeKey()` on `BENCHMARK_API_KEY_ENCRYPTION_KEY` at module-init time, throwing `TypeError: The first argument must be of type string ... Received undefined` before any test runs.

Same pattern as the JWT secret + callback secret: `env.schema.ts` marks the var optional under `NODE_ENV=test`, but the service constructor still needs *something* non-empty to boot. Inject a 32-byte all-zero base64 placeholder.

## Verification

- [x] `pnpm -F @modeldoctor/api test:e2e` — 31/31 across 7 spec files
- [x] `pnpm -F @modeldoctor/api type-check` — clean

This should unblock PR #20 (`feat/restructure → main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)