### PR TITLE
fix(web/auth): dedup BootGate refresh to avoid StrictMode reuse-detection

### DIFF
--- a/apps/web/src/features/auth/ProtectedRoute.tsx
+++ b/apps/web/src/features/auth/ProtectedRoute.tsx
@@ -1,3 +1,4 @@
+import { refreshAccessToken } from "@/lib/api-client";
 import { useAuthStore } from "@/stores/auth-store";
 import { type ReactNode, useEffect, useState } from "react";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
@@ -8,32 +9,24 @@ interface BootGateProps {
 
 function BootGate({ children }: BootGateProps) {
   // On mount, attempt a silent /api/auth/refresh so reloads re-hydrate the
-  // session via the HttpOnly cookie. Shows nothing while the probe is in
-  // flight to avoid a login-flash.
+  // session via the HttpOnly cookie. Delegates to api-client's module-level
+  // refreshAccessToken so React StrictMode's double-invoked effects in dev
+  // dedup against a single in-flight refresh — otherwise both POSTs would
+  // carry the same cookie, and the server's rotation guard would treat the
+  // second arrival as a reuse attack and invalidate the whole session.
   const [probed, setProbed] = useState(false);
-  const setAuth = useAuthStore((s) => s.setAuth);
 
   useEffect(() => {
     let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetch("/api/auth/refresh", {
-          method: "POST",
-          credentials: "include",
-        });
-        if (!cancelled && res.ok) {
-          const body = await res.json();
-          setAuth(body.accessToken, body.user);
-        }
-      } catch {
-        // ignore — no cookie, just proceed to login
-      }
+    void refreshAccessToken().finally(() => {
+      // refreshAccessToken populates the auth store on success; the only
+      // job left here is to release the loading gate so child routes render.
       if (!cancelled) setProbed(true);
-    })();
+    });
     return () => {
       cancelled = true;
     };
-  }, [setAuth]);
+  }, []);
 
   if (!probed) return null;
   return <>{children}</>;

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -15,9 +15,15 @@ export class ApiError extends Error {
 }
 
 // Serialize concurrent refresh attempts so multiple 401s only issue ONE refresh.
+// Also exported as `refreshAccessToken` so the BootGate (and any other top-level
+// consumer) can dedup against the same in-flight promise. Without dedup,
+// React StrictMode's double-invoked effects in dev fire two parallel
+// /api/auth/refresh POSTs, both carrying the original cookie value; the
+// server's rotation guard sees the second arrival as token reuse and
+// invalidates the entire session.
 let refreshInFlight: Promise<string | null> | null = null;
 
-async function refreshAccessToken(): Promise<string | null> {
+export async function refreshAccessToken(): Promise<string | null> {
   if (!refreshInFlight) {
     const p: Promise<string | null> = (async () => {
       try {


### PR DESCRIPTION
## Summary

User report: refreshing any protected page (e.g. \`/benchmarks/<id>\`) intermittently bounced to \`/login\` with API logs showing \`Refresh token reused; session invalidated\`.

### Root cause

React 18 \`<StrictMode>\` in dev double-invokes effects (mount → cleanup → re-mount). \`BootGate\` had its own \`useEffect\` that POSTed to \`/api/auth/refresh\` directly. The two effect runs fire two parallel network requests, both carrying the original cookie. The server's rotation guard:

\`\`\`ts
if (row.revokedAt !== null) {
  // THEFT DETECTION → revoke ALL of this user's outstanding tokens
  ...
  throw new UnauthorizedException("Refresh token reused; session invalidated");
}
\`\`\`

…sees the second request, treats it as a stolen-token replay, and nukes the whole token family. Production isn't affected (StrictMode is dev-only) but it makes local dev unusable for any reload-heavy testing.

### Fix

\`apps/web/src/lib/api-client.ts\` already had a module-level \`refreshInFlight\` promise to dedup concurrent 401-driven refreshes. Export it as \`refreshAccessToken\` and reuse from BootGate so the second StrictMode invocation shares the in-flight request rather than starting a fresh one.

Side benefit: BootGate no longer duplicates the JSON parsing / auth-store population that \`api-client\` already does correctly.

### Files

- \`apps/web/src/lib/api-client.ts\` — change \`refreshAccessToken\` from module-private to \`export\`. Add a comment explaining why.
- \`apps/web/src/features/auth/ProtectedRoute.tsx\` — replace inline fetch with \`refreshAccessToken()\` call.

### Verification

- [x] \`pnpm -F @modeldoctor/web type-check\` — clean
- [x] \`pnpm -F @modeldoctor/web test ProtectedRoute -- --run\` — 3/3 pass
- [x] \`pnpm -F @modeldoctor/web exec biome check src/features/auth src/lib\` — clean
- [ ] Manual smoke: reload \`/benchmarks/<id>\` 10× — no auth bounce (user to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)