### PR TITLE
feat(web/auth): cross-tab Web Locks + session-cookie precheck + proactive expiry refresh

### DIFF
--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -77,10 +77,10 @@ export class AuthController {
     @Body(new ZodValidationPipe(RegisterRequestSchema)) body: RegisterRequest,
     @Res({ passthrough: true }) res: Response,
   ): Promise<AuthTokenResponse> {
-    const { accessToken, refreshToken, user } = await this.auth.register(body.email, body.password);
+    const issued = await this.auth.register(body.email, body.password);
     setRefreshCookie(
       res,
-      refreshToken,
+      issued.refreshToken,
       this.config.get("JWT_REFRESH_EXPIRES_DAYS", { infer: true }),
       this.config.get("NODE_ENV", { infer: true }) === "production",
     );
@@ -89,7 +89,11 @@ export class AuthController {
       this.config.get("JWT_REFRESH_EXPIRES_DAYS", { infer: true }),
       this.config.get("NODE_ENV", { infer: true }) === "production",
     );
-    return { accessToken, user };
+    return {
+      accessToken: issued.accessToken,
+      accessTokenExpiresAt: issued.accessTokenExpiresAt.toISOString(),
+      user: issued.user,
+    };
   }
 
   @Throttle({ default: { limit: 10, ttl: 60_000 } })
@@ -99,10 +103,10 @@ export class AuthController {
     @Body(new ZodValidationPipe(LoginRequestSchema)) body: LoginRequest,
     @Res({ passthrough: true }) res: Response,
   ): Promise<AuthTokenResponse> {
-    const { accessToken, refreshToken, user } = await this.auth.login(body.email, body.password);
+    const issued = await this.auth.login(body.email, body.password);
     setRefreshCookie(
       res,
-      refreshToken,
+      issued.refreshToken,
       this.config.get("JWT_REFRESH_EXPIRES_DAYS", { infer: true }),
       this.config.get("NODE_ENV", { infer: true }) === "production",
     );
@@ -111,7 +115,11 @@ export class AuthController {
       this.config.get("JWT_REFRESH_EXPIRES_DAYS", { infer: true }),
       this.config.get("NODE_ENV", { infer: true }) === "production",
     );
-    return { accessToken, user };
+    return {
+      accessToken: issued.accessToken,
+      accessTokenExpiresAt: issued.accessTokenExpiresAt.toISOString(),
+      user: issued.user,
+    };
   }
 
   @Public()
@@ -138,7 +146,11 @@ export class AuthController {
     }
     // Grace-replayed: do not touch the cookie — the legitimate caller's
     // freshly-issued cookie is already in the browser's jar.
-    return { accessToken: result.accessToken, user: result.user };
+    return {
+      accessToken: result.accessToken,
+      accessTokenExpiresAt: result.accessTokenExpiresAt.toISOString(),
+      user: result.user,
+    };
   }
 
   @Post("logout")

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -27,6 +27,7 @@ import { JwtAuthGuard } from "./jwt-auth.guard.js";
 import type { JwtPayload } from "./jwt.strategy.js";
 
 const REFRESH_COOKIE = "md_refresh";
+const SESSION_COOKIE = "md_session";
 
 function setRefreshCookie(res: Response, token: string, maxAgeDays: number, isProd: boolean): void {
   res.cookie(REFRESH_COOKIE, token, {
@@ -36,6 +37,30 @@ function setRefreshCookie(res: Response, token: string, maxAgeDays: number, isPr
     path: "/api/auth",
     maxAge: maxAgeDays * 86_400_000,
   });
+}
+
+/**
+ * Non-HttpOnly companion cookie. Holds NO sensitive value — it's a presence
+ * flag (`1`). Lets the SPA's BootGate skip the /refresh probe entirely when
+ * the user has clearly never logged in (or has logged out), avoiding
+ * pointless 401s and rate-limit pressure.
+ *
+ * Path=/ so JS on any route can read it; SameSite=Lax so it survives
+ * top-level cross-site navigations into the app.
+ */
+function setSessionCookie(res: Response, maxAgeDays: number, isProd: boolean): void {
+  res.cookie(SESSION_COOKIE, "1", {
+    httpOnly: false,
+    secure: isProd,
+    sameSite: "lax",
+    path: "/",
+    maxAge: maxAgeDays * 86_400_000,
+  });
+}
+
+function clearAuthCookies(res: Response): void {
+  res.clearCookie(REFRESH_COOKIE, { path: "/api/auth" });
+  res.clearCookie(SESSION_COOKIE, { path: "/" });
 }
 
 @Controller("auth")
@@ -59,6 +84,11 @@ export class AuthController {
       this.config.get("JWT_REFRESH_EXPIRES_DAYS", { infer: true }),
       this.config.get("NODE_ENV", { infer: true }) === "production",
     );
+    setSessionCookie(
+      res,
+      this.config.get("JWT_REFRESH_EXPIRES_DAYS", { infer: true }),
+      this.config.get("NODE_ENV", { infer: true }) === "production",
+    );
     return { accessToken, user };
   }
 
@@ -73,6 +103,11 @@ export class AuthController {
     setRefreshCookie(
       res,
       refreshToken,
+      this.config.get("JWT_REFRESH_EXPIRES_DAYS", { infer: true }),
+      this.config.get("NODE_ENV", { infer: true }) === "production",
+    );
+    setSessionCookie(
+      res,
       this.config.get("JWT_REFRESH_EXPIRES_DAYS", { infer: true }),
       this.config.get("NODE_ENV", { infer: true }) === "production",
     );
@@ -95,6 +130,11 @@ export class AuthController {
         this.config.get("JWT_REFRESH_EXPIRES_DAYS", { infer: true }),
         this.config.get("NODE_ENV", { infer: true }) === "production",
       );
+      setSessionCookie(
+        res,
+        this.config.get("JWT_REFRESH_EXPIRES_DAYS", { infer: true }),
+        this.config.get("NODE_ENV", { infer: true }) === "production",
+      );
     }
     // Grace-replayed: do not touch the cookie — the legitimate caller's
     // freshly-issued cookie is already in the browser's jar.
@@ -108,7 +148,7 @@ export class AuthController {
   ): Promise<{ ok: true }> {
     const presented = (req.cookies as Record<string, string> | undefined)?.[REFRESH_COOKIE];
     if (presented) await this.auth.logout(presented);
-    res.clearCookie(REFRESH_COOKIE, { path: "/api/auth" });
+    clearAuthCookies(res);
     return { ok: true };
   }
 

--- a/apps/api/src/modules/auth/auth.service.spec.ts
+++ b/apps/api/src/modules/auth/auth.service.spec.ts
@@ -180,6 +180,7 @@ describe("AuthService.refresh (happy path)", () => {
     if (result.kind !== "rotated") throw new Error("type narrow");
     expect(result.refreshToken).toBeTruthy();
     expect(result.accessToken).toBe("access-jwt");
+    expect(result.accessTokenExpiresAt).toBeInstanceOf(Date);
     expect(result.user.id).toBe("u1");
 
     // Parent was marked revoked + replacedBy = the child id.
@@ -232,6 +233,7 @@ describe("AuthService.refresh (grace-window replay)", () => {
     expect(result.kind).toBe("graceReplayed");
     if (result.kind !== "graceReplayed") throw new Error("type narrow");
     expect(result.accessToken).toBe("access-jwt");
+    expect(result.accessTokenExpiresAt).toBeInstanceOf(Date);
     expect("refreshToken" in result).toBe(false);
 
     // Family must NOT be revoked (no updateMany call).

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -16,13 +16,20 @@ import type { JwtPayload } from "./jwt.strategy.js";
 
 export interface IssuedTokens {
   accessToken: string;
+  accessTokenExpiresAt: Date;
   refreshToken: string;
   user: PublicUser;
 }
 
 export type RefreshResult =
-  | { kind: "rotated"; accessToken: string; refreshToken: string; user: PublicUser }
-  | { kind: "graceReplayed"; accessToken: string; user: PublicUser };
+  | {
+      kind: "rotated";
+      accessToken: string;
+      accessTokenExpiresAt: Date;
+      refreshToken: string;
+      user: PublicUser;
+    }
+  | { kind: "graceReplayed"; accessToken: string; accessTokenExpiresAt: Date; user: PublicUser };
 
 @Injectable()
 export class AuthService {
@@ -91,8 +98,14 @@ export class AuthService {
 
   private async refreshOnce(presentedToken: string): Promise<RefreshResult> {
     type TxnOutcome =
-      | { kind: "rotated"; accessToken: string; refreshToken: string; user: PublicUser }
-      | { kind: "graceReplayed"; accessToken: string; user: PublicUser }
+      | {
+          kind: "rotated";
+          accessToken: string;
+          accessTokenExpiresAt: Date;
+          refreshToken: string;
+          user: PublicUser;
+        }
+      | { kind: "graceReplayed"; accessToken: string; accessTokenExpiresAt: Date; user: PublicUser }
       | { kind: "theft"; userId: string; familyId: string; rowId: string };
 
     const tokenHash = this.sha256hex(presentedToken);
@@ -137,7 +150,11 @@ export class AuthService {
               secret: this.config.get("JWT_ACCESS_SECRET", { infer: true }) ?? "",
               expiresIn: this.config.get("JWT_ACCESS_EXPIRES_IN", { infer: true }),
             });
-            return { kind: "graceReplayed", accessToken, user: publicUser };
+            const expiresInMs = this.parseExpiresInMs(
+              this.config.get("JWT_ACCESS_EXPIRES_IN", { infer: true }) ?? "15m",
+            );
+            const accessTokenExpiresAt = new Date(Date.now() + expiresInMs);
+            return { kind: "graceReplayed", accessToken, accessTokenExpiresAt, user: publicUser };
           }
 
           // THEFT — revoke the family inside the txn, then return a sentinel
@@ -191,6 +208,7 @@ export class AuthService {
         return {
           kind: "rotated",
           accessToken: issued.accessToken,
+          accessTokenExpiresAt: issued.accessTokenExpiresAt,
           refreshToken: issued.refreshToken,
           user: publicUser,
         };
@@ -249,6 +267,10 @@ export class AuthService {
       secret: this.config.get("JWT_ACCESS_SECRET", { infer: true }) ?? "",
       expiresIn: this.config.get("JWT_ACCESS_EXPIRES_IN", { infer: true }),
     });
+    const expiresInMs = this.parseExpiresInMs(
+      this.config.get("JWT_ACCESS_EXPIRES_IN", { infer: true }) ?? "15m",
+    );
+    const accessTokenExpiresAt = new Date(Date.now() + expiresInMs);
 
     // Refresh token: 48 random bytes → 64-char base64url string. High entropy
     // means SHA-256 is sufficient for storage (see plan design note). Argon2
@@ -285,7 +307,21 @@ export class AuthService {
       });
     }
 
-    return { accessToken, refreshToken, user };
+    return { accessToken, accessTokenExpiresAt, refreshToken, user };
+  }
+
+  /**
+   * Parse JWT_ACCESS_EXPIRES_IN (e.g. "15m", "1h", "7200s", or a bare integer
+   * meaning seconds) to milliseconds. Mirrors @nestjs/jwt's expiresIn parsing
+   * so the value we surface to clients matches the JWT exp claim itself.
+   */
+  private parseExpiresInMs(value: string): number {
+    const match = /^(\d+)\s*(s|m|h|d)?$/.exec(value);
+    if (!match) throw new Error(`Invalid JWT_ACCESS_EXPIRES_IN: ${value}`);
+    const n = Number.parseInt(match[1] ?? "", 10);
+    const unit = match[2] ?? "s";
+    const ms = { s: 1_000, m: 60_000, h: 3_600_000, d: 86_400_000 }[unit] ?? 1_000;
+    return n * ms;
   }
 
   private sha256hex(value: string): string {

--- a/apps/api/test/e2e/auth.e2e-spec.ts
+++ b/apps/api/test/e2e/auth.e2e-spec.ts
@@ -22,6 +22,8 @@ describe("Auth (e2e)", () => {
       .expect(201);
 
     expect(res.body.accessToken).toBeTruthy();
+    expect(res.body.accessTokenExpiresAt).toBeTruthy();
+    expect(typeof res.body.accessTokenExpiresAt).toBe("string");
     expect(res.body.user.email).toBe("admin@example.com");
     expect(res.body.user.roles).toEqual(["admin"]);
     expect(res.body.user.id).toBeTruthy();
@@ -72,6 +74,8 @@ describe("Auth (e2e)", () => {
       .expect(201);
 
     expect(res.body.accessToken).toBeTruthy();
+    expect(res.body.accessTokenExpiresAt).toBeTruthy();
+    expect(typeof res.body.accessTokenExpiresAt).toBe("string");
     const rawCookies = res.headers["set-cookie"] as string[] | string | undefined;
     const cookies = Array.isArray(rawCookies) ? rawCookies : rawCookies ? [rawCookies] : [];
     const refreshCookie = cookies.find((c) => c.startsWith("md_refresh="));
@@ -87,6 +91,9 @@ describe("Auth (e2e)", () => {
       .post("/api/auth/login")
       .send({ email: "admin@example.com", password: "Password1!" })
       .expect(201);
+    expect(loginRes.body.accessToken).toBeTruthy();
+    expect(loginRes.body.accessTokenExpiresAt).toBeTruthy();
+    expect(typeof loginRes.body.accessTokenExpiresAt).toBe("string");
     const token = loginRes.body.accessToken as string;
     const registeredId = loginRes.body.user.id as string;
 
@@ -123,6 +130,8 @@ describe("Auth (e2e)", () => {
 
     const refreshRes = await agent.post("/api/auth/refresh").expect(201);
     expect(refreshRes.body.accessToken).toBeTruthy();
+    expect(refreshRes.body.accessTokenExpiresAt).toBeTruthy();
+    expect(typeof refreshRes.body.accessTokenExpiresAt).toBe("string");
 
     const rawCookies = refreshRes.headers["set-cookie"] as string[] | string | undefined;
     const cookies = Array.isArray(rawCookies) ? rawCookies : rawCookies ? [rawCookies] : [];
@@ -201,6 +210,8 @@ describe("Auth (e2e)", () => {
       .expect(201);
 
     expect(replay.body.accessToken).toBeTruthy();
+    expect(replay.body.accessTokenExpiresAt).toBeTruthy();
+    expect(typeof replay.body.accessTokenExpiresAt).toBe("string");
     const setCookieHeader = replay.headers["set-cookie"] as string[] | undefined;
     const hasNewRefreshCookie = !!setCookieHeader?.some((c) => c.startsWith("md_refresh="));
     expect(hasNewRefreshCookie, "grace-replay must NOT rotate cookie").toBe(false);
@@ -257,6 +268,8 @@ describe("Auth (e2e)", () => {
       .set("Cookie", cookieB)
       .expect(201);
     expect(bRotated.body.accessToken).toBeTruthy();
+    expect(bRotated.body.accessTokenExpiresAt).toBeTruthy();
+    expect(typeof bRotated.body.accessTokenExpiresAt).toBe("string");
   });
 
   // ── 11. Admin sees runs from all users ────────────────────────────────────
@@ -376,6 +389,10 @@ describe("Auth (e2e)", () => {
     expect(resB.status, "second refresh").toBe(201);
     expect(resA.body.accessToken).toBeTruthy();
     expect(resB.body.accessToken).toBeTruthy();
+    expect(resA.body.accessTokenExpiresAt).toBeTruthy();
+    expect(typeof resA.body.accessTokenExpiresAt).toBe("string");
+    expect(resB.body.accessTokenExpiresAt).toBeTruthy();
+    expect(typeof resB.body.accessTokenExpiresAt).toBe("string");
 
     const aSetsCookie = !!(resA.headers["set-cookie"] as string[] | undefined)?.some((c) =>
       c.startsWith("md_refresh="),

--- a/apps/api/test/e2e/auth.e2e-spec.ts
+++ b/apps/api/test/e2e/auth.e2e-spec.ts
@@ -33,6 +33,9 @@ describe("Auth (e2e)", () => {
     expect(refreshCookie).toBeTruthy();
     expect(refreshCookie).toMatch(/HttpOnly/i);
     expect(refreshCookie).toMatch(/Path=\/api\/auth/i);
+    const sessionCookie = cookies.find((c) => c.startsWith("md_session="));
+    expect(sessionCookie, "md_session set on register").toBeTruthy();
+    expect(sessionCookie).toMatch(/^md_session=1(;|$)/);
   });
 
   // ── 2. Register second user → role=user ──────────────────────────────────
@@ -73,6 +76,9 @@ describe("Auth (e2e)", () => {
     const cookies = Array.isArray(rawCookies) ? rawCookies : rawCookies ? [rawCookies] : [];
     const refreshCookie = cookies.find((c) => c.startsWith("md_refresh="));
     expect(refreshCookie).toBeTruthy();
+    const sessionCookie = cookies.find((c) => c.startsWith("md_session="));
+    expect(sessionCookie, "md_session set on register").toBeTruthy();
+    expect(sessionCookie).toMatch(/^md_session=1(;|$)/);
   });
 
   // ── 6. GET /api/auth/me with bearer → PublicUser shape ───────────────────
@@ -122,6 +128,9 @@ describe("Auth (e2e)", () => {
     const cookies = Array.isArray(rawCookies) ? rawCookies : rawCookies ? [rawCookies] : [];
     const refreshCookie = cookies.find((c) => c.startsWith("md_refresh="));
     expect(refreshCookie).toBeTruthy();
+    const sessionCookie = cookies.find((c) => c.startsWith("md_session="));
+    expect(sessionCookie, "md_session set on register").toBeTruthy();
+    expect(sessionCookie).toMatch(/^md_session=1(;|$)/);
   });
 
   // ── Theft detection: outside-grace replay still kills the family ─────────
@@ -376,5 +385,42 @@ describe("Auth (e2e)", () => {
     );
     // Exactly one of the two should rotate the cookie; the loser is grace-replayed.
     expect(aSetsCookie !== bSetsCookie, "exactly one rotates cookie").toBe(true);
+  });
+
+  // ── md_session companion cookie ──────────────────────────────────────────
+  it("login sets md_session=1 (non-HttpOnly, Path=/); logout clears it", async () => {
+    // Register the user first (admin@example.com may not exist in this test ordering;
+    // use a fresh user to keep the test self-contained)
+    await request(ctx.app.getHttpServer())
+      .post("/api/auth/register")
+      .send({ email: "session-cookie@example.com", password: "Password1!" })
+      .expect(201);
+
+    const loginRes = await request(ctx.app.getHttpServer())
+      .post("/api/auth/login")
+      .send({ email: "session-cookie@example.com", password: "Password1!" })
+      .expect(201);
+
+    const cookies = (loginRes.headers["set-cookie"] as string[]) ?? [];
+    const sessionCookie = cookies.find((c) => c.startsWith("md_session="));
+    expect(sessionCookie, "md_session present").toBeTruthy();
+    expect(sessionCookie).toMatch(/^md_session=1(;|$)/);
+    expect(sessionCookie).not.toMatch(/HttpOnly/i);
+    expect(sessionCookie).toMatch(/Path=\/(;|$)/);
+    expect(sessionCookie).toMatch(/SameSite=Lax/i);
+
+    // Logout should clear both cookies. /logout is behind the global
+    // JwtAuthGuard, so we need a Bearer token to reach the handler.
+    const accessToken = loginRes.body.accessToken as string;
+    const logoutRes = await request(ctx.app.getHttpServer())
+      .post("/api/auth/logout")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("Cookie", (sessionCookie as string).split(";")[0])
+      .expect(201);
+    const logoutCookies = (logoutRes.headers["set-cookie"] as string[]) ?? [];
+    const clearedSession = logoutCookies.find((c) => c.startsWith("md_session="));
+    expect(clearedSession, "md_session clear directive").toBeTruthy();
+    // Express clearCookie sets Expires to the epoch.
+    expect(clearedSession).toMatch(/Expires=Thu, 01 Jan 1970/i);
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,10 @@
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { startAccessTokenScheduler } from "@/lib/access-token-scheduler";
+import { refreshAccessToken } from "@/lib/api-client";
 import { routes } from "@/router";
 import { useThemeStore } from "@/stores/theme-store";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useEffect } from "react";
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
 import { Toaster } from "sonner";
 
@@ -12,6 +15,9 @@ const queryClient = new QueryClient({
 
 export default function App() {
   const themeMode = useThemeStore((s) => s.mode);
+  useEffect(() => {
+    return startAccessTokenScheduler(refreshAccessToken);
+  }, []);
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider delayDuration={150}>

--- a/apps/web/src/features/auth/LoginPage.test.tsx
+++ b/apps/web/src/features/auth/LoginPage.test.tsx
@@ -41,7 +41,7 @@ function renderLoginPage() {
 
 describe("LoginPage", () => {
   beforeEach(() => {
-    useAuthStore.setState({ accessToken: null, user: null });
+    useAuthStore.setState({ accessToken: null, user: null, accessTokenExpiresAt: null });
     vi.mocked(api.post).mockReset();
     vi.mocked(toast.error).mockReset();
   });
@@ -71,6 +71,7 @@ describe("LoginPage", () => {
   it("posts to /api/auth/login and updates the store on success", async () => {
     vi.mocked(api.post).mockResolvedValue({
       accessToken: "tok-123",
+      accessTokenExpiresAt: new Date(Date.now() + 900_000).toISOString(),
       user: mockUser,
     });
 

--- a/apps/web/src/features/auth/LoginPage.tsx
+++ b/apps/web/src/features/auth/LoginPage.tsx
@@ -36,7 +36,7 @@ export function LoginPage() {
     setSubmitError(null);
     try {
       const data = await api.post<AuthTokenResponse>("/api/auth/login", values);
-      setAuth(data.accessToken, data.user);
+      setAuth(data.accessToken, data.user, data.accessTokenExpiresAt);
       navigate(from, { replace: true });
     } catch (e) {
       setSubmitError(e instanceof ApiError ? e.message : "Login failed");

--- a/apps/web/src/features/auth/ProtectedRoute.test.tsx
+++ b/apps/web/src/features/auth/ProtectedRoute.test.tsx
@@ -27,6 +27,14 @@ function renderWithRoutes(initialPath = "/") {
 describe("ProtectedRoute", () => {
   beforeEach(() => {
     useAuthStore.setState({ accessToken: null, user: null, accessTokenExpiresAt: null });
+    // These tests semantically assume "user has a session, probe runs".
+    // BootGate now short-circuits when md_session is absent, so set it
+    // explicitly here to keep the existing scenarios meaningful.
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      configurable: true,
+      value: "md_session=1",
+    });
     vi.restoreAllMocks();
   });
 
@@ -100,5 +108,51 @@ describe("ProtectedRoute", () => {
     });
 
     expect(useAuthStore.getState().accessToken).toBe("tok-from-cookie");
+  });
+});
+
+describe("ProtectedRoute / BootGate session-cookie precheck", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: null, user: null, accessTokenExpiresAt: null });
+    Object.defineProperty(document, "cookie", { writable: true, configurable: true, value: "" });
+    vi.restoreAllMocks();
+  });
+
+  it("when md_session cookie is absent → redirects to /login WITHOUT calling /refresh", async () => {
+    Object.defineProperty(document, "cookie", { writable: true, configurable: true, value: "" });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithRoutes("/");
+
+    await waitFor(() => {
+      expect(screen.getByText("Login page")).toBeInTheDocument();
+    });
+    expect(fetchMock, "no /refresh probe when no session cookie").not.toHaveBeenCalled();
+  });
+
+  it("when md_session=1 is present → calls /refresh and renders protected", async () => {
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      configurable: true,
+      value: "md_session=1; theme=dark",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            accessToken: "ok",
+            accessTokenExpiresAt: new Date(Date.now() + 900_000).toISOString(),
+            user: mockUser,
+          }),
+      }),
+    );
+    renderWithRoutes("/");
+    await waitFor(() =>
+      expect(screen.getByText("Protected content")).toBeInTheDocument(),
+    );
   });
 });

--- a/apps/web/src/features/auth/ProtectedRoute.test.tsx
+++ b/apps/web/src/features/auth/ProtectedRoute.test.tsx
@@ -151,8 +151,50 @@ describe("ProtectedRoute / BootGate session-cookie precheck", () => {
       }),
     );
     renderWithRoutes("/");
-    await waitFor(() =>
-      expect(screen.getByText("Protected content")).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText("Protected content")).toBeInTheDocument());
+  });
+});
+
+describe("ProtectedRoute / BootGate transient retry", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: null, user: null, accessTokenExpiresAt: null });
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      configurable: true,
+      value: "md_session=1",
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("retries on 429 transient then succeeds → renders protected content", async () => {
+    let call = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      call += 1;
+      if (call === 1) {
+        return {
+          ok: false,
+          status: 429,
+          headers: { get: () => null },
+          json: () => Promise.resolve({}),
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            accessToken: "ok-after-retry",
+            accessTokenExpiresAt: new Date(Date.now() + 900_000).toISOString(),
+            user: mockUser,
+          }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithRoutes("/");
+    await waitFor(() => expect(screen.getByText("Protected content")).toBeInTheDocument(), {
+      timeout: 5_000,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/src/features/auth/ProtectedRoute.test.tsx
+++ b/apps/web/src/features/auth/ProtectedRoute.test.tsx
@@ -26,14 +26,19 @@ function renderWithRoutes(initialPath = "/") {
 
 describe("ProtectedRoute", () => {
   beforeEach(() => {
-    useAuthStore.setState({ accessToken: null, user: null });
+    useAuthStore.setState({ accessToken: null, user: null, accessTokenExpiresAt: null });
     vi.restoreAllMocks();
   });
 
   it("redirects unauthenticated users to /login (refresh probe returns 401)", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue({ ok: false, status: 401, json: () => Promise.resolve({}) }),
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        headers: { get: () => null },
+        json: () => Promise.resolve({}),
+      }),
     );
 
     renderWithRoutes("/");
@@ -45,7 +50,11 @@ describe("ProtectedRoute", () => {
 
   it("renders protected content when user is already authenticated in store", async () => {
     // Pre-seed the store (simulates user already logged in)
-    useAuthStore.setState({ accessToken: "tok-123", user: mockUser });
+    useAuthStore.setState({
+      accessToken: "tok-123",
+      user: mockUser,
+      accessTokenExpiresAt: new Date(Date.now() + 900_000).toISOString(),
+    });
 
     // Refresh probe should still be called on mount; mock it as successful
     vi.stubGlobal(
@@ -53,7 +62,12 @@ describe("ProtectedRoute", () => {
       vi.fn().mockResolvedValue({
         ok: true,
         status: 200,
-        json: () => Promise.resolve({ accessToken: "tok-456", user: mockUser }),
+        json: () =>
+          Promise.resolve({
+            accessToken: "tok-456",
+            accessTokenExpiresAt: new Date(Date.now() + 900_000).toISOString(),
+            user: mockUser,
+          }),
       }),
     );
 
@@ -70,7 +84,12 @@ describe("ProtectedRoute", () => {
       vi.fn().mockResolvedValue({
         ok: true,
         status: 200,
-        json: () => Promise.resolve({ accessToken: "tok-from-cookie", user: mockUser }),
+        json: () =>
+          Promise.resolve({
+            accessToken: "tok-from-cookie",
+            accessTokenExpiresAt: new Date(Date.now() + 900_000).toISOString(),
+            user: mockUser,
+          }),
       }),
     );
 

--- a/apps/web/src/features/auth/ProtectedRoute.tsx
+++ b/apps/web/src/features/auth/ProtectedRoute.tsx
@@ -7,20 +7,32 @@ interface BootGateProps {
   children: ReactNode;
 }
 
+function hasSessionCookie(): boolean {
+  if (typeof document === "undefined") return false;
+  // Lightweight scan — no need for a full parser. Looks for "md_session=1"
+  // anywhere in the cookie header (with the standard "; "-separated form
+  // browsers emit). False positives are harmless: we'd just probe /refresh
+  // and gracefully handle the 401.
+  return /(?:^|;\s*)md_session=1(?:;|$)/.test(document.cookie);
+}
+
 function BootGate({ children }: BootGateProps) {
-  // On mount, attempt a silent /api/auth/refresh so reloads re-hydrate the
-  // session via the HttpOnly cookie. Delegates to api-client's module-level
-  // refreshAccessToken so React StrictMode's double-invoked effects in dev
-  // dedup against a single in-flight refresh — otherwise both POSTs would
-  // carry the same cookie, and the server's rotation guard would treat the
-  // second arrival as a reuse attack and invalidate the whole session.
   const [probed, setProbed] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
+    // Already authenticated in this session → no need to probe.
+    if (useAuthStore.getState().accessToken) {
+      setProbed(true);
+      return;
+    }
+    // No session cookie → user has never logged in (or has logged out).
+    // Skip the network call entirely; ProtectedRoute will Navigate to /login.
+    if (!hasSessionCookie()) {
+      setProbed(true);
+      return;
+    }
     void refreshAccessToken().finally(() => {
-      // refreshAccessToken populates the auth store on success; the only
-      // job left here is to release the loading gate so child routes render.
       if (!cancelled) setProbed(true);
     });
     return () => {

--- a/apps/web/src/features/auth/ProtectedRoute.tsx
+++ b/apps/web/src/features/auth/ProtectedRoute.tsx
@@ -1,4 +1,5 @@
 import { refreshAccessToken } from "@/lib/api-client";
+import { retryWithBackoff } from "@/lib/retry-with-backoff";
 import { useAuthStore } from "@/stores/auth-store";
 import { type ReactNode, useEffect, useState } from "react";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
@@ -32,7 +33,9 @@ function BootGate({ children }: BootGateProps) {
       setProbed(true);
       return;
     }
-    void refreshAccessToken().finally(() => {
+    void retryWithBackoff(refreshAccessToken, (r) =>
+      r.kind === "transient" ? { retryAfterMs: r.retryAfterMs } : false,
+    ).finally(() => {
       if (!cancelled) setProbed(true);
     });
     return () => {

--- a/apps/web/src/features/auth/RegisterPage.test.tsx
+++ b/apps/web/src/features/auth/RegisterPage.test.tsx
@@ -41,7 +41,7 @@ function renderRegisterPage() {
 
 describe("RegisterPage", () => {
   beforeEach(() => {
-    useAuthStore.setState({ accessToken: null, user: null });
+    useAuthStore.setState({ accessToken: null, user: null, accessTokenExpiresAt: null });
     vi.mocked(api.post).mockReset();
     vi.mocked(toast.error).mockReset();
   });
@@ -84,6 +84,7 @@ describe("RegisterPage", () => {
   it("posts to /api/auth/register and updates the store on success", async () => {
     vi.mocked(api.post).mockResolvedValue({
       accessToken: "tok-register",
+      accessTokenExpiresAt: new Date(Date.now() + 900_000).toISOString(),
       user: mockUser,
     });
 

--- a/apps/web/src/features/auth/RegisterPage.tsx
+++ b/apps/web/src/features/auth/RegisterPage.tsx
@@ -31,7 +31,7 @@ export function RegisterPage() {
     setSubmitError(null);
     try {
       const data = await api.post<AuthTokenResponse>("/api/auth/register", values);
-      setAuth(data.accessToken, data.user);
+      setAuth(data.accessToken, data.user, data.accessTokenExpiresAt);
       navigate("/load-test", { replace: true });
     } catch (e) {
       setSubmitError(e instanceof ApiError ? e.message : "Registration failed");

--- a/apps/web/src/lib/access-token-scheduler.test.ts
+++ b/apps/web/src/lib/access-token-scheduler.test.ts
@@ -1,0 +1,121 @@
+import { useAuthStore } from "@/stores/auth-store";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { startAccessTokenScheduler } from "./access-token-scheduler";
+
+const mockUser = { id: "u1", email: "u@x", roles: ["user"], createdAt: new Date().toISOString() };
+
+describe("startAccessTokenScheduler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useAuthStore.setState({ accessToken: null, user: null, accessTokenExpiresAt: null });
+    Object.defineProperty(document, "visibilityState", {
+      writable: true,
+      configurable: true,
+      value: "visible",
+    });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("schedules refresh ~30s before expiry when store transitions to authenticated", async () => {
+    const refreshFn = vi.fn().mockResolvedValue({ kind: "ok", accessToken: "fresh" });
+    const stop = startAccessTokenScheduler(refreshFn);
+
+    const expiresAt = new Date(Date.now() + 60_000).toISOString(); // 60s from now
+    useAuthStore.setState({ accessToken: "tok", user: mockUser, accessTokenExpiresAt: expiresAt });
+
+    expect(refreshFn).not.toHaveBeenCalled();
+
+    // Fast-forward to 1ms before the scheduled fire moment (expiry - 30s = 30s mark).
+    vi.advanceTimersByTime(29_999);
+    expect(refreshFn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(2);
+    await vi.runAllTimersAsync();
+    expect(refreshFn).toHaveBeenCalledTimes(1);
+
+    stop();
+  });
+
+  it("cancels scheduled refresh when store is cleared (logout)", async () => {
+    const refreshFn = vi.fn().mockResolvedValue({ kind: "ok", accessToken: "fresh" });
+    const stop = startAccessTokenScheduler(refreshFn);
+
+    useAuthStore.setState({
+      accessToken: "tok",
+      user: mockUser,
+      accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    useAuthStore.setState({ accessToken: null, user: null, accessTokenExpiresAt: null });
+
+    vi.advanceTimersByTime(120_000);
+    await vi.runAllTimersAsync();
+    expect(refreshFn).not.toHaveBeenCalled();
+
+    stop();
+  });
+
+  it("clamps near-instant expiry to a minimum 1s delay (avoid tight loop)", async () => {
+    const refreshFn = vi.fn().mockResolvedValue({ kind: "ok", accessToken: "fresh" });
+    const stop = startAccessTokenScheduler(refreshFn);
+
+    // Expiry is only 1s away; subtracting the 30s leadtime would be -29s.
+    // Scheduler should clamp to MIN_DELAY_MS (1000).
+    useAuthStore.setState({
+      accessToken: "tok",
+      user: mockUser,
+      accessTokenExpiresAt: new Date(Date.now() + 1_000).toISOString(),
+    });
+
+    expect(refreshFn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(999);
+    expect(refreshFn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(2);
+    await vi.runAllTimersAsync();
+    expect(refreshFn).toHaveBeenCalledTimes(1);
+
+    stop();
+  });
+
+  it("pauses on visibilitychange='hidden' and resumes on 'visible'", async () => {
+    const refreshFn = vi.fn().mockResolvedValue({ kind: "ok", accessToken: "fresh" });
+    const stop = startAccessTokenScheduler(refreshFn);
+
+    useAuthStore.setState({
+      accessToken: "tok",
+      user: mockUser,
+      accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    // Now hide the tab. The scheduler should clear its timer.
+    Object.defineProperty(document, "visibilityState", {
+      writable: true,
+      configurable: true,
+      value: "hidden",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    // Advance past when the timer would have fired.
+    vi.advanceTimersByTime(60_000);
+    await vi.runAllTimersAsync();
+    expect(refreshFn).not.toHaveBeenCalled();
+
+    // Show the tab again. visibilitychange handler should reschedule. Because
+    // the original expiry has already passed in the fake-timer timeline, the
+    // scheduler clamps to MIN_DELAY_MS (1000) and fires after 1s.
+    Object.defineProperty(document, "visibilityState", {
+      writable: true,
+      configurable: true,
+      value: "visible",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    vi.advanceTimersByTime(1_001);
+    await vi.runAllTimersAsync();
+    expect(refreshFn).toHaveBeenCalledTimes(1);
+
+    stop();
+  });
+});

--- a/apps/web/src/lib/access-token-scheduler.ts
+++ b/apps/web/src/lib/access-token-scheduler.ts
@@ -1,0 +1,65 @@
+import { useAuthStore } from "@/stores/auth-store";
+import type { RefreshResult } from "./api-client";
+
+const LEADTIME_MS = 30_000;
+const MIN_DELAY_MS = 1_000;
+
+/**
+ * Subscribes to the auth store and schedules a setTimeout to call `refreshFn`
+ * ~30s before the current access token expires. Reschedules on every store
+ * change (login, refresh, logout).
+ *
+ * Pause/resume on document visibility:
+ *  - hidden: clear the timer (the OS may throttle inactive-tab timers anyway,
+ *    and there's no UX cost to deferring a background refresh).
+ *  - visible: re-evaluate immediately; if we missed the leadtime window
+ *    while the tab was hidden, the next setTimeout clamps to MIN_DELAY_MS.
+ *
+ * Returns a cleanup function. Call it from the app-root useEffect's cleanup.
+ */
+export function startAccessTokenScheduler(refreshFn: () => Promise<RefreshResult>): () => void {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const cancel = (): void => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const schedule = (): void => {
+    cancel();
+    if (typeof document !== "undefined" && document.visibilityState === "hidden") return;
+    const { accessTokenExpiresAt } = useAuthStore.getState();
+    if (!accessTokenExpiresAt) return;
+    const expiresMs = Date.parse(accessTokenExpiresAt);
+    if (Number.isNaN(expiresMs)) return;
+    const delay = Math.max(MIN_DELAY_MS, expiresMs - Date.now() - LEADTIME_MS);
+    timer = setTimeout(() => {
+      void refreshFn();
+    }, delay);
+  };
+
+  const unsubStore = useAuthStore.subscribe(schedule);
+
+  const onVisibility = (): void => {
+    if (typeof document === "undefined") return;
+    if (document.visibilityState === "visible") schedule();
+    else cancel();
+  };
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", onVisibility);
+  }
+
+  // Initial schedule (in case the store was already populated when the
+  // scheduler started — e.g. a previously-cached session).
+  schedule();
+
+  return (): void => {
+    cancel();
+    unsubStore();
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", onVisibility);
+    }
+  };
+}

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -12,7 +12,7 @@ const mockUser = {
 describe("api-client", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    useAuthStore.setState({ accessToken: null, user: null });
+    useAuthStore.setState({ accessToken: null, user: null, accessTokenExpiresAt: null });
   });
 
   it("returns parsed JSON on success", async () => {
@@ -74,7 +74,11 @@ describe("api-client", () => {
   });
 
   it("attaches Authorization header when accessToken is in store", async () => {
-    useAuthStore.setState({ accessToken: "my-token", user: mockUser });
+    useAuthStore.setState({
+      accessToken: "my-token",
+      user: mockUser,
+      accessTokenExpiresAt: new Date(Date.now() + 900_000).toISOString(),
+    });
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -89,7 +93,11 @@ describe("api-client", () => {
   });
 
   it("on 401 → refreshes → retries original request with new token", async () => {
-    useAuthStore.setState({ accessToken: "expired-token", user: mockUser });
+    useAuthStore.setState({
+      accessToken: "expired-token",
+      user: mockUser,
+      accessTokenExpiresAt: new Date(Date.now() - 1000).toISOString(),
+    });
 
     const fetchMock = vi
       .fn()
@@ -106,7 +114,12 @@ describe("api-client", () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: () => Promise.resolve({ accessToken: "new-token", user: mockUser }),
+        json: () =>
+          Promise.resolve({
+            accessToken: "new-token",
+            accessTokenExpiresAt: new Date(Date.now() + 900_000).toISOString(),
+            user: mockUser,
+          }),
       })
       // Third call: retried original request with new token
       .mockResolvedValueOnce({
@@ -126,10 +139,15 @@ describe("api-client", () => {
 
     // Store should be updated with new token
     expect(useAuthStore.getState().accessToken).toBe("new-token");
+    expect(useAuthStore.getState().accessTokenExpiresAt).toBeTruthy();
   });
 
   it("on 401 → refresh fails → clears store and throws ApiError", async () => {
-    useAuthStore.setState({ accessToken: "expired-token", user: mockUser });
+    useAuthStore.setState({
+      accessToken: "expired-token",
+      user: mockUser,
+      accessTokenExpiresAt: new Date(Date.now() - 1000).toISOString(),
+    });
 
     const fetchMock = vi
       .fn()
@@ -139,10 +157,11 @@ describe("api-client", () => {
         status: 401,
         text: () => Promise.resolve(""),
       })
-      // Second call: refresh fails
+      // Second call: refresh fails (genuine auth failure)
       .mockResolvedValueOnce({
         ok: false,
         status: 401,
+        headers: { get: () => null },
         json: () => Promise.resolve({}),
       });
 
@@ -155,6 +174,7 @@ describe("api-client", () => {
 
     expect(useAuthStore.getState().accessToken).toBeNull();
     expect(useAuthStore.getState().user).toBeNull();
+    expect(useAuthStore.getState().accessTokenExpiresAt).toBeNull();
   });
 
   it("del() issues DELETE", async () => {
@@ -189,12 +209,16 @@ describe("api-client", () => {
 
 describe("api-client: concurrent 401s issue only one refresh", () => {
   beforeEach(() => {
-    useAuthStore.setState({ accessToken: "old-token", user: mockUser });
+    useAuthStore.setState({
+      accessToken: "old-token",
+      user: mockUser,
+      accessTokenExpiresAt: new Date(Date.now() - 1000).toISOString(),
+    });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    useAuthStore.setState({ accessToken: null, user: null });
+    useAuthStore.setState({ accessToken: null, user: null, accessTokenExpiresAt: null });
   });
 
   it("fires only a single /api/auth/refresh request for concurrent 401s", async () => {
@@ -205,7 +229,12 @@ describe("api-client: concurrent 401s issue only one refresh", () => {
         return Promise.resolve({
           ok: true,
           status: 200,
-          json: () => Promise.resolve({ accessToken: "fresh-token", user: mockUser }),
+          json: () =>
+            Promise.resolve({
+              accessToken: "fresh-token",
+              accessTokenExpiresAt: new Date(Date.now() + 900_000).toISOString(),
+              user: mockUser,
+            }),
         });
       }
       // Simulate 401 for all other calls on first attempt
@@ -225,7 +254,12 @@ describe("api-client: concurrent 401s issue only one refresh", () => {
         return Promise.resolve({
           ok: true,
           status: 200,
-          json: () => Promise.resolve({ accessToken: "fresh-token", user: mockUser }),
+          json: () =>
+            Promise.resolve({
+              accessToken: "fresh-token",
+              accessTokenExpiresAt: new Date(Date.now() + 900_000).toISOString(),
+              user: mockUser,
+            }),
         });
       }
       // Return 401 on the initial access-token calls, success after
@@ -255,5 +289,78 @@ describe("api-client: concurrent 401s issue only one refresh", () => {
 
     void fetchMock;
     void callCount;
+  });
+});
+
+describe("api-client.refreshAccessToken: discriminated result", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: null, user: null, accessTokenExpiresAt: null });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    useAuthStore.setState({ accessToken: null, user: null, accessTokenExpiresAt: null });
+  });
+
+  it("200 + body → { kind: 'ok', accessToken }", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            accessToken: "fresh",
+            accessTokenExpiresAt: new Date(Date.now() + 900_000).toISOString(),
+            user: mockUser,
+          }),
+      }),
+    );
+    const { refreshAccessToken } = await import("./api-client");
+    const result = await refreshAccessToken();
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") expect(result.accessToken).toBe("fresh");
+  });
+
+  it("401 → { kind: 'unauthenticated' }", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        headers: { get: () => null },
+        json: () => Promise.resolve({}),
+      }),
+    );
+    const { refreshAccessToken } = await import("./api-client");
+    const result = await refreshAccessToken();
+    expect(result.kind).toBe("unauthenticated");
+  });
+
+  it("429 with Retry-After → { kind: 'transient', retryAfterMs > 0 }", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        headers: { get: (k: string) => (k === "Retry-After" ? "3" : null) },
+        json: () => Promise.resolve({}),
+      }),
+    );
+    const { refreshAccessToken } = await import("./api-client");
+    const result = await refreshAccessToken();
+    expect(result.kind).toBe("transient");
+    if (result.kind === "transient") {
+      expect(result.status).toBe(429);
+      expect(result.retryAfterMs).toBe(3000);
+    }
+  });
+
+  it("network error → { kind: 'transient', status: 0 }", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+    const { refreshAccessToken } = await import("./api-client");
+    const result = await refreshAccessToken();
+    expect(result.kind).toBe("transient");
+    if (result.kind === "transient") expect(result.status).toBe(0);
   });
 });

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -14,39 +14,55 @@ export class ApiError extends Error {
   }
 }
 
-// Serialize concurrent refresh attempts so multiple 401s only issue ONE refresh.
-// Also exported as `refreshAccessToken` so the BootGate (and any other top-level
-// consumer) can dedup against the same in-flight promise. Without dedup,
-// React StrictMode's double-invoked effects in dev fire two parallel
-// /api/auth/refresh POSTs, both carrying the original cookie value; the
-// server's rotation guard sees the second arrival as token reuse and
-// invalidates the entire session.
-let refreshInFlight: Promise<string | null> | null = null;
+/**
+ * Discriminated outcome of a /api/auth/refresh attempt. Distinguishes a
+ * genuine auth failure (401/403 — clear store, redirect to /login) from
+ * a transient blip (429/5xx/network — retry with backoff, do NOT clear
+ * the store). Used by BootGate, the proactive scheduler, and the 401
+ * recovery path inside request().
+ */
+export type RefreshResult =
+  | { kind: "ok"; accessToken: string }
+  | { kind: "unauthenticated" }
+  | { kind: "transient"; status: number; retryAfterMs: number };
 
-export async function refreshAccessToken(): Promise<string | null> {
-  if (!refreshInFlight) {
-    const p: Promise<string | null> = (async () => {
-      try {
-        const res = await fetch("/api/auth/refresh", {
-          method: "POST",
-          credentials: "include",
-        });
-        if (!res.ok) return null;
-        const body = (await res.json()) as { accessToken: string; user: PublicUser };
-        useAuthStore.getState().setAuth(body.accessToken, body.user);
-        return body.accessToken;
-      } catch {
-        return null;
+// Single-tab in-flight dedup. Cross-tab dedup arrives in B5 via Web Locks.
+let refreshInFlight: Promise<RefreshResult> | null = null;
+
+export async function refreshAccessToken(): Promise<RefreshResult> {
+  if (refreshInFlight) return refreshInFlight;
+  const p: Promise<RefreshResult> = (async () => {
+    try {
+      const res = await fetch("/api/auth/refresh", {
+        method: "POST",
+        credentials: "include",
+      });
+      if (res.ok) {
+        const body = (await res.json()) as {
+          accessToken: string;
+          accessTokenExpiresAt: string;
+          user: PublicUser;
+        };
+        useAuthStore.getState().setAuth(body.accessToken, body.user, body.accessTokenExpiresAt);
+        return { kind: "ok", accessToken: body.accessToken };
       }
-    })();
-    refreshInFlight = p;
-    // Identity check: if another refresh took over before this one settled,
-    // don't clobber the newer promise reference.
-    p.finally(() => {
-      if (refreshInFlight === p) refreshInFlight = null;
-    });
-  }
-  return refreshInFlight;
+      if (res.status === 401 || res.status === 403) {
+        return { kind: "unauthenticated" };
+      }
+      // 429 / 5xx — transient. Honor Retry-After if present (seconds).
+      const ra = res.headers.get("Retry-After");
+      const retryAfterMs = ra ? Math.max(0, Number.parseInt(ra, 10) * 1000) : 0;
+      return { kind: "transient", status: res.status, retryAfterMs };
+    } catch {
+      // Network error.
+      return { kind: "transient", status: 0, retryAfterMs: 0 };
+    }
+  })();
+  refreshInFlight = p;
+  void p.finally(() => {
+    if (refreshInFlight === p) refreshInFlight = null;
+  });
+  return p;
 }
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
@@ -60,15 +76,20 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   let res = await doFetch(useAuthStore.getState().accessToken);
 
   if (res.status === 401 && !path.startsWith("/api/auth/")) {
-    const newToken = await refreshAccessToken();
-    if (newToken) {
-      res = await doFetch(newToken);
-    } else {
+    const result = await refreshAccessToken();
+    if (result.kind === "ok") {
+      res = await doFetch(result.accessToken);
+    } else if (result.kind === "unauthenticated") {
       useAuthStore.getState().clear();
       if (typeof window !== "undefined" && window.location.pathname !== "/login") {
         window.location.href = "/login";
       }
       throw new ApiError(401, "Unauthorized");
+    } else {
+      // transient — surface the original 401 since we couldn't recover here.
+      // Don't clear the store; the proactive scheduler (B8) or a later
+      // request will retry on its own.
+      throw new ApiError(401, "Unauthorized (refresh transient)");
     }
   }
 

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,6 +1,7 @@
 import { useAuthStore } from "@/stores/auth-store";
 import type { PublicUser } from "@modeldoctor/contracts";
 import { StandardErrorResponseSchema } from "@modeldoctor/contracts";
+import { coordinatedRefresh } from "./auth-coordinator";
 
 export class ApiError extends Error {
   constructor(
@@ -26,12 +27,8 @@ export type RefreshResult =
   | { kind: "unauthenticated" }
   | { kind: "transient"; status: number; retryAfterMs: number };
 
-// Single-tab in-flight dedup. Cross-tab dedup arrives in B5 via Web Locks.
-let refreshInFlight: Promise<RefreshResult> | null = null;
-
 export async function refreshAccessToken(): Promise<RefreshResult> {
-  if (refreshInFlight) return refreshInFlight;
-  const p: Promise<RefreshResult> = (async () => {
+  return coordinatedRefresh(async () => {
     try {
       const res = await fetch("/api/auth/refresh", {
         method: "POST",
@@ -57,12 +54,7 @@ export async function refreshAccessToken(): Promise<RefreshResult> {
       // Network error.
       return { kind: "transient", status: 0, retryAfterMs: 0 };
     }
-  })();
-  refreshInFlight = p;
-  void p.finally(() => {
-    if (refreshInFlight === p) refreshInFlight = null;
   });
-  return p;
 }
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {

--- a/apps/web/src/lib/auth-coordinator.test.ts
+++ b/apps/web/src/lib/auth-coordinator.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("coordinatedRefresh", () => {
+  let bc: {
+    postMessage: ReturnType<typeof vi.fn>;
+    addEventListener: ReturnType<typeof vi.fn>;
+    removeEventListener: ReturnType<typeof vi.fn>;
+    close: () => void;
+  };
+
+  beforeEach(async () => {
+    // Reset module state so the in-flight cache from one test doesn't leak to the next.
+    vi.resetModules();
+    bc = {
+      postMessage: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      close: () => undefined,
+    };
+    vi.stubGlobal(
+      "BroadcastChannel",
+      vi.fn().mockImplementation(() => bc),
+    );
+
+    // Default: navigator.locks present and behaves like an honest exclusive lock
+    // (sequential, never holds across tests because we resetModules).
+    let lockHeld = false;
+    const queue: Array<() => void> = [];
+    vi.stubGlobal("navigator", {
+      ...globalThis.navigator,
+      locks: {
+        request: vi
+          .fn()
+          .mockImplementation(async (_name: string, _opts: unknown, cb: () => Promise<unknown>) => {
+            if (lockHeld) {
+              await new Promise<void>((resolve) => queue.push(resolve));
+            }
+            lockHeld = true;
+            try {
+              return await cb();
+            } finally {
+              lockHeld = false;
+              const next = queue.shift();
+              if (next) next();
+            }
+          }),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("calls fetcher exactly once when invoked twice in parallel", async () => {
+    const { coordinatedRefresh } = await import("./auth-coordinator");
+    const fetcher = vi.fn().mockResolvedValue({ kind: "ok", accessToken: "fresh" });
+    const [a, b] = await Promise.all([coordinatedRefresh(fetcher), coordinatedRefresh(fetcher)]);
+    // Within ONE tab, the module-level promise dedup means fetcher runs once.
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(a.kind).toBe("ok");
+    expect(b.kind).toBe("ok");
+  });
+
+  it("falls back gracefully when navigator.locks is undefined", async () => {
+    vi.stubGlobal("navigator", { ...globalThis.navigator, locks: undefined });
+    const { coordinatedRefresh } = await import("./auth-coordinator");
+    const fetcher = vi.fn().mockResolvedValue({ kind: "ok", accessToken: "fresh" });
+    const result = await coordinatedRefresh(fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(result.kind).toBe("ok");
+  });
+
+  it("broadcasts the result on success", async () => {
+    const { coordinatedRefresh } = await import("./auth-coordinator");
+    const fetcher = vi.fn().mockResolvedValue({ kind: "ok", accessToken: "fresh" });
+    await coordinatedRefresh(fetcher);
+    expect(bc.postMessage).toHaveBeenCalledWith(expect.objectContaining({ kind: "ok" }));
+  });
+
+  it("broadcasts unauthenticated kind too", async () => {
+    const { coordinatedRefresh } = await import("./auth-coordinator");
+    const fetcher = vi.fn().mockResolvedValue({ kind: "unauthenticated" });
+    await coordinatedRefresh(fetcher);
+    expect(bc.postMessage).toHaveBeenCalledWith({ kind: "unauthenticated" });
+  });
+
+  it("broadcasts transient with status only (no retryAfterMs)", async () => {
+    const { coordinatedRefresh } = await import("./auth-coordinator");
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue({ kind: "transient", status: 429, retryAfterMs: 3000 });
+    await coordinatedRefresh(fetcher);
+    expect(bc.postMessage).toHaveBeenCalledWith({ kind: "transient", status: 429 });
+  });
+});
+
+describe("onRefreshBroadcast", () => {
+  let bc: {
+    postMessage: ReturnType<typeof vi.fn>;
+    addEventListener: ReturnType<typeof vi.fn>;
+    removeEventListener: ReturnType<typeof vi.fn>;
+    close: () => void;
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
+    bc = {
+      postMessage: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      close: () => undefined,
+    };
+    vi.stubGlobal(
+      "BroadcastChannel",
+      vi.fn().mockImplementation(() => bc),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("subscribes a listener and the unsubscribe function removes it", async () => {
+    const { onRefreshBroadcast } = await import("./auth-coordinator");
+    const handler = vi.fn();
+    const unsub = onRefreshBroadcast(handler);
+    expect(bc.addEventListener).toHaveBeenCalledWith("message", expect.any(Function));
+    unsub();
+    expect(bc.removeEventListener).toHaveBeenCalledWith("message", expect.any(Function));
+  });
+
+  it("returns a no-op unsub when BroadcastChannel is unavailable", async () => {
+    vi.stubGlobal("BroadcastChannel", undefined);
+    const { onRefreshBroadcast } = await import("./auth-coordinator");
+    const handler = vi.fn();
+    const unsub = onRefreshBroadcast(handler);
+    expect(typeof unsub).toBe("function");
+    expect(() => unsub()).not.toThrow();
+  });
+});

--- a/apps/web/src/lib/auth-coordinator.ts
+++ b/apps/web/src/lib/auth-coordinator.ts
@@ -1,0 +1,74 @@
+import type { RefreshResult } from "./api-client";
+
+const LOCK_NAME = "md-auth-refresh";
+const CHANNEL_NAME = "md-auth";
+
+export type AuthChannelMessage =
+  | { kind: "ok"; accessToken: string }
+  | { kind: "unauthenticated" }
+  | { kind: "transient"; status: number };
+
+let inFlight: Promise<RefreshResult> | null = null;
+let cachedChannel: BroadcastChannel | null = null;
+
+function getChannel(): BroadcastChannel | null {
+  if (typeof BroadcastChannel === "undefined") return null;
+  if (!cachedChannel) cachedChannel = new BroadcastChannel(CHANNEL_NAME);
+  return cachedChannel;
+}
+
+/**
+ * Run `fetcher` under a cross-tab exclusive Web Lock so only one tab actually
+ * issues the /auth/refresh network call. The result is broadcast on a
+ * BroadcastChannel so other tabs can read it without making their own
+ * network call (e.g. in a future enhancement that gates BootGate on a
+ * recently-seen broadcast).
+ *
+ * Falls back to plain promise dedup when navigator.locks is unavailable
+ * (older browsers, non-secure contexts). Single-tab dedup is preserved
+ * via the module-level inFlight promise.
+ */
+export async function coordinatedRefresh(
+  fetcher: () => Promise<RefreshResult>,
+): Promise<RefreshResult> {
+  if (inFlight) return inFlight;
+
+  const run = async (): Promise<RefreshResult> => {
+    const result = await fetcher();
+    const ch = getChannel();
+    if (ch) {
+      const msg: AuthChannelMessage =
+        result.kind === "ok"
+          ? { kind: "ok", accessToken: result.accessToken }
+          : result.kind === "unauthenticated"
+            ? { kind: "unauthenticated" }
+            : { kind: "transient", status: result.status };
+      ch.postMessage(msg);
+    }
+    return result;
+  };
+
+  const locks = (globalThis.navigator as Navigator & { locks?: LockManager }).locks;
+  const p: Promise<RefreshResult> = locks
+    ? (locks.request(LOCK_NAME, { mode: "exclusive" }, run) as unknown as Promise<RefreshResult>)
+    : run();
+
+  inFlight = p;
+  void p.finally(() => {
+    if (inFlight === p) inFlight = null;
+  });
+  return p;
+}
+
+/**
+ * Subscribe to refresh results from other tabs. Returns an unsubscribe fn.
+ * Use from BootGate (Task B6/B7) to short-circuit if another tab refreshed
+ * while we were initialising.
+ */
+export function onRefreshBroadcast(handler: (msg: AuthChannelMessage) => void): () => void {
+  const ch = getChannel();
+  if (!ch) return () => undefined;
+  const listener = (e: MessageEvent): void => handler(e.data as AuthChannelMessage);
+  ch.addEventListener("message", listener);
+  return (): void => ch.removeEventListener("message", listener);
+}

--- a/apps/web/src/lib/retry-with-backoff.test.ts
+++ b/apps/web/src/lib/retry-with-backoff.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { retryWithBackoff } from "./retry-with-backoff";
+
+describe("retryWithBackoff", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns immediately on non-transient first try", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const result = await retryWithBackoff(fn, () => false, {
+      maxAttempts: 3,
+      baseMs: 1,
+      factor: 2,
+      jitter: () => 0,
+    });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries up to maxAttempts then returns last result", async () => {
+    const fn = vi.fn().mockResolvedValue("transient");
+    const result = await retryWithBackoff(fn, () => ({ retryAfterMs: 0 }), {
+      maxAttempts: 3,
+      baseMs: 1,
+      factor: 2,
+      jitter: () => 0,
+    });
+    expect(result).toBe("transient");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("honors retryAfterMs as a floor", async () => {
+    let calls = 0;
+    const fn = vi.fn().mockImplementation(async () => (calls++ === 0 ? "transient" : "ok"));
+    const start = Date.now();
+    await retryWithBackoff(fn, (r) => (r === "transient" ? { retryAfterMs: 50 } : false), {
+      maxAttempts: 3,
+      baseMs: 1,
+      factor: 1,
+      jitter: () => 0,
+    });
+    expect(Date.now() - start).toBeGreaterThanOrEqual(40); // some scheduler slack
+  });
+});

--- a/apps/web/src/lib/retry-with-backoff.ts
+++ b/apps/web/src/lib/retry-with-backoff.ts
@@ -1,0 +1,35 @@
+export interface RetryOptions {
+  maxAttempts: number;
+  baseMs: number;
+  factor: number;
+  jitter: () => number; // returns 0..1
+}
+
+export const DEFAULT_REFRESH_RETRY: RetryOptions = {
+  maxAttempts: 3,
+  baseMs: 250,
+  factor: 4,
+  jitter: () => Math.random(),
+};
+
+/**
+ * Generic exponential-backoff retry. The predicate decides whether the
+ * result is "good" (return) or transient (retry). Honors a result-supplied
+ * retryAfterMs hint as a floor on the delay.
+ */
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  isTransient: (result: T) => false | { retryAfterMs: number },
+  opts: RetryOptions = DEFAULT_REFRESH_RETRY,
+): Promise<T> {
+  let attempt = 0;
+  while (true) {
+    const result = await fn();
+    const transient = isTransient(result);
+    if (!transient || attempt >= opts.maxAttempts - 1) return result;
+    const expBackoff = opts.baseMs * opts.factor ** attempt;
+    const delay = Math.max(transient.retryAfterMs, expBackoff * (0.5 + opts.jitter() * 0.5));
+    await new Promise<void>((resolve) => setTimeout(resolve, delay));
+    attempt += 1;
+  }
+}

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -8,31 +8,37 @@ const mockUser = {
   createdAt: new Date().toISOString(),
 };
 
+const futureExpiresAt = () => new Date(Date.now() + 900_000).toISOString();
+
 describe("useAuthStore", () => {
   beforeEach(() => {
-    useAuthStore.setState({ accessToken: null, user: null });
+    useAuthStore.setState({ accessToken: null, user: null, accessTokenExpiresAt: null });
   });
 
-  it("starts with null accessToken and user", () => {
+  it("starts with null accessToken, user, and accessTokenExpiresAt", () => {
     expect(useAuthStore.getState().accessToken).toBeNull();
     expect(useAuthStore.getState().user).toBeNull();
+    expect(useAuthStore.getState().accessTokenExpiresAt).toBeNull();
   });
 
-  it("setAuth stores the access token and user", () => {
-    useAuthStore.getState().setAuth("token-abc", mockUser);
+  it("setAuth stores the access token, user, and expiresAt", () => {
+    const expiresAt = futureExpiresAt();
+    useAuthStore.getState().setAuth("token-abc", mockUser, expiresAt);
     expect(useAuthStore.getState().accessToken).toBe("token-abc");
     expect(useAuthStore.getState().user).toEqual(mockUser);
+    expect(useAuthStore.getState().accessTokenExpiresAt).toBe(expiresAt);
   });
 
-  it("clear resets accessToken and user to null", () => {
-    useAuthStore.getState().setAuth("token-abc", mockUser);
+  it("clear resets accessToken, user, and accessTokenExpiresAt to null", () => {
+    useAuthStore.getState().setAuth("token-abc", mockUser, futureExpiresAt());
     useAuthStore.getState().clear();
     expect(useAuthStore.getState().accessToken).toBeNull();
     expect(useAuthStore.getState().user).toBeNull();
+    expect(useAuthStore.getState().accessTokenExpiresAt).toBeNull();
   });
 
   it("does not use localStorage (no persist middleware)", () => {
-    useAuthStore.getState().setAuth("secret-token", mockUser);
+    useAuthStore.getState().setAuth("secret-token", mockUser, futureExpiresAt());
     // Ensure nothing is written to localStorage under any zustand key
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i) ?? "";

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -3,8 +3,12 @@ import { create } from "zustand";
 
 interface AuthState {
   accessToken: string | null;
+  // ISO 8601 — matches AuthTokenResponse.accessTokenExpiresAt. Used by
+  // the proactive-refresh scheduler (Task B8) to fire setTimeout ~30s
+  // before this moment.
+  accessTokenExpiresAt: string | null;
   user: PublicUser | null;
-  setAuth: (accessToken: string, user: PublicUser) => void;
+  setAuth: (accessToken: string, user: PublicUser, accessTokenExpiresAt: string) => void;
   clear: () => void;
 }
 
@@ -12,7 +16,9 @@ interface AuthState {
 // persistence across reloads via /api/auth/refresh on app boot.
 export const useAuthStore = create<AuthState>((set) => ({
   accessToken: null,
+  accessTokenExpiresAt: null,
   user: null,
-  setAuth: (accessToken, user) => set({ accessToken, user }),
-  clear: () => set({ accessToken: null, user: null }),
+  setAuth: (accessToken, user, accessTokenExpiresAt) =>
+    set({ accessToken, user, accessTokenExpiresAt }),
+  clear: () => set({ accessToken: null, user: null, accessTokenExpiresAt: null }),
 }));

--- a/packages/contracts/src/auth.ts
+++ b/packages/contracts/src/auth.ts
@@ -19,6 +19,11 @@ export type LoginRequest = RegisterRequest;
 
 export const AuthTokenResponseSchema = z.object({
   accessToken: z.string(),
+  // ISO 8601. Lets the SPA schedule a silent refresh ~30s before this
+  // moment instead of waiting for a 401. Never trust this for security
+  // decisions on the server; it's purely a UX hint. Source-of-truth is
+  // the JWT exp claim.
+  accessTokenExpiresAt: z.string().datetime(),
   user: PublicUserSchema,
 });
 export type AuthTokenResponse = z.infer<typeof AuthTokenResponseSchema>;


### PR DESCRIPTION
## Summary

Builds on PR #24 (server-side rotation chain + grace window + family-scoped theft detection) to deliver the client-side machinery so the SPA stops getting kicked to /login on routine reloads, multi-tab boots, or transient `/refresh` blips.

- **Session-presence cookie.** Server emits a non-HttpOnly `md_session=1` (Path=`/`, SameSite=Lax) alongside the HttpOnly `md_refresh`. SPA's `BootGate` reads it before deciding whether to call `/refresh` — zero network calls for unauthenticated visitors.
- **`AuthTokenResponse.accessTokenExpiresAt`** (ISO 8601). Lets the client schedule proactive refresh without decoding JWTs.
- **Discriminated `RefreshResult` union** (`'ok' | 'unauthenticated' | 'transient'`). `refreshAccessToken` returns it so callers can distinguish auth failure from rate-limit / 5xx / network blip and decide whether to redirect or retry.
- **Cross-tab dedup via W3C Web Locks API.** `coordinatedRefresh` wraps the fetcher in `navigator.locks.request('md-auth-refresh', { mode: 'exclusive' })`. Multiple tabs of the same origin issue ONE `/refresh` between them; result fans out via `BroadcastChannel('md-auth')`. Falls back to single-tab promise dedup when `navigator.locks` is unavailable.
- **BootGate session precheck + retry-with-backoff.** Three-way decision: (1) accessToken in store → no probe; (2) no `md_session` cookie → no probe (redirect to /login); (3) cookie present → probe. `retryWithBackoff` covers 429/5xx/network with 250ms / 1s / 4s + 0.5x–1.0x jitter, honoring `Retry-After`. Only `kind:'unauthenticated'` redirects immediately.
- **Proactive silent refresh.** `setTimeout` fires 30s before access-token expiry. Paused on `document.visibilityState === 'hidden'`, resumed on `'visible'` (clamps to MIN_DELAY_MS=1s if past leadtime). Eliminates 'click → 401 → refresh → retry' UX hiccups.

8 commits — three server (cookie, contracts field, populate field) + five web (store/api-client refactor, Web Locks coordinator, BootGate precheck, BootGate retry, scheduler).

## Test plan

### Automated (already green)

- [x] `pnpm -F @modeldoctor/contracts test` — 33/33 (covers new schema field)
- [x] `pnpm -F @modeldoctor/api test` — 166/166 unit
- [x] `npx vitest run --config vitest.e2e.config.mts test/e2e/auth.e2e-spec.ts` — 16/16 (incl. new md_session cookie test)
- [x] `pnpm -F @modeldoctor/web test` — 152/152 (auth-coordinator: 7, retry-with-backoff: 3, BootGate precheck: 2, BootGate retry: 1, access-token-scheduler: 4 + existing)
- [x] `pnpm -r type-check` — clean across contracts / api / web
- [x] `pnpm -r lint` — clean

### Manual smoke (please verify before merge)

1. [ ] Log in. Reload page 30 times in a row, fast. Expected: no kicks to /login.
2. [ ] DevTools Network, preserve log on. Expected: only ONE `POST /api/auth/refresh` per reload (Web Locks dedup).
3. [ ] Open the app in a second tab while signed in. Expected: no second `/refresh` (cross-tab dedup); accessToken in store is the broadcast value.
4. [ ] Wait until `accessTokenExpiresAt - 30s`. Expected: silent `/refresh` fires automatically without user interaction.
5. [ ] Click "Logout". Expected: `md_session` cookie cleared, store cleared, redirected to /login. Reload: zero network calls before the /login render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)