### PR TITLE
feat(regression-suite): Playground Phase 1 chat MVP + E2E smoke matrix

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -18,6 +18,7 @@ import { DebugProxyModule } from "./modules/debug-proxy/debug-proxy.module.js";
 import { E2ETestModule } from "./modules/e2e-test/e2e-test.module.js";
 import { HealthModule } from "./modules/health/health.module.js";
 import { LoadTestModule } from "./modules/load-test/load-test.module.js";
+import { PlaygroundModule } from "./modules/playground/playground.module.js";
 import { UsersModule } from "./modules/users/users.module.js";
 
 @Module({
@@ -64,6 +65,7 @@ import { UsersModule } from "./modules/users/users.module.js";
     DebugProxyModule,
     E2ETestModule,
     LoadTestModule,
+    PlaygroundModule,
     BenchmarkModule,
     ScheduleModule.forRoot(),
     UsersModule,

--- a/apps/api/src/modules/playground/chat.controller.ts
+++ b/apps/api/src/modules/playground/chat.controller.ts
@@ -1,0 +1,30 @@
+import {
+  type PlaygroundChatRequest,
+  PlaygroundChatRequestSchema,
+  type PlaygroundChatResponse,
+  PlaygroundChatResponseSchema,
+} from "@modeldoctor/contracts";
+import { Body, Controller, HttpCode, HttpStatus, Post, UsePipes } from "@nestjs/common";
+import { ApiBody, ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { createZodDto } from "nestjs-zod";
+import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
+import { ChatService } from "./chat.service.js";
+
+class PlaygroundChatRequestDto extends createZodDto(PlaygroundChatRequestSchema) {}
+class PlaygroundChatResponseDto extends createZodDto(PlaygroundChatResponseSchema) {}
+
+@ApiTags("playground")
+@Controller("playground")
+export class ChatController {
+  constructor(private readonly svc: ChatService) {}
+
+  @ApiOperation({ summary: "Send a chat completion via the Playground (non-streaming)" })
+  @ApiBody({ type: PlaygroundChatRequestDto })
+  @ApiOkResponse({ type: PlaygroundChatResponseDto })
+  @Post("chat")
+  @HttpCode(HttpStatus.OK)
+  @UsePipes(new ZodValidationPipe(PlaygroundChatRequestSchema))
+  chat(@Body() body: PlaygroundChatRequest): Promise<PlaygroundChatResponse> {
+    return this.svc.run(body);
+  }
+}

--- a/apps/api/src/modules/playground/chat.service.spec.ts
+++ b/apps/api/src/modules/playground/chat.service.spec.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatService } from "./chat.service.js";
+
+describe("ChatService.run", () => {
+  let svc: ChatService;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    svc = new ChatService();
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts to {apiBaseUrl}/v1/chat/completions with Bearer auth and OpenAI body shape", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "hello back", role: "assistant" } }],
+          usage: { prompt_tokens: 5, completion_tokens: 7, total_tokens: 12 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const out = await svc.run({
+      apiBaseUrl: "http://upstream.test",
+      apiKey: "sk-1",
+      model: "m1",
+      messages: [{ role: "user", content: "hello" }],
+      params: {},
+    });
+
+    expect(out.success).toBe(true);
+    expect(out.content).toBe("hello back");
+    expect(out.usage?.total_tokens).toBe(12);
+    expect(out.latencyMs).toBeGreaterThanOrEqual(0);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://upstream.test/v1/chat/completions");
+    expect((init as RequestInit).method).toBe("POST");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer sk-1");
+    expect(headers["Content-Type"]).toBe("application/json");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.model).toBe("m1");
+    expect(body.messages).toEqual([{ role: "user", content: "hello" }]);
+  });
+
+  it("honours pathOverride", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 }),
+    );
+    await svc.run({
+      apiBaseUrl: "http://x",
+      apiKey: "k",
+      model: "m",
+      pathOverride: "/custom/chat",
+      messages: [{ role: "user", content: "h" }],
+      params: {},
+    });
+    expect(fetchMock.mock.calls[0][0]).toBe("http://x/custom/chat");
+  });
+
+  it("maps OpenAI-style snake_case params from camelCase", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 }),
+    );
+    await svc.run({
+      apiBaseUrl: "http://x",
+      apiKey: "k",
+      model: "m",
+      messages: [{ role: "user", content: "h" }],
+      params: {
+        temperature: 0.7,
+        maxTokens: 256,
+        topP: 0.9,
+        frequencyPenalty: 0.1,
+        presencePenalty: 0.2,
+        seed: 42,
+        stop: ["</s>"],
+      },
+    });
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.temperature).toBe(0.7);
+    expect(body.max_tokens).toBe(256);
+    expect(body.top_p).toBe(0.9);
+    expect(body.frequency_penalty).toBe(0.1);
+    expect(body.presence_penalty).toBe(0.2);
+    expect(body.seed).toBe(42);
+    expect(body.stop).toEqual(["</s>"]);
+  });
+
+  it("merges customHeaders (newline-delimited 'K: v' pairs)", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 }),
+    );
+    await svc.run({
+      apiBaseUrl: "http://x",
+      apiKey: "k",
+      model: "m",
+      customHeaders: "X-Foo: bar\nX-Baz: qux",
+      messages: [{ role: "user", content: "h" }],
+      params: {},
+    });
+    const headers = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+    expect(headers["X-Foo"]).toBe("bar");
+    expect(headers["X-Baz"]).toBe("qux");
+  });
+
+  it("returns success=false with upstream body when status >= 400", async () => {
+    fetchMock.mockResolvedValue(new Response("model not found", { status: 404 }));
+    const out = await svc.run({
+      apiBaseUrl: "http://x",
+      apiKey: "k",
+      model: "m",
+      messages: [{ role: "user", content: "h" }],
+      params: {},
+    });
+    expect(out.success).toBe(false);
+    expect(out.error).toMatch(/404/);
+    expect(out.error).toMatch(/model not found/);
+  });
+
+  it("returns success=false on network error", async () => {
+    fetchMock.mockRejectedValue(new Error("network kaboom"));
+    const out = await svc.run({
+      apiBaseUrl: "http://x",
+      apiKey: "k",
+      model: "m",
+      messages: [{ role: "user", content: "h" }],
+      params: {},
+    });
+    expect(out.success).toBe(false);
+    expect(out.error).toMatch(/network kaboom/);
+  });
+});

--- a/apps/api/src/modules/playground/chat.service.spec.ts
+++ b/apps/api/src/modules/playground/chat.service.spec.ts
@@ -137,4 +137,36 @@ describe("ChatService.run", () => {
     expect(out.success).toBe(false);
     expect(out.error).toMatch(/network kaboom/);
   });
+
+  it("collapses trailing slash in apiBaseUrl to a single slash", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 }),
+    );
+    await svc.run({
+      apiBaseUrl: "http://x.test/",
+      apiKey: "k",
+      model: "m",
+      messages: [{ role: "user", content: "h" }],
+      params: {},
+    });
+    expect(fetchMock.mock.calls[0][0]).toBe("http://x.test/v1/chat/completions");
+  });
+
+  it("appends queryParams (newline-delimited key=value) to the URL", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 }),
+    );
+    await svc.run({
+      apiBaseUrl: "http://x",
+      apiKey: "k",
+      model: "m",
+      queryParams: "api-version=2024-02-01\nfoo=bar",
+      messages: [{ role: "user", content: "h" }],
+      params: {},
+    });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("api-version=2024-02-01");
+    expect(url).toContain("foo=bar");
+    expect(url.split("?")[0]).toBe("http://x/v1/chat/completions");
+  });
 });

--- a/apps/api/src/modules/playground/chat.service.ts
+++ b/apps/api/src/modules/playground/chat.service.ts
@@ -2,6 +2,7 @@ import type { PlaygroundChatRequest, PlaygroundChatResponse } from "@modeldoctor
 import { Injectable } from "@nestjs/common";
 
 const DEFAULT_PATH = "/v1/chat/completions";
+const MAX_ERROR_BODY_BYTES = 1024;
 
 function parseHeaderLines(s: string | undefined): Record<string, string> {
   const out: Record<string, string> = {};
@@ -9,6 +10,17 @@ function parseHeaderLines(s: string | undefined): Record<string, string> {
   for (const rawLine of s.split("\n").map((l) => l.trim())) {
     if (!rawLine || !rawLine.includes(":")) continue;
     const idx = rawLine.indexOf(":");
+    out[rawLine.slice(0, idx).trim()] = rawLine.slice(idx + 1).trim();
+  }
+  return out;
+}
+
+function parseQueryLines(s: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!s || !s.trim()) return out;
+  for (const rawLine of s.split("\n").map((l) => l.trim())) {
+    if (!rawLine || !rawLine.includes("=")) continue;
+    const idx = rawLine.indexOf("=");
     out[rawLine.slice(0, idx).trim()] = rawLine.slice(idx + 1).trim();
   }
   return out;
@@ -34,7 +46,16 @@ function buildBody(req: PlaygroundChatRequest): Record<string, unknown> {
 @Injectable()
 export class ChatService {
   async run(req: PlaygroundChatRequest): Promise<PlaygroundChatResponse> {
-    const url = req.apiBaseUrl + (req.pathOverride ?? DEFAULT_PATH);
+    const base = req.apiBaseUrl.replace(/\/+$/, "");
+    const path = (req.pathOverride ?? DEFAULT_PATH).replace(/^(?!\/)/, "/");
+    let url = base + path;
+    const qp = parseQueryLines(req.queryParams);
+    const qpKeys = Object.keys(qp);
+    if (qpKeys.length > 0) {
+      const search = new URLSearchParams();
+      for (const k of qpKeys) search.set(k, qp[k]);
+      url += (url.includes("?") ? "&" : "?") + search.toString();
+    }
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
       Authorization: `Bearer ${req.apiKey}`,
@@ -52,7 +73,7 @@ export class ChatService {
         const text = await res.text().catch(() => "");
         return {
           success: false,
-          error: `upstream ${res.status}: ${text || res.statusText}`.slice(0, 1024),
+          error: `upstream ${res.status}: ${text || res.statusText}`.slice(0, MAX_ERROR_BODY_BYTES),
           latencyMs,
         };
       }

--- a/apps/api/src/modules/playground/chat.service.ts
+++ b/apps/api/src/modules/playground/chat.service.ts
@@ -1,0 +1,78 @@
+import type { PlaygroundChatRequest, PlaygroundChatResponse } from "@modeldoctor/contracts";
+import { Injectable } from "@nestjs/common";
+
+const DEFAULT_PATH = "/v1/chat/completions";
+
+function parseHeaderLines(s: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!s || !s.trim()) return out;
+  for (const rawLine of s.split("\n").map((l) => l.trim())) {
+    if (!rawLine || !rawLine.includes(":")) continue;
+    const idx = rawLine.indexOf(":");
+    out[rawLine.slice(0, idx).trim()] = rawLine.slice(idx + 1).trim();
+  }
+  return out;
+}
+
+function buildBody(req: PlaygroundChatRequest): Record<string, unknown> {
+  const p = req.params ?? {};
+  const body: Record<string, unknown> = {
+    model: req.model,
+    messages: req.messages,
+  };
+  if (p.temperature !== undefined) body.temperature = p.temperature;
+  if (p.maxTokens !== undefined) body.max_tokens = p.maxTokens;
+  if (p.topP !== undefined) body.top_p = p.topP;
+  if (p.frequencyPenalty !== undefined) body.frequency_penalty = p.frequencyPenalty;
+  if (p.presencePenalty !== undefined) body.presence_penalty = p.presencePenalty;
+  if (p.seed !== undefined) body.seed = p.seed;
+  if (p.stop !== undefined) body.stop = p.stop;
+  // Phase 1: stream is ignored (always non-streaming).
+  return body;
+}
+
+@Injectable()
+export class ChatService {
+  async run(req: PlaygroundChatRequest): Promise<PlaygroundChatResponse> {
+    const url = req.apiBaseUrl + (req.pathOverride ?? DEFAULT_PATH);
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${req.apiKey}`,
+      ...parseHeaderLines(req.customHeaders),
+    };
+    const start = Date.now();
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(buildBody(req)),
+      });
+      const latencyMs = Date.now() - start;
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        return {
+          success: false,
+          error: `upstream ${res.status}: ${text || res.statusText}`.slice(0, 1024),
+          latencyMs,
+        };
+      }
+      const json = (await res.json()) as {
+        choices?: Array<{ message?: { content?: string } }>;
+        usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+      };
+      const content = json.choices?.[0]?.message?.content ?? "";
+      return {
+        success: true,
+        content,
+        latencyMs,
+        usage: json.usage,
+      };
+    } catch (e) {
+      return {
+        success: false,
+        error: e instanceof Error ? e.message : String(e),
+        latencyMs: Date.now() - start,
+      };
+    }
+  }
+}

--- a/apps/api/src/modules/playground/playground.module.ts
+++ b/apps/api/src/modules/playground/playground.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { ChatController } from "./chat.controller.js";
+import { ChatService } from "./chat.service.js";
+
+@Module({
+  controllers: [ChatController],
+  providers: [ChatService],
+})
+export class PlaygroundModule {}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-scroll-area": "^1",
     "@radix-ui/react-select": "^2",
     "@radix-ui/react-separator": "^1",
+    "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1",
     "@radix-ui/react-switch": "^1",
     "@radix-ui/react-tabs": "^1",

--- a/apps/web/src/components/sidebar/sidebar-config.tsx
+++ b/apps/web/src/components/sidebar/sidebar-config.tsx
@@ -1,5 +1,6 @@
 import {
   Activity,
+  Boxes,
   Bug,
   CheckCircle2,
   Database,
@@ -7,7 +8,11 @@ import {
   GitCompare,
   HeartPulse,
   History,
+  Image as ImageIcon,
+  ListOrdered,
   type LucideIcon,
+  MessageSquare,
+  Mic,
   Settings,
   Timer,
   Zap,
@@ -27,6 +32,32 @@ export interface SidebarGroup {
 }
 
 export const sidebarGroups: SidebarGroup[] = [
+  {
+    id: "playground",
+    labelKey: "groups.playground",
+    items: [
+      { to: "/playground/chat", icon: MessageSquare, labelKey: "items.playgroundChat" },
+      {
+        to: "/playground/image",
+        icon: ImageIcon,
+        labelKey: "items.playgroundImage",
+        comingSoon: true,
+      },
+      { to: "/playground/audio", icon: Mic, labelKey: "items.playgroundAudio", comingSoon: true },
+      {
+        to: "/playground/embeddings",
+        icon: Boxes,
+        labelKey: "items.playgroundEmbeddings",
+        comingSoon: true,
+      },
+      {
+        to: "/playground/rerank",
+        icon: ListOrdered,
+        labelKey: "items.playgroundRerank",
+        comingSoon: true,
+      },
+    ],
+  },
   {
     id: "performance",
     labelKey: "groups.performance",

--- a/apps/web/src/components/ui/slider.tsx
+++ b/apps/web/src/components/ui/slider.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils";
+import * as SliderPrimitive from "@radix-ui/react-slider";
+import * as React from "react";
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn("relative flex w-full touch-none select-none items-center", className)}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-secondary">
+      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
+  </SliderPrimitive.Root>
+));
+Slider.displayName = SliderPrimitive.Root.displayName;
+
+export { Slider };

--- a/apps/web/src/features/connections/ConnectionDialog.test.tsx
+++ b/apps/web/src/features/connections/ConnectionDialog.test.tsx
@@ -1,0 +1,68 @@
+import "@/lib/i18n";
+import { useConnectionsStore } from "@/stores/connections-store";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ConnectionDialog } from "./ConnectionDialog";
+
+async function fillBaseFields(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/^name$/i), "n1");
+  await user.type(screen.getByLabelText(/api base url/i), "http://x.test");
+  await user.type(screen.getByLabelText(/api key/i), "sk-1");
+  await user.type(screen.getByLabelText(/^model$/i), "m1");
+}
+
+describe("ConnectionDialog (category + tags)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useConnectionsStore.setState({ connections: [] });
+  });
+
+  it("requires a category before save", async () => {
+    const user = userEvent.setup();
+    render(<ConnectionDialog open onOpenChange={() => {}} />);
+    await fillBaseFields(user);
+    await user.click(screen.getByRole("button", { name: /save|保存/i }));
+
+    // The dialog should still be open because category is required.
+    expect(screen.getAllByText(/category|分类/i).length).toBeGreaterThan(0);
+    expect(useConnectionsStore.getState().list()).toHaveLength(0);
+  });
+
+  it("creates a connection with selected category and entered tags", async () => {
+    const user = userEvent.setup();
+    render(<ConnectionDialog open onOpenChange={() => {}} />);
+    await fillBaseFields(user);
+
+    // Open category dropdown and pick "Chat"
+    await user.click(screen.getByRole("combobox", { name: /category|分类/i }));
+    await user.click(screen.getByRole("option", { name: /^chat$|^对话$/i }));
+
+    // Add two tags
+    const tagInput = screen.getByLabelText(/^tags$/i);
+    await user.type(tagInput, "vLLM{Enter}");
+    await user.type(tagInput, "production{Enter}");
+
+    await user.click(screen.getByRole("button", { name: /save|保存/i }));
+
+    await waitFor(() => {
+      const list = useConnectionsStore.getState().list();
+      expect(list).toHaveLength(1);
+      expect(list[0].category).toBe("chat");
+      expect(list[0].tags).toEqual(["vLLM", "production"]);
+    });
+  });
+
+  it("removing a chip drops the tag", async () => {
+    const user = userEvent.setup();
+    render(<ConnectionDialog open onOpenChange={() => {}} />);
+    const tagInput = screen.getByLabelText(/^tags$/i);
+    await user.type(tagInput, "x{Enter}");
+    await user.type(tagInput, "y{Enter}");
+
+    await user.click(screen.getByRole("button", { name: /remove tag x|移除标签 x/i }));
+
+    expect(screen.queryByText("x")).not.toBeInTheDocument();
+    expect(screen.getByText("y")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/connections/ConnectionDialog.tsx
+++ b/apps/web/src/features/connections/ConnectionDialog.tsx
@@ -140,224 +140,230 @@ export function ConnectionDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="flex max-h-[90vh] max-w-2xl flex-col">
         <DialogHeader>
           <DialogTitle>{connection ? t("dialog.editTitle") : t("dialog.createTitle")}</DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={onSubmit} className="space-y-4">
-          <details className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm">
-            <summary className="cursor-pointer text-xs font-medium text-muted-foreground hover:text-foreground">
-              {t("dialog.curl.import")}
-            </summary>
-            <div className="mt-2 space-y-2">
-              <Textarea
-                rows={5}
-                value={curlInput}
-                onChange={(e) => setCurlInput(e.target.value)}
-                placeholder={t("dialog.curl.placeholder")}
-                className="font-mono text-xs"
-              />
-              <Button type="button" size="sm" variant="outline" onClick={onParseCurl}>
-                {t("dialog.curl.parse")}
-              </Button>
+        <form onSubmit={onSubmit} className="flex min-h-0 flex-1 flex-col gap-4">
+          <div className="flex-1 space-y-4 overflow-y-auto pr-1">
+            <details className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm">
+              <summary className="cursor-pointer text-xs font-medium text-muted-foreground hover:text-foreground">
+                {t("dialog.curl.import")}
+              </summary>
+              <div className="mt-2 space-y-2">
+                <Textarea
+                  rows={5}
+                  value={curlInput}
+                  onChange={(e) => setCurlInput(e.target.value)}
+                  placeholder={t("dialog.curl.placeholder")}
+                  className="font-mono text-xs"
+                />
+                <Button type="button" size="sm" variant="outline" onClick={onParseCurl}>
+                  {t("dialog.curl.parse")}
+                </Button>
+              </div>
+            </details>
+
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div>
+                <Label htmlFor="name">{t("dialog.fields.name")}</Label>
+                <Input
+                  id="name"
+                  autoComplete="off"
+                  placeholder={t("dialog.fields.namePlaceholder")}
+                  {...form.register("name")}
+                />
+                {form.formState.errors.name ? (
+                  <p className="mt-1 text-xs text-destructive">{tc("errors.required")}</p>
+                ) : null}
+              </div>
+
+              <div>
+                <Label htmlFor="category">{t("dialog.fields.category")}</Label>
+                {/* onBlur not wired — RHF default mode is onSubmit; revisit if mode changes to onBlur/all */}
+                <Controller
+                  control={form.control}
+                  name="category"
+                  render={({ field }) => (
+                    <Select value={field.value ?? ""} onValueChange={field.onChange}>
+                      <SelectTrigger id="category" aria-label={t("dialog.fields.category")}>
+                        <SelectValue placeholder={t("dialog.fields.categoryPlaceholder")} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {CATEGORIES.map((c) => (
+                          <SelectItem key={c} value={c}>
+                            {t(`dialog.categoryOptions.${c}`)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
+                />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {t("dialog.fields.categoryHelp")}
+                </p>
+                {form.formState.errors.category ? (
+                  <p className="mt-1 text-xs text-destructive">{tc("errors.required")}</p>
+                ) : null}
+              </div>
             </div>
-          </details>
 
-          <div>
-            <Label htmlFor="name">{t("dialog.fields.name")}</Label>
-            <Input
-              id="name"
-              autoComplete="off"
-              placeholder={t("dialog.fields.namePlaceholder")}
-              {...form.register("name")}
-            />
-            {form.formState.errors.name ? (
-              <p className="mt-1 text-xs text-destructive">{tc("errors.required")}</p>
-            ) : null}
-          </div>
-
-          <div>
-            <Label htmlFor="apiBaseUrl">{t("dialog.fields.apiBaseUrl")}</Label>
-            <Input
-              id="apiBaseUrl"
-              autoComplete="off"
-              placeholder={t("dialog.fields.apiBaseUrlPlaceholder")}
-              {...form.register("apiBaseUrl")}
-            />
-            {form.formState.errors.apiBaseUrl ? (
-              <p className="mt-1 text-xs text-destructive">{t("dialog.errors.invalidUrl")}</p>
-            ) : null}
-            <p className="mt-1 text-xs text-muted-foreground">
-              {t("dialog.fields.apiBaseUrlHelp")}
-            </p>
-          </div>
-
-          <div>
-            <Label htmlFor="apiKey">{t("dialog.fields.apiKey")}</Label>
-            <div className="relative">
+            <div>
+              <Label htmlFor="apiBaseUrl">{t("dialog.fields.apiBaseUrl")}</Label>
               <Input
-                id="apiKey"
+                id="apiBaseUrl"
                 autoComplete="off"
-                type={revealKey ? "text" : "password"}
-                placeholder={t("dialog.fields.apiKeyPlaceholder")}
-                {...form.register("apiKey")}
+                placeholder={t("dialog.fields.apiBaseUrlPlaceholder")}
+                {...form.register("apiBaseUrl")}
               />
-              <button
-                type="button"
-                onClick={() => setRevealKey((v) => !v)}
-                className="absolute inset-y-0 right-2 flex items-center text-muted-foreground hover:text-foreground"
-                aria-label={revealKey ? "hide" : "show"}
-              >
-                {revealKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-              </button>
+              {form.formState.errors.apiBaseUrl ? (
+                <p className="mt-1 text-xs text-destructive">{t("dialog.errors.invalidUrl")}</p>
+              ) : null}
+              <p className="mt-1 text-xs text-muted-foreground">
+                {t("dialog.fields.apiBaseUrlHelp")}
+              </p>
             </div>
-            {form.formState.errors.apiKey ? (
-              <p className="mt-1 text-xs text-destructive">{tc("errors.required")}</p>
-            ) : null}
-          </div>
 
-          <div>
-            <Label htmlFor="model">{t("dialog.fields.model")}</Label>
-            <Input
-              id="model"
-              autoComplete="off"
-              placeholder={t("dialog.fields.modelPlaceholder")}
-              {...form.register("model")}
-            />
-            {form.formState.errors.model ? (
-              <p className="mt-1 text-xs text-destructive">{tc("errors.required")}</p>
-            ) : null}
-          </div>
+            <div>
+              <Label htmlFor="apiKey">{t("dialog.fields.apiKey")}</Label>
+              <div className="relative">
+                <Input
+                  id="apiKey"
+                  autoComplete="off"
+                  type={revealKey ? "text" : "password"}
+                  placeholder={t("dialog.fields.apiKeyPlaceholder")}
+                  {...form.register("apiKey")}
+                />
+                <button
+                  type="button"
+                  onClick={() => setRevealKey((v) => !v)}
+                  className="absolute inset-y-0 right-2 flex items-center text-muted-foreground hover:text-foreground"
+                  aria-label={revealKey ? "hide" : "show"}
+                >
+                  {revealKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
+              </div>
+              {form.formState.errors.apiKey ? (
+                <p className="mt-1 text-xs text-destructive">{tc("errors.required")}</p>
+              ) : null}
+            </div>
 
-          <div>
-            <Label htmlFor="category">{t("dialog.fields.category")}</Label>
-            {/* onBlur not wired — RHF default mode is onSubmit; revisit if mode changes to onBlur/all */}
-            <Controller
-              control={form.control}
-              name="category"
-              render={({ field }) => (
-                <Select value={field.value ?? ""} onValueChange={field.onChange}>
-                  <SelectTrigger id="category" aria-label={t("dialog.fields.category")}>
-                    <SelectValue placeholder={t("dialog.fields.categoryPlaceholder")} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {CATEGORIES.map((c) => (
-                      <SelectItem key={c} value={c}>
-                        {t(`dialog.categoryOptions.${c}`)}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              )}
-            />
-            <p className="mt-1 text-xs text-muted-foreground">{t("dialog.fields.categoryHelp")}</p>
-            {form.formState.errors.category ? (
-              <p className="mt-1 text-xs text-destructive">{tc("errors.required")}</p>
-            ) : null}
-          </div>
+            <div>
+              <Label htmlFor="model">{t("dialog.fields.model")}</Label>
+              <Input
+                id="model"
+                autoComplete="off"
+                placeholder={t("dialog.fields.modelPlaceholder")}
+                {...form.register("model")}
+              />
+              {form.formState.errors.model ? (
+                <p className="mt-1 text-xs text-destructive">{tc("errors.required")}</p>
+              ) : null}
+            </div>
 
-          <div>
-            <Label htmlFor="tags">{t("dialog.fields.tags")}</Label>
-            <Controller
-              control={form.control}
-              name="tags"
-              render={({ field }) => {
-                const current = field.value ?? [];
-                const tryAdd = (raw: string) => {
-                  const trimmed = raw.trim();
-                  if (!trimmed) return;
-                  if (current.includes(trimmed)) return;
-                  field.onChange([...current, trimmed]);
-                };
-                const remove = (tag: string) =>
-                  field.onChange(current.filter((item: string) => item !== tag));
-                const suggestions = PRESET_TAGS.filter((p) => !current.includes(p));
-                return (
-                  <div className="space-y-2">
-                    <div className="flex flex-wrap gap-1">
-                      {current.map((tag: string) => (
-                        <span
-                          key={tag}
-                          className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 text-xs"
-                        >
-                          {tag}
-                          <button
-                            type="button"
-                            aria-label={t("dialog.fields.tagsRemove", {
-                              tag,
-                              defaultValue: `Remove tag ${tag}`,
-                            })}
-                            onClick={() => remove(tag)}
-                          >
-                            <XIcon className="h-3 w-3" />
-                          </button>
-                        </span>
-                      ))}
-                    </div>
-                    <Input
-                      id="tags"
-                      value={tagDraft}
-                      onChange={(e) => setTagDraft(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") {
-                          e.preventDefault();
-                          tryAdd(tagDraft);
-                          setTagDraft("");
-                        }
-                      }}
-                      placeholder={t("dialog.fields.tagsPlaceholder")}
-                    />
-                    {suggestions.length > 0 ? (
+            <div>
+              <Label htmlFor="tags">{t("dialog.fields.tags")}</Label>
+              <Controller
+                control={form.control}
+                name="tags"
+                render={({ field }) => {
+                  const current = field.value ?? [];
+                  const tryAdd = (raw: string) => {
+                    const trimmed = raw.trim();
+                    if (!trimmed) return;
+                    if (current.includes(trimmed)) return;
+                    field.onChange([...current, trimmed]);
+                  };
+                  const remove = (tag: string) =>
+                    field.onChange(current.filter((item: string) => item !== tag));
+                  const suggestions = PRESET_TAGS.filter((p) => !current.includes(p));
+                  return (
+                    <div className="space-y-2">
                       <div className="flex flex-wrap gap-1">
-                        {suggestions.slice(0, MAX_SUGGESTION_CHIPS).map((s) => (
-                          <button
-                            type="button"
-                            key={s}
-                            onClick={() => tryAdd(s)}
-                            className="rounded-full border border-dashed border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent/40"
+                        {current.map((tag: string) => (
+                          <span
+                            key={tag}
+                            className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 text-xs"
                           >
-                            + {s}
-                          </button>
+                            {tag}
+                            <button
+                              type="button"
+                              aria-label={t("dialog.fields.tagsRemove", {
+                                tag,
+                                defaultValue: `Remove tag ${tag}`,
+                              })}
+                              onClick={() => remove(tag)}
+                            >
+                              <XIcon className="h-3 w-3" />
+                            </button>
+                          </span>
                         ))}
                       </div>
-                    ) : null}
-                  </div>
-                );
-              }}
-            />
-            <p className="mt-1 text-xs text-muted-foreground">{t("dialog.fields.tagsHelp")}</p>
+                      <Input
+                        id="tags"
+                        value={tagDraft}
+                        onChange={(e) => setTagDraft(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            e.preventDefault();
+                            tryAdd(tagDraft);
+                            setTagDraft("");
+                          }
+                        }}
+                        placeholder={t("dialog.fields.tagsPlaceholder")}
+                      />
+                      {suggestions.length > 0 ? (
+                        <div className="flex flex-wrap gap-1">
+                          {suggestions.slice(0, MAX_SUGGESTION_CHIPS).map((s) => (
+                            <button
+                              type="button"
+                              key={s}
+                              onClick={() => tryAdd(s)}
+                              className="rounded-full border border-dashed border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent/40"
+                            >
+                              + {s}
+                            </button>
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+                  );
+                }}
+              />
+              <p className="mt-1 text-xs text-muted-foreground">{t("dialog.fields.tagsHelp")}</p>
+            </div>
+
+            <div>
+              <Label htmlFor="customHeaders">{t("dialog.fields.customHeaders")}</Label>
+              <Textarea
+                id="customHeaders"
+                rows={3}
+                placeholder={t("dialog.fields.customHeadersPlaceholder")}
+                {...form.register("customHeaders")}
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="queryParams">{t("dialog.fields.queryParams")}</Label>
+              <Textarea
+                id="queryParams"
+                rows={2}
+                placeholder={t("dialog.fields.queryParamsPlaceholder")}
+                {...form.register("queryParams")}
+              />
+            </div>
+
+            {submitError ? (
+              <p className="text-sm text-destructive">
+                {submitError.toLowerCase().includes("exists")
+                  ? t("dialog.errors.duplicateName")
+                  : submitError}
+              </p>
+            ) : null}
           </div>
 
-          <div>
-            <Label htmlFor="customHeaders">{t("dialog.fields.customHeaders")}</Label>
-            <Textarea
-              id="customHeaders"
-              rows={3}
-              placeholder={t("dialog.fields.customHeadersPlaceholder")}
-              {...form.register("customHeaders")}
-            />
-          </div>
-
-          <div>
-            <Label htmlFor="queryParams">{t("dialog.fields.queryParams")}</Label>
-            <Textarea
-              id="queryParams"
-              rows={2}
-              placeholder={t("dialog.fields.queryParamsPlaceholder")}
-              {...form.register("queryParams")}
-            />
-          </div>
-
-          {submitError ? (
-            <p className="text-sm text-destructive">
-              {submitError.toLowerCase().includes("exists")
-                ? t("dialog.errors.duplicateName")
-                : submitError}
-            </p>
-          ) : null}
-
-          <DialogFooter>
+          <DialogFooter className="border-t border-border pt-3">
             <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
               {tc("actions.cancel")}
             </Button>

--- a/apps/web/src/features/connections/ConnectionDialog.tsx
+++ b/apps/web/src/features/connections/ConnectionDialog.tsx
@@ -55,6 +55,8 @@ const empty: Partial<ConnectionInput> = {
 };
 
 const CATEGORIES: ModalityCategory[] = ["chat", "audio", "embeddings", "rerank", "image"];
+const MAX_SUGGESTION_CHIPS = 8;
+
 const PRESET_TAGS = [
   "vLLM",
   "SGLang",
@@ -230,6 +232,7 @@ export function ConnectionDialog({
 
           <div>
             <Label htmlFor="category">{t("dialog.fields.category")}</Label>
+            {/* onBlur not wired — RHF default mode is onSubmit; revisit if mode changes to onBlur/all */}
             <Controller
               control={form.control}
               name="category"
@@ -268,7 +271,7 @@ export function ConnectionDialog({
                   field.onChange([...current, trimmed]);
                 };
                 const remove = (tag: string) =>
-                  field.onChange(current.filter((t: string) => t !== tag));
+                  field.onChange(current.filter((item: string) => item !== tag));
                 const suggestions = PRESET_TAGS.filter((p) => !current.includes(p));
                 return (
                   <div className="space-y-2">
@@ -307,7 +310,7 @@ export function ConnectionDialog({
                     />
                     {suggestions.length > 0 ? (
                       <div className="flex flex-wrap gap-1">
-                        {suggestions.slice(0, 8).map((s) => (
+                        {suggestions.slice(0, MAX_SUGGESTION_CHIPS).map((s) => (
                           <button
                             type="button"
                             key={s}

--- a/apps/web/src/features/connections/ConnectionDialog.tsx
+++ b/apps/web/src/features/connections/ConnectionDialog.tsx
@@ -8,15 +8,23 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { type EndpointKey, applyCurlToEndpoint } from "@/lib/apply-curl-to-endpoint";
 import { parseCurlCommand, toApiBaseUrl } from "@/lib/curl-parser";
 import { useConnectionsStore } from "@/stores/connections-store";
 import type { Connection } from "@/types/connection";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Eye, EyeOff } from "lucide-react";
+import type { ModalityCategory } from "@modeldoctor/contracts";
+import { Eye, EyeOff, X as XIcon } from "lucide-react";
 import { useEffect, useState } from "react";
-import { useForm } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { type ConnectionInput, connectionInputSchema } from "./schema";
@@ -34,14 +42,31 @@ interface ConnectionDialogProps {
   onSaved?: (c: Connection) => void;
 }
 
-const empty: ConnectionInput = {
+// Defaults for a fresh dialog. Intentionally Partial so `category` can be
+// unset — the user must pick one to satisfy the schema's required enum.
+const empty: Partial<ConnectionInput> = {
   name: "",
   apiBaseUrl: "",
   apiKey: "",
   model: "",
   customHeaders: "",
   queryParams: "",
+  tags: [],
 };
+
+const CATEGORIES: ModalityCategory[] = ["chat", "audio", "embeddings", "rerank", "image"];
+const PRESET_TAGS = [
+  "vLLM",
+  "SGLang",
+  "TGI",
+  "Ollama",
+  "OpenAI",
+  "Anthropic",
+  "multimodal",
+  "streaming",
+  "production",
+  "test",
+];
 
 export function ConnectionDialog({
   open,
@@ -57,6 +82,7 @@ export function ConnectionDialog({
   const [revealKey, setRevealKey] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [curlInput, setCurlInput] = useState("");
+  const [tagDraft, setTagDraft] = useState("");
 
   const form = useForm<ConnectionInput>({
     resolver: zodResolver(connectionInputSchema),
@@ -69,6 +95,7 @@ export function ConnectionDialog({
       setSubmitError(null);
       setRevealKey(false);
       setCurlInput("");
+      setTagDraft("");
     }
   }, [open, connection, initialValues, form]);
 
@@ -199,6 +226,104 @@ export function ConnectionDialog({
             {form.formState.errors.model ? (
               <p className="mt-1 text-xs text-destructive">{tc("errors.required")}</p>
             ) : null}
+          </div>
+
+          <div>
+            <Label htmlFor="category">{t("dialog.fields.category")}</Label>
+            <Controller
+              control={form.control}
+              name="category"
+              render={({ field }) => (
+                <Select value={field.value ?? ""} onValueChange={field.onChange}>
+                  <SelectTrigger id="category" aria-label={t("dialog.fields.category")}>
+                    <SelectValue placeholder={t("dialog.fields.categoryPlaceholder")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {CATEGORIES.map((c) => (
+                      <SelectItem key={c} value={c}>
+                        {t(`dialog.categoryOptions.${c}`)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            <p className="mt-1 text-xs text-muted-foreground">{t("dialog.fields.categoryHelp")}</p>
+            {form.formState.errors.category ? (
+              <p className="mt-1 text-xs text-destructive">{tc("errors.required")}</p>
+            ) : null}
+          </div>
+
+          <div>
+            <Label htmlFor="tags">{t("dialog.fields.tags")}</Label>
+            <Controller
+              control={form.control}
+              name="tags"
+              render={({ field }) => {
+                const current = field.value ?? [];
+                const tryAdd = (raw: string) => {
+                  const trimmed = raw.trim();
+                  if (!trimmed) return;
+                  if (current.includes(trimmed)) return;
+                  field.onChange([...current, trimmed]);
+                };
+                const remove = (tag: string) =>
+                  field.onChange(current.filter((t: string) => t !== tag));
+                const suggestions = PRESET_TAGS.filter((p) => !current.includes(p));
+                return (
+                  <div className="space-y-2">
+                    <div className="flex flex-wrap gap-1">
+                      {current.map((tag: string) => (
+                        <span
+                          key={tag}
+                          className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 text-xs"
+                        >
+                          {tag}
+                          <button
+                            type="button"
+                            aria-label={t("dialog.fields.tagsRemove", {
+                              tag,
+                              defaultValue: `Remove tag ${tag}`,
+                            })}
+                            onClick={() => remove(tag)}
+                          >
+                            <XIcon className="h-3 w-3" />
+                          </button>
+                        </span>
+                      ))}
+                    </div>
+                    <Input
+                      id="tags"
+                      value={tagDraft}
+                      onChange={(e) => setTagDraft(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          tryAdd(tagDraft);
+                          setTagDraft("");
+                        }
+                      }}
+                      placeholder={t("dialog.fields.tagsPlaceholder")}
+                    />
+                    {suggestions.length > 0 ? (
+                      <div className="flex flex-wrap gap-1">
+                        {suggestions.slice(0, 8).map((s) => (
+                          <button
+                            type="button"
+                            key={s}
+                            onClick={() => tryAdd(s)}
+                            className="rounded-full border border-dashed border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent/40"
+                          >
+                            + {s}
+                          </button>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                );
+              }}
+            />
+            <p className="mt-1 text-xs text-muted-foreground">{t("dialog.fields.tagsHelp")}</p>
           </div>
 
           <div>

--- a/apps/web/src/features/connections/ConnectionsImportDialog.tsx
+++ b/apps/web/src/features/connections/ConnectionsImportDialog.tsx
@@ -78,7 +78,7 @@ export function ConnectionsImportDialog({ open, onOpenChange }: Props) {
         <Textarea
           rows={8}
           className="font-mono text-xs"
-          placeholder='{"version":1,"connections":[…]}'
+          placeholder='{"version":2,"connections":[…]}'
           value={json}
           onChange={(e) => setJson(e.target.value)}
         />

--- a/apps/web/src/features/connections/ConnectionsPage.test.tsx
+++ b/apps/web/src/features/connections/ConnectionsPage.test.tsx
@@ -1,0 +1,66 @@
+import "@/lib/i18n";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useConnectionsStore } from "@/stores/connections-store";
+import { ConnectionsPage } from "./ConnectionsPage";
+
+function seed() {
+  const s = useConnectionsStore.getState();
+  s.create({
+    name: "chat-prod",
+    apiBaseUrl: "http://a",
+    apiKey: "k",
+    model: "qwen",
+    customHeaders: "",
+    queryParams: "",
+    category: "chat",
+    tags: ["vLLM", "production"],
+  });
+  s.create({
+    name: "embed-test",
+    apiBaseUrl: "http://b",
+    apiKey: "k",
+    model: "bge",
+    customHeaders: "",
+    queryParams: "",
+    category: "embeddings",
+    tags: ["TEI"],
+  });
+}
+
+describe("ConnectionsPage (category + tags)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useConnectionsStore.setState({ connections: [] });
+  });
+
+  it("renders category badge and tag chips for each row", () => {
+    seed();
+    render(
+      <MemoryRouter>
+        <ConnectionsPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("chat-prod")).toBeInTheDocument();
+    expect(screen.getByText("embed-test")).toBeInTheDocument();
+    expect(screen.getByText("vLLM")).toBeInTheDocument();
+    expect(screen.getByText("TEI")).toBeInTheDocument();
+  });
+
+  it("filtering by category hides non-matching rows", async () => {
+    const user = userEvent.setup();
+    seed();
+    render(
+      <MemoryRouter>
+        <ConnectionsPage />
+      </MemoryRouter>,
+    );
+    await user.click(screen.getByRole("combobox", { name: /category|分类/i }));
+    await user.click(screen.getByRole("option", { name: /^chat$|^对话$/i }));
+
+    expect(screen.getByText("chat-prod")).toBeInTheDocument();
+    expect(screen.queryByText("embed-test")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/connections/ConnectionsPage.test.tsx
+++ b/apps/web/src/features/connections/ConnectionsPage.test.tsx
@@ -1,9 +1,9 @@
 import "@/lib/i18n";
+import { useConnectionsStore } from "@/stores/connections-store";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it } from "vitest";
-import { useConnectionsStore } from "@/stores/connections-store";
 import { ConnectionsPage } from "./ConnectionsPage";
 
 function seed() {

--- a/apps/web/src/features/connections/ConnectionsPage.tsx
+++ b/apps/web/src/features/connections/ConnectionsPage.tsx
@@ -10,7 +10,15 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   Table,
   TableBody,
@@ -21,6 +29,7 @@ import {
 } from "@/components/ui/table";
 import { useConnectionsStore } from "@/stores/connections-store";
 import type { Connection } from "@/types/connection";
+import type { ModalityCategory } from "@modeldoctor/contracts";
 import { format } from "date-fns";
 import { Database, Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
@@ -34,6 +43,17 @@ export function ConnectionsPage() {
   const list = useConnectionsStore((s) => s.list());
   const removeConn = useConnectionsStore((s) => s.remove);
   const exportAll = useConnectionsStore((s) => s.exportAll);
+
+  const [filterCategory, setFilterCategory] = useState<ModalityCategory | "all">("all");
+  const [filterTag, setFilterTag] = useState<string | "all">("all");
+
+  const allTags = Array.from(new Set(list.flatMap((c) => c.tags))).sort();
+
+  const filtered = list.filter((c) => {
+    if (filterCategory !== "all" && c.category !== filterCategory) return false;
+    if (filterTag !== "all" && !c.tags.includes(filterTag)) return false;
+    return true;
+  });
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editing, setEditing] = useState<Connection | undefined>(undefined);
@@ -95,6 +115,32 @@ export function ConnectionsPage() {
             }
           />
         ) : (
+          <>
+          <div className="mb-3 flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">{t("filters.label")}:</span>
+            <Select value={filterCategory} onValueChange={(v) => setFilterCategory(v as ModalityCategory | "all")}>
+              <SelectTrigger className="h-8 w-40 text-xs" aria-label={t("dialog.fields.category")}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{t("filters.allCategories")}</SelectItem>
+                {(["chat", "audio", "embeddings", "rerank", "image"] as ModalityCategory[]).map((c) => (
+                  <SelectItem key={c} value={c}>{t(`dialog.categoryOptions.${c}`)}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={filterTag} onValueChange={setFilterTag}>
+              <SelectTrigger className="h-8 w-40 text-xs" aria-label={t("dialog.fields.tags")}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{t("filters.allTags")}</SelectItem>
+                {allTags.map((tag) => (
+                  <SelectItem key={tag} value={tag}>{tag}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
           <div className="rounded-lg border border-border bg-card">
             <Table>
               <TableHeader>
@@ -102,17 +148,33 @@ export function ConnectionsPage() {
                   <TableHead>{t("table.name")}</TableHead>
                   <TableHead>{t("table.apiBaseUrl")}</TableHead>
                   <TableHead>{t("table.model")}</TableHead>
+                  <TableHead>{t("table.category")}</TableHead>
+                  <TableHead>{t("table.tags")}</TableHead>
                   <TableHead>{t("table.customHeaders")}</TableHead>
                   <TableHead>{t("table.createdAt")}</TableHead>
                   <TableHead className="w-[120px] text-right">{t("table.actions")}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {list.map((c) => (
+                {filtered.map((c) => (
                   <TableRow key={c.id}>
                     <TableCell className="font-medium">{c.name}</TableCell>
                     <TableCell className="font-mono text-xs">{c.apiBaseUrl}</TableCell>
                     <TableCell className="font-mono text-xs">{c.model}</TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className="text-xs">
+                        {t(`dialog.categoryOptions.${c.category}`)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap gap-1">
+                        {c.tags.map((tag) => (
+                          <span key={tag} className="rounded-full bg-secondary px-2 py-0.5 text-[10px]">
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    </TableCell>
                     <TableCell className="text-xs text-muted-foreground">
                       {c.customHeaders ? `${c.customHeaders.split("\n")[0]}…` : "—"}
                     </TableCell>
@@ -145,6 +207,7 @@ export function ConnectionsPage() {
               </TableBody>
             </Table>
           </div>
+          </>
         )}
       </div>
 

--- a/apps/web/src/features/connections/ConnectionsPage.tsx
+++ b/apps/web/src/features/connections/ConnectionsPage.tsx
@@ -116,97 +116,112 @@ export function ConnectionsPage() {
           />
         ) : (
           <>
-          <div className="mb-3 flex items-center gap-2">
-            <span className="text-xs text-muted-foreground">{t("filters.label")}:</span>
-            <Select value={filterCategory} onValueChange={(v) => setFilterCategory(v as ModalityCategory | "all")}>
-              <SelectTrigger className="h-8 w-40 text-xs" aria-label={t("dialog.fields.category")}>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">{t("filters.allCategories")}</SelectItem>
-                {(["chat", "audio", "embeddings", "rerank", "image"] as ModalityCategory[]).map((c) => (
-                  <SelectItem key={c} value={c}>{t(`dialog.categoryOptions.${c}`)}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Select value={filterTag} onValueChange={setFilterTag}>
-              <SelectTrigger className="h-8 w-40 text-xs" aria-label={t("dialog.fields.tags")}>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">{t("filters.allTags")}</SelectItem>
-                {allTags.map((tag) => (
-                  <SelectItem key={tag} value={tag}>{tag}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="rounded-lg border border-border bg-card">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>{t("table.name")}</TableHead>
-                  <TableHead>{t("table.apiBaseUrl")}</TableHead>
-                  <TableHead>{t("table.model")}</TableHead>
-                  <TableHead>{t("table.category")}</TableHead>
-                  <TableHead>{t("table.tags")}</TableHead>
-                  <TableHead>{t("table.customHeaders")}</TableHead>
-                  <TableHead>{t("table.createdAt")}</TableHead>
-                  <TableHead className="w-[120px] text-right">{t("table.actions")}</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {filtered.map((c) => (
-                  <TableRow key={c.id}>
-                    <TableCell className="font-medium">{c.name}</TableCell>
-                    <TableCell className="font-mono text-xs">{c.apiBaseUrl}</TableCell>
-                    <TableCell className="font-mono text-xs">{c.model}</TableCell>
-                    <TableCell>
-                      <Badge variant="outline" className="text-xs">
-                        {t(`dialog.categoryOptions.${c.category}`)}
-                      </Badge>
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex flex-wrap gap-1">
-                        {c.tags.map((tag) => (
-                          <span key={tag} className="rounded-full bg-secondary px-2 py-0.5 text-[10px]">
-                            {tag}
-                          </span>
-                        ))}
-                      </div>
-                    </TableCell>
-                    <TableCell className="text-xs text-muted-foreground">
-                      {c.customHeaders ? `${c.customHeaders.split("\n")[0]}…` : "—"}
-                    </TableCell>
-                    <TableCell className="text-xs text-muted-foreground">
-                      {format(new Date(c.createdAt), "yyyy-MM-dd HH:mm")}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        aria-label={t("actions.edit")}
-                        onClick={() => {
-                          setEditing(c);
-                          setDialogOpen(true);
-                        }}
-                      >
-                        <Pencil className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        aria-label={t("actions.delete")}
-                        onClick={() => setPendingDelete(c)}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </TableCell>
+            <div className="mb-3 flex items-center gap-2">
+              <span className="text-xs text-muted-foreground">{t("filters.label")}:</span>
+              <Select
+                value={filterCategory}
+                onValueChange={(v) => setFilterCategory(v as ModalityCategory | "all")}
+              >
+                <SelectTrigger
+                  className="h-8 w-40 text-xs"
+                  aria-label={t("dialog.fields.category")}
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t("filters.allCategories")}</SelectItem>
+                  {(["chat", "audio", "embeddings", "rerank", "image"] as ModalityCategory[]).map(
+                    (c) => (
+                      <SelectItem key={c} value={c}>
+                        {t(`dialog.categoryOptions.${c}`)}
+                      </SelectItem>
+                    ),
+                  )}
+                </SelectContent>
+              </Select>
+              <Select value={filterTag} onValueChange={setFilterTag}>
+                <SelectTrigger className="h-8 w-40 text-xs" aria-label={t("dialog.fields.tags")}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t("filters.allTags")}</SelectItem>
+                  {allTags.map((tag) => (
+                    <SelectItem key={tag} value={tag}>
+                      {tag}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="rounded-lg border border-border bg-card">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{t("table.name")}</TableHead>
+                    <TableHead>{t("table.apiBaseUrl")}</TableHead>
+                    <TableHead>{t("table.model")}</TableHead>
+                    <TableHead>{t("table.category")}</TableHead>
+                    <TableHead>{t("table.tags")}</TableHead>
+                    <TableHead>{t("table.customHeaders")}</TableHead>
+                    <TableHead>{t("table.createdAt")}</TableHead>
+                    <TableHead className="w-[120px] text-right">{t("table.actions")}</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
+                </TableHeader>
+                <TableBody>
+                  {filtered.map((c) => (
+                    <TableRow key={c.id}>
+                      <TableCell className="font-medium">{c.name}</TableCell>
+                      <TableCell className="font-mono text-xs">{c.apiBaseUrl}</TableCell>
+                      <TableCell className="font-mono text-xs">{c.model}</TableCell>
+                      <TableCell>
+                        <Badge variant="outline" className="text-xs">
+                          {t(`dialog.categoryOptions.${c.category}`)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-1">
+                          {c.tags.map((tag) => (
+                            <span
+                              key={tag}
+                              className="rounded-full bg-secondary px-2 py-0.5 text-[10px]"
+                            >
+                              {tag}
+                            </span>
+                          ))}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {c.customHeaders ? `${c.customHeaders.split("\n")[0]}…` : "—"}
+                      </TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {format(new Date(c.createdAt), "yyyy-MM-dd HH:mm")}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          aria-label={t("actions.edit")}
+                          onClick={() => {
+                            setEditing(c);
+                            setDialogOpen(true);
+                          }}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          aria-label={t("actions.delete")}
+                          onClick={() => setPendingDelete(c)}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
           </>
         )}
       </div>

--- a/apps/web/src/features/connections/ConnectionsPage.tsx
+++ b/apps/web/src/features/connections/ConnectionsPage.tsx
@@ -32,7 +32,7 @@ import type { Connection } from "@/types/connection";
 import type { ModalityCategory } from "@modeldoctor/contracts";
 import { format } from "date-fns";
 import { Database, Pencil, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ConnectionDialog } from "./ConnectionDialog";
 import { ConnectionsImportDialog } from "./ConnectionsImportDialog";
@@ -48,6 +48,12 @@ export function ConnectionsPage() {
   const [filterTag, setFilterTag] = useState<string | "all">("all");
 
   const allTags = Array.from(new Set(list.flatMap((c) => c.tags))).sort();
+
+  useEffect(() => {
+    if (filterTag !== "all" && !allTags.includes(filterTag)) {
+      setFilterTag("all");
+    }
+  }, [allTags, filterTag]);
 
   const filtered = list.filter((c) => {
     if (filterCategory !== "all" && c.category !== filterCategory) return false;

--- a/apps/web/src/features/connections/schema.test.ts
+++ b/apps/web/src/features/connections/schema.test.ts
@@ -9,6 +9,7 @@ describe("connectionInputSchema", () => {
     model: "qwen-2.5-7b",
     customHeaders: "",
     queryParams: "",
+    category: "chat" as const,
   };
 
   it("accepts a valid input", () => {
@@ -45,5 +46,40 @@ describe("connectionInputSchema", () => {
     });
     expect(r.success).toBe(true);
     if (r.success) expect(r.data.name).toBe("staging");
+  });
+});
+
+describe("connectionInputSchema (category + tags)", () => {
+  const baseInput = {
+    name: "n",
+    apiBaseUrl: "http://x",
+    apiKey: "k",
+    model: "m",
+    customHeaders: "",
+    queryParams: "",
+  };
+
+  it("requires a category", () => {
+    expect(() => connectionInputSchema.parse({ ...baseInput, tags: [] })).toThrow();
+  });
+
+  it("rejects an unknown category", () => {
+    expect(() =>
+      connectionInputSchema.parse({ ...baseInput, category: "video", tags: [] }),
+    ).toThrow();
+  });
+
+  it("trims and dedupes tags", () => {
+    const out = connectionInputSchema.parse({
+      ...baseInput,
+      category: "chat",
+      tags: ["  vLLM  ", "vLLM", "production", ""],
+    });
+    expect(out.tags).toEqual(["vLLM", "production"]);
+  });
+
+  it("defaults tags to an empty array when omitted", () => {
+    const out = connectionInputSchema.parse({ ...baseInput, category: "chat" });
+    expect(out.tags).toEqual([]);
   });
 });

--- a/apps/web/src/features/connections/schema.ts
+++ b/apps/web/src/features/connections/schema.ts
@@ -1,3 +1,4 @@
+import { ModalityCategorySchema } from "@modeldoctor/contracts";
 import { z } from "zod";
 
 export const connectionInputSchema = z.object({
@@ -10,6 +11,21 @@ export const connectionInputSchema = z.object({
   model: z.string().min(1, "required"),
   customHeaders: z.string(),
   queryParams: z.string(),
+  category: ModalityCategorySchema,
+  tags: z
+    .array(z.string())
+    .default([])
+    .transform((arr) => {
+      const seen = new Set<string>();
+      const out: string[] = [];
+      for (const t of arr) {
+        const trimmed = t.trim();
+        if (!trimmed || seen.has(trimmed)) continue;
+        seen.add(trimmed);
+        out.push(trimmed);
+      }
+      return out;
+    }),
 });
 
 export type ConnectionInput = z.infer<typeof connectionInputSchema>;

--- a/apps/web/src/features/connections/schema.ts
+++ b/apps/web/src/features/connections/schema.ts
@@ -13,16 +13,15 @@ export const connectionInputSchema = z.object({
   queryParams: z.string(),
   category: ModalityCategorySchema,
   tags: z
-    .array(z.string())
+    .array(z.string().trim())
     .default([])
     .transform((arr) => {
       const seen = new Set<string>();
       const out: string[] = [];
       for (const t of arr) {
-        const trimmed = t.trim();
-        if (!trimmed || seen.has(trimmed)) continue;
-        seen.add(trimmed);
-        out.push(trimmed);
+        if (!t || seen.has(t)) continue;
+        seen.add(t);
+        out.push(t);
       }
       return out;
     }),

--- a/apps/web/src/features/playground/CategoryEndpointSelector.test.tsx
+++ b/apps/web/src/features/playground/CategoryEndpointSelector.test.tsx
@@ -1,0 +1,93 @@
+import "@/lib/i18n";
+import { useConnectionsStore } from "@/stores/connections-store";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CategoryEndpointSelector } from "./CategoryEndpointSelector";
+
+function seed() {
+  const s = useConnectionsStore.getState();
+  s.create({
+    name: "chat-A",
+    apiBaseUrl: "http://a",
+    apiKey: "k",
+    model: "m",
+    customHeaders: "",
+    queryParams: "",
+    category: "chat",
+    tags: [],
+  });
+  s.create({
+    name: "embed-B",
+    apiBaseUrl: "http://b",
+    apiKey: "k",
+    model: "m",
+    customHeaders: "",
+    queryParams: "",
+    category: "embeddings",
+    tags: [],
+  });
+}
+
+describe("CategoryEndpointSelector", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useConnectionsStore.setState({ connections: [] });
+  });
+
+  it("only lists connections of the matching category by default", async () => {
+    const user = userEvent.setup();
+    seed();
+    render(
+      <CategoryEndpointSelector category="chat" selectedConnectionId={null} onSelect={vi.fn()} />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByRole("option", { name: /chat-A/i })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /embed-B/i })).not.toBeInTheDocument();
+  });
+
+  it("show-all toggle reveals all connections", async () => {
+    const user = userEvent.setup();
+    seed();
+    render(
+      <CategoryEndpointSelector category="chat" selectedConnectionId={null} onSelect={vi.fn()} />,
+    );
+    await user.click(screen.getByRole("checkbox", { name: /show all|显示全部/i }));
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByRole("option", { name: /chat-A/i })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /embed-B/i })).toBeInTheDocument();
+  });
+
+  it("warns when selected connection's category mismatches", () => {
+    seed();
+    const embedId =
+      useConnectionsStore
+        .getState()
+        .list()
+        .find((c) => c.name === "embed-B")?.id ?? null;
+    render(
+      <CategoryEndpointSelector
+        category="chat"
+        selectedConnectionId={embedId}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/doesn't match|不符/i)).toBeInTheDocument();
+  });
+
+  it("emits onSelect with the picked connection id", async () => {
+    const user = userEvent.setup();
+    seed();
+    const onSelect = vi.fn();
+    render(
+      <CategoryEndpointSelector category="chat" selectedConnectionId={null} onSelect={onSelect} />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /chat-A/i }));
+    const expectedId = useConnectionsStore
+      .getState()
+      .list()
+      .find((c) => c.name === "chat-A")?.id;
+    expect(onSelect).toHaveBeenCalledWith(expectedId);
+  });
+});

--- a/apps/web/src/features/playground/CategoryEndpointSelector.tsx
+++ b/apps/web/src/features/playground/CategoryEndpointSelector.tsx
@@ -1,0 +1,98 @@
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useConnectionsStore } from "@/stores/connections-store";
+import type { ModalityCategory } from "@modeldoctor/contracts";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+export interface CategoryEndpointSelectorProps {
+  category: ModalityCategory;
+  selectedConnectionId: string | null;
+  onSelect: (id: string | null) => void;
+}
+
+export function CategoryEndpointSelector({
+  category,
+  selectedConnectionId,
+  onSelect,
+}: CategoryEndpointSelectorProps) {
+  const { t } = useTranslation("playground");
+  const { t: tc } = useTranslation("connections");
+  const list = useConnectionsStore((s) => s.list());
+  const [showAll, setShowAll] = useState(false);
+
+  const visible = showAll ? list : list.filter((c) => c.category === category);
+  const selected = selectedConnectionId
+    ? (list.find((c) => c.id === selectedConnectionId) ?? null)
+    : null;
+  const mismatched = selected && selected.category !== category;
+  const showAllId = "playground-show-all-connections";
+
+  return (
+    <div className="space-y-2">
+      <Select value={selectedConnectionId ?? ""} onValueChange={(v) => onSelect(v || null)}>
+        <SelectTrigger className="w-full">
+          <SelectValue
+            placeholder={t("endpoint.noMatchingConnections", {
+              category: tc(`dialog.categoryOptions.${category}`),
+            })}
+          />
+        </SelectTrigger>
+        <SelectContent>
+          {visible.length === 0 ? (
+            <div className="px-2 py-1.5 text-xs text-muted-foreground">
+              {t("endpoint.noMatchingConnections", {
+                category: tc(`dialog.categoryOptions.${category}`),
+              })}
+            </div>
+          ) : (
+            visible.map((c) => (
+              <SelectItem
+                key={c.id}
+                value={c.id}
+                className={c.category !== category ? "opacity-60" : ""}
+              >
+                {c.name}
+              </SelectItem>
+            ))
+          )}
+        </SelectContent>
+      </Select>
+
+      <label htmlFor={showAllId} className="flex items-center gap-2 text-xs text-muted-foreground">
+        <input
+          id={showAllId}
+          type="checkbox"
+          checked={showAll}
+          onChange={(e) => setShowAll(e.target.checked)}
+        />
+        {t("endpoint.showAll")}
+      </label>
+
+      {mismatched ? (
+        <div className="flex items-center gap-2 rounded-md border border-warning/40 bg-warning/10 px-2 py-1 text-xs text-warning-foreground">
+          <span>
+            {t("endpoint.categoryMismatch", {
+              category: tc(`dialog.categoryOptions.${selected?.category}`),
+            })}
+          </span>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-6 px-2 text-xs"
+            onClick={() => onSelect(null)}
+          >
+            {t("endpoint.clearSelection")}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/playground/CategoryEndpointSelector.tsx
+++ b/apps/web/src/features/playground/CategoryEndpointSelector.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/select";
 import { useConnectionsStore } from "@/stores/connections-store";
 import type { ModalityCategory } from "@modeldoctor/contracts";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 export interface CategoryEndpointSelectorProps {
@@ -32,7 +32,7 @@ export function CategoryEndpointSelector({
     ? (list.find((c) => c.id === selectedConnectionId) ?? null)
     : null;
   const mismatched = selected && selected.category !== category;
-  const showAllId = "playground-show-all-connections";
+  const showAllId = useId();
 
   return (
     <div className="space-y-2">
@@ -76,7 +76,7 @@ export function CategoryEndpointSelector({
       </label>
 
       {mismatched ? (
-        <div className="flex items-center gap-2 rounded-md border border-warning/40 bg-warning/10 px-2 py-1 text-xs text-warning-foreground">
+        <div className="flex items-center gap-2 rounded-md border border-warning/40 bg-warning/10 px-2 py-1 text-xs text-warning">
           <span>
             {t("endpoint.categoryMismatch", {
               category: tc(`dialog.categoryOptions.${selected?.category}`),

--- a/apps/web/src/features/playground/ParamsPanel.tsx
+++ b/apps/web/src/features/playground/ParamsPanel.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+interface ParamsPanelProps {
+  open: boolean;
+  children: ReactNode;
+}
+
+export function ParamsPanel({ open, children }: ParamsPanelProps) {
+  if (!open) return null;
+  return (
+    <aside
+      className={cn("w-80 shrink-0 overflow-y-auto border-l border-border bg-card", "px-4 py-4")}
+    >
+      {children}
+    </aside>
+  );
+}

--- a/apps/web/src/features/playground/PlaygroundShell.test.tsx
+++ b/apps/web/src/features/playground/PlaygroundShell.test.tsx
@@ -1,0 +1,50 @@
+import "@/lib/i18n";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { PlaygroundShell } from "./PlaygroundShell";
+
+describe("PlaygroundShell", () => {
+  it("renders main content and params slot side by side", () => {
+    render(
+      <PlaygroundShell category="chat" paramsSlot={<div>params-here</div>}>
+        <div>main-here</div>
+      </PlaygroundShell>,
+    );
+    expect(screen.getByText("main-here")).toBeInTheDocument();
+    expect(screen.getByText("params-here")).toBeInTheDocument();
+  });
+
+  it("renders tabs and calls onTabChange when clicked", async () => {
+    const user = userEvent.setup();
+    const onTabChange = vi.fn();
+    render(
+      <PlaygroundShell
+        category="chat"
+        tabs={[
+          { key: "single", label: "Single" },
+          { key: "compare", label: "Compare" },
+        ]}
+        activeTab="single"
+        onTabChange={onTabChange}
+        paramsSlot={null}
+      >
+        <div />
+      </PlaygroundShell>,
+    );
+    await user.click(screen.getByRole("button", { name: "Compare" }));
+    expect(onTabChange).toHaveBeenCalledWith("compare");
+  });
+
+  it("collapse button hides the params panel", async () => {
+    const user = userEvent.setup();
+    render(
+      <PlaygroundShell category="chat" paramsSlot={<div>panel-x</div>}>
+        <div />
+      </PlaygroundShell>,
+    );
+    expect(screen.getByText("panel-x")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /collapse|折叠/i }));
+    expect(screen.queryByText("panel-x")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/playground/PlaygroundShell.tsx
+++ b/apps/web/src/features/playground/PlaygroundShell.tsx
@@ -1,0 +1,73 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { ModalityCategory } from "@modeldoctor/contracts";
+import { PanelRightClose, PanelRightOpen } from "lucide-react";
+import { type ReactNode, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ParamsPanel } from "./ParamsPanel";
+
+export interface PlaygroundShellProps {
+  category: ModalityCategory;
+  tabs?: Array<{ key: string; label: string }>;
+  activeTab?: string;
+  onTabChange?: (k: string) => void;
+  paramsSlot: ReactNode;
+  rightPanelDefaultOpen?: boolean;
+  children: ReactNode;
+}
+
+export function PlaygroundShell({
+  tabs,
+  activeTab,
+  onTabChange,
+  paramsSlot,
+  rightPanelDefaultOpen = true,
+  children,
+}: PlaygroundShellProps) {
+  const { t: tc } = useTranslation("common");
+  const [panelOpen, setPanelOpen] = useState(rightPanelDefaultOpen);
+
+  return (
+    <div className="flex h-[calc(100vh-0px)] min-h-0 flex-col">
+      <header className="flex items-center justify-between border-b border-border px-6 py-3">
+        <div className="flex items-center gap-1">
+          {tabs?.map((tab) => (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => onTabChange?.(tab.key)}
+              className={cn(
+                "rounded-md px-3 py-1.5 text-sm",
+                tab.key === activeTab
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground hover:bg-accent/40 hover:text-foreground",
+              )}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setPanelOpen((v) => !v)}
+          aria-label={
+            panelOpen
+              ? tc("sidebar.collapse", { defaultValue: "Collapse" })
+              : tc("sidebar.expand", { defaultValue: "Expand" })
+          }
+        >
+          {panelOpen ? (
+            <PanelRightClose className="h-4 w-4" />
+          ) : (
+            <PanelRightOpen className="h-4 w-4" />
+          )}
+        </Button>
+      </header>
+      <div className="flex min-h-0 flex-1">
+        <main className="flex min-w-0 flex-1 flex-col overflow-hidden">{children}</main>
+        <ParamsPanel open={panelOpen}>{paramsSlot}</ParamsPanel>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/playground/PlaygroundShell.tsx
+++ b/apps/web/src/features/playground/PlaygroundShell.tsx
@@ -28,7 +28,7 @@ export function PlaygroundShell({
   const [panelOpen, setPanelOpen] = useState(rightPanelDefaultOpen);
 
   return (
-    <div className="flex h-[calc(100vh-0px)] min-h-0 flex-col">
+    <div className="flex h-screen min-h-0 flex-col">
       <header className="flex items-center justify-between border-b border-border px-6 py-3">
         <div className="flex items-center gap-1">
           {tabs?.map((tab) => (

--- a/apps/web/src/features/playground/chat/ChatPage.test.tsx
+++ b/apps/web/src/features/playground/chat/ChatPage.test.tsx
@@ -113,4 +113,45 @@ describe("ChatPage", () => {
       expect(screen.getByText(/upstream 500: boom/)).toBeInTheDocument();
     });
   });
+
+  it("multi-turn: turn 2 sends [user-1, assistant-1, user-2] without duplicates", async () => {
+    // Turn 1: success returns "reply-1"
+    vi.mocked(api.post)
+      .mockResolvedValueOnce({ success: true, content: "reply-1", latencyMs: 1 })
+      .mockResolvedValueOnce({ success: true, content: "reply-2", latencyMs: 1 });
+
+    seedChatConn();
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <ChatPage />
+      </MemoryRouter>,
+    );
+
+    // Pick connection
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /chat-1/i }));
+
+    // Turn 1
+    const input = screen.getByPlaceholderText(/type your message|输入消息/i);
+    await user.type(input, "hi 1");
+    await user.click(screen.getByRole("button", { name: /^send$|^发送$/i }));
+    await waitFor(() => expect(screen.getByText("reply-1")).toBeInTheDocument());
+
+    // Turn 2
+    await user.type(input, "hi 2");
+    await user.click(screen.getByRole("button", { name: /^send$|^发送$/i }));
+
+    await waitFor(() => {
+      // Confirm second call's payload has 3 messages, no duplicates
+      const secondCall = vi.mocked(api.post).mock.calls[1];
+      expect(secondCall[0]).toBe("/api/playground/chat");
+      const body = secondCall[1] as { messages: Array<{ role: string; content: string }> };
+      expect(body.messages).toEqual([
+        { role: "user", content: "hi 1" },
+        { role: "assistant", content: "reply-1" },
+        { role: "user", content: "hi 2" },
+      ]);
+    });
+  });
 });

--- a/apps/web/src/features/playground/chat/ChatPage.test.tsx
+++ b/apps/web/src/features/playground/chat/ChatPage.test.tsx
@@ -1,0 +1,116 @@
+import "@/lib/i18n";
+import { useConnectionsStore } from "@/stores/connections-store";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatPage } from "./ChatPage";
+import { useChatStore } from "./store";
+
+vi.mock("@/lib/api-client", () => {
+  class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  }
+  return {
+    ApiError,
+    api: { get: vi.fn(), post: vi.fn() },
+  };
+});
+
+import { api } from "@/lib/api-client";
+
+function seedChatConn() {
+  useConnectionsStore.getState().create({
+    name: "chat-1",
+    apiBaseUrl: "http://x",
+    apiKey: "k",
+    model: "m",
+    customHeaders: "",
+    queryParams: "",
+    category: "chat",
+    tags: [],
+  });
+}
+
+describe("ChatPage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useConnectionsStore.setState({ connections: [] });
+    useChatStore.getState().reset();
+    vi.mocked(api.post).mockReset();
+  });
+
+  it("send button is disabled until a connection is selected", () => {
+    seedChatConn();
+    render(
+      <MemoryRouter>
+        <ChatPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("button", { name: /send|发送/i })).toBeDisabled();
+  });
+
+  it("sends to /api/playground/chat and renders the assistant reply", async () => {
+    vi.mocked(api.post).mockResolvedValue({
+      success: true,
+      content: "hello back",
+      latencyMs: 12,
+    });
+    seedChatConn();
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <ChatPage />
+      </MemoryRouter>,
+    );
+
+    // Pick the connection
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /chat-1/i }));
+
+    // Type message
+    const input = screen.getByPlaceholderText(/type your message|输入消息/i);
+    await user.type(input, "hi there");
+    await user.click(screen.getByRole("button", { name: /^send$|^发送$/i }));
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith(
+        "/api/playground/chat",
+        expect.objectContaining({
+          apiBaseUrl: "http://x",
+          apiKey: "k",
+          model: "m",
+          messages: [{ role: "user", content: "hi there" }],
+        }),
+      );
+      expect(screen.getByText("hello back")).toBeInTheDocument();
+    });
+  });
+
+  it("renders an error toast (or inline error) when api returns success=false", async () => {
+    vi.mocked(api.post).mockResolvedValue({
+      success: false,
+      error: "upstream 500: boom",
+      latencyMs: 1,
+    });
+    seedChatConn();
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <ChatPage />
+      </MemoryRouter>,
+    );
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /chat-1/i }));
+    await user.type(screen.getByPlaceholderText(/type your message|输入消息/i), "hi");
+    await user.click(screen.getByRole("button", { name: /^send$|^发送$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/upstream 500: boom/)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/features/playground/chat/ChatPage.tsx
+++ b/apps/web/src/features/playground/chat/ChatPage.tsx
@@ -1,13 +1,104 @@
-// apps/web/src/features/playground/chat/ChatPage.tsx (Task 6 stub — replaced in Task 13)
 import { PageHeader } from "@/components/common/page-header";
+import { ApiError, api } from "@/lib/api-client";
+import { useConnectionsStore } from "@/stores/connections-store";
+import type {
+  ChatMessage,
+  PlaygroundChatRequest,
+  PlaygroundChatResponse,
+} from "@modeldoctor/contracts";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { CategoryEndpointSelector } from "../CategoryEndpointSelector";
+import { PlaygroundShell } from "../PlaygroundShell";
+import { ChatParams } from "./ChatParams";
+import { MessageComposer } from "./MessageComposer";
+import { MessageList } from "./MessageList";
+import { useChatStore } from "./store";
 
 export function ChatPage() {
   const { t } = useTranslation("playground");
+  const slice = useChatStore();
+  const conn = useConnectionsStore((s) =>
+    slice.selectedConnectionId ? s.get(slice.selectedConnectionId) : null,
+  );
+
+  const canSend = !!conn;
+  const disabledReason = canSend ? undefined : t("chat.composer.needConnection");
+
+  const onSend = async (text: string) => {
+    if (!conn) return;
+    slice.appendMessage({ role: "user", content: text });
+    slice.setSending(true);
+    slice.setError(null);
+
+    const messages: ChatMessage[] = [
+      ...(slice.systemMessage.trim()
+        ? [{ role: "system" as const, content: slice.systemMessage.trim() }]
+        : []),
+      ...slice.messages,
+      { role: "user" as const, content: text },
+    ];
+
+    const body: PlaygroundChatRequest = {
+      apiBaseUrl: conn.apiBaseUrl,
+      apiKey: conn.apiKey,
+      model: conn.model,
+      customHeaders: conn.customHeaders || undefined,
+      queryParams: conn.queryParams || undefined,
+      messages,
+      params: slice.params,
+    };
+    try {
+      const res = await api.post<PlaygroundChatResponse>("/api/playground/chat", body);
+      if (res.success) {
+        slice.appendMessage({ role: "assistant", content: res.content ?? "" });
+      } else {
+        const msg = res.error ?? "unknown";
+        slice.setError(msg);
+        toast.error(t("chat.errors.send", { message: msg }));
+      }
+    } catch (e) {
+      const msg = e instanceof ApiError ? e.message : "network";
+      slice.setError(msg);
+      toast.error(t("chat.errors.send", { message: msg }));
+    } finally {
+      slice.setSending(false);
+    }
+  };
+
   return (
-    <>
+    <PlaygroundShell
+      category="chat"
+      paramsSlot={
+        <div className="space-y-4">
+          <CategoryEndpointSelector
+            category="chat"
+            selectedConnectionId={slice.selectedConnectionId}
+            onSelect={slice.setSelected}
+          />
+          <ChatParams value={slice.params} onChange={slice.patchParams} />
+        </div>
+      }
+    >
       <PageHeader title={t("chat.title")} subtitle={t("chat.subtitle")} />
-      <div className="px-8 py-6 text-sm text-muted-foreground">Stub — built in Task 13.</div>
-    </>
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex-1 overflow-y-auto">
+          <MessageList messages={slice.messages} />
+          {slice.error ? (
+            <div className="mx-6 mt-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+              {slice.error}
+            </div>
+          ) : null}
+        </div>
+        <MessageComposer
+          systemMessage={slice.systemMessage}
+          onSystemMessageChange={slice.setSystemMessage}
+          onSend={onSend}
+          sending={slice.sending}
+          disabled={!canSend}
+          disabledReason={disabledReason}
+        />
+      </div>
+    </PlaygroundShell>
   );
 }

--- a/apps/web/src/features/playground/chat/ChatPage.tsx
+++ b/apps/web/src/features/playground/chat/ChatPage.tsx
@@ -1,0 +1,13 @@
+// apps/web/src/features/playground/chat/ChatPage.tsx (Task 6 stub — replaced in Task 13)
+import { PageHeader } from "@/components/common/page-header";
+import { useTranslation } from "react-i18next";
+
+export function ChatPage() {
+  const { t } = useTranslation("playground");
+  return (
+    <>
+      <PageHeader title={t("chat.title")} subtitle={t("chat.subtitle")} />
+      <div className="px-8 py-6 text-sm text-muted-foreground">Stub — built in Task 13.</div>
+    </>
+  );
+}

--- a/apps/web/src/features/playground/chat/ChatParams.tsx
+++ b/apps/web/src/features/playground/chat/ChatParams.tsx
@@ -1,5 +1,6 @@
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
 import type { ChatParams as ChatParamsType } from "@modeldoctor/contracts";
 import { useTranslation } from "react-i18next";
 
@@ -39,49 +40,100 @@ function NumField({
   );
 }
 
+function SliderField({
+  label,
+  value,
+  onChange,
+  min,
+  max,
+  step,
+  defaultDisplayValue,
+}: {
+  label: string;
+  value: number | undefined;
+  onChange: (v: number | undefined) => void;
+  min: number;
+  max: number;
+  step: number;
+  defaultDisplayValue: number;
+}) {
+  const sliderValue = value ?? defaultDisplayValue;
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-2">
+        <Label className="text-xs text-muted-foreground">{label}</Label>
+        <Input
+          type="number"
+          step={step}
+          min={min}
+          max={max}
+          value={value ?? ""}
+          onChange={(e) => onChange(e.target.value === "" ? undefined : Number(e.target.value))}
+          className="h-7 w-20 text-xs"
+        />
+      </div>
+      <Slider
+        value={[sliderValue]}
+        min={min}
+        max={max}
+        step={step}
+        onValueChange={(v) => onChange(v[0])}
+        className="mt-2"
+        aria-label={label}
+      />
+    </div>
+  );
+}
+
 export function ChatParams({ value, onChange }: ChatParamsProps) {
   const { t } = useTranslation("playground");
   return (
     <div className="space-y-3">
       <h3 className="text-sm font-semibold">{t("chat.params.title")}</h3>
-      <NumField
+      <SliderField
         label={t("chat.params.temperature")}
         value={value.temperature}
         onChange={(v) => onChange({ temperature: v })}
-        step={0.1}
         min={0}
         max={2}
+        step={0.1}
+        defaultDisplayValue={1}
       />
-      <NumField
+      <SliderField
         label={t("chat.params.maxTokens")}
         value={value.maxTokens}
         onChange={(v) => onChange({ maxTokens: v })}
-        step={1}
         min={1}
+        max={8192}
+        step={1}
+        defaultDisplayValue={1024}
       />
-      <NumField
+      <SliderField
         label={t("chat.params.topP")}
         value={value.topP}
         onChange={(v) => onChange({ topP: v })}
-        step={0.05}
         min={0}
         max={1}
+        step={0.05}
+        defaultDisplayValue={1}
       />
-      <NumField
+      <SliderField
         label={t("chat.params.frequencyPenalty")}
         value={value.frequencyPenalty}
         onChange={(v) => onChange({ frequencyPenalty: v })}
-        step={0.1}
         min={-2}
         max={2}
+        step={0.1}
+        defaultDisplayValue={0}
       />
-      <NumField
+      <SliderField
         label={t("chat.params.presencePenalty")}
         value={value.presencePenalty}
         onChange={(v) => onChange({ presencePenalty: v })}
-        step={0.1}
         min={-2}
         max={2}
+        step={0.1}
+        defaultDisplayValue={0}
       />
       <NumField
         label={t("chat.params.seed")}

--- a/apps/web/src/features/playground/chat/ChatParams.tsx
+++ b/apps/web/src/features/playground/chat/ChatParams.tsx
@@ -93,17 +93,14 @@ export function ChatParams({ value, onChange }: ChatParamsProps) {
         <Label className="text-xs text-muted-foreground">{t("chat.params.stop")}</Label>
         <Input
           value={value.stop?.join(",") ?? ""}
-          onChange={(e) =>
-            onChange({
-              stop: e.target.value
-                ? e.target.value
-                    .split(",")
-                    .map((s) => s.trim())
-                    .filter(Boolean)
-                : undefined,
-            })
-          }
-          placeholder=","
+          onChange={(e) => {
+            const parts = e.target.value
+              .split(",")
+              .map((s) => s.trim())
+              .filter(Boolean);
+            onChange({ stop: parts.length > 0 ? parts : undefined });
+          }}
+          placeholder="stop1, stop2"
           className="h-8 text-xs"
         />
       </div>

--- a/apps/web/src/features/playground/chat/ChatParams.tsx
+++ b/apps/web/src/features/playground/chat/ChatParams.tsx
@@ -1,0 +1,113 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { ChatParams as ChatParamsType } from "@modeldoctor/contracts";
+import { useTranslation } from "react-i18next";
+
+interface ChatParamsProps {
+  value: ChatParamsType;
+  onChange: (patch: Partial<ChatParamsType>) => void;
+}
+
+function NumField({
+  label,
+  value,
+  onChange,
+  step = 0.1,
+  min,
+  max,
+}: {
+  label: string;
+  value: number | undefined;
+  onChange: (v: number | undefined) => void;
+  step?: number;
+  min?: number;
+  max?: number;
+}) {
+  return (
+    <div>
+      <Label className="text-xs text-muted-foreground">{label}</Label>
+      <Input
+        type="number"
+        step={step}
+        min={min}
+        max={max}
+        value={value ?? ""}
+        onChange={(e) => onChange(e.target.value === "" ? undefined : Number(e.target.value))}
+        className="h-8 text-xs"
+      />
+    </div>
+  );
+}
+
+export function ChatParams({ value, onChange }: ChatParamsProps) {
+  const { t } = useTranslation("playground");
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-semibold">{t("chat.params.title")}</h3>
+      <NumField
+        label={t("chat.params.temperature")}
+        value={value.temperature}
+        onChange={(v) => onChange({ temperature: v })}
+        step={0.1}
+        min={0}
+        max={2}
+      />
+      <NumField
+        label={t("chat.params.maxTokens")}
+        value={value.maxTokens}
+        onChange={(v) => onChange({ maxTokens: v })}
+        step={1}
+        min={1}
+      />
+      <NumField
+        label={t("chat.params.topP")}
+        value={value.topP}
+        onChange={(v) => onChange({ topP: v })}
+        step={0.05}
+        min={0}
+        max={1}
+      />
+      <NumField
+        label={t("chat.params.frequencyPenalty")}
+        value={value.frequencyPenalty}
+        onChange={(v) => onChange({ frequencyPenalty: v })}
+        step={0.1}
+        min={-2}
+        max={2}
+      />
+      <NumField
+        label={t("chat.params.presencePenalty")}
+        value={value.presencePenalty}
+        onChange={(v) => onChange({ presencePenalty: v })}
+        step={0.1}
+        min={-2}
+        max={2}
+      />
+      <NumField
+        label={t("chat.params.seed")}
+        value={value.seed}
+        onChange={(v) => onChange({ seed: v })}
+        step={1}
+      />
+      <div>
+        <Label className="text-xs text-muted-foreground">{t("chat.params.stop")}</Label>
+        <Input
+          value={value.stop?.join(",") ?? ""}
+          onChange={(e) =>
+            onChange({
+              stop: e.target.value
+                ? e.target.value
+                    .split(",")
+                    .map((s) => s.trim())
+                    .filter(Boolean)
+                : undefined,
+            })
+          }
+          placeholder=","
+          className="h-8 text-xs"
+        />
+      </div>
+      <p className="text-[10px] italic text-muted-foreground">{t("chat.params.stream")}</p>
+    </div>
+  );
+}

--- a/apps/web/src/features/playground/chat/MessageComposer.tsx
+++ b/apps/web/src/features/playground/chat/MessageComposer.tsx
@@ -68,6 +68,9 @@ export function MessageComposer({
           {sending ? t("chat.composer.sending") : t("chat.composer.send")}
         </Button>
       </div>
+      {disabled && disabledReason ? (
+        <output className="mt-1 block text-[11px] text-muted-foreground">{disabledReason}</output>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/playground/chat/MessageComposer.tsx
+++ b/apps/web/src/features/playground/chat/MessageComposer.tsx
@@ -1,0 +1,73 @@
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+interface MessageComposerProps {
+  systemMessage: string;
+  onSystemMessageChange: (s: string) => void;
+  onSend: (text: string) => void;
+  sending: boolean;
+  disabled: boolean;
+  disabledReason?: string;
+}
+
+export function MessageComposer({
+  systemMessage,
+  onSystemMessageChange,
+  onSend,
+  sending,
+  disabled,
+  disabledReason,
+}: MessageComposerProps) {
+  const { t } = useTranslation("playground");
+  const [draft, setDraft] = useState("");
+
+  const submit = () => {
+    if (disabled || sending) return;
+    const text = draft.trim();
+    if (!text) return;
+    onSend(text);
+    setDraft("");
+  };
+
+  return (
+    <div className="border-t border-border bg-card px-6 py-3">
+      <details className="mb-2">
+        <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
+          {t("chat.system.label")}
+        </summary>
+        <Textarea
+          rows={2}
+          value={systemMessage}
+          onChange={(e) => onSystemMessageChange(e.target.value)}
+          placeholder={t("chat.system.placeholder")}
+          className="mt-2 font-mono text-xs"
+        />
+      </details>
+      <div className="flex gap-2">
+        <Textarea
+          rows={2}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              submit();
+            }
+          }}
+          placeholder={t("chat.composer.placeholder")}
+          className="text-sm"
+          disabled={disabled || sending}
+        />
+        <Button
+          onClick={submit}
+          disabled={disabled || sending || !draft.trim()}
+          title={disabled ? disabledReason : undefined}
+        >
+          {sending ? t("chat.composer.sending") : t("chat.composer.send")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/playground/chat/MessageList.tsx
+++ b/apps/web/src/features/playground/chat/MessageList.tsx
@@ -20,7 +20,8 @@ export function MessageList({ messages }: { messages: ChatMessage[] }) {
   return (
     <div className="flex flex-col gap-3 px-6 py-4">
       {messages.map((m, idx) => (
-        <div key={`${idx}-${m.role}`} className="rounded-md border border-border bg-card p-3">
+        // biome-ignore lint/suspicious/noArrayIndexKey: append-only Phase 1; stable id is a Phase 2 concern
+        <div key={idx} className="rounded-md border border-border bg-card p-3">
           <div className="mb-1 text-xs font-semibold text-muted-foreground">
             {t(`chat.messages.${m.role}`)}
           </div>

--- a/apps/web/src/features/playground/chat/MessageList.tsx
+++ b/apps/web/src/features/playground/chat/MessageList.tsx
@@ -1,0 +1,32 @@
+import type { ChatMessage } from "@modeldoctor/contracts";
+import { useTranslation } from "react-i18next";
+
+function renderContent(m: ChatMessage): string {
+  if (typeof m.content === "string") return m.content;
+  return m.content.map((p) => (p.type === "text" ? p.text : `[${p.type}]`)).join(" ");
+}
+
+export function MessageList({ messages }: { messages: ChatMessage[] }) {
+  const { t } = useTranslation("playground");
+
+  if (messages.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        {t("chat.messages.empty")}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3 px-6 py-4">
+      {messages.map((m, idx) => (
+        <div key={`${idx}-${m.role}`} className="rounded-md border border-border bg-card p-3">
+          <div className="mb-1 text-xs font-semibold text-muted-foreground">
+            {t(`chat.messages.${m.role}`)}
+          </div>
+          <div className="whitespace-pre-wrap text-sm">{renderContent(m)}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/features/playground/chat/store.test.ts
+++ b/apps/web/src/features/playground/chat/store.test.ts
@@ -1,0 +1,52 @@
+import type { ChatMessage } from "@modeldoctor/contracts";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useChatStore } from "./store";
+
+describe("useChatStore", () => {
+  beforeEach(() => {
+    useChatStore.getState().reset();
+  });
+
+  it("starts empty", () => {
+    const s = useChatStore.getState();
+    expect(s.selectedConnectionId).toBeNull();
+    expect(s.messages).toEqual([]);
+    expect(s.systemMessage).toBe("");
+    expect(s.sending).toBe(false);
+  });
+
+  it("appendMessage adds to the end", () => {
+    const m: ChatMessage = { role: "user", content: "hi" };
+    useChatStore.getState().appendMessage(m);
+    expect(useChatStore.getState().messages).toEqual([m]);
+  });
+
+  it("setSelected stores the connection id", () => {
+    useChatStore.getState().setSelected("conn-1");
+    expect(useChatStore.getState().selectedConnectionId).toBe("conn-1");
+  });
+
+  it("patchParams merges with existing params", () => {
+    useChatStore.getState().patchParams({ temperature: 0.5 });
+    useChatStore.getState().patchParams({ maxTokens: 100 });
+    expect(useChatStore.getState().params).toEqual({ temperature: 0.5, maxTokens: 100 });
+  });
+
+  it("clearMessages keeps system message but drops messages", () => {
+    useChatStore.getState().setSystemMessage("you are helpful");
+    useChatStore.getState().appendMessage({ role: "user", content: "hi" });
+    useChatStore.getState().clearMessages();
+    expect(useChatStore.getState().messages).toEqual([]);
+    expect(useChatStore.getState().systemMessage).toBe("you are helpful");
+  });
+
+  it("reset wipes everything", () => {
+    useChatStore.getState().setSystemMessage("x");
+    useChatStore.getState().appendMessage({ role: "user", content: "y" });
+    useChatStore.getState().setSelected("c");
+    useChatStore.getState().reset();
+    expect(useChatStore.getState().selectedConnectionId).toBeNull();
+    expect(useChatStore.getState().messages).toEqual([]);
+    expect(useChatStore.getState().systemMessage).toBe("");
+  });
+});

--- a/apps/web/src/features/playground/chat/store.test.ts
+++ b/apps/web/src/features/playground/chat/store.test.ts
@@ -15,6 +15,16 @@ describe("useChatStore", () => {
     expect(s.sending).toBe(false);
   });
 
+  it("initializes params with OpenAI-default values for the 5 sliderable fields", () => {
+    expect(useChatStore.getState().params).toEqual({
+      temperature: 1,
+      maxTokens: 1024,
+      topP: 1,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+    });
+  });
+
   it("appendMessage adds to the end", () => {
     const m: ChatMessage = { role: "user", content: "hi" };
     useChatStore.getState().appendMessage(m);
@@ -29,7 +39,10 @@ describe("useChatStore", () => {
   it("patchParams merges with existing params", () => {
     useChatStore.getState().patchParams({ temperature: 0.5 });
     useChatStore.getState().patchParams({ maxTokens: 100 });
-    expect(useChatStore.getState().params).toEqual({ temperature: 0.5, maxTokens: 100 });
+    expect(useChatStore.getState().params).toMatchObject({
+      temperature: 0.5,
+      maxTokens: 100,
+    });
   });
 
   it("clearMessages keeps system message but drops messages", () => {

--- a/apps/web/src/features/playground/chat/store.ts
+++ b/apps/web/src/features/playground/chat/store.ts
@@ -1,0 +1,40 @@
+import type { ChatMessage, ChatParams } from "@modeldoctor/contracts";
+import { create } from "zustand";
+
+export interface ChatStoreState {
+  selectedConnectionId: string | null;
+  systemMessage: string;
+  messages: ChatMessage[];
+  params: ChatParams;
+  sending: boolean;
+  error: string | null;
+  setSelected: (id: string | null) => void;
+  setSystemMessage: (s: string) => void;
+  appendMessage: (m: ChatMessage) => void;
+  clearMessages: () => void;
+  patchParams: (p: Partial<ChatParams>) => void;
+  setSending: (b: boolean) => void;
+  setError: (s: string | null) => void;
+  reset: () => void;
+}
+
+const initial = {
+  selectedConnectionId: null,
+  systemMessage: "",
+  messages: [] as ChatMessage[],
+  params: {} as ChatParams,
+  sending: false,
+  error: null as string | null,
+};
+
+export const useChatStore = create<ChatStoreState>((set) => ({
+  ...initial,
+  setSelected: (id) => set({ selectedConnectionId: id }),
+  setSystemMessage: (s) => set({ systemMessage: s }),
+  appendMessage: (m) => set((s) => ({ messages: [...s.messages, m] })),
+  clearMessages: () => set({ messages: [] }),
+  patchParams: (p) => set((s) => ({ params: { ...s.params, ...p } })),
+  setSending: (b) => set({ sending: b }),
+  setError: (e) => set({ error: e }),
+  reset: () => set({ ...initial }),
+}));

--- a/apps/web/src/features/playground/chat/store.ts
+++ b/apps/web/src/features/playground/chat/store.ts
@@ -1,6 +1,26 @@
 import type { ChatMessage, ChatParams } from "@modeldoctor/contracts";
 import { create } from "zustand";
 
+/**
+ * OpenAI-documented defaults for the 5 sliderable chat params. These are
+ * pre-loaded into the store so the input boxes and slider thumbs stay in
+ * sync from the very first render. `seed` and `stop` are intentionally
+ * excluded — they have no meaningful default.
+ *
+ * Note: backend's buildBody only sends fields where value !== undefined,
+ * so loading these defaults DOES send them to the upstream. For an
+ * OpenAI-compatible server this is a no-op (server would have used the
+ * same default if the field were absent), but it makes the wire payload
+ * slightly larger and is observable in the network tab.
+ */
+export const DEFAULT_CHAT_PARAMS: ChatParams = {
+  temperature: 1,
+  maxTokens: 1024,
+  topP: 1,
+  frequencyPenalty: 0,
+  presencePenalty: 0,
+};
+
 export interface ChatStoreState {
   selectedConnectionId: string | null;
   systemMessage: string;
@@ -22,7 +42,7 @@ const initial = {
   selectedConnectionId: null,
   systemMessage: "",
   messages: [] as ChatMessage[],
-  params: {} as ChatParams,
+  params: { ...DEFAULT_CHAT_PARAMS },
   sending: false,
   error: null as string | null,
 };

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -7,6 +7,7 @@ import enConnections from "@/locales/en-US/connections.json";
 import enDebug from "@/locales/en-US/debug.json";
 import enE2E from "@/locales/en-US/e2e.json";
 import enLoadTest from "@/locales/en-US/load-test.json";
+import enPlayground from "@/locales/en-US/playground.json";
 import enSettings from "@/locales/en-US/settings.json";
 import enSidebar from "@/locales/en-US/sidebar.json";
 import zhBenchmark from "@/locales/zh-CN/benchmark.json";
@@ -15,6 +16,7 @@ import zhConnections from "@/locales/zh-CN/connections.json";
 import zhDebug from "@/locales/zh-CN/debug.json";
 import zhE2E from "@/locales/zh-CN/e2e.json";
 import zhLoadTest from "@/locales/zh-CN/load-test.json";
+import zhPlayground from "@/locales/zh-CN/playground.json";
 import zhSettings from "@/locales/zh-CN/settings.json";
 import zhSidebar from "@/locales/zh-CN/sidebar.json";
 
@@ -29,6 +31,7 @@ void i18n.use(initReactI18next).init({
       debug: enDebug,
       settings: enSettings,
       benchmark: enBenchmark,
+      playground: enPlayground,
     },
     "zh-CN": {
       common: zhCommon,
@@ -39,12 +42,23 @@ void i18n.use(initReactI18next).init({
       debug: zhDebug,
       settings: zhSettings,
       benchmark: zhBenchmark,
+      playground: zhPlayground,
     },
   },
   // `lng` is set by main.tsx from the locale store before first render.
   fallbackLng: "en-US",
   defaultNS: "common",
-  ns: ["common", "sidebar", "connections", "load-test", "e2e", "debug", "settings", "benchmark"],
+  ns: [
+    "common",
+    "sidebar",
+    "connections",
+    "load-test",
+    "e2e",
+    "debug",
+    "settings",
+    "benchmark",
+    "playground",
+  ],
   interpolation: { escapeValue: false },
   returnNull: false,
 });

--- a/apps/web/src/locales/en-US/connections.json
+++ b/apps/web/src/locales/en-US/connections.json
@@ -7,7 +7,9 @@
     "model": "Model",
     "customHeaders": "Headers",
     "createdAt": "Created",
-    "actions": "Actions"
+    "actions": "Actions",
+    "category": "Category",
+    "tags": "Tags"
   },
   "dialog": {
     "createTitle": "New connection",
@@ -25,7 +27,21 @@
       "customHeaders": "Custom headers (one per line)",
       "customHeadersPlaceholder": "Header-Name: value",
       "queryParams": "Query parameters (one per line)",
-      "queryParamsPlaceholder": "key=value"
+      "queryParamsPlaceholder": "key=value",
+      "category": "Category",
+      "categoryHelp": "Used by the Playground to filter the connection picker.",
+      "categoryPlaceholder": "Select a category…",
+      "tags": "Tags",
+      "tagsPlaceholder": "Type and press Enter (e.g. vLLM, production)",
+      "tagsHelp": "Optional. Used for grouping and quick filtering.",
+      "tagsRemove": "Remove tag {{tag}}"
+    },
+    "categoryOptions": {
+      "chat": "Chat",
+      "audio": "Audio",
+      "embeddings": "Embeddings",
+      "rerank": "Rerank",
+      "image": "Image"
     },
     "errors": {
       "duplicateName": "A connection with this name already exists",

--- a/apps/web/src/locales/en-US/connections.json
+++ b/apps/web/src/locales/en-US/connections.json
@@ -86,7 +86,6 @@
   "filters": {
     "label": "Filter",
     "allCategories": "All categories",
-    "allTags": "All tags",
-    "clear": "Clear filters"
+    "allTags": "All tags"
   }
 }

--- a/apps/web/src/locales/en-US/connections.json
+++ b/apps/web/src/locales/en-US/connections.json
@@ -82,5 +82,11 @@
     "title": "No connections yet",
     "body": "Click New connection to add one.",
     "create": "New connection"
+  },
+  "filters": {
+    "label": "Filter",
+    "allCategories": "All categories",
+    "allTags": "All tags",
+    "clear": "Clear filters"
   }
 }

--- a/apps/web/src/locales/en-US/playground.json
+++ b/apps/web/src/locales/en-US/playground.json
@@ -1,0 +1,56 @@
+{
+  "title": "Playground",
+  "categories": {
+    "chat": "Chat",
+    "audio": "Audio",
+    "embeddings": "Embeddings",
+    "rerank": "Rerank",
+    "image": "Image"
+  },
+  "endpoint": {
+    "categoryFilter": "Category filter",
+    "showAll": "Show all",
+    "categoryMismatch": "Selected connection's category ({{category}}) doesn't match this page",
+    "clearSelection": "Clear",
+    "noMatchingConnections": "No {{category}} connections yet",
+    "newConnection": "+ New connection"
+  },
+  "chat": {
+    "title": "Chat",
+    "subtitle": "Send a single message to a chat-completions endpoint and see the reply.",
+    "system": {
+      "label": "System message",
+      "placeholder": "Optional. e.g. You are a helpful assistant."
+    },
+    "composer": {
+      "placeholder": "Type your message…",
+      "send": "Send",
+      "sending": "Sending…",
+      "needConnection": "Pick a chat connection first"
+    },
+    "messages": {
+      "system": "system",
+      "user": "user",
+      "assistant": "assistant",
+      "empty": "Send a message to get started."
+    },
+    "params": {
+      "title": "Parameters",
+      "temperature": "Temperature",
+      "maxTokens": "Max Tokens",
+      "topP": "Top P",
+      "frequencyPenalty": "Frequency Penalty",
+      "presencePenalty": "Presence Penalty",
+      "seed": "Seed",
+      "stop": "Stop Sequence",
+      "stream": "Stream (Phase 2)"
+    },
+    "errors": {
+      "send": "Failed to send: {{message}}"
+    }
+  },
+  "comingSoon": {
+    "title": "Coming in Phase {{phase}}",
+    "body": "This modality is part of the Playground roadmap but isn't built yet."
+  }
+}

--- a/apps/web/src/locales/en-US/sidebar.json
+++ b/apps/web/src/locales/en-US/sidebar.json
@@ -1,5 +1,6 @@
 {
   "groups": {
+    "playground": "Playground",
     "performance": "Performance",
     "correctness": "Correctness",
     "observability": "Observability",
@@ -9,6 +10,11 @@
     "comingSoon": "Soon"
   },
   "items": {
+    "playgroundChat": "Chat",
+    "playgroundImage": "Image",
+    "playgroundAudio": "Audio",
+    "playgroundEmbeddings": "Embeddings",
+    "playgroundRerank": "Rerank",
     "loadTest": "Load Test",
     "benchmark": "Benchmark",
     "soak": "Soak / Stability",

--- a/apps/web/src/locales/zh-CN/connections.json
+++ b/apps/web/src/locales/zh-CN/connections.json
@@ -7,7 +7,9 @@
     "model": "模型",
     "customHeaders": "自定义 Headers",
     "createdAt": "创建时间",
-    "actions": "操作"
+    "actions": "操作",
+    "category": "分类",
+    "tags": "标签"
   },
   "dialog": {
     "createTitle": "新建连接",
@@ -25,7 +27,21 @@
       "customHeaders": "自定义 Headers（每行一条）",
       "customHeadersPlaceholder": "Header-Name: value",
       "queryParams": "查询参数（每行一条）",
-      "queryParamsPlaceholder": "key=value"
+      "queryParamsPlaceholder": "key=value",
+      "category": "分类",
+      "categoryHelp": "Playground 用它来过滤连接下拉。",
+      "categoryPlaceholder": "请选择分类…",
+      "tags": "标签",
+      "tagsPlaceholder": "输入后按回车（如 vLLM、production）",
+      "tagsHelp": "可选。用于分组和快速筛选。",
+      "tagsRemove": "移除标签 {{tag}}"
+    },
+    "categoryOptions": {
+      "chat": "对话",
+      "audio": "语音",
+      "embeddings": "嵌入",
+      "rerank": "重排",
+      "image": "图像"
     },
     "errors": {
       "duplicateName": "已存在同名连接",

--- a/apps/web/src/locales/zh-CN/connections.json
+++ b/apps/web/src/locales/zh-CN/connections.json
@@ -82,5 +82,11 @@
     "title": "尚未创建任何连接",
     "body": "点击「新建连接」开始。",
     "create": "新建连接"
+  },
+  "filters": {
+    "label": "筛选",
+    "allCategories": "全部分类",
+    "allTags": "全部标签",
+    "clear": "清除筛选"
   }
 }

--- a/apps/web/src/locales/zh-CN/connections.json
+++ b/apps/web/src/locales/zh-CN/connections.json
@@ -86,7 +86,6 @@
   "filters": {
     "label": "筛选",
     "allCategories": "全部分类",
-    "allTags": "全部标签",
-    "clear": "清除筛选"
+    "allTags": "全部标签"
   }
 }

--- a/apps/web/src/locales/zh-CN/playground.json
+++ b/apps/web/src/locales/zh-CN/playground.json
@@ -1,0 +1,56 @@
+{
+  "title": "试验场",
+  "categories": {
+    "chat": "对话",
+    "audio": "语音",
+    "embeddings": "嵌入",
+    "rerank": "重排",
+    "image": "图像"
+  },
+  "endpoint": {
+    "categoryFilter": "分类过滤",
+    "showAll": "显示全部",
+    "categoryMismatch": "当前连接是 {{category}} 类，与本页不符",
+    "clearSelection": "清除",
+    "noMatchingConnections": "暂无 {{category}} 类连接",
+    "newConnection": "+ 新建连接"
+  },
+  "chat": {
+    "title": "对话",
+    "subtitle": "向 chat-completions 接口发送一条消息，查看回复。",
+    "system": {
+      "label": "系统消息",
+      "placeholder": "可选。如：你是一个有帮助的助手。"
+    },
+    "composer": {
+      "placeholder": "输入消息…",
+      "send": "发送",
+      "sending": "发送中…",
+      "needConnection": "请先选择一个对话类连接"
+    },
+    "messages": {
+      "system": "系统",
+      "user": "用户",
+      "assistant": "助手",
+      "empty": "发送一条消息开始对话。"
+    },
+    "params": {
+      "title": "参数",
+      "temperature": "Temperature",
+      "maxTokens": "Max Tokens",
+      "topP": "Top P",
+      "frequencyPenalty": "Frequency Penalty",
+      "presencePenalty": "Presence Penalty",
+      "seed": "Seed",
+      "stop": "停止序列",
+      "stream": "流式 (Phase 2)"
+    },
+    "errors": {
+      "send": "发送失败：{{message}}"
+    }
+  },
+  "comingSoon": {
+    "title": "Phase {{phase}} 推出",
+    "body": "本模态在 Playground 路线图中，但还没实现。"
+  }
+}

--- a/apps/web/src/locales/zh-CN/sidebar.json
+++ b/apps/web/src/locales/zh-CN/sidebar.json
@@ -1,5 +1,6 @@
 {
   "groups": {
+    "playground": "试验场",
     "performance": "性能",
     "correctness": "正确性",
     "observability": "可观测性",
@@ -9,6 +10,11 @@
     "comingSoon": "即将推出"
   },
   "items": {
+    "playgroundChat": "对话",
+    "playgroundImage": "图像",
+    "playgroundAudio": "语音",
+    "playgroundEmbeddings": "嵌入",
+    "playgroundRerank": "重排",
     "loadTest": "压力测试",
     "benchmark": "基准测试",
     "soak": "稳定性测试",

--- a/apps/web/src/router/index.tsx
+++ b/apps/web/src/router/index.tsx
@@ -9,14 +9,19 @@ import { E2ESmokePage } from "@/features/e2e-smoke/E2ESmokePage";
 import { ErrorPage } from "@/features/error/ErrorPage";
 import { LoadTestPage } from "@/features/load-test/LoadTestPage";
 import { NotFoundPage } from "@/features/not-found/NotFoundPage";
+import { ChatPage } from "@/features/playground/chat/ChatPage";
 import { RequestDebugPage } from "@/features/request-debug/RequestDebugPage";
 import { SettingsPage } from "@/features/settings/SettingsPage";
 import { AppShell } from "@/layouts/AppShell";
 import {
   type Activity,
+  Boxes,
   GitCompare,
   HeartPulse,
   History as HistoryIcon,
+  Image as ImageIcon,
+  ListOrdered,
+  Mic,
   Timer,
   Zap,
 } from "lucide-react";
@@ -74,6 +79,24 @@ export const routes: RouteObject[] = [
           { path: "debug", element: <RequestDebugPage /> },
           { path: "connections", element: <ConnectionsPage /> },
           { path: "settings", element: <SettingsPage /> },
+          { path: "playground", element: <Navigate to="/playground/chat" replace /> },
+          { path: "playground/chat", element: <ChatPage /> },
+          {
+            path: "playground/image",
+            element: <ComingSoonRoute icon={ImageIcon} itemKey="playgroundImage" />,
+          },
+          {
+            path: "playground/audio",
+            element: <ComingSoonRoute icon={Mic} itemKey="playgroundAudio" />,
+          },
+          {
+            path: "playground/embeddings",
+            element: <ComingSoonRoute icon={Boxes} itemKey="playgroundEmbeddings" />,
+          },
+          {
+            path: "playground/rerank",
+            element: <ComingSoonRoute icon={ListOrdered} itemKey="playgroundRerank" />,
+          },
           { path: "*", element: <NotFoundPage /> },
         ],
       },

--- a/apps/web/src/stores/connections-store.test.ts
+++ b/apps/web/src/stores/connections-store.test.ts
@@ -8,6 +8,8 @@ const baseInput = {
   model: "m1",
   customHeaders: "",
   queryParams: "",
+  category: "chat" as const,
+  tags: [] as string[],
 };
 
 describe("connectionsStore", () => {
@@ -63,22 +65,24 @@ describe("connectionsStore", () => {
     useConnectionsStore.getState().create(baseInput);
     const json = useConnectionsStore.getState().exportAll();
     const parsed = JSON.parse(json);
-    expect(parsed.version).toBe(1);
+    expect(parsed.version).toBe(2);
     expect(parsed.connections).toHaveLength(1);
   });
 
   it("importAll merge preserves existing names and skips collisions", () => {
     useConnectionsStore.getState().create(baseInput);
     const incoming = JSON.stringify({
-      version: 1,
+      version: 2,
       connections: [
-        { ...baseInput, id: "ext-1", createdAt: "x", updatedAt: "x" },
+        { ...baseInput, id: "ext-1", createdAt: "x", updatedAt: "x", category: "chat", tags: [] },
         {
           ...baseInput,
           id: "ext-2",
           name: "new",
           createdAt: "x",
           updatedAt: "x",
+          category: "chat",
+          tags: [],
         },
       ],
     });
@@ -91,7 +95,7 @@ describe("connectionsStore", () => {
   it("importAll replace wipes existing", () => {
     useConnectionsStore.getState().create(baseInput);
     const incoming = JSON.stringify({
-      version: 1,
+      version: 2,
       connections: [
         {
           ...baseInput,
@@ -99,6 +103,8 @@ describe("connectionsStore", () => {
           name: "only",
           createdAt: "x",
           updatedAt: "x",
+          category: "chat",
+          tags: [],
         },
       ],
     });
@@ -116,8 +122,16 @@ describe("connectionsStore", () => {
     ).toThrow(/version/i);
   });
 
-  it("drops persisted v0 state on version mismatch", async () => {
-    // Pre-populate localStorage with an "old format" snapshot at version 0.
+  it("importAll rejects v1 envelopes (no longer supported)", () => {
+    expect(() =>
+      useConnectionsStore
+        .getState()
+        .importAll(JSON.stringify({ version: 1, connections: [] }), "merge"),
+    ).toThrow(/version/i);
+  });
+
+  it("drops persisted v1 state on version mismatch", async () => {
+    // Pre-populate localStorage with a v1 snapshot — must be discarded.
     localStorage.setItem(
       "modeldoctor-connections",
       JSON.stringify({
@@ -126,21 +140,21 @@ describe("connectionsStore", () => {
             {
               id: "c-old",
               name: "old",
-              apiUrl: "http://old.example.com/v1/chat/completions",
+              apiBaseUrl: "http://old.example.com",
               apiKey: "k",
               model: "m",
               customHeaders: "",
               queryParams: "",
               createdAt: new Date().toISOString(),
               updatedAt: new Date().toISOString(),
+              // no category / no tags — v1 record
             },
           ],
         },
-        version: 0,
+        version: 1,
       }),
     );
 
-    // Re-import the store as a fresh module so zustand re-reads localStorage.
     vi.resetModules();
     const { useConnectionsStore: fresh } = await import("./connections-store");
     expect(fresh.getState().list()).toEqual([]);

--- a/apps/web/src/stores/connections-store.ts
+++ b/apps/web/src/stores/connections-store.ts
@@ -79,7 +79,7 @@ export const useConnectionsStore = create<ConnectionsStore>()(
       },
       exportAll: () => {
         const env: ConnectionsExport = {
-          version: 1,
+          version: 2,
           connections: get().connections,
         };
         return JSON.stringify(env, null, 2);
@@ -87,7 +87,7 @@ export const useConnectionsStore = create<ConnectionsStore>()(
       reset: () => set({ connections: [] }),
       importAll: (json, mode) => {
         const parsed = JSON.parse(json) as ConnectionsExport;
-        if (parsed.version !== 1) {
+        if (parsed.version !== 2) {
           throw new Error(`Unsupported export version: ${parsed.version}`);
         }
         if (mode === "replace") {
@@ -111,7 +111,7 @@ export const useConnectionsStore = create<ConnectionsStore>()(
     }),
     {
       name: "modeldoctor-connections",
-      version: 1, // bumped from default 0; old format (apiUrl with full URL) is dropped
+      version: 2, // bumped from 1; v1 (pre-category) data is dropped
       partialize: (state) => ({ connections: state.connections }),
     },
   ),

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -2,14 +2,21 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
 
-// jsdom@24 does not implement Pointer Events or scrollIntoView.
-// Radix UI primitives (Select, DropdownMenu, Dialog, Tabs) call these APIs,
-// so we polyfill them globally once here rather than repeating the block in
-// every test file that renders a Radix component.
+// jsdom@24 does not implement Pointer Events, scrollIntoView, or ResizeObserver.
+// Radix UI primitives (Select, DropdownMenu, Dialog, Tabs, Slider) call these
+// APIs, so we polyfill them globally once here rather than repeating the block
+// in every test file that renders a Radix component.
 window.HTMLElement.prototype.hasPointerCapture = () => false;
 window.HTMLElement.prototype.setPointerCapture = () => {};
 window.HTMLElement.prototype.releasePointerCapture = () => {};
 window.HTMLElement.prototype.scrollIntoView = () => {};
+
+// @radix-ui/react-slider uses ResizeObserver to track track/thumb dimensions.
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
 
 afterEach(() => {
   cleanup();

--- a/apps/web/src/types/connection.ts
+++ b/apps/web/src/types/connection.ts
@@ -1,3 +1,5 @@
+import type { ModalityCategory } from "@modeldoctor/contracts";
+
 export interface Connection {
   id: string;
   name: string;
@@ -6,6 +8,8 @@ export interface Connection {
   model: string;
   customHeaders: string;
   queryParams: string;
+  category: ModalityCategory;
+  tags: string[];
   createdAt: string;
   updatedAt: string;
 }
@@ -25,6 +29,6 @@ export const emptyEndpointValues: EndpointValues = {
 };
 
 export interface ConnectionsExport {
-  version: 1;
+  version: 2;
   connections: Connection[];
 }

--- a/docs/superpowers/plans/2026-04-29-playground-phase-1-foundation.md
+++ b/docs/superpowers/plans/2026-04-29-playground-phase-1-foundation.md
@@ -1,0 +1,3141 @@
+# Playground Phase 1 — Foundation + Minimal Chat E2E
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the minimum that proves the Playground end-to-end loop: user creates a `chat`-category Connection, navigates to `/playground/chat`, sends a single text message, and sees the assistant's reply rendered. No streaming, no multimodal, no history, no compare, no View Code yet — those come in Phase 2/3.
+
+**Architecture:** Frontend = new `apps/web/src/features/playground/` directory with a `PlaygroundShell` (header + main + right `ParamsPanel`) that all 5 modality pages will eventually share, plus a `CategoryEndpointSelector` that filters connections by category. Backend = new `apps/api/src/modules/playground/` Nest module with one controller `POST /api/playground/chat` (non-streaming) that proxies to the user's upstream URL. Connection model gains `category` (required single-pick) and `tags` (optional string array); localStorage version bumps `1 → 2` and discards old data per the no-compat-shims policy.
+
+**Tech Stack:** NestJS 10 / Vite 5 / React 18 / Zustand 4 + persist / react-hook-form + zod / vitest + RTL / shadcn UI / TailwindCSS.
+
+**Spec:** [`../specs/2026-04-29-playground-design.md`](../specs/2026-04-29-playground-design.md).
+
+**Phase 1 deliberate omissions** (deferred to Phase 2 to honor YAGNI; spec § 10 lists them as "Phase 1 components" but Phase 1 has no consumer):
+
+- `ViewCodeDialog` — no Phase 1 consumer
+- `HistoryStore` — Phase 1 ChatPage explicitly "不带历史"
+- `apps/api/src/integrations/openai-client/` shared client — only one wire (chat) needed in Phase 1; defer extraction to Phase 2 when Embeddings/Rerank/Images need it (per spec § 13.1)
+
+---
+
+## File Map
+
+### Created
+
+| Path | Responsibility |
+|---|---|
+| `packages/contracts/src/modality.ts` | `ModalityCategorySchema` enum (chat/audio/embeddings/rerank/image) — single source of truth shared by Connection + e2e probes |
+| `packages/contracts/src/playground.ts` | `PlaygroundChatRequestSchema`, `PlaygroundChatResponseSchema`, `ChatMessageSchema` — wire contract for `POST /api/playground/chat` |
+| `apps/web/src/features/playground/PlaygroundShell.tsx` | Layout wrapper: header (tabs + collapse btn) + main slot + right `ParamsPanel` slot |
+| `apps/web/src/features/playground/ParamsPanel.tsx` | Right column container with collapse animation + scroll |
+| `apps/web/src/features/playground/CategoryEndpointSelector.tsx` | Connection picker filtered by `category` with "Show all" toggle and category-mismatch warning |
+| `apps/web/src/features/playground/chat/ChatPage.tsx` | Compose Shell + Selector + MessageList + Composer + ChatParams + send-message effect |
+| `apps/web/src/features/playground/chat/ChatPage.test.tsx` | Smoke RTL test: renders, send disabled until connection chosen, success path mocks `/api/playground/chat` and renders assistant reply |
+| `apps/web/src/features/playground/chat/MessageList.tsx` | Render array of messages with role labels |
+| `apps/web/src/features/playground/chat/MessageComposer.tsx` | System message textarea + user input textarea + Send button (no attachments in Phase 1) |
+| `apps/web/src/features/playground/chat/ChatParams.tsx` | Slider + input controls for the 8 chat params |
+| `apps/web/src/features/playground/chat/store.ts` | Zustand chat slice: connection id, endpoint, messages, params, sending bool |
+| `apps/web/src/features/playground/chat/store.test.ts` | Reducer-style tests for store actions |
+| `apps/web/src/features/playground/CategoryEndpointSelector.test.tsx` | RTL: filtered list, "show all" toggle, mismatch warning chip, "+ new" prefill |
+| `apps/web/src/features/playground/PlaygroundShell.test.tsx` | RTL: tab change callback, collapse btn toggles params panel visibility |
+| `apps/web/src/locales/en-US/playground.json` | Phase 1 keys: chat-only structure |
+| `apps/web/src/locales/zh-CN/playground.json` | zh translations (mirror of en) |
+| `apps/api/src/modules/playground/playground.module.ts` | NestJS module wiring |
+| `apps/api/src/modules/playground/chat.controller.ts` | `POST /api/playground/chat` controller with `ZodValidationPipe(PlaygroundChatRequestSchema)` |
+| `apps/api/src/modules/playground/chat.service.ts` | Build upstream URL/headers, fetch, parse OpenAI chat-completions JSON, return shape |
+| `apps/api/src/modules/playground/chat.service.spec.ts` | vitest: mock global `fetch`, assert URL + headers + body construction + response parsing + error mapping |
+
+### Modified
+
+| Path | Change |
+|---|---|
+| `packages/contracts/src/e2e-test.ts` | Replace `ProbeCategorySchema` body with `export const ProbeCategorySchema = ModalityCategorySchema;` (alias). Keep `ProbeCategory` type alias. |
+| `packages/contracts/src/index.ts` | Add `export * from "./modality.js"; export * from "./playground.js";` |
+| `apps/web/src/types/connection.ts` | Add `category: ModalityCategory` (required) and `tags: string[]` to `Connection`; add to `emptyEndpointValues`'s sibling? — only Connection itself, not EndpointValues (endpoint values stay shape-stable) |
+| `apps/web/src/features/connections/schema.ts` | Add `category` and `tags` to `connectionInputSchema` |
+| `apps/web/src/features/connections/schema.test.ts` | New tests covering category-required and tags-trim |
+| `apps/web/src/stores/connections-store.ts` | Bump persist `version` `1 → 2`; default `category: "chat"` and `tags: []` not applied to old data — old data is discarded by zustand persist version mismatch; `exportAll` writes `version: 2`; `importAll` rejects non-2 |
+| `apps/web/src/stores/connections-store.test.ts` | Update existing tests to pass `category` + `tags` in inputs; add v1→v2 drop test |
+| `apps/web/src/features/connections/ConnectionDialog.tsx` | Add category `<Select>` + tag chip input; reset/save logic includes new fields |
+| `apps/web/src/features/connections/ConnectionsPage.tsx` | Add table columns for category (badge) + tags (chip strip); add header filters for both |
+| `apps/web/src/locales/en-US/connections.json` | Add `category.label`, `category.options.{chat,audio,embeddings,rerank,image}`, `tags.label`, `tags.placeholder`, `tags.suggestions`, table column labels |
+| `apps/web/src/locales/zh-CN/connections.json` | Mirror zh translations |
+| `apps/web/src/locales/en-US/sidebar.json` | Add `groups.playground` and 5 `items.{playgroundChat,playgroundImage,playgroundAudio,playgroundEmbeddings,playgroundRerank}` |
+| `apps/web/src/locales/zh-CN/sidebar.json` | Mirror zh |
+| `apps/web/src/components/sidebar/sidebar-config.tsx` | Insert `playground` group BEFORE `performance`; `chat` is real, the other 4 are `comingSoon: true` until Phase 2/3 |
+| `apps/web/src/router/index.tsx` | Add `/playground` redirect → `/playground/chat`; `/playground/chat` → `<ChatPage/>`; the other 4 modalities use `<ComingSoonRoute/>` placeholders |
+| `apps/web/src/lib/i18n.ts` | Register the new `playground` namespace in resources + ns array |
+| `apps/api/src/app.module.ts` | Register `PlaygroundModule` in `imports` |
+
+---
+
+## Task 1: Extract `ModalityCategorySchema` to its own contract module
+
+**Files:**
+- Create: `packages/contracts/src/modality.ts`
+- Modify: `packages/contracts/src/e2e-test.ts:26-27`
+- Modify: `packages/contracts/src/index.ts`
+
+- [ ] **Step 1: Write the failing test for the new module**
+
+Create `packages/contracts/src/modality.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { ModalityCategorySchema, type ModalityCategory } from "./modality.js";
+
+describe("ModalityCategorySchema", () => {
+  it("accepts each of the 5 known categories", () => {
+    for (const c of ["chat", "audio", "embeddings", "rerank", "image"] as ModalityCategory[]) {
+      expect(ModalityCategorySchema.parse(c)).toBe(c);
+    }
+  });
+
+  it("rejects unknown values", () => {
+    expect(() => ModalityCategorySchema.parse("video")).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm -F @modeldoctor/contracts test --run src/modality.test.ts
+```
+
+Expected: FAIL — `Cannot find module './modality.js'`.
+
+- [ ] **Step 3: Create the schema module**
+
+Create `packages/contracts/src/modality.ts`:
+
+```ts
+import { z } from "zod";
+
+/**
+ * Single source of truth for the 5 model-service categories. Both the
+ * `Connection.category` field (in the web app) and the e2e-probe categories
+ * use this enum — keep it in sync.
+ *
+ * Iteration order determines display order in UI dropdowns.
+ */
+export const ModalityCategorySchema = z.enum(["chat", "audio", "embeddings", "rerank", "image"]);
+export type ModalityCategory = z.infer<typeof ModalityCategorySchema>;
+```
+
+- [ ] **Step 4: Update `e2e-test.ts` to alias the new schema**
+
+Open `packages/contracts/src/e2e-test.ts` and replace the existing `ProbeCategorySchema` definition (lines 26-27) with:
+
+```ts
+import { ModalityCategorySchema } from "./modality.js";
+
+// Alias kept for backwards-compatible naming inside e2e-probe code paths.
+export const ProbeCategorySchema = ModalityCategorySchema;
+export type ProbeCategory = z.infer<typeof ProbeCategorySchema>;
+```
+
+(Leave the rest of the file unchanged. The `import { z } from "zod"` line at the top stays.)
+
+- [ ] **Step 5: Re-export from `index.ts`**
+
+Add to `packages/contracts/src/index.ts` (keep alphabetical order is not enforced; just add a new line above `e2e-test.js`):
+
+```ts
+export * from "./modality.js";
+```
+
+- [ ] **Step 6: Run the new test plus the existing contracts test suite**
+
+```bash
+pnpm -F @modeldoctor/contracts test --run
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 7: Verify the contracts package still builds**
+
+```bash
+pnpm -F @modeldoctor/contracts build
+```
+
+Expected: clean build.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/contracts/src/modality.ts packages/contracts/src/modality.test.ts packages/contracts/src/e2e-test.ts packages/contracts/src/index.ts
+git commit -m "$(cat <<'EOF'
+refactor(contracts): extract ModalityCategorySchema as shared enum
+
+Both Connection (web) and e2e-probes use the same 5-category enum.
+Pull it into its own module so the upcoming playground feature can import
+it without dragging in the full e2e-test schema. ProbeCategorySchema is
+kept as a re-export for callsite stability.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Add `category` + `tags` to the Connection type and zod schema
+
+**Files:**
+- Modify: `apps/web/src/types/connection.ts`
+- Modify: `apps/web/src/features/connections/schema.ts`
+- Modify: `apps/web/src/features/connections/schema.test.ts`
+
+- [ ] **Step 1: Add the new fields to the schema's failing tests**
+
+Open `apps/web/src/features/connections/schema.test.ts`. Append:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { connectionInputSchema } from "./schema";
+
+describe("connectionInputSchema (category + tags)", () => {
+  const baseInput = {
+    name: "n",
+    apiBaseUrl: "http://x",
+    apiKey: "k",
+    model: "m",
+    customHeaders: "",
+    queryParams: "",
+  };
+
+  it("requires a category", () => {
+    expect(() => connectionInputSchema.parse({ ...baseInput, tags: [] })).toThrow();
+  });
+
+  it("rejects an unknown category", () => {
+    expect(() =>
+      connectionInputSchema.parse({ ...baseInput, category: "video", tags: [] }),
+    ).toThrow();
+  });
+
+  it("trims and dedupes tags", () => {
+    const out = connectionInputSchema.parse({
+      ...baseInput,
+      category: "chat",
+      tags: ["  vLLM  ", "vLLM", "production", ""],
+    });
+    expect(out.tags).toEqual(["vLLM", "production"]);
+  });
+
+  it("defaults tags to an empty array when omitted", () => {
+    const out = connectionInputSchema.parse({ ...baseInput, category: "chat" });
+    expect(out.tags).toEqual([]);
+  });
+});
+```
+
+(If the file already has a top describe block, place this as a sibling describe.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm -F @modeldoctor/web test --run src/features/connections/schema.test.ts
+```
+
+Expected: FAIL — schema does not yet validate `category` / `tags`.
+
+- [ ] **Step 3: Update the zod schema**
+
+Open `apps/web/src/features/connections/schema.ts` and replace the file contents:
+
+```ts
+import { ModalityCategorySchema } from "@modeldoctor/contracts";
+import { z } from "zod";
+
+export const connectionInputSchema = z.object({
+  name: z
+    .string()
+    .transform((v) => v.trim())
+    .pipe(z.string().min(1, "required")),
+  apiBaseUrl: z.string().url("invalid URL"),
+  apiKey: z.string().min(1, "required"),
+  model: z.string().min(1, "required"),
+  customHeaders: z.string(),
+  queryParams: z.string(),
+  category: ModalityCategorySchema,
+  tags: z
+    .array(z.string())
+    .default([])
+    .transform((arr) => {
+      const seen = new Set<string>();
+      const out: string[] = [];
+      for (const t of arr) {
+        const trimmed = t.trim();
+        if (!trimmed || seen.has(trimmed)) continue;
+        seen.add(trimmed);
+        out.push(trimmed);
+      }
+      return out;
+    }),
+});
+
+export type ConnectionInput = z.infer<typeof connectionInputSchema>;
+```
+
+- [ ] **Step 4: Update the Connection type**
+
+Open `apps/web/src/types/connection.ts` and replace its contents:
+
+```ts
+import type { ModalityCategory } from "@modeldoctor/contracts";
+
+export interface Connection {
+  id: string;
+  name: string;
+  apiBaseUrl: string;
+  apiKey: string;
+  model: string;
+  customHeaders: string;
+  queryParams: string;
+  category: ModalityCategory;
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** The subset of Connection fields a feature page edits inline. */
+export type EndpointValues = Pick<
+  Connection,
+  "apiBaseUrl" | "apiKey" | "model" | "customHeaders" | "queryParams"
+>;
+
+export const emptyEndpointValues: EndpointValues = {
+  apiBaseUrl: "",
+  apiKey: "",
+  model: "",
+  customHeaders: "",
+  queryParams: "",
+};
+
+export interface ConnectionsExport {
+  version: 2;
+  connections: Connection[];
+}
+```
+
+(Note: `EndpointValues` purposely does NOT gain `category` / `tags` — those live on the Connection record only; inline endpoint editors don't change them.)
+
+- [ ] **Step 5: Run the schema test to verify it passes**
+
+```bash
+pnpm -F @modeldoctor/web test --run src/features/connections/schema.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run type-check (the rest of the codebase will scream)**
+
+```bash
+pnpm -F @modeldoctor/web type-check
+```
+
+Expected: many errors — connections-store and ConnectionDialog now miss the required fields. **That's the next two tasks.** Note them and proceed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/types/connection.ts apps/web/src/features/connections/schema.ts apps/web/src/features/connections/schema.test.ts
+git commit -m "$(cat <<'EOF'
+feat(connections): add category + tags to Connection type and zod schema
+
+Category (single-pick from the 5-modality enum) is required so the
+upcoming playground UI can deterministically filter the connection
+picker. Tags are an optional, free-form, deduped+trimmed string array
+for vendor / wire / environment labels (vLLM, SGLang, production, …).
+
+Type-check fails until the store and dialog adopt the new fields — see
+the next two commits.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Bump connections-store to v2 (drop legacy data) and surface category/tags
+
+**Files:**
+- Modify: `apps/web/src/stores/connections-store.ts`
+- Modify: `apps/web/src/stores/connections-store.test.ts`
+
+- [ ] **Step 1: Update existing tests to include `category` + `tags` in `baseInput`, and add a v1→v2 drop test**
+
+Open `apps/web/src/stores/connections-store.test.ts` and:
+
+(a) Replace the `baseInput` constant near the top:
+
+```ts
+const baseInput = {
+  name: "prod",
+  apiBaseUrl: "http://x",
+  apiKey: "sk-1",
+  model: "m1",
+  customHeaders: "",
+  queryParams: "",
+  category: "chat" as const,
+  tags: [] as string[],
+};
+```
+
+(b) Update the `exportAll produces a versioned envelope` test to expect version `2`:
+
+```ts
+it("exportAll produces a versioned envelope", () => {
+  useConnectionsStore.getState().create(baseInput);
+  const json = useConnectionsStore.getState().exportAll();
+  const parsed = JSON.parse(json);
+  expect(parsed.version).toBe(2);
+  expect(parsed.connections).toHaveLength(1);
+});
+```
+
+(c) Update the two `importAll` tests to use `version: 2` in the `incoming` envelopes (search for `version: 1` and replace with `version: 2`; also add `category: "chat"`, `tags: []` to each connection record literal).
+
+(d) Update the `importAll rejects unknown version` test — it now should also reject version 1:
+
+```ts
+it("importAll rejects unknown version", () => {
+  expect(() =>
+    useConnectionsStore
+      .getState()
+      .importAll(JSON.stringify({ version: 99, connections: [] }), "merge"),
+  ).toThrow(/version/i);
+});
+
+it("importAll rejects v1 envelopes (no longer supported)", () => {
+  expect(() =>
+    useConnectionsStore
+      .getState()
+      .importAll(JSON.stringify({ version: 1, connections: [] }), "merge"),
+  ).toThrow(/version/i);
+});
+```
+
+(e) Replace the `drops persisted v0 state on version mismatch` test name + body to drop v1 state instead:
+
+```ts
+it("drops persisted v1 state on version mismatch", async () => {
+  // Pre-populate localStorage with a v1 snapshot — must be discarded.
+  localStorage.setItem(
+    "modeldoctor-connections",
+    JSON.stringify({
+      state: {
+        connections: [
+          {
+            id: "c-old",
+            name: "old",
+            apiBaseUrl: "http://old.example.com",
+            apiKey: "k",
+            model: "m",
+            customHeaders: "",
+            queryParams: "",
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            // no category / no tags — v1 record
+          },
+        ],
+      },
+      version: 1,
+    }),
+  );
+
+  vi.resetModules();
+  const { useConnectionsStore: fresh } = await import("./connections-store");
+  expect(fresh.getState().list()).toEqual([]);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+pnpm -F @modeldoctor/web test --run src/stores/connections-store.test.ts
+```
+
+Expected: FAIL — store still on version 1, doesn't accept `category`/`tags`.
+
+- [ ] **Step 3: Update the store**
+
+Open `apps/web/src/stores/connections-store.ts`. Make these changes:
+
+(a) Update `ConnectionsExport` import-or-redeclare to `version: 2`:
+
+```ts
+// `Connection` type already has category + tags from Task 2.
+// `ConnectionsExport` already has version: 2 from Task 2 type update.
+```
+
+(b) Update `exportAll` to emit version 2 (it reads from `ConnectionsExport`'s type — should be a one-line literal):
+
+```ts
+exportAll: () => {
+  const env: ConnectionsExport = {
+    version: 2,
+    connections: get().connections,
+  };
+  return JSON.stringify(env, null, 2);
+},
+```
+
+(c) Update `importAll`'s parse + version check:
+
+```ts
+importAll: (json, mode) => {
+  const parsed = JSON.parse(json) as ConnectionsExport;
+  if (parsed.version !== 2) {
+    throw new Error(`Unsupported export version: ${parsed.version}`);
+  }
+  // ... rest of body unchanged
+},
+```
+
+(d) Bump persist version from 1 to 2 in the persist config at the bottom of the file:
+
+```ts
+{
+  name: "modeldoctor-connections",
+  version: 2, // bumped from 1; v1 (pre-category) data is dropped
+  partialize: (state) => ({ connections: state.connections }),
+},
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+pnpm -F @modeldoctor/web test --run src/stores/connections-store.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/stores/connections-store.ts apps/web/src/stores/connections-store.test.ts
+git commit -m "$(cat <<'EOF'
+feat(connections): bump store to v2 with category + tags fields
+
+Category is required, so any v1 snapshot in localStorage is missing
+the field and would fail validation downstream. Per CLAUDE.md
+no-compat-shims policy, zustand persist version mismatch silently
+discards old data; users re-create or re-import.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: ConnectionDialog — add category select + tag chip input
+
+**Files:**
+- Modify: `apps/web/src/features/connections/ConnectionDialog.tsx`
+- Modify: `apps/web/src/locales/en-US/connections.json`
+- Modify: `apps/web/src/locales/zh-CN/connections.json`
+- Create: `apps/web/src/features/connections/ConnectionDialog.test.tsx`
+
+- [ ] **Step 1: Add the i18n keys (en-US first)**
+
+Open `apps/web/src/locales/en-US/connections.json` and add inside `dialog.fields`:
+
+```json
+"category": "Category",
+"categoryHelp": "Used by the Playground to filter the connection picker.",
+"tags": "Tags",
+"tagsPlaceholder": "Type and press Enter (e.g. vLLM, production)",
+"tagsHelp": "Optional. Used for grouping and quick filtering."
+```
+
+Add a sibling `categoryOptions` block under `dialog`:
+
+```json
+"categoryOptions": {
+  "chat": "Chat",
+  "audio": "Audio",
+  "embeddings": "Embeddings",
+  "rerank": "Rerank",
+  "image": "Image"
+}
+```
+
+Add at the top level of the file:
+
+```json
+"table": {
+  ...existing keys,
+  "category": "Category",
+  "tags": "Tags"
+}
+```
+
+(If `table` already exists, just add the two new keys.)
+
+- [ ] **Step 2: Mirror the keys in zh-CN**
+
+Open `apps/web/src/locales/zh-CN/connections.json` and add the same shape with Chinese text:
+
+```json
+"category": "分类",
+"categoryHelp": "Playground 用它来过滤连接下拉。",
+"tags": "标签",
+"tagsPlaceholder": "输入后按回车（如 vLLM、production）",
+"tagsHelp": "可选。用于分组和快速筛选。"
+```
+
+```json
+"categoryOptions": {
+  "chat": "对话",
+  "audio": "语音",
+  "embeddings": "嵌入",
+  "rerank": "重排",
+  "image": "图像"
+}
+```
+
+```json
+"table": {
+  "category": "分类",
+  "tags": "标签"
+}
+```
+
+- [ ] **Step 3: Write the failing dialog tests**
+
+Create `apps/web/src/features/connections/ConnectionDialog.test.tsx`:
+
+```tsx
+import "@/lib/i18n";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useConnectionsStore } from "@/stores/connections-store";
+import { ConnectionDialog } from "./ConnectionDialog";
+
+function fillBaseFields(user: ReturnType<typeof userEvent.setup>) {
+  return Promise.all([
+    user.type(screen.getByLabelText(/^name$/i), "n1"),
+    user.type(screen.getByLabelText(/api base url/i), "http://x.test"),
+    user.type(screen.getByLabelText(/api key/i), "sk-1"),
+    user.type(screen.getByLabelText(/^model$/i), "m1"),
+  ]);
+}
+
+describe("ConnectionDialog (category + tags)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useConnectionsStore.setState({ connections: [] });
+  });
+
+  it("requires a category before save", async () => {
+    const user = userEvent.setup();
+    render(<ConnectionDialog open onOpenChange={() => {}} />);
+    await fillBaseFields(user);
+    await user.click(screen.getByRole("button", { name: /save|保存/i }));
+
+    // The dialog should still be open because category is required.
+    expect(screen.getByText(/category|分类/i)).toBeInTheDocument();
+    expect(useConnectionsStore.getState().list()).toHaveLength(0);
+  });
+
+  it("creates a connection with selected category and entered tags", async () => {
+    const user = userEvent.setup();
+    render(<ConnectionDialog open onOpenChange={() => {}} />);
+    await fillBaseFields(user);
+
+    // Open category dropdown and pick "Chat"
+    await user.click(screen.getByRole("combobox", { name: /category|分类/i }));
+    await user.click(screen.getByRole("option", { name: /^chat$|^对话$/i }));
+
+    // Add two tags
+    const tagInput = screen.getByPlaceholderText(/vLLM/i);
+    await user.type(tagInput, "vLLM{Enter}");
+    await user.type(tagInput, "production{Enter}");
+
+    await user.click(screen.getByRole("button", { name: /save|保存/i }));
+
+    await waitFor(() => {
+      const list = useConnectionsStore.getState().list();
+      expect(list).toHaveLength(1);
+      expect(list[0].category).toBe("chat");
+      expect(list[0].tags).toEqual(["vLLM", "production"]);
+    });
+  });
+
+  it("removing a chip drops the tag", async () => {
+    const user = userEvent.setup();
+    render(<ConnectionDialog open onOpenChange={() => {}} />);
+    const tagInput = screen.getByPlaceholderText(/vLLM/i);
+    await user.type(tagInput, "x{Enter}");
+    await user.type(tagInput, "y{Enter}");
+
+    await user.click(screen.getByRole("button", { name: /remove tag x|移除标签 x/i }));
+
+    expect(screen.queryByText("x")).not.toBeInTheDocument();
+    expect(screen.getByText("y")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 4: Run the tests to verify they fail**
+
+```bash
+pnpm -F @modeldoctor/web test --run src/features/connections/ConnectionDialog.test.tsx
+```
+
+Expected: FAIL — UI lacks category + tags fields.
+
+- [ ] **Step 5: Update `ConnectionDialog.tsx` — add category Select + tags chip input**
+
+Edit `apps/web/src/features/connections/ConnectionDialog.tsx`:
+
+(a) Add imports:
+
+```tsx
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import type { ModalityCategory } from "@modeldoctor/contracts";
+import { Controller } from "react-hook-form";
+import { X as XIcon } from "lucide-react";
+```
+
+(b) Update the `empty` constant to include the new fields:
+
+```tsx
+const empty: ConnectionInput = {
+  name: "",
+  apiBaseUrl: "",
+  apiKey: "",
+  model: "",
+  customHeaders: "",
+  queryParams: "",
+  category: "chat",
+  tags: [],
+};
+```
+
+(c) Add a constant for category options near the top of the file (outside the component):
+
+```tsx
+const CATEGORIES: ModalityCategory[] = ["chat", "audio", "embeddings", "rerank", "image"];
+const PRESET_TAGS = [
+  "vLLM",
+  "SGLang",
+  "TGI",
+  "Ollama",
+  "OpenAI",
+  "Anthropic",
+  "multimodal",
+  "streaming",
+  "production",
+  "test",
+];
+```
+
+(d) Inside the component, near `useState` calls, add:
+
+```tsx
+const [tagDraft, setTagDraft] = useState("");
+```
+
+(e) Inside the `<form>` JSX, AFTER the `model` field's `</div>` and BEFORE the `customHeaders` field, insert:
+
+```tsx
+<div>
+  <Label htmlFor="category">{t("dialog.fields.category")}</Label>
+  <Controller
+    control={form.control}
+    name="category"
+    render={({ field }) => (
+      <Select value={field.value} onValueChange={field.onChange}>
+        <SelectTrigger id="category" aria-label={t("dialog.fields.category")}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {CATEGORIES.map((c) => (
+            <SelectItem key={c} value={c}>
+              {t(`dialog.categoryOptions.${c}`)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    )}
+  />
+  <p className="mt-1 text-xs text-muted-foreground">{t("dialog.fields.categoryHelp")}</p>
+</div>
+
+<div>
+  <Label htmlFor="tags">{t("dialog.fields.tags")}</Label>
+  <Controller
+    control={form.control}
+    name="tags"
+    render={({ field }) => {
+      const current = field.value ?? [];
+      const tryAdd = (raw: string) => {
+        const trimmed = raw.trim();
+        if (!trimmed) return;
+        if (current.includes(trimmed)) return;
+        field.onChange([...current, trimmed]);
+      };
+      const remove = (tag: string) => field.onChange(current.filter((t: string) => t !== tag));
+      const suggestions = PRESET_TAGS.filter((p) => !current.includes(p));
+      return (
+        <div className="space-y-2">
+          <div className="flex flex-wrap gap-1">
+            {current.map((tag: string) => (
+              <span
+                key={tag}
+                className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 text-xs"
+              >
+                {tag}
+                <button
+                  type="button"
+                  aria-label={t("dialog.fields.tagsRemove", { tag, defaultValue: `Remove tag ${tag}` })}
+                  onClick={() => remove(tag)}
+                >
+                  <XIcon className="h-3 w-3" />
+                </button>
+              </span>
+            ))}
+          </div>
+          <Input
+            id="tags"
+            value={tagDraft}
+            onChange={(e) => setTagDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                tryAdd(tagDraft);
+                setTagDraft("");
+              }
+            }}
+            placeholder={t("dialog.fields.tagsPlaceholder")}
+          />
+          {suggestions.length > 0 ? (
+            <div className="flex flex-wrap gap-1">
+              {suggestions.slice(0, 8).map((s) => (
+                <button
+                  type="button"
+                  key={s}
+                  onClick={() => tryAdd(s)}
+                  className="rounded-full border border-dashed border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent/40"
+                >
+                  + {s}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      );
+    }}
+  />
+  <p className="mt-1 text-xs text-muted-foreground">{t("dialog.fields.tagsHelp")}</p>
+</div>
+```
+
+Add the `tagsRemove` key to both locale files:
+
+`en-US/connections.json` → `dialog.fields.tagsRemove`: `"Remove tag {{tag}}"`
+
+`zh-CN/connections.json` → `dialog.fields.tagsRemove`: `"移除标签 {{tag}}"`
+
+(f) **No change** to `onSubmit` — `react-hook-form` will already include `category` and `tags` since they are registered via `Controller`.
+
+- [ ] **Step 6: Run the dialog tests to verify they pass**
+
+```bash
+pnpm -F @modeldoctor/web test --run src/features/connections/ConnectionDialog.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/features/connections/ConnectionDialog.tsx apps/web/src/features/connections/ConnectionDialog.test.tsx apps/web/src/locales/en-US/connections.json apps/web/src/locales/zh-CN/connections.json
+git commit -m "$(cat <<'EOF'
+feat(web/connections): category select + tag chips in dialog
+
+Required-Select for category (5 options) and chip-input for tags with
+preset suggestions (vLLM, SGLang, …). Tags trim/dedupe at the schema
+layer (Task 2).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: ConnectionsPage — show category badge + tag chips, with header filters
+
+**Files:**
+- Modify: `apps/web/src/features/connections/ConnectionsPage.tsx`
+- Modify: `apps/web/src/locales/en-US/connections.json`
+- Modify: `apps/web/src/locales/zh-CN/connections.json`
+- Create: `apps/web/src/features/connections/ConnectionsPage.test.tsx`
+
+- [ ] **Step 1: Add filter-strip i18n keys**
+
+Add to `en-US/connections.json` at top level:
+
+```json
+"filters": {
+  "label": "Filter",
+  "allCategories": "All categories",
+  "allTags": "All tags",
+  "clear": "Clear filters"
+}
+```
+
+Mirror to zh-CN:
+
+```json
+"filters": {
+  "label": "筛选",
+  "allCategories": "全部分类",
+  "allTags": "全部标签",
+  "clear": "清除筛选"
+}
+```
+
+- [ ] **Step 2: Write the failing list test**
+
+Create `apps/web/src/features/connections/ConnectionsPage.test.tsx`:
+
+```tsx
+import "@/lib/i18n";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useConnectionsStore } from "@/stores/connections-store";
+import { ConnectionsPage } from "./ConnectionsPage";
+
+function seed() {
+  const s = useConnectionsStore.getState();
+  s.create({
+    name: "chat-prod",
+    apiBaseUrl: "http://a",
+    apiKey: "k",
+    model: "qwen",
+    customHeaders: "",
+    queryParams: "",
+    category: "chat",
+    tags: ["vLLM", "production"],
+  });
+  s.create({
+    name: "embed-test",
+    apiBaseUrl: "http://b",
+    apiKey: "k",
+    model: "bge",
+    customHeaders: "",
+    queryParams: "",
+    category: "embeddings",
+    tags: ["TEI"],
+  });
+}
+
+describe("ConnectionsPage (category + tags)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useConnectionsStore.setState({ connections: [] });
+  });
+
+  it("renders category badge and tag chips for each row", () => {
+    seed();
+    render(
+      <MemoryRouter>
+        <ConnectionsPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("chat-prod")).toBeInTheDocument();
+    expect(screen.getByText("embed-test")).toBeInTheDocument();
+    expect(screen.getByText("vLLM")).toBeInTheDocument();
+    expect(screen.getByText("TEI")).toBeInTheDocument();
+  });
+
+  it("filtering by category hides non-matching rows", async () => {
+    const user = userEvent.setup();
+    seed();
+    render(
+      <MemoryRouter>
+        <ConnectionsPage />
+      </MemoryRouter>,
+    );
+    await user.click(screen.getByRole("combobox", { name: /category|分类/i }));
+    await user.click(screen.getByRole("option", { name: /^chat$|^对话$/i }));
+
+    expect(screen.getByText("chat-prod")).toBeInTheDocument();
+    expect(screen.queryByText("embed-test")).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+pnpm -F @modeldoctor/web test --run src/features/connections/ConnectionsPage.test.tsx
+```
+
+Expected: FAIL — table doesn't render category/tags yet.
+
+- [ ] **Step 4: Update `ConnectionsPage.tsx` to render the new columns and filter state**
+
+Open `apps/web/src/features/connections/ConnectionsPage.tsx`. Add imports + filter state + filtered list + new table columns:
+
+(a) Add to imports:
+
+```tsx
+import { Badge } from "@/components/ui/badge";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import type { ModalityCategory } from "@modeldoctor/contracts";
+```
+
+(b) Inside the component, add filter state above the existing dialog state:
+
+```tsx
+const [filterCategory, setFilterCategory] = useState<ModalityCategory | "all">("all");
+const [filterTag, setFilterTag] = useState<string | "all">("all");
+
+const allTags = Array.from(new Set(list.flatMap((c) => c.tags))).sort();
+
+const filtered = list.filter((c) => {
+  if (filterCategory !== "all" && c.category !== filterCategory) return false;
+  if (filterTag !== "all" && !c.tags.includes(filterTag)) return false;
+  return true;
+});
+```
+
+(c) Replace the `list.map` body inside the `TableBody` with `filtered.map(...)`.
+
+(d) Insert the filter strip BEFORE the `<Table>` element:
+
+```tsx
+<div className="mb-3 flex items-center gap-2">
+  <span className="text-xs text-muted-foreground">{t("filters.label")}:</span>
+  <Select value={filterCategory} onValueChange={(v) => setFilterCategory(v as ModalityCategory | "all")}>
+    <SelectTrigger className="h-8 w-40 text-xs" aria-label={t("dialog.fields.category")}>
+      <SelectValue />
+    </SelectTrigger>
+    <SelectContent>
+      <SelectItem value="all">{t("filters.allCategories")}</SelectItem>
+      {(["chat", "audio", "embeddings", "rerank", "image"] as ModalityCategory[]).map((c) => (
+        <SelectItem key={c} value={c}>{t(`dialog.categoryOptions.${c}`)}</SelectItem>
+      ))}
+    </SelectContent>
+  </Select>
+  <Select value={filterTag} onValueChange={setFilterTag}>
+    <SelectTrigger className="h-8 w-40 text-xs" aria-label={t("dialog.fields.tags")}>
+      <SelectValue />
+    </SelectTrigger>
+    <SelectContent>
+      <SelectItem value="all">{t("filters.allTags")}</SelectItem>
+      {allTags.map((tag) => (
+        <SelectItem key={tag} value={tag}>{tag}</SelectItem>
+      ))}
+    </SelectContent>
+  </Select>
+</div>
+```
+
+(e) Add new `<TableHead>` cells for `category` and `tags` BEFORE `customHeaders`:
+
+```tsx
+<TableHead>{t("table.category")}</TableHead>
+<TableHead>{t("table.tags")}</TableHead>
+```
+
+(f) Add corresponding `<TableCell>` rendering inside the row body, matching column position:
+
+```tsx
+<TableCell>
+  <Badge variant="outline" className="text-xs">
+    {t(`dialog.categoryOptions.${c.category}`)}
+  </Badge>
+</TableCell>
+<TableCell>
+  <div className="flex flex-wrap gap-1">
+    {c.tags.map((tag) => (
+      <span key={tag} className="rounded-full bg-secondary px-2 py-0.5 text-[10px]">
+        {tag}
+      </span>
+    ))}
+  </div>
+</TableCell>
+```
+
+- [ ] **Step 5: Run the page test**
+
+```bash
+pnpm -F @modeldoctor/web test --run src/features/connections/ConnectionsPage.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/features/connections/ConnectionsPage.tsx apps/web/src/features/connections/ConnectionsPage.test.tsx apps/web/src/locales/en-US/connections.json apps/web/src/locales/zh-CN/connections.json
+git commit -m "$(cat <<'EOF'
+feat(web/connections): table columns + filter strip for category and tags
+
+Adds two columns (Category badge, Tags chip strip) and a header filter
+strip with two Select dropdowns. Tag dropdown auto-collects every tag
+from the current connection list.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Playground i18n namespace + sidebar group + routes (placeholders for non-chat modalities)
+
+**Files:**
+- Create: `apps/web/src/locales/en-US/playground.json`
+- Create: `apps/web/src/locales/zh-CN/playground.json`
+- Modify: `apps/web/src/lib/i18n.ts`
+- Modify: `apps/web/src/locales/en-US/sidebar.json`
+- Modify: `apps/web/src/locales/zh-CN/sidebar.json`
+- Modify: `apps/web/src/components/sidebar/sidebar-config.tsx`
+- Modify: `apps/web/src/router/index.tsx`
+
+- [ ] **Step 1: Create `playground.json` (en-US) with the Phase 1 chat-only structure**
+
+Create `apps/web/src/locales/en-US/playground.json`:
+
+```json
+{
+  "title": "Playground",
+  "categories": {
+    "chat": "Chat",
+    "audio": "Audio",
+    "embeddings": "Embeddings",
+    "rerank": "Rerank",
+    "image": "Image"
+  },
+  "endpoint": {
+    "categoryFilter": "Category filter",
+    "showAll": "Show all",
+    "categoryMismatch": "Selected connection's category ({{category}}) doesn't match this page",
+    "clearSelection": "Clear",
+    "noMatchingConnections": "No {{category}} connections yet",
+    "newConnection": "+ New connection"
+  },
+  "chat": {
+    "title": "Chat",
+    "subtitle": "Send a single message to a chat-completions endpoint and see the reply.",
+    "system": {
+      "label": "System message",
+      "placeholder": "Optional. e.g. You are a helpful assistant."
+    },
+    "composer": {
+      "placeholder": "Type your message…",
+      "send": "Send",
+      "sending": "Sending…",
+      "needConnection": "Pick a chat connection first"
+    },
+    "messages": {
+      "system": "system",
+      "user": "user",
+      "assistant": "assistant",
+      "empty": "Send a message to get started."
+    },
+    "params": {
+      "title": "Parameters",
+      "temperature": "Temperature",
+      "maxTokens": "Max Tokens",
+      "topP": "Top P",
+      "frequencyPenalty": "Frequency Penalty",
+      "presencePenalty": "Presence Penalty",
+      "seed": "Seed",
+      "stop": "Stop Sequence",
+      "stream": "Stream (Phase 2)"
+    },
+    "errors": {
+      "send": "Failed to send: {{message}}"
+    }
+  },
+  "comingSoon": {
+    "title": "Coming in Phase {{phase}}",
+    "body": "This modality is part of the Playground roadmap but isn't built yet."
+  }
+}
+```
+
+- [ ] **Step 2: Create the zh-CN mirror**
+
+Create `apps/web/src/locales/zh-CN/playground.json`:
+
+```json
+{
+  "title": "试验场",
+  "categories": {
+    "chat": "对话",
+    "audio": "语音",
+    "embeddings": "嵌入",
+    "rerank": "重排",
+    "image": "图像"
+  },
+  "endpoint": {
+    "categoryFilter": "分类过滤",
+    "showAll": "显示全部",
+    "categoryMismatch": "当前连接是 {{category}} 类，与本页不符",
+    "clearSelection": "清除",
+    "noMatchingConnections": "暂无 {{category}} 类连接",
+    "newConnection": "+ 新建连接"
+  },
+  "chat": {
+    "title": "对话",
+    "subtitle": "向 chat-completions 接口发送一条消息，查看回复。",
+    "system": {
+      "label": "系统消息",
+      "placeholder": "可选。如：你是一个有帮助的助手。"
+    },
+    "composer": {
+      "placeholder": "输入消息…",
+      "send": "发送",
+      "sending": "发送中…",
+      "needConnection": "请先选择一个对话类连接"
+    },
+    "messages": {
+      "system": "系统",
+      "user": "用户",
+      "assistant": "助手",
+      "empty": "发送一条消息开始对话。"
+    },
+    "params": {
+      "title": "参数",
+      "temperature": "Temperature",
+      "maxTokens": "Max Tokens",
+      "topP": "Top P",
+      "frequencyPenalty": "Frequency Penalty",
+      "presencePenalty": "Presence Penalty",
+      "seed": "Seed",
+      "stop": "停止序列",
+      "stream": "流式 (Phase 2)"
+    },
+    "errors": {
+      "send": "发送失败：{{message}}"
+    }
+  },
+  "comingSoon": {
+    "title": "Phase {{phase}} 推出",
+    "body": "本模态在 Playground 路线图中，但还没实现。"
+  }
+}
+```
+
+- [ ] **Step 3: Register the new namespace in `i18n.ts`**
+
+Open `apps/web/src/lib/i18n.ts`. Add imports:
+
+```ts
+import enPlayground from "@/locales/en-US/playground.json";
+import zhPlayground from "@/locales/zh-CN/playground.json";
+```
+
+Add `playground: enPlayground` to the `en-US` resources object and `playground: zhPlayground` to the `zh-CN` resources object. Add `"playground"` to the `ns` array.
+
+- [ ] **Step 4: Add sidebar group label + 5 item labels (en-US then zh-CN)**
+
+Open `apps/web/src/locales/en-US/sidebar.json`. Add inside `groups`:
+
+```json
+"playground": "Playground"
+```
+
+Add inside `items`:
+
+```json
+"playgroundChat": "Chat",
+"playgroundImage": "Image",
+"playgroundAudio": "Audio",
+"playgroundEmbeddings": "Embeddings",
+"playgroundRerank": "Rerank"
+```
+
+Mirror in `zh-CN/sidebar.json`:
+
+```json
+"playground": "试验场"
+```
+
+```json
+"playgroundChat": "对话",
+"playgroundImage": "图像",
+"playgroundAudio": "语音",
+"playgroundEmbeddings": "嵌入",
+"playgroundRerank": "重排"
+```
+
+- [ ] **Step 5: Update `sidebar-config.tsx` to insert the playground group at the top**
+
+Open `apps/web/src/components/sidebar/sidebar-config.tsx`. Add icon imports (use lucide icons that are already available or compatible — `MessageSquare`, `Image`, `Mic`, `Boxes`, `ListOrdered`):
+
+```tsx
+import { Boxes, Image as ImageIcon, ListOrdered, MessageSquare, Mic } from "lucide-react";
+```
+
+Then prepend a new group BEFORE the `performance` group in the `sidebarGroups` array:
+
+```tsx
+{
+  id: "playground",
+  labelKey: "groups.playground",
+  items: [
+    { to: "/playground/chat", icon: MessageSquare, labelKey: "items.playgroundChat" },
+    { to: "/playground/image", icon: ImageIcon, labelKey: "items.playgroundImage", comingSoon: true },
+    { to: "/playground/audio", icon: Mic, labelKey: "items.playgroundAudio", comingSoon: true },
+    { to: "/playground/embeddings", icon: Boxes, labelKey: "items.playgroundEmbeddings", comingSoon: true },
+    { to: "/playground/rerank", icon: ListOrdered, labelKey: "items.playgroundRerank", comingSoon: true },
+  ],
+},
+```
+
+- [ ] **Step 6: Add the `/playground` routes to `router/index.tsx`**
+
+Open `apps/web/src/router/index.tsx`. Add the `Navigate` already imported is fine. Add an import:
+
+```tsx
+// Placeholder — ChatPage is created in Task 13.
+// Use a tiny inline stub here so the route resolves; we'll swap it.
+```
+
+Actually the cleanest path: create the file `apps/web/src/features/playground/chat/ChatPage.tsx` as a one-liner stub now, and fully implement it in Task 13. Insert the stub:
+
+```tsx
+// apps/web/src/features/playground/chat/ChatPage.tsx (Task 6 stub — replaced in Task 13)
+import { PageHeader } from "@/components/common/page-header";
+import { useTranslation } from "react-i18next";
+
+export function ChatPage() {
+  const { t } = useTranslation("playground");
+  return (
+    <>
+      <PageHeader title={t("chat.title")} subtitle={t("chat.subtitle")} />
+      <div className="px-8 py-6 text-sm text-muted-foreground">Stub — built in Task 13.</div>
+    </>
+  );
+}
+```
+
+Add the route children, BEFORE the `path: "*"` catch-all:
+
+```tsx
+{ path: "playground", element: <Navigate to="/playground/chat" replace /> },
+{ path: "playground/chat", element: <ChatPage /> },
+{
+  path: "playground/image",
+  element: <ComingSoonRoute icon={ImageIcon} itemKey="playgroundImage" />,
+},
+{
+  path: "playground/audio",
+  element: <ComingSoonRoute icon={Mic} itemKey="playgroundAudio" />,
+},
+{
+  path: "playground/embeddings",
+  element: <ComingSoonRoute icon={Boxes} itemKey="playgroundEmbeddings" />,
+},
+{
+  path: "playground/rerank",
+  element: <ComingSoonRoute icon={ListOrdered} itemKey="playgroundRerank" />,
+},
+```
+
+Add the corresponding imports at the top of `router/index.tsx`:
+
+```tsx
+import { ChatPage } from "@/features/playground/chat/ChatPage";
+import { Boxes, Image as ImageIcon, ListOrdered, Mic } from "lucide-react";
+```
+
+(MessageSquare not needed in router since chat has no ComingSoonRoute.)
+
+- [ ] **Step 7: Verify the dev server boots and the route resolves**
+
+```bash
+pnpm -F @modeldoctor/web type-check
+pnpm -F @modeldoctor/web test --run
+```
+
+Expected: type-check clean; existing tests still pass. Manual smoke (optional but encouraged):
+
+```bash
+pnpm -F @modeldoctor/web dev
+```
+
+Then open `http://localhost:5173/playground/chat` and confirm the stub page renders with title "Chat" and the sidebar shows the new "Playground" group with 5 items.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/locales/en-US/playground.json apps/web/src/locales/zh-CN/playground.json apps/web/src/lib/i18n.ts apps/web/src/locales/en-US/sidebar.json apps/web/src/locales/zh-CN/sidebar.json apps/web/src/components/sidebar/sidebar-config.tsx apps/web/src/router/index.tsx apps/web/src/features/playground/chat/ChatPage.tsx
+git commit -m "$(cat <<'EOF'
+feat(web/playground): scaffold sidebar group, routes, and i18n namespace
+
+New top-level "Playground" group above Performance, with chat live and
+the other four modalities marked coming-soon. Adds the playground i18n
+namespace (en + zh) covering Phase 1 chat copy. ChatPage is a stub
+that is replaced by the real implementation in Task 13.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `PlaygroundShell` + `ParamsPanel` shared layout components
+
+**Files:**
+- Create: `apps/web/src/features/playground/PlaygroundShell.tsx`
+- Create: `apps/web/src/features/playground/ParamsPanel.tsx`
+- Create: `apps/web/src/features/playground/PlaygroundShell.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web/src/features/playground/PlaygroundShell.test.tsx`:
+
+```tsx
+import "@/lib/i18n";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { PlaygroundShell } from "./PlaygroundShell";
+
+describe("PlaygroundShell", () => {
+  it("renders main content and params slot side by side", () => {
+    render(
+      <PlaygroundShell category="chat" paramsSlot={<div>params-here</div>}>
+        <div>main-here</div>
+      </PlaygroundShell>,
+    );
+    expect(screen.getByText("main-here")).toBeInTheDocument();
+    expect(screen.getByText("params-here")).toBeInTheDocument();
+  });
+
+  it("renders tabs and calls onTabChange when clicked", async () => {
+    const user = userEvent.setup();
+    const onTabChange = vi.fn();
+    render(
+      <PlaygroundShell
+        category="chat"
+        tabs={[
+          { key: "single", label: "Single" },
+          { key: "compare", label: "Compare" },
+        ]}
+        activeTab="single"
+        onTabChange={onTabChange}
+        paramsSlot={null}
+      >
+        <div />
+      </PlaygroundShell>,
+    );
+    await user.click(screen.getByRole("button", { name: "Compare" }));
+    expect(onTabChange).toHaveBeenCalledWith("compare");
+  });
+
+  it("collapse button hides the params panel", async () => {
+    const user = userEvent.setup();
+    render(
+      <PlaygroundShell category="chat" paramsSlot={<div>panel-x</div>}>
+        <div />
+      </PlaygroundShell>,
+    );
+    expect(screen.getByText("panel-x")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /collapse|折叠/i }));
+    expect(screen.queryByText("panel-x")).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+pnpm -F @modeldoctor/web test --run src/features/playground/PlaygroundShell.test.tsx
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `ParamsPanel.tsx`**
+
+Create `apps/web/src/features/playground/ParamsPanel.tsx`:
+
+```tsx
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+interface ParamsPanelProps {
+  open: boolean;
+  children: ReactNode;
+}
+
+export function ParamsPanel({ open, children }: ParamsPanelProps) {
+  if (!open) return null;
+  return (
+    <aside
+      className={cn(
+        "w-80 shrink-0 overflow-y-auto border-l border-border bg-card",
+        "px-4 py-4",
+      )}
+    >
+      {children}
+    </aside>
+  );
+}
+```
+
+- [ ] **Step 4: Implement `PlaygroundShell.tsx`**
+
+Create `apps/web/src/features/playground/PlaygroundShell.tsx`:
+
+```tsx
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { ModalityCategory } from "@modeldoctor/contracts";
+import { PanelRightClose, PanelRightOpen } from "lucide-react";
+import { type ReactNode, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ParamsPanel } from "./ParamsPanel";
+
+export interface PlaygroundShellProps {
+  category: ModalityCategory;
+  tabs?: Array<{ key: string; label: string }>;
+  activeTab?: string;
+  onTabChange?: (k: string) => void;
+  paramsSlot: ReactNode;
+  rightPanelDefaultOpen?: boolean;
+  children: ReactNode;
+}
+
+export function PlaygroundShell({
+  tabs,
+  activeTab,
+  onTabChange,
+  paramsSlot,
+  rightPanelDefaultOpen = true,
+  children,
+}: PlaygroundShellProps) {
+  const { t: tc } = useTranslation("common");
+  const [panelOpen, setPanelOpen] = useState(rightPanelDefaultOpen);
+
+  return (
+    <div className="flex h-[calc(100vh-0px)] min-h-0 flex-col">
+      <header className="flex items-center justify-between border-b border-border px-6 py-3">
+        <div className="flex items-center gap-1">
+          {tabs?.map((tab) => (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => onTabChange?.(tab.key)}
+              className={cn(
+                "rounded-md px-3 py-1.5 text-sm",
+                tab.key === activeTab
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground hover:bg-accent/40 hover:text-foreground",
+              )}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setPanelOpen((v) => !v)}
+          aria-label={panelOpen ? tc("sidebar.collapse", { defaultValue: "Collapse" }) : tc("sidebar.expand", { defaultValue: "Expand" })}
+        >
+          {panelOpen ? <PanelRightClose className="h-4 w-4" /> : <PanelRightOpen className="h-4 w-4" />}
+        </Button>
+      </header>
+      <div className="flex min-h-0 flex-1">
+        <main className="flex min-w-0 flex-1 flex-col overflow-hidden">{children}</main>
+        <ParamsPanel open={panelOpen}>{paramsSlot}</ParamsPanel>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+pnpm -F @modeldoctor/web test --run src/features/playground/PlaygroundShell.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/features/playground/PlaygroundShell.tsx apps/web/src/features/playground/ParamsPanel.tsx apps/web/src/features/playground/PlaygroundShell.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(web/playground): PlaygroundShell + ParamsPanel layout primitives
+
+Shared layout for all 5 modality sub-pages: header (optional tabs +
+collapse-panel button), main slot, right ParamsPanel. The panel can
+collapse to give the main area more room.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: `CategoryEndpointSelector` — connection picker filtered by category
+
+**Files:**
+- Create: `apps/web/src/features/playground/CategoryEndpointSelector.tsx`
+- Create: `apps/web/src/features/playground/CategoryEndpointSelector.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web/src/features/playground/CategoryEndpointSelector.test.tsx`:
+
+```tsx
+import "@/lib/i18n";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useConnectionsStore } from "@/stores/connections-store";
+import { CategoryEndpointSelector } from "./CategoryEndpointSelector";
+
+function seed() {
+  const s = useConnectionsStore.getState();
+  s.create({
+    name: "chat-A",
+    apiBaseUrl: "http://a",
+    apiKey: "k",
+    model: "m",
+    customHeaders: "",
+    queryParams: "",
+    category: "chat",
+    tags: [],
+  });
+  s.create({
+    name: "embed-B",
+    apiBaseUrl: "http://b",
+    apiKey: "k",
+    model: "m",
+    customHeaders: "",
+    queryParams: "",
+    category: "embeddings",
+    tags: [],
+  });
+}
+
+describe("CategoryEndpointSelector", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useConnectionsStore.setState({ connections: [] });
+  });
+
+  it("only lists connections of the matching category by default", async () => {
+    const user = userEvent.setup();
+    seed();
+    render(
+      <CategoryEndpointSelector
+        category="chat"
+        selectedConnectionId={null}
+        onSelect={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByRole("option", { name: /chat-A/i })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /embed-B/i })).not.toBeInTheDocument();
+  });
+
+  it("show-all toggle reveals all connections", async () => {
+    const user = userEvent.setup();
+    seed();
+    render(
+      <CategoryEndpointSelector
+        category="chat"
+        selectedConnectionId={null}
+        onSelect={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("checkbox", { name: /show all|显示全部/i }));
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByRole("option", { name: /chat-A/i })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /embed-B/i })).toBeInTheDocument();
+  });
+
+  it("warns when selected connection's category mismatches", () => {
+    seed();
+    const embedId = useConnectionsStore.getState().list().find((c) => c.name === "embed-B")!.id;
+    render(
+      <CategoryEndpointSelector
+        category="chat"
+        selectedConnectionId={embedId}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/doesn't match|不符/i)).toBeInTheDocument();
+  });
+
+  it("emits onSelect with the picked connection id", async () => {
+    const user = userEvent.setup();
+    seed();
+    const onSelect = vi.fn();
+    render(
+      <CategoryEndpointSelector
+        category="chat"
+        selectedConnectionId={null}
+        onSelect={onSelect}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /chat-A/i }));
+    const expectedId = useConnectionsStore.getState().list().find((c) => c.name === "chat-A")!.id;
+    expect(onSelect).toHaveBeenCalledWith(expectedId);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm -F @modeldoctor/web test --run src/features/playground/CategoryEndpointSelector.test.tsx
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `CategoryEndpointSelector.tsx`**
+
+Create `apps/web/src/features/playground/CategoryEndpointSelector.tsx`:
+
+```tsx
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useConnectionsStore } from "@/stores/connections-store";
+import type { ModalityCategory } from "@modeldoctor/contracts";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+export interface CategoryEndpointSelectorProps {
+  category: ModalityCategory;
+  selectedConnectionId: string | null;
+  onSelect: (id: string | null) => void;
+}
+
+export function CategoryEndpointSelector({
+  category,
+  selectedConnectionId,
+  onSelect,
+}: CategoryEndpointSelectorProps) {
+  const { t } = useTranslation("playground");
+  const { t: tc } = useTranslation("connections");
+  const list = useConnectionsStore((s) => s.list());
+  const [showAll, setShowAll] = useState(false);
+
+  const visible = showAll ? list : list.filter((c) => c.category === category);
+  const selected = selectedConnectionId
+    ? list.find((c) => c.id === selectedConnectionId) ?? null
+    : null;
+  const mismatched = selected && selected.category !== category;
+  const showAllId = "playground-show-all-connections";
+
+  return (
+    <div className="space-y-2">
+      <Select
+        value={selectedConnectionId ?? ""}
+        onValueChange={(v) => onSelect(v || null)}
+      >
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder={t("endpoint.noMatchingConnections", {
+            category: tc(`dialog.categoryOptions.${category}`),
+          })} />
+        </SelectTrigger>
+        <SelectContent>
+          {visible.length === 0 ? (
+            <div className="px-2 py-1.5 text-xs text-muted-foreground">
+              {t("endpoint.noMatchingConnections", {
+                category: tc(`dialog.categoryOptions.${category}`),
+              })}
+            </div>
+          ) : (
+            visible.map((c) => (
+              <SelectItem
+                key={c.id}
+                value={c.id}
+                className={c.category !== category ? "opacity-60" : ""}
+              >
+                {c.name}
+              </SelectItem>
+            ))
+          )}
+        </SelectContent>
+      </Select>
+
+      <label htmlFor={showAllId} className="flex items-center gap-2 text-xs text-muted-foreground">
+        <input
+          id={showAllId}
+          type="checkbox"
+          checked={showAll}
+          onChange={(e) => setShowAll(e.target.checked)}
+        />
+        {t("endpoint.showAll")}
+      </label>
+
+      {mismatched ? (
+        <div className="flex items-center gap-2 rounded-md border border-warning/40 bg-warning/10 px-2 py-1 text-xs text-warning-foreground">
+          <span>
+            {t("endpoint.categoryMismatch", {
+              category: tc(`dialog.categoryOptions.${selected!.category}`),
+            })}
+          </span>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-6 px-2 text-xs"
+            onClick={() => onSelect(null)}
+          >
+            {t("endpoint.clearSelection")}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+pnpm -F @modeldoctor/web test --run src/features/playground/CategoryEndpointSelector.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/features/playground/CategoryEndpointSelector.tsx apps/web/src/features/playground/CategoryEndpointSelector.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(web/playground): CategoryEndpointSelector with show-all + mismatch warn
+
+Connection picker that defaults to category-filtered, with a "show all"
+toggle for multi-modal endpoints and a warning chip when the currently
+selected connection's category doesn't match the page.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Playground contracts (chat request + response + message schemas)
+
+**Files:**
+- Create: `packages/contracts/src/playground.ts`
+- Create: `packages/contracts/src/playground.test.ts`
+- Modify: `packages/contracts/src/index.ts`
+
+- [ ] **Step 1: Write the failing schema tests**
+
+Create `packages/contracts/src/playground.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  ChatMessageSchema,
+  PlaygroundChatRequestSchema,
+  PlaygroundChatResponseSchema,
+} from "./playground.js";
+
+describe("ChatMessageSchema", () => {
+  it("accepts a string-content message", () => {
+    expect(() =>
+      ChatMessageSchema.parse({ role: "user", content: "hello" }),
+    ).not.toThrow();
+  });
+
+  it("accepts a content-parts array with text + image_url", () => {
+    expect(() =>
+      ChatMessageSchema.parse({
+        role: "user",
+        content: [
+          { type: "text", text: "what is in this image?" },
+          { type: "image_url", image_url: { url: "data:image/png;base64,iVB..." } },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects an unknown role", () => {
+    expect(() =>
+      ChatMessageSchema.parse({ role: "tool", content: "hi" }),
+    ).toThrow();
+  });
+});
+
+describe("PlaygroundChatRequestSchema", () => {
+  const base = {
+    apiBaseUrl: "http://x.test",
+    apiKey: "k",
+    model: "m",
+    messages: [{ role: "user", content: "hi" }],
+  };
+
+  it("accepts a minimal request", () => {
+    expect(() => PlaygroundChatRequestSchema.parse(base)).not.toThrow();
+  });
+
+  it("requires at least one message", () => {
+    expect(() =>
+      PlaygroundChatRequestSchema.parse({ ...base, messages: [] }),
+    ).toThrow();
+  });
+
+  it("defaults params to an empty object", () => {
+    const out = PlaygroundChatRequestSchema.parse(base);
+    expect(out.params).toEqual({});
+  });
+});
+
+describe("PlaygroundChatResponseSchema", () => {
+  it("accepts the OK shape", () => {
+    expect(() =>
+      PlaygroundChatResponseSchema.parse({
+        success: true,
+        content: "hi back",
+        latencyMs: 123,
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts an error shape", () => {
+    expect(() =>
+      PlaygroundChatResponseSchema.parse({
+        success: false,
+        error: "upstream 500",
+        latencyMs: 50,
+      }),
+    ).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+pnpm -F @modeldoctor/contracts test --run src/playground.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `playground.ts` schemas**
+
+Create `packages/contracts/src/playground.ts`:
+
+```ts
+import { z } from "zod";
+
+/**
+ * OpenAI-compatible chat message. Content is either a plain string OR an
+ * array of typed content parts (used for multimodal — image_url, input_audio
+ * — added in Phase 2).
+ */
+export const ChatMessageContentPartSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("text"), text: z.string() }),
+  z.object({
+    type: z.literal("image_url"),
+    image_url: z.object({ url: z.string() }),
+  }),
+  z.object({
+    type: z.literal("input_audio"),
+    input_audio: z.object({ data: z.string(), format: z.string() }),
+  }),
+]);
+
+export const ChatMessageSchema = z.object({
+  role: z.enum(["user", "assistant", "system"]),
+  content: z.union([z.string(), z.array(ChatMessageContentPartSchema)]),
+});
+export type ChatMessage = z.infer<typeof ChatMessageSchema>;
+
+export const ChatParamsSchema = z
+  .object({
+    temperature: z.number().optional(),
+    maxTokens: z.number().int().positive().optional(),
+    topP: z.number().optional(),
+    frequencyPenalty: z.number().optional(),
+    presencePenalty: z.number().optional(),
+    seed: z.number().int().optional(),
+    stop: z.array(z.string()).optional(),
+    stream: z.boolean().optional(),
+  })
+  .partial();
+export type ChatParams = z.infer<typeof ChatParamsSchema>;
+
+export const PlaygroundChatRequestSchema = z.object({
+  apiBaseUrl: z.string().min(1),
+  apiKey: z.string().min(1),
+  model: z.string().min(1),
+  customHeaders: z.string().optional(),
+  queryParams: z.string().optional(),
+  /** Override the default `/v1/chat/completions` path tail. */
+  pathOverride: z.string().optional(),
+  messages: z.array(ChatMessageSchema).min(1),
+  params: ChatParamsSchema.default({}),
+});
+export type PlaygroundChatRequest = z.infer<typeof PlaygroundChatRequestSchema>;
+
+export const PlaygroundChatResponseSchema = z.object({
+  success: z.boolean(),
+  /** Assistant's reply text. Present iff success === true. */
+  content: z.string().optional(),
+  /** Error message. Present iff success === false. */
+  error: z.string().optional(),
+  /** End-to-end wall-clock duration of the upstream call. */
+  latencyMs: z.number(),
+  /** Raw OpenAI usage block (if returned). */
+  usage: z
+    .object({
+      prompt_tokens: z.number().optional(),
+      completion_tokens: z.number().optional(),
+      total_tokens: z.number().optional(),
+    })
+    .optional(),
+});
+export type PlaygroundChatResponse = z.infer<typeof PlaygroundChatResponseSchema>;
+```
+
+- [ ] **Step 4: Re-export from `index.ts`**
+
+Add to `packages/contracts/src/index.ts`:
+
+```ts
+export * from "./playground.js";
+```
+
+- [ ] **Step 5: Run tests + build to verify**
+
+```bash
+pnpm -F @modeldoctor/contracts test --run
+pnpm -F @modeldoctor/contracts build
+```
+
+Expected: ALL PASS, clean build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/contracts/src/playground.ts packages/contracts/src/playground.test.ts packages/contracts/src/index.ts
+git commit -m "$(cat <<'EOF'
+feat(contracts): playground chat request/response + message schemas
+
+Wire shape for POST /api/playground/chat (Phase 1, non-streaming).
+ChatMessageContentPartSchema covers text + image_url + input_audio so
+Phase 2 multimodal Chat doesn't need another schema bump.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Backend `PlaygroundModule` + `ChatController` + `ChatService` (non-streaming)
+
+**Files:**
+- Create: `apps/api/src/modules/playground/playground.module.ts`
+- Create: `apps/api/src/modules/playground/chat.controller.ts`
+- Create: `apps/api/src/modules/playground/chat.service.ts`
+- Create: `apps/api/src/modules/playground/chat.service.spec.ts`
+- Modify: `apps/api/src/app.module.ts`
+
+- [ ] **Step 1: Write the failing service test**
+
+Create `apps/api/src/modules/playground/chat.service.spec.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatService } from "./chat.service.js";
+
+describe("ChatService.run", () => {
+  let svc: ChatService;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    svc = new ChatService();
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts to {apiBaseUrl}/v1/chat/completions with Bearer auth and OpenAI body shape", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "hello back", role: "assistant" } }],
+          usage: { prompt_tokens: 5, completion_tokens: 7, total_tokens: 12 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const out = await svc.run({
+      apiBaseUrl: "http://upstream.test",
+      apiKey: "sk-1",
+      model: "m1",
+      messages: [{ role: "user", content: "hello" }],
+      params: {},
+    });
+
+    expect(out.success).toBe(true);
+    expect(out.content).toBe("hello back");
+    expect(out.usage?.total_tokens).toBe(12);
+    expect(out.latencyMs).toBeGreaterThanOrEqual(0);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://upstream.test/v1/chat/completions");
+    expect((init as RequestInit).method).toBe("POST");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer sk-1");
+    expect(headers["Content-Type"]).toBe("application/json");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.model).toBe("m1");
+    expect(body.messages).toEqual([{ role: "user", content: "hello" }]);
+  });
+
+  it("honours pathOverride", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 }),
+    );
+    await svc.run({
+      apiBaseUrl: "http://x",
+      apiKey: "k",
+      model: "m",
+      pathOverride: "/custom/chat",
+      messages: [{ role: "user", content: "h" }],
+      params: {},
+    });
+    expect(fetchMock.mock.calls[0][0]).toBe("http://x/custom/chat");
+  });
+
+  it("maps OpenAI-style snake_case params from camelCase", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 }),
+    );
+    await svc.run({
+      apiBaseUrl: "http://x",
+      apiKey: "k",
+      model: "m",
+      messages: [{ role: "user", content: "h" }],
+      params: {
+        temperature: 0.7,
+        maxTokens: 256,
+        topP: 0.9,
+        frequencyPenalty: 0.1,
+        presencePenalty: 0.2,
+        seed: 42,
+        stop: ["</s>"],
+      },
+    });
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.temperature).toBe(0.7);
+    expect(body.max_tokens).toBe(256);
+    expect(body.top_p).toBe(0.9);
+    expect(body.frequency_penalty).toBe(0.1);
+    expect(body.presence_penalty).toBe(0.2);
+    expect(body.seed).toBe(42);
+    expect(body.stop).toEqual(["</s>"]);
+  });
+
+  it("merges customHeaders (newline-delimited 'K: v' pairs)", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 }),
+    );
+    await svc.run({
+      apiBaseUrl: "http://x",
+      apiKey: "k",
+      model: "m",
+      customHeaders: "X-Foo: bar\nX-Baz: qux",
+      messages: [{ role: "user", content: "h" }],
+      params: {},
+    });
+    const headers = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+    expect(headers["X-Foo"]).toBe("bar");
+    expect(headers["X-Baz"]).toBe("qux");
+  });
+
+  it("returns success=false with upstream body when status >= 400", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("model not found", { status: 404 }),
+    );
+    const out = await svc.run({
+      apiBaseUrl: "http://x",
+      apiKey: "k",
+      model: "m",
+      messages: [{ role: "user", content: "h" }],
+      params: {},
+    });
+    expect(out.success).toBe(false);
+    expect(out.error).toMatch(/404/);
+    expect(out.error).toMatch(/model not found/);
+  });
+
+  it("returns success=false on network error", async () => {
+    fetchMock.mockRejectedValue(new Error("network kaboom"));
+    const out = await svc.run({
+      apiBaseUrl: "http://x",
+      apiKey: "k",
+      model: "m",
+      messages: [{ role: "user", content: "h" }],
+      params: {},
+    });
+    expect(out.success).toBe(false);
+    expect(out.error).toMatch(/network kaboom/);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm -F @modeldoctor/api test --run src/modules/playground/chat.service.spec.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `chat.service.ts`**
+
+Create `apps/api/src/modules/playground/chat.service.ts`:
+
+```ts
+import type { PlaygroundChatRequest, PlaygroundChatResponse } from "@modeldoctor/contracts";
+import { Injectable } from "@nestjs/common";
+
+const DEFAULT_PATH = "/v1/chat/completions";
+
+function parseHeaderLines(s: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!s || !s.trim()) return out;
+  for (const rawLine of s.split("\n").map((l) => l.trim())) {
+    if (!rawLine || !rawLine.includes(":")) continue;
+    const idx = rawLine.indexOf(":");
+    out[rawLine.slice(0, idx).trim()] = rawLine.slice(idx + 1).trim();
+  }
+  return out;
+}
+
+function buildBody(req: PlaygroundChatRequest): Record<string, unknown> {
+  const p = req.params ?? {};
+  const body: Record<string, unknown> = {
+    model: req.model,
+    messages: req.messages,
+  };
+  if (p.temperature !== undefined) body.temperature = p.temperature;
+  if (p.maxTokens !== undefined) body.max_tokens = p.maxTokens;
+  if (p.topP !== undefined) body.top_p = p.topP;
+  if (p.frequencyPenalty !== undefined) body.frequency_penalty = p.frequencyPenalty;
+  if (p.presencePenalty !== undefined) body.presence_penalty = p.presencePenalty;
+  if (p.seed !== undefined) body.seed = p.seed;
+  if (p.stop !== undefined) body.stop = p.stop;
+  // Phase 1: stream is ignored (always non-streaming).
+  return body;
+}
+
+@Injectable()
+export class ChatService {
+  async run(req: PlaygroundChatRequest): Promise<PlaygroundChatResponse> {
+    const url = req.apiBaseUrl + (req.pathOverride ?? DEFAULT_PATH);
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${req.apiKey}`,
+      ...parseHeaderLines(req.customHeaders),
+    };
+    const start = Date.now();
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(buildBody(req)),
+      });
+      const latencyMs = Date.now() - start;
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        return {
+          success: false,
+          error: `upstream ${res.status}: ${text || res.statusText}`.slice(0, 1024),
+          latencyMs,
+        };
+      }
+      const json = (await res.json()) as {
+        choices?: Array<{ message?: { content?: string } }>;
+        usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+      };
+      const content = json.choices?.[0]?.message?.content ?? "";
+      return {
+        success: true,
+        content,
+        latencyMs,
+        usage: json.usage,
+      };
+    } catch (e) {
+      return {
+        success: false,
+        error: e instanceof Error ? e.message : String(e),
+        latencyMs: Date.now() - start,
+      };
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Implement `chat.controller.ts`**
+
+Create `apps/api/src/modules/playground/chat.controller.ts`:
+
+```ts
+import {
+  type PlaygroundChatRequest,
+  PlaygroundChatRequestSchema,
+  type PlaygroundChatResponse,
+  PlaygroundChatResponseSchema,
+} from "@modeldoctor/contracts";
+import { Body, Controller, HttpCode, HttpStatus, Post, UsePipes } from "@nestjs/common";
+import { ApiBody, ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { createZodDto } from "nestjs-zod";
+import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
+import { ChatService } from "./chat.service.js";
+
+class PlaygroundChatRequestDto extends createZodDto(PlaygroundChatRequestSchema) {}
+class PlaygroundChatResponseDto extends createZodDto(PlaygroundChatResponseSchema) {}
+
+@ApiTags("playground")
+@Controller("playground")
+export class ChatController {
+  constructor(private readonly svc: ChatService) {}
+
+  @ApiOperation({ summary: "Send a chat completion via the Playground (non-streaming)" })
+  @ApiBody({ type: PlaygroundChatRequestDto })
+  @ApiOkResponse({ type: PlaygroundChatResponseDto })
+  @Post("chat")
+  @HttpCode(HttpStatus.OK)
+  @UsePipes(new ZodValidationPipe(PlaygroundChatRequestSchema))
+  chat(@Body() body: PlaygroundChatRequest): Promise<PlaygroundChatResponse> {
+    return this.svc.run(body);
+  }
+}
+```
+
+- [ ] **Step 5: Implement `playground.module.ts`**
+
+Create `apps/api/src/modules/playground/playground.module.ts`:
+
+```ts
+import { Module } from "@nestjs/common";
+import { ChatController } from "./chat.controller.js";
+import { ChatService } from "./chat.service.js";
+
+@Module({
+  controllers: [ChatController],
+  providers: [ChatService],
+})
+export class PlaygroundModule {}
+```
+
+- [ ] **Step 6: Register the module in `app.module.ts`**
+
+Open `apps/api/src/app.module.ts`. Add the import alphabetically near other modules:
+
+```ts
+import { PlaygroundModule } from "./modules/playground/playground.module.js";
+```
+
+Add to the `imports` array (after `LoadTestModule` is fine):
+
+```ts
+LoadTestModule,
+PlaygroundModule,
+BenchmarkModule,
+```
+
+- [ ] **Step 7: Run the service spec to verify it passes**
+
+```bash
+pnpm -F @modeldoctor/api test --run src/modules/playground/chat.service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run the full api test suite + type-check**
+
+```bash
+pnpm -F @modeldoctor/api test --run
+pnpm -F @modeldoctor/api type-check
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/src/modules/playground/playground.module.ts apps/api/src/modules/playground/chat.controller.ts apps/api/src/modules/playground/chat.service.ts apps/api/src/modules/playground/chat.service.spec.ts apps/api/src/app.module.ts
+git commit -m "$(cat <<'EOF'
+feat(api/playground): POST /api/playground/chat (non-streaming)
+
+Forwards a chat-completions request to the user's upstream URL with
+Bearer auth and merged custom headers. CamelCase params are mapped to
+the OpenAI-canonical snake_case body. Errors (upstream non-2xx + network
+faults) are returned as { success: false, error, latencyMs }.
+
+Streaming SSE is deferred to Phase 2.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Frontend chat store
+
+**Files:**
+- Create: `apps/web/src/features/playground/chat/store.ts`
+- Create: `apps/web/src/features/playground/chat/store.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `apps/web/src/features/playground/chat/store.test.ts`:
+
+```ts
+import type { ChatMessage } from "@modeldoctor/contracts";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useChatStore } from "./store";
+
+describe("useChatStore", () => {
+  beforeEach(() => {
+    useChatStore.getState().reset();
+  });
+
+  it("starts empty", () => {
+    const s = useChatStore.getState();
+    expect(s.selectedConnectionId).toBeNull();
+    expect(s.messages).toEqual([]);
+    expect(s.systemMessage).toBe("");
+    expect(s.sending).toBe(false);
+  });
+
+  it("appendMessage adds to the end", () => {
+    const m: ChatMessage = { role: "user", content: "hi" };
+    useChatStore.getState().appendMessage(m);
+    expect(useChatStore.getState().messages).toEqual([m]);
+  });
+
+  it("setSelected stores the connection id", () => {
+    useChatStore.getState().setSelected("conn-1");
+    expect(useChatStore.getState().selectedConnectionId).toBe("conn-1");
+  });
+
+  it("patchParams merges with existing params", () => {
+    useChatStore.getState().patchParams({ temperature: 0.5 });
+    useChatStore.getState().patchParams({ maxTokens: 100 });
+    expect(useChatStore.getState().params).toEqual({ temperature: 0.5, maxTokens: 100 });
+  });
+
+  it("clearMessages keeps system message but drops messages", () => {
+    useChatStore.getState().setSystemMessage("you are helpful");
+    useChatStore.getState().appendMessage({ role: "user", content: "hi" });
+    useChatStore.getState().clearMessages();
+    expect(useChatStore.getState().messages).toEqual([]);
+    expect(useChatStore.getState().systemMessage).toBe("you are helpful");
+  });
+
+  it("reset wipes everything", () => {
+    useChatStore.getState().setSystemMessage("x");
+    useChatStore.getState().appendMessage({ role: "user", content: "y" });
+    useChatStore.getState().setSelected("c");
+    useChatStore.getState().reset();
+    expect(useChatStore.getState().selectedConnectionId).toBeNull();
+    expect(useChatStore.getState().messages).toEqual([]);
+    expect(useChatStore.getState().systemMessage).toBe("");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm -F @modeldoctor/web test --run src/features/playground/chat/store.test.ts
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `store.ts`**
+
+Create `apps/web/src/features/playground/chat/store.ts`:
+
+```ts
+import type { ChatMessage, ChatParams } from "@modeldoctor/contracts";
+import { create } from "zustand";
+
+export interface ChatStoreState {
+  selectedConnectionId: string | null;
+  systemMessage: string;
+  messages: ChatMessage[];
+  params: ChatParams;
+  sending: boolean;
+  error: string | null;
+  setSelected: (id: string | null) => void;
+  setSystemMessage: (s: string) => void;
+  appendMessage: (m: ChatMessage) => void;
+  clearMessages: () => void;
+  patchParams: (p: Partial<ChatParams>) => void;
+  setSending: (b: boolean) => void;
+  setError: (s: string | null) => void;
+  reset: () => void;
+}
+
+const initial = {
+  selectedConnectionId: null,
+  systemMessage: "",
+  messages: [] as ChatMessage[],
+  params: {} as ChatParams,
+  sending: false,
+  error: null as string | null,
+};
+
+export const useChatStore = create<ChatStoreState>((set) => ({
+  ...initial,
+  setSelected: (id) => set({ selectedConnectionId: id }),
+  setSystemMessage: (s) => set({ systemMessage: s }),
+  appendMessage: (m) => set((s) => ({ messages: [...s.messages, m] })),
+  clearMessages: () => set({ messages: [] }),
+  patchParams: (p) => set((s) => ({ params: { ...s.params, ...p } })),
+  setSending: (b) => set({ sending: b }),
+  setError: (e) => set({ error: e }),
+  reset: () => set({ ...initial }),
+}));
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm -F @modeldoctor/web test --run src/features/playground/chat/store.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/features/playground/chat/store.ts apps/web/src/features/playground/chat/store.test.ts
+git commit -m "$(cat <<'EOF'
+feat(web/playground/chat): zustand store for chat session state
+
+Plain in-memory store (no persist) — Phase 2 will add the per-modality
+HistoryStore that wraps it. Holds the selected connection id, system
+message, message list, params, send-in-flight bool, and last error.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Chat sub-components — `MessageList`, `MessageComposer`, `ChatParams`
+
+**Files:**
+- Create: `apps/web/src/features/playground/chat/MessageList.tsx`
+- Create: `apps/web/src/features/playground/chat/MessageComposer.tsx`
+- Create: `apps/web/src/features/playground/chat/ChatParams.tsx`
+
+These three are presentational, get tested transitively by `ChatPage.test.tsx` in Task 13. No standalone tests — keeps Phase 1 lean.
+
+- [ ] **Step 1: Implement `MessageList.tsx`**
+
+Create `apps/web/src/features/playground/chat/MessageList.tsx`:
+
+```tsx
+import type { ChatMessage } from "@modeldoctor/contracts";
+import { useTranslation } from "react-i18next";
+
+function renderContent(m: ChatMessage): string {
+  if (typeof m.content === "string") return m.content;
+  return m.content
+    .map((p) => (p.type === "text" ? p.text : `[${p.type}]`))
+    .join(" ");
+}
+
+export function MessageList({ messages }: { messages: ChatMessage[] }) {
+  const { t } = useTranslation("playground");
+
+  if (messages.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        {t("chat.messages.empty")}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3 px-6 py-4">
+      {messages.map((m, idx) => (
+        <div key={`${idx}-${m.role}`} className="rounded-md border border-border bg-card p-3">
+          <div className="mb-1 text-xs font-semibold text-muted-foreground">
+            {t(`chat.messages.${m.role}`)}
+          </div>
+          <div className="whitespace-pre-wrap text-sm">{renderContent(m)}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Implement `MessageComposer.tsx`**
+
+Create `apps/web/src/features/playground/chat/MessageComposer.tsx`:
+
+```tsx
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+interface MessageComposerProps {
+  systemMessage: string;
+  onSystemMessageChange: (s: string) => void;
+  onSend: (text: string) => void;
+  sending: boolean;
+  disabled: boolean;
+  disabledReason?: string;
+}
+
+export function MessageComposer({
+  systemMessage,
+  onSystemMessageChange,
+  onSend,
+  sending,
+  disabled,
+  disabledReason,
+}: MessageComposerProps) {
+  const { t } = useTranslation("playground");
+  const [draft, setDraft] = useState("");
+
+  const submit = () => {
+    if (disabled || sending) return;
+    const text = draft.trim();
+    if (!text) return;
+    onSend(text);
+    setDraft("");
+  };
+
+  return (
+    <div className="border-t border-border bg-card px-6 py-3">
+      <details className="mb-2">
+        <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
+          {t("chat.system.label")}
+        </summary>
+        <Textarea
+          rows={2}
+          value={systemMessage}
+          onChange={(e) => onSystemMessageChange(e.target.value)}
+          placeholder={t("chat.system.placeholder")}
+          className="mt-2 font-mono text-xs"
+        />
+      </details>
+      <div className="flex gap-2">
+        <Textarea
+          rows={2}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              submit();
+            }
+          }}
+          placeholder={t("chat.composer.placeholder")}
+          className="text-sm"
+          disabled={disabled || sending}
+        />
+        <Button
+          onClick={submit}
+          disabled={disabled || sending || !draft.trim()}
+          title={disabled ? disabledReason : undefined}
+        >
+          {sending ? t("chat.composer.sending") : t("chat.composer.send")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Implement `ChatParams.tsx`**
+
+Create `apps/web/src/features/playground/chat/ChatParams.tsx`:
+
+```tsx
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { ChatParams as ChatParamsType } from "@modeldoctor/contracts";
+import { useTranslation } from "react-i18next";
+
+interface ChatParamsProps {
+  value: ChatParamsType;
+  onChange: (patch: Partial<ChatParamsType>) => void;
+}
+
+function NumField({
+  label,
+  value,
+  onChange,
+  step = 0.1,
+  min,
+  max,
+}: {
+  label: string;
+  value: number | undefined;
+  onChange: (v: number | undefined) => void;
+  step?: number;
+  min?: number;
+  max?: number;
+}) {
+  return (
+    <div>
+      <Label className="text-xs text-muted-foreground">{label}</Label>
+      <Input
+        type="number"
+        step={step}
+        min={min}
+        max={max}
+        value={value ?? ""}
+        onChange={(e) => onChange(e.target.value === "" ? undefined : Number(e.target.value))}
+        className="h-8 text-xs"
+      />
+    </div>
+  );
+}
+
+export function ChatParams({ value, onChange }: ChatParamsProps) {
+  const { t } = useTranslation("playground");
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-semibold">{t("chat.params.title")}</h3>
+      <NumField label={t("chat.params.temperature")} value={value.temperature} onChange={(v) => onChange({ temperature: v })} step={0.1} min={0} max={2} />
+      <NumField label={t("chat.params.maxTokens")} value={value.maxTokens} onChange={(v) => onChange({ maxTokens: v })} step={1} min={1} />
+      <NumField label={t("chat.params.topP")} value={value.topP} onChange={(v) => onChange({ topP: v })} step={0.05} min={0} max={1} />
+      <NumField label={t("chat.params.frequencyPenalty")} value={value.frequencyPenalty} onChange={(v) => onChange({ frequencyPenalty: v })} step={0.1} min={-2} max={2} />
+      <NumField label={t("chat.params.presencePenalty")} value={value.presencePenalty} onChange={(v) => onChange({ presencePenalty: v })} step={0.1} min={-2} max={2} />
+      <NumField label={t("chat.params.seed")} value={value.seed} onChange={(v) => onChange({ seed: v })} step={1} />
+      <div>
+        <Label className="text-xs text-muted-foreground">{t("chat.params.stop")}</Label>
+        <Input
+          value={value.stop?.join(",") ?? ""}
+          onChange={(e) => onChange({ stop: e.target.value ? e.target.value.split(",").map((s) => s.trim()).filter(Boolean) : undefined })}
+          placeholder=","
+          className="h-8 text-xs"
+        />
+      </div>
+      <p className="text-[10px] italic text-muted-foreground">{t("chat.params.stream")}</p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+pnpm -F @modeldoctor/web type-check
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/features/playground/chat/MessageList.tsx apps/web/src/features/playground/chat/MessageComposer.tsx apps/web/src/features/playground/chat/ChatParams.tsx
+git commit -m "$(cat <<'EOF'
+feat(web/playground/chat): MessageList, MessageComposer, ChatParams
+
+Three presentational pieces consumed by ChatPage. Composer collapses
+the system-message field into a <details> to keep visual weight low.
+Params are 8 number/text inputs (no sliders in Phase 1 — defer until
+the design system has a slider primitive).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Assemble `ChatPage` and wire end-to-end
+
+**Files:**
+- Modify (replace stub): `apps/web/src/features/playground/chat/ChatPage.tsx`
+- Create: `apps/web/src/features/playground/chat/ChatPage.test.tsx`
+
+- [ ] **Step 1: Write the failing page test**
+
+Create `apps/web/src/features/playground/chat/ChatPage.test.tsx`:
+
+```tsx
+import "@/lib/i18n";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useConnectionsStore } from "@/stores/connections-store";
+import { ChatPage } from "./ChatPage";
+import { useChatStore } from "./store";
+
+vi.mock("@/lib/api-client", () => {
+  class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  }
+  return {
+    ApiError,
+    api: { get: vi.fn(), post: vi.fn() },
+  };
+});
+
+import { api } from "@/lib/api-client";
+
+function seedChatConn() {
+  useConnectionsStore.getState().create({
+    name: "chat-1",
+    apiBaseUrl: "http://x",
+    apiKey: "k",
+    model: "m",
+    customHeaders: "",
+    queryParams: "",
+    category: "chat",
+    tags: [],
+  });
+}
+
+describe("ChatPage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useConnectionsStore.setState({ connections: [] });
+    useChatStore.getState().reset();
+    vi.mocked(api.post).mockReset();
+  });
+
+  it("send button is disabled until a connection is selected", () => {
+    seedChatConn();
+    render(
+      <MemoryRouter>
+        <ChatPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("button", { name: /send|发送/i })).toBeDisabled();
+  });
+
+  it("sends to /api/playground/chat and renders the assistant reply", async () => {
+    vi.mocked(api.post).mockResolvedValue({
+      success: true,
+      content: "hello back",
+      latencyMs: 12,
+    });
+    seedChatConn();
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <ChatPage />
+      </MemoryRouter>,
+    );
+
+    // Pick the connection
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /chat-1/i }));
+
+    // Type message
+    const input = screen.getByPlaceholderText(/type your message|输入消息/i);
+    await user.type(input, "hi there");
+    await user.click(screen.getByRole("button", { name: /^send$|^发送$/i }));
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith(
+        "/api/playground/chat",
+        expect.objectContaining({
+          apiBaseUrl: "http://x",
+          apiKey: "k",
+          model: "m",
+          messages: [{ role: "user", content: "hi there" }],
+        }),
+      );
+      expect(screen.getByText("hello back")).toBeInTheDocument();
+    });
+  });
+
+  it("renders an error toast (or inline error) when api returns success=false", async () => {
+    vi.mocked(api.post).mockResolvedValue({
+      success: false,
+      error: "upstream 500: boom",
+      latencyMs: 1,
+    });
+    seedChatConn();
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <ChatPage />
+      </MemoryRouter>,
+    );
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /chat-1/i }));
+    await user.type(screen.getByPlaceholderText(/type your message|输入消息/i), "hi");
+    await user.click(screen.getByRole("button", { name: /^send$|^发送$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/upstream 500: boom/)).toBeInTheDocument();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm -F @modeldoctor/web test --run src/features/playground/chat/ChatPage.test.tsx
+```
+
+Expected: FAIL — ChatPage is still the stub.
+
+- [ ] **Step 3: Replace the stub with the real `ChatPage.tsx`**
+
+Open `apps/web/src/features/playground/chat/ChatPage.tsx` and overwrite with:
+
+```tsx
+import { PageHeader } from "@/components/common/page-header";
+import { ApiError, api } from "@/lib/api-client";
+import { useConnectionsStore } from "@/stores/connections-store";
+import type { PlaygroundChatRequest, PlaygroundChatResponse } from "@modeldoctor/contracts";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { CategoryEndpointSelector } from "../CategoryEndpointSelector";
+import { PlaygroundShell } from "../PlaygroundShell";
+import { ChatParams } from "./ChatParams";
+import { MessageComposer } from "./MessageComposer";
+import { MessageList } from "./MessageList";
+import { useChatStore } from "./store";
+
+export function ChatPage() {
+  const { t } = useTranslation("playground");
+  const slice = useChatStore();
+  const conn = useConnectionsStore((s) =>
+    slice.selectedConnectionId ? s.get(slice.selectedConnectionId) : null,
+  );
+
+  const canSend = !!conn;
+  const disabledReason = canSend ? undefined : t("chat.composer.needConnection");
+
+  const onSend = async (text: string) => {
+    if (!conn) return;
+    slice.appendMessage({ role: "user", content: text });
+    slice.setSending(true);
+    slice.setError(null);
+
+    const messages = (
+      slice.systemMessage.trim()
+        ? [{ role: "system" as const, content: slice.systemMessage.trim() }]
+        : []
+    )
+      .concat(slice.messages)
+      .concat([{ role: "user", content: text }]);
+
+    const body: PlaygroundChatRequest = {
+      apiBaseUrl: conn.apiBaseUrl,
+      apiKey: conn.apiKey,
+      model: conn.model,
+      customHeaders: conn.customHeaders || undefined,
+      queryParams: conn.queryParams || undefined,
+      messages,
+      params: slice.params,
+    };
+    try {
+      const res = await api.post<PlaygroundChatResponse>("/api/playground/chat", body);
+      if (res.success) {
+        slice.appendMessage({ role: "assistant", content: res.content ?? "" });
+      } else {
+        const msg = res.error ?? "unknown";
+        slice.setError(msg);
+        toast.error(t("chat.errors.send", { message: msg }));
+      }
+    } catch (e) {
+      const msg = e instanceof ApiError ? e.message : "network";
+      slice.setError(msg);
+      toast.error(t("chat.errors.send", { message: msg }));
+    } finally {
+      slice.setSending(false);
+    }
+  };
+
+  return (
+    <PlaygroundShell
+      category="chat"
+      paramsSlot={
+        <div className="space-y-4">
+          <CategoryEndpointSelector
+            category="chat"
+            selectedConnectionId={slice.selectedConnectionId}
+            onSelect={slice.setSelected}
+          />
+          <ChatParams value={slice.params} onChange={slice.patchParams} />
+        </div>
+      }
+    >
+      <PageHeader title={t("chat.title")} subtitle={t("chat.subtitle")} />
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex-1 overflow-y-auto">
+          <MessageList messages={slice.messages} />
+          {slice.error ? (
+            <div className="mx-6 mt-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+              {slice.error}
+            </div>
+          ) : null}
+        </div>
+        <MessageComposer
+          systemMessage={slice.systemMessage}
+          onSystemMessageChange={slice.setSystemMessage}
+          onSend={onSend}
+          sending={slice.sending}
+          disabled={!canSend}
+          disabledReason={disabledReason}
+        />
+      </div>
+    </PlaygroundShell>
+  );
+}
+```
+
+- [ ] **Step 4: Run the page test to verify it passes**
+
+```bash
+pnpm -F @modeldoctor/web test --run src/features/playground/chat/ChatPage.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full web test suite + type-check**
+
+```bash
+pnpm -F @modeldoctor/web test --run
+pnpm -F @modeldoctor/web type-check
+```
+
+Expected: ALL PASS, type-check clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/features/playground/chat/ChatPage.tsx apps/web/src/features/playground/chat/ChatPage.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(web/playground/chat): wire ChatPage end-to-end
+
+Replaces the Task 6 stub: assembles PlaygroundShell + Selector +
+MessageList + MessageComposer + ChatParams, and on Send POSTs to
+/api/playground/chat. Errors surface as both an inline error block and
+a toast.
+
+Phase 1 omits streaming, multimodal attachments, view-code, and
+history — all in subsequent phases.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: End-to-end manual smoke verification
+
+No code, no commit — this is the human acceptance gate. **Do not skip.**
+
+- [ ] **Step 1: Start the backend**
+
+```bash
+pnpm -F @modeldoctor/api dev
+```
+
+Expected: Nest boots cleanly; logs include `playground` controller registration around `[RouterExplorer]`.
+
+- [ ] **Step 2: Start the frontend in a separate shell**
+
+```bash
+pnpm -F @modeldoctor/web dev
+```
+
+Expected: Vite serves at `http://localhost:5173` (or printed port).
+
+- [ ] **Step 3: Smoke the new flow in a browser**
+
+1. Visit `http://localhost:5173/connections`. Confirm: empty connections page (any prior v1 data was discarded by Task 3).
+2. Click `+ New connection`. Confirm: dialog now shows a `Category` dropdown and a `Tags` input strip.
+3. Create a chat connection pointing at any OpenAI-compatible endpoint you control (e.g., a local vLLM, an LM Studio, or a free OpenRouter key). Choose category `Chat`, optionally add tag `vLLM`.
+4. Confirm the row appears with a `Chat` badge and the chip in the table.
+5. Click the new `Playground → Chat` item in the sidebar. URL should be `/playground/chat`.
+6. Confirm: right ParamsPanel shows the connection picker with **only your chat connection** listed (since show-all is off).
+7. Pick the connection. Type "say hello in one word" in the composer. Press Enter (or click Send).
+8. Confirm: a `user` bubble appears with your text, and within a few seconds an `assistant` bubble appears with the model's reply.
+9. Confirm: the network tab shows a single `POST /api/playground/chat` returning 200 with `{success: true, content: "...", latencyMs: ...}`.
+10. Force an error: edit the connection's `apiBaseUrl` to `http://127.0.0.1:1` (a closed port). Send another message. Confirm: a red inline error block AND a toast both surface the network error message.
+11. Sidebar smoke: confirm the four other Playground items (`Image / Audio / Embeddings / Rerank`) all show the "coming soon" badge and route to the existing `<ComingSoonRoute>` placeholder.
+
+If any of the 11 checks fails, file the issue against the corresponding task and fix before merging.
+
+---
+
+## Self-Review (run before opening PR)
+
+These checks were performed against the spec and the plan above before this plan was finalized. Re-run them after implementation to catch drift:
+
+1. **Spec coverage** — Phase 1 deliverables in spec § 10 mapped to tasks:
+   - "提取 ModalityCategorySchema" → Task 1 ✓
+   - "Connection 模型加 category + tags" → Tasks 2-5 ✓
+   - "CategoryEndpointSelector / PlaygroundShell / ParamsPanel" → Tasks 7, 8 ✓
+   - "ViewCodeDialog / HistoryStore" → **Deferred** (documented in Phase 1 omissions header)
+   - "路由壳 + sidebar 分组 + i18n key 落位" → Task 6 ✓
+   - "ChatPage 仅文本、非流式、不带历史" → Tasks 11, 12, 13 ✓
+   - "后端 /api/playground/chat 非流式" → Tasks 9, 10 ✓
+   - "验收标准" → Task 14 ✓
+
+2. **Placeholder scan** — no TBD/TODO/"similar to" patterns. Every code block is concrete.
+
+3. **Type consistency** —
+   - `ModalityCategory` used identically in `Connection`, `connectionInputSchema`, `CategoryEndpointSelector`, sidebar config: ✓
+   - `ChatMessage`, `ChatParams`, `PlaygroundChatRequest`, `PlaygroundChatResponse` consumed identically by frontend store, ChatPage, backend service, and contracts: ✓
+   - `useChatStore` action names (`appendMessage`, `clearMessages`, `patchParams`, `setSelected`, `setSending`, `setError`, `setSystemMessage`, `reset`) consistent across store + ChatPage + tests: ✓
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-29-playground-phase-1-foundation.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — Execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-29-playground-design.md
+++ b/docs/superpowers/specs/2026-04-29-playground-design.md
@@ -1,0 +1,516 @@
+# Playground 设计方案
+
+**日期**：2026-04-29
+**作者**：weetime001@gmail.com（与 Claude 协同 brainstorming）
+**状态**：approved — 待 writing-plans 拆解
+**相关**：
+- 复用 E2E Smoke 的 `ProbeCategorySchema`（[`packages/contracts/src/e2e-test.ts`](../../../packages/contracts/src/e2e-test.ts)）
+- 复用 `EndpointPicker` / `EndpointSelector` 模式（[`apps/web/src/components/connection/EndpointPicker.tsx`](../../../apps/web/src/components/connection/EndpointPicker.tsx)）
+- 参照 GPUStack Playground UX（chat / image / audio / embedding / rerank 5 sub-page）
+
+## 1. 目标
+
+为 ModelDoctor 增加一个手动验证用的 Playground 区域，覆盖 5 类模态：对话 / 图像 / 语音 (TTS+ASR) / 嵌入 / 重排。Playground 与现有的"性能 / 正确性 / 可观测性"侧边栏分组并列，定位是**手动体验 + 调参 + 生成示例代码**，与 E2E Smoke 的"自动化 probe"和 Load Test 的"压测"互补。
+
+同时为支持 Playground 的"按模态过滤连接"体验，扩展 Connection 数据模型，加入 `category`（必填单选）+ `tags`（自由多选），并在所有 Connection 相关 UI 中展示与编辑。
+
+## 2. 范围
+
+### 2.1 v1 包含
+
+- 5 个模态 sub-page：Chat / Image / Audio / Embeddings / Rerank
+- 多模型对比（Chat 的 2/3/4 panel 并排）
+- Embeddings 输出的 2D PCA 可视化（自写 SVG）
+- 各模态独立的会话历史（localStorage，最近 20 条）
+- View Code 弹窗：curl / Python / Node.js
+- Connection 模型扩展：category + tags
+- "智能默认 + 手动展开" 的连接过滤策略
+
+### 2.2 v1 不包含（留 v2+）
+
+- Image 编辑/inpaint（蒙版画布交互）
+- Compare 模式扩展到 6 panel
+- 历史持久化到后端
+- "文件" 类多模态附件（仅 placeholder）
+- PCA 升级到完整图表库
+
+## 3. 数据模型变更
+
+### 3.1 Connection 扩展
+
+`apps/web/src/types/connection.ts`：
+
+```ts
+export type ConnectionCategory = 'chat' | 'audio' | 'embeddings' | 'rerank' | 'image';
+
+export interface Connection {
+  id: string;
+  name: string;
+  apiBaseUrl: string;
+  apiKey: string;
+  model: string;
+  customHeaders: string;
+  queryParams: string;
+  category: ConnectionCategory;   // 新增·必填
+  tags: string[];                  // 新增·可选 (默认 [])
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+### 3.2 Contracts 共用化
+
+把 `packages/contracts/src/e2e-test.ts` 中的 `ProbeCategorySchema` 提到新文件 `packages/contracts/src/modality.ts` 重命名为 `ModalityCategorySchema`：
+
+```ts
+export const ModalityCategorySchema = z.enum(['chat', 'audio', 'embeddings', 'rerank', 'image']);
+export type ModalityCategory = z.infer<typeof ModalityCategorySchema>;
+```
+
+`e2e-test.ts` 改为 `export const ProbeCategorySchema = ModalityCategorySchema;` 别名（保留向后兼容的命名）。前端 `Connection.category` 直接用 `ModalityCategory`。
+
+### 3.3 localStorage 迁移
+
+`connections-store` 的 persist version 由 `1` bump 到 `2`。按 CLAUDE.md "no compat shims" 政策：旧数据被 zustand persist 自动丢弃，UI 显示空连接库提示。导出 JSON 的 `version` 字段同步 bump（旧导出文件导入时报错"版本不兼容"）。
+
+### 3.4 Tag 预设
+
+`ConnectionDialog` 的 tag 输入下方建议列表 = `所有现有 connection 的 tags ∪ 内置预设`：
+
+```ts
+const PRESET_TAGS = ['vLLM', 'SGLang', 'TGI', 'Ollama', 'OpenAI', 'Anthropic', '多模态', 'streaming', 'production', 'test'];
+```
+
+校验：去重 + trim + 过滤空字符串。
+
+## 4. 路由 & 侧边栏
+
+### 4.1 新路由（`apps/web/src/router/index.tsx`）
+
+```
+/playground                 → redirect /playground/chat
+/playground/chat            → ChatPage
+/playground/chat/compare    → ChatComparePage
+/playground/image           → ImagePage
+/playground/audio           → AudioPage   (内部 ?tab=tts|stt)
+/playground/embeddings      → EmbeddingsPage
+/playground/rerank          → RerankPage
+```
+
+均位于 `<ProtectedRoute>` 之下，与现有页面同级。
+
+### 4.2 侧边栏分组
+
+新增 group `playground` 排在 `performance` 之上：
+
+```
+▼ Playground
+  💬 Chat
+  🖼 Image
+  🎙 Audio
+  🧬 Embeddings
+  ↕ Rerank
+▼ Performance
+  ...
+```
+
+`Compare` 不作为单独侧边栏 item — 它是 ChatPage 顶部的二级 tab。
+
+### 4.3 i18n 命名空间
+
+新增 `apps/web/src/locales/{en-US,zh-CN}/playground.json`，结构：
+
+```json
+{
+  "title": "Playground",
+  "categories": { "chat": "...", "image": "...", "audio": "...", "embeddings": "...", "rerank": "..." },
+  "chat": { "system": {}, "composer": {}, "params": {}, "compare": {} },
+  "image": {}, "audio": { "tts": {}, "stt": {} }, "embeddings": {}, "rerank": {},
+  "viewCode": { "title", "copy", "keyPlaceholder" },
+  "history": { "title", "newSession", "restore", "empty" },
+  "endpoint": { "categoryFilter", "showAll", "categoryMismatch" }
+}
+```
+
+`sidebar.json` 加 `groups.playground` + 5 个 items。`connections.json` 加 `category.*` + `tags.*` 相关 key。
+
+## 5. 共用 UI 组件
+
+### 5.1 `PlaygroundShell`
+
+所有 sub-page 套这个壳。布局：
+
+```
+┌────────────────────────────────────────────────────────┐
+│ [tabs (可选)]                  [</> 查看代码] [⊟ 折叠] │  header
+├──────────────────────────────────────┬─────────────────┤
+│                                      │  连接 ▾          │
+│  主区 (sub-page 自定义内容)           │  ─────────────  │
+│                                      │  <paramsSlot/>   │
+└──────────────────────────────────────┴─────────────────┘
+```
+
+Props：
+
+```ts
+interface PlaygroundShellProps {
+  category: ModalityCategory;
+  tabs?: Array<{ key: string; label: string }>;
+  activeTab?: string;
+  onTabChange?: (k: string) => void;
+  viewCodeSnippets?: { curl: string; python: string; node: string } | null;
+  paramsSlot: React.ReactNode;
+  rightPanelDefaultOpen?: boolean;
+  children: React.ReactNode; // 主区
+}
+```
+
+折叠状态由各模态 store 持久化。
+
+### 5.2 `CategoryEndpointSelector`
+
+新建组件（**不改** 现有 `EndpointSelector`，避免破坏 Load Test/E2E 已有窄场景）。
+
+行为：
+- 默认下拉只列 `c.category === category` 的连接
+- 列表顶部 `[显示全部 □]` toggle；勾选后所有连接列出，但 `c.category !== category` 项**置灰** + hover tooltip "category 不匹配（仍可选用）"
+- 当前选中连接如不在过滤集合且 toggle 关闭：picker 顶部显示 warning chip "当前连接是 X 类，与本页 Y 不符 [清除选择]"
+- 底部 "+ 新建连接" 入口预填 `category = <当前页>`
+
+### 5.3 `ConnectionDialog` 升级
+
+- 新增 `category` 必填 `Select`（5 选项）
+- 新增 `tags` 输入：chip 风格 + Enter 添加 + 下方建议列表
+- 新增校验：category 必填；tags 去重 trim
+
+### 5.4 `ConnectionsPage` 升级
+
+表格新增 `category` 列（彩色徽章）+ `tags` 列（chip 串）；列表头加 `[category ▾]` `[tag ▾]` 多选 chip 过滤器。
+
+### 5.5 `ParamsPanel`
+
+极薄包装：折叠/展开过渡 + 滚动条 + 一致 padding/字号；不强制结构。
+
+### 5.6 `ViewCodeDialog`
+
+```ts
+interface ViewCodeDialogProps {
+  snippets: { curl: string; python: string; node: string };
+  open: boolean;
+  onOpenChange: (b: boolean) => void;
+}
+```
+
+shadcn `Tabs` × 3 + 每 tab 一个 `<pre>` + `[复制]` 按钮 + 底部小字 "API key replaced with placeholder"。
+
+### 5.7 `HistoryStore`
+
+每模态独立的 zustand store，key 区分（`md-playground-history-chat` 等）。
+
+```ts
+interface HistoryEntry<S> {
+  id: string;
+  createdAt: string;
+  connectionName: string | null;
+  snapshot: S;            // 模态 store 的可序列化部分
+  preview: string;        // UI 展示用的一行摘要
+}
+```
+
+语义：列表中**最新一条** ≡ 当前会话。即每个模态打开时，要么继承最新条目作为当前 session，要么（新用户/无历史）即 instant 创建一条空白条目作为 current。
+
+行为：
+- store 任何变更（消息、参数、连接）触发 debounce 1500ms → 更新当前条目（同一 id）的 snapshot + preview
+- 用户点 `[+ 新会话]`：在列表头部 prepend 新空白条目 → 当前 session 切到这条 → 旧条目自然变成"历史"
+- 列表 ≥ 20 时 LRU 淘汰最旧
+- 点击非当前条目 → 弹 confirm "覆盖当前会话？" → 把目标条目的 snapshot copy 进当前条目（不删除原条目；原条目变成"历史"中的一条）
+
+## 6. 各模态页面细节
+
+所有页面继承 `PlaygroundShell`，主区结构如下。
+
+### 6.1 Chat (`/playground/chat`)
+
+**主区**：
+- 顶部：`system message` 单行可编辑 textarea
+- 中：消息流。每条 = `<MessageBubble>`，含 role 切换 (user/assistant) / 删除 / 编辑；assistant 渲染 markdown + code-block + 复制按钮
+- 底：composer = 多行输入 + `[🖼 上传图]` `[🎙 上传音]` `[📄 文件 (placeholder)]` + `[+ 添加] [▷ 发送 / ⬛ 停止]`
+- 流式：assistant 消息一边到达一边渲染；停止按钮 abort `AbortController`
+
+**右侧参数**（连接 ▾ 之下）：Temperature / Max Tokens / Top P / Frequency Penalty / Presence Penalty / Seed / Stop Sequence / Stream toggle (默认 on)
+
+**多模态附件**：
+- 图：base64 → `image_url` content part
+- 音：base64 → `input_audio` content part
+- 文件：仅显示文件名（v1 不发送）
+
+**store**：
+
+```ts
+interface ChatStore {
+  selectedConnectionId: string | null;
+  endpoint: EndpointValues;
+  systemMessage: string;
+  messages: Message[];
+  params: ChatParams;
+  streaming: boolean;
+  rightPanelOpen: boolean;
+  // actions...
+}
+```
+
+**API**：`POST /api/playground/chat`
+
+### 6.2 Chat Compare (`/playground/chat/compare`)
+
+**顶部**：`[2 ▢▢] [3 ▢▢▢] [4 ▢▢▢▢]` panel 数切换
+
+**下方**：N 列并排，每列 = mini ChatPage（独立 connection / params / messages / streaming）。共用 `system message` 和顶部 composer。
+
+**发送**：composer 触发 → 并行 broadcast user message 到 N 个 panel → 各 panel 独立流式展示。
+
+**store**：`panels: PanelState[]`（每 panel 独立的 connection、params、messages、streaming）
+
+### 6.3 Image (`/playground/image`)
+
+**主区**：
+- 大块预览区（占 65vh 左右）：默认 placeholder "生成的图片将出现在这里"
+- 底部：prompt 输入 + `[🎲 随机]` 按钮 + `[▷ 发送]`
+- 生成完成后图片下方：`[下载] [复制 base64] [作为新输入]`
+
+**右侧参数**：尺寸 (256² / 512² / 1024² / 自定义) / Seed / 随机种子 toggle / N（默认 1）
+
+**store**：`prompt`, `params`, `result?: { url?: string, b64?: string }[]`, `loading`
+
+**API**：`POST /api/playground/images`
+
+### 6.4 Audio (`/playground/audio`)
+
+内部 tabs `文本转语音 / 语音转文本`，URL `?tab=tts|stt`（默认 tts）。
+
+#### 6.4.1 TTS
+
+**主区**：
+- 大预览区：音频 player (`<audio controls>`) 或 placeholder
+- 底部：文本输入 + `自动播放 ☑` toggle + `[▷ 发送]`
+
+**右侧参数**：声音 voice (string) / 格式 format (mp3 / wav / flac) / `▼ 高级`：任务类型 / 语言 / 说明 / Max Tokens / 参考音频上传 / 参考音频文本
+
+**API**：`POST /api/playground/audio/tts`
+
+#### 6.4.2 STT
+
+**主区**：上传区（drag & drop + `[🎙 录音]`）→ audio player → `[▷ 转录]` → 文本结果（可复制）
+
+**录音**：`MediaRecorder` API。非 https/localhost 时按钮 disabled + tooltip。权限拒绝走 toast.error。
+
+**右侧参数**：语言 (auto / zh / en / …) / 任务类型 (transcribe / translate)
+
+**API**：`POST /api/playground/audio/transcriptions`（multipart/form-data）
+
+### 6.5 Embeddings (`/playground/embeddings`)
+
+**主区上半**：编号文本行 + `[+ 添加文本] [清除] 批量输入 ☑` + `[▷ 发送]`。批量输入开启后变成单 textarea，按 `\n` split。
+
+**主区下半**：输出区
+- 子 tabs `图表 / JSON`
+- 图表：自写 SVG 散点图，输入数 ≥ 3 才出图（否则显示 "≥3 条文本才能可视化"）。点 hover 显示对应文本。PCA 实现：`apps/web/src/features/playground/embeddings/pca.ts` 纯函数 `computePca2D(vectors: number[][]): [x, y][]`，用 power-iteration 求前 2 个主成分（~80 行 TS，无外部依赖；典型 ≤ 30 点 × ≤ 4096 维 < 50ms）。
+- JSON：折叠 raw embeddings 数组，可复制
+
+**右侧参数**：encoding_format (float / base64) / dimensions (可选)
+
+**API**：`POST /api/playground/embeddings`
+
+### 6.6 Rerank (`/playground/rerank`)
+
+**主区**：query 单行 → 文档列表（同 Embeddings 编号行 + 批量模式）→ `[▷ 发送]` → 结果列表（按 score 降序，每条带 score 进度条 + 原始 index）
+
+**右侧参数**：Top N (默认 3) / return_documents toggle
+
+**API**：`POST /api/playground/rerank`（兼容 cohere 与 tei 两种 wire；通过 `pathOverride` 区分）
+
+## 7. 后端
+
+### 7.1 模块结构
+
+新增 `apps/api/src/modules/playground/`：
+
+```
+playground/
+├── playground.module.ts
+├── playground.controller.ts
+├── playground.service.ts
+├── chat/
+│   ├── chat.controller.ts        # POST /api/playground/chat (含 SSE 模式)
+│   └── chat.service.ts
+├── embeddings/  (controller + service)
+├── rerank/      (controller + service)
+├── images/      (controller + service)
+└── audio/
+    ├── tts.controller.ts          # POST /api/playground/audio/tts
+    └── stt.controller.ts          # POST /api/playground/audio/transcriptions (multipart)
+```
+
+### 7.2 共用 OpenAI 客户端
+
+把 E2E probe 现有的"构造 OpenAI 兼容请求 + 解析响应"逻辑抽到 `apps/api/src/integrations/openai-client/`：
+
+- `buildHeaders(apiKey, customHeaders)`
+- `buildUrl(apiBaseUrl, defaultPath, pathOverride)`
+- 各 wire 的 builder（chat / embeddings / rerank-cohere / rerank-tei / images / tts / stt）
+- 各 wire 的 response parser
+
+E2E probe 重构使用同一套（同一 PR 内或单独 refactor PR，留 plan 决定）。
+
+### 7.3 SSE 流式转发
+
+Chat 当 `params.stream === true`：
+
+```ts
+@Post('chat')
+async chat(@Body() body, @Res() res: Response) {
+  if (body.params?.stream) {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    const upstream = await fetch(url, { ... });
+    if (!upstream.body) throw ...;
+    const reader = upstream.body.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      res.write(value);
+    }
+    res.end();
+    return;
+  }
+  // 非流式：原样 JSON 透传
+  ...
+}
+```
+
+前端用 `fetch` + `reader.read()` 解析 SSE chunk（不用 `EventSource`，因为 `EventSource` 不支持 POST + Authorization header）。
+
+### 7.4 Contracts (`packages/contracts/src/playground.ts`)
+
+```ts
+export const PlaygroundChatRequestSchema = z.object({
+  apiBaseUrl: z.string().min(1),
+  apiKey: z.string().min(1),
+  model: z.string().min(1),
+  customHeaders: z.string().optional(),
+  queryParams: z.string().optional(),
+  pathOverride: z.string().optional(),
+  systemMessage: z.string().optional(),
+  messages: z.array(ChatMessageSchema).min(1),
+  params: z.object({
+    temperature: z.number().optional(),
+    maxTokens: z.number().int().positive().optional(),
+    topP: z.number().optional(),
+    frequencyPenalty: z.number().optional(),
+    presencePenalty: z.number().optional(),
+    seed: z.number().int().optional(),
+    stop: z.array(z.string()).optional(),
+    stream: z.boolean().optional(),
+  }).default({}),
+});
+
+export const ChatMessageSchema = z.object({
+  role: z.enum(['user', 'assistant', 'system']),
+  content: z.union([
+    z.string(),
+    z.array(z.discriminatedUnion('type', [
+      z.object({ type: z.literal('text'), text: z.string() }),
+      z.object({ type: z.literal('image_url'), image_url: z.object({ url: z.string() }) }),
+      z.object({ type: z.literal('input_audio'), input_audio: z.object({ data: z.string(), format: z.string() }) }),
+    ])),
+  ]),
+});
+
+// 类似的：PlaygroundEmbeddingsRequestSchema / Rerank / Images / TTS / STT
+```
+
+## 8. 代码生成
+
+每模态一个 pure 函数 `genSnippets(state): { curl, python, node }`：
+
+- `curl`：`curl -X POST $URL -H "Authorization: Bearer <YOUR_API_KEY>" -H "Content-Type: application/json" -d '<pretty json>'`
+- `python`：`from openai import OpenAI; client = OpenAI(base_url=..., api_key="<YOUR_API_KEY>"); resp = client.chat.completions.create(...)`
+- `node`：`import OpenAI from 'openai'; const client = new OpenAI({ baseURL: ..., apiKey: '<YOUR_API_KEY>' }); const resp = await client.chat.completions.create(...)`
+
+API key **始终** 用 `<YOUR_API_KEY>` 占位，不输出真实 key。弹窗底部小字声明这一点。
+
+## 9. 测试策略
+
+| 层 | 范围 | 工具 |
+|---|---|---|
+| Connection store | category 必填 / 默认 tags / v1→v2 reset / 导出 version 升级 | vitest |
+| 各模态 store | 增删消息 / patch params / 历史 LRU / restore 覆盖 | vitest |
+| `CategoryEndpointSelector` | 默认过滤 / 显示全部 / 不匹配 warning chip / "+ 新建" 预填 | vitest + RTL |
+| `ConnectionDialog` | category 必填校验 / tag chip 增删 / autocomplete 建议过滤 | vitest + RTL |
+| 各 sub-page render smoke | 空态、提交按钮 disabled 条件、流式中断 | vitest + RTL（mock fetch） |
+| `code-snippets` | snapshot：5 模态 × 3 语言 = 15 个 snapshot | vitest |
+| 后端 playground service | URL 拼接 / header 注入 / SSE pipe / 错误透传 | vitest（mock fetch） |
+| **不做** | 浏览器到真实上游的 e2e | — |
+
+## 10. 分阶段交付
+
+3 个 phase = 3 个 PR，从 `main` 切 `feat/playground-phase-N-<slug>` 分支。
+
+### Phase 1 · 地基（~2-3 天）
+
+- 提取 `ModalityCategorySchema` 到 `packages/contracts/src/modality.ts`，e2e-test 改用别名
+- Connection 模型加 category + tags（含 store v1→v2、Dialog UI、表格 UI、过滤 chip）
+- `CategoryEndpointSelector` 组件 + `PlaygroundShell` + `ParamsPanel` + `ViewCodeDialog` + `HistoryStore`
+- 路由壳 + sidebar 分组 + i18n key 落位
+- ChatPage **仅文本、非流式、不带历史** —— 跑通最小端到端
+- 后端 `/api/playground/chat` 非流式
+- 验收：能从空连接库新建 chat 类连接，在 ChatPage 选中，发一句话拿到 assistant 回复
+
+### Phase 2 · Chat 完善 + 三个静态模态（~3-4 天）
+
+- Chat 加 SSE 流式 / 多模态附件 / 停止按钮
+- ImagePage + EmbeddingsPage + RerankPage 完整
+- 各模态 ViewCode + History 接通
+- PCA SVG 自写
+- 后端 `/api/playground/{embeddings,rerank,images}` + chat SSE
+- 验收：4 模态 + ViewCode + History 全部可用
+
+### Phase 3 · Audio + Compare（~3-4 天）
+
+- AudioPage TTS + STT（含 MediaRecorder）
+- 后端 `/api/playground/audio/{tts,transcriptions}`（multipart 的 transcriptions）
+- ChatComparePage 2/3/4 panel 并行
+- 验收：5 模态全开 + 多模型对比
+
+## 11. 项目约束自查
+
+- `apps/api/tsconfig.json` 不动 `incremental` ✓
+- vitest@2 / vitest@1 不统一 ✓
+- 无新增顶层依赖（PCA 自写 SVG）✓
+- 不动 prisma migrations / docker compose ✓
+- localStorage v1→v2 直接丢旧数据（已与用户确认）✓
+- conventional commits + 一 phase 一 PR ✓
+
+## 12. 与 E2E Smoke 的关系
+
+E2E Smoke 在 Playground 上线后**保留**，定位为互补而非替代：
+
+| 维度 | E2E Smoke | Playground |
+|---|---|---|
+| 任务 | 自动化 probe，输出 pass/fail | 手动体验 + 调参 |
+| 输入 | 固定 canned input | 用户自由输入 |
+| 输出 | 结构化 checks（latency / JSON 形状 / MIME / 内容不为空） | 模型原始响应 |
+| 协议探测 | 同 category 跑多个 wire 变体（`embeddings-openai` + `embeddings-tei` 都试） | 用户事先在 Connection 里指定 |
+| 典型时机 | 部署后快速验活、CI、连接配置完成后一键验证 | prompt 工程、demo、参数调优、问题复现 |
+
+典型互补流程：连接配错 → Playground 报错没头绪 → 切 E2E Smoke 一键看是 `tei` 还是 `openai` 形状能通 → 回去改 Connection 的 path → 再回 Playground 继续。
+
+**未来动作**：v2 观测到使用率重叠后再考虑是否把 E2E Smoke 降级为 Playground 内的一个 `[🩺 Smoke 检查]` 二级 tab。v1 保持现状。
+
+## 13. 开放问题（writing-plans 阶段决定）
+
+1. **E2E probe 的 `openai-client` 抽取的 PR 切法**。两种选项：
+   - (a) Phase 1 内做（reasonable，因为 Phase 1 后端就要用同一套 builder/parser；E2E 切换到新 client 是机械重构）
+   - (b) 单独前置 PR `refactor/openai-client-extraction`，再做 Phase 1
+   - 倾向 (b)，避免 Phase 1 PR 体积爆炸；但 plan 阶段可重新评估实际工作量。
+2. **历史条目的"复制覆盖" vs "切换指针"语义**（§ 5.7）：当前 spec 选 "复制" 以避免误编辑历史条目；如果 plan 阶段评估实现复杂度后觉得"切指针 + 显式只读"更简单，可重新讨论。

--- a/packages/contracts/src/e2e-test.ts
+++ b/packages/contracts/src/e2e-test.ts
@@ -23,7 +23,10 @@ export const ProbeNameSchema = z.enum([
 ]);
 export type ProbeName = z.infer<typeof ProbeNameSchema>;
 
-export const ProbeCategorySchema = z.enum(["chat", "audio", "embeddings", "rerank", "image"]);
+import { ModalityCategorySchema } from "./modality.js";
+
+// Alias kept for backwards-compatible naming inside e2e-probe code paths.
+export const ProbeCategorySchema = ModalityCategorySchema;
 export type ProbeCategory = z.infer<typeof ProbeCategorySchema>;
 
 /**

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -12,6 +12,7 @@ export * from "./errors.js";
 export * from "./common.js";
 export * from "./health.js";
 export * from "./debug-proxy.js";
+export * from "./modality.js";
 export * from "./e2e-test.js";
 export * from "./load-test.js";
 export * from "./auth.js";

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -17,3 +17,4 @@ export * from "./e2e-test.js";
 export * from "./load-test.js";
 export * from "./auth.js";
 export * from "./benchmark.js";
+export * from "./playground.js";

--- a/packages/contracts/src/modality.test.ts
+++ b/packages/contracts/src/modality.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { ModalityCategorySchema, type ModalityCategory } from "./modality.js";
+
+describe("ModalityCategorySchema", () => {
+  it("accepts each of the 5 known categories", () => {
+    for (const c of ["chat", "audio", "embeddings", "rerank", "image"] as ModalityCategory[]) {
+      expect(ModalityCategorySchema.parse(c)).toBe(c);
+    }
+  });
+
+  it("rejects unknown values", () => {
+    expect(() => ModalityCategorySchema.parse("video")).toThrow();
+  });
+});

--- a/packages/contracts/src/modality.test.ts
+++ b/packages/contracts/src/modality.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ModalityCategorySchema, type ModalityCategory } from "./modality.js";
+import { type ModalityCategory, ModalityCategorySchema } from "./modality.js";
 
 describe("ModalityCategorySchema", () => {
   it("accepts each of the 5 known categories", () => {

--- a/packages/contracts/src/modality.ts
+++ b/packages/contracts/src/modality.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+/**
+ * Single source of truth for the 5 model-service categories. Both the
+ * `Connection.category` field (in the web app) and the e2e-probe categories
+ * use this enum — keep it in sync.
+ *
+ * Iteration order determines display order in UI dropdowns.
+ */
+export const ModalityCategorySchema = z.enum(["chat", "audio", "embeddings", "rerank", "image"]);
+export type ModalityCategory = z.infer<typeof ModalityCategorySchema>;

--- a/packages/contracts/src/playground.test.ts
+++ b/packages/contracts/src/playground.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ChatMessage,
+  ChatMessageSchema,
+  type PlaygroundChatRequest,
+  PlaygroundChatRequestSchema,
+  type PlaygroundChatResponse,
+  PlaygroundChatResponseSchema,
+} from "./playground.js";
+
+describe("ChatMessageSchema", () => {
+  it("accepts a string-content message", () => {
+    expect(() => ChatMessageSchema.parse({ role: "user", content: "hello" })).not.toThrow();
+  });
+
+  it("accepts a content-parts array with text + image_url", () => {
+    expect(() =>
+      ChatMessageSchema.parse({
+        role: "user",
+        content: [
+          { type: "text", text: "what is in this image?" },
+          { type: "image_url", image_url: { url: "data:image/png;base64,iVB..." } },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects an unknown role", () => {
+    expect(() => ChatMessageSchema.parse({ role: "tool", content: "hi" })).toThrow();
+  });
+});
+
+describe("PlaygroundChatRequestSchema", () => {
+  const base = {
+    apiBaseUrl: "http://x.test",
+    apiKey: "k",
+    model: "m",
+    messages: [{ role: "user", content: "hi" }],
+  };
+
+  it("accepts a minimal request", () => {
+    expect(() => PlaygroundChatRequestSchema.parse(base)).not.toThrow();
+  });
+
+  it("requires at least one message", () => {
+    expect(() => PlaygroundChatRequestSchema.parse({ ...base, messages: [] })).toThrow();
+  });
+
+  it("defaults params to an empty object", () => {
+    const out = PlaygroundChatRequestSchema.parse(base);
+    expect(out.params).toEqual({});
+  });
+});
+
+describe("PlaygroundChatResponseSchema", () => {
+  it("accepts the OK shape", () => {
+    expect(() =>
+      PlaygroundChatResponseSchema.parse({
+        success: true,
+        content: "hi back",
+        latencyMs: 123,
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts an error shape", () => {
+    expect(() =>
+      PlaygroundChatResponseSchema.parse({
+        success: false,
+        error: "upstream 500",
+        latencyMs: 50,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/contracts/src/playground.ts
+++ b/packages/contracts/src/playground.ts
@@ -16,6 +16,7 @@ export const ChatMessageContentPartSchema = z.discriminatedUnion("type", [
     input_audio: z.object({ data: z.string(), format: z.string() }),
   }),
 ]);
+export type ChatMessageContentPart = z.infer<typeof ChatMessageContentPartSchema>;
 
 export const ChatMessageSchema = z.object({
   role: z.enum(["user", "assistant", "system"]),
@@ -37,6 +38,14 @@ export const ChatParamsSchema = z
   .partial();
 export type ChatParams = z.infer<typeof ChatParamsSchema>;
 
+/**
+ * Phase 1 request to POST /api/playground/chat (non-streaming).
+ *
+ * Note: there's no separate `systemMessage` field — callers prepend
+ * `{ role: "system", content: ... }` to `messages` directly. This keeps
+ * the wire shape closer to OpenAI's native chat-completions API and
+ * removes a layer of frontend-side message-array rebuilding.
+ */
 export const PlaygroundChatRequestSchema = z.object({
   apiBaseUrl: z.string().min(1),
   apiKey: z.string().min(1),

--- a/packages/contracts/src/playground.ts
+++ b/packages/contracts/src/playground.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+/**
+ * OpenAI-compatible chat message. Content is either a plain string OR an
+ * array of typed content parts (used for multimodal — image_url, input_audio
+ * — added in Phase 2).
+ */
+export const ChatMessageContentPartSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("text"), text: z.string() }),
+  z.object({
+    type: z.literal("image_url"),
+    image_url: z.object({ url: z.string() }),
+  }),
+  z.object({
+    type: z.literal("input_audio"),
+    input_audio: z.object({ data: z.string(), format: z.string() }),
+  }),
+]);
+
+export const ChatMessageSchema = z.object({
+  role: z.enum(["user", "assistant", "system"]),
+  content: z.union([z.string(), z.array(ChatMessageContentPartSchema)]),
+});
+export type ChatMessage = z.infer<typeof ChatMessageSchema>;
+
+export const ChatParamsSchema = z
+  .object({
+    temperature: z.number().optional(),
+    maxTokens: z.number().int().positive().optional(),
+    topP: z.number().optional(),
+    frequencyPenalty: z.number().optional(),
+    presencePenalty: z.number().optional(),
+    seed: z.number().int().optional(),
+    stop: z.array(z.string()).optional(),
+    stream: z.boolean().optional(),
+  })
+  .partial();
+export type ChatParams = z.infer<typeof ChatParamsSchema>;
+
+export const PlaygroundChatRequestSchema = z.object({
+  apiBaseUrl: z.string().min(1),
+  apiKey: z.string().min(1),
+  model: z.string().min(1),
+  customHeaders: z.string().optional(),
+  queryParams: z.string().optional(),
+  /** Override the default `/v1/chat/completions` path tail. */
+  pathOverride: z.string().optional(),
+  messages: z.array(ChatMessageSchema).min(1),
+  params: ChatParamsSchema.default({}),
+});
+export type PlaygroundChatRequest = z.infer<typeof PlaygroundChatRequestSchema>;
+
+export const PlaygroundChatResponseSchema = z.object({
+  success: z.boolean(),
+  /** Assistant's reply text. Present iff success === true. */
+  content: z.string().optional(),
+  /** Error message. Present iff success === false. */
+  error: z.string().optional(),
+  /** End-to-end wall-clock duration of the upstream call. */
+  latencyMs: z.number(),
+  /** Raw OpenAI usage block (if returned). */
+  usage: z
+    .object({
+      prompt_tokens: z.number().optional(),
+      completion_tokens: z.number().optional(),
+      total_tokens: z.number().optional(),
+    })
+    .optional(),
+});
+export type PlaygroundChatResponse = z.infer<typeof PlaygroundChatResponseSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,7 +155,7 @@ importers:
         version: 5.1.4(typescript@5.7.2)(vite@5.4.21(@types/node@20.19.39)(terser@5.46.1))
       vitest:
         specifier: ^2
-        version: 2.1.9(@types/node@20.19.39)(@vitest/ui@1.6.1)(jsdom@24.1.3)(terser@5.46.1)
+        version: 2.1.9(@types/node@20.19.39)(@vitest/ui@1.6.1(vitest@1.6.1))(jsdom@24.1.3)(terser@5.46.1)
 
   apps/web:
     dependencies:
@@ -192,6 +192,9 @@ importers:
       '@radix-ui/react-separator':
         specifier: ^1
         version: 1.1.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slider':
+        specifier: ^1.3.6
+        version: 1.3.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot':
         specifier: ^1
         version: 1.2.4(@types/react@18.3.28)(react@18.3.1)
@@ -1331,6 +1334,19 @@ packages:
 
   '@radix-ui/react-separator@1.1.8':
     resolution: {integrity: sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slider@1.3.6':
+    resolution: {integrity: sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6029,6 +6045,25 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-slider@1.3.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
   '@radix-ui/react-slot@1.2.3(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
@@ -9673,7 +9708,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@20.19.39)(@vitest/ui@1.6.1)(jsdom@24.1.3)(terser@5.46.1):
+  vitest@2.1.9(@types/node@20.19.39)(@vitest/ui@1.6.1(vitest@1.6.1))(jsdom@24.1.3)(terser@5.46.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.39)(terser@5.46.1))


### PR DESCRIPTION
## Summary

Two related deliverables on this branch:

**1. Playground Phase 1 — chat MVP + connection categorization** (the headline work)

Users can now create a `chat`-category Connection (with optional free-form `tags`), navigate to `/playground/chat`, pick the connection from a category-filtered dropdown, set parameters via slider+input combos, and exchange messages with the upstream model — all wired through `POST /api/playground/chat` (NestJS, non-streaming).

- **Connection model**: + `category: 'chat'|'audio'|'embeddings'|'rerank'|'image'` (required, single) + `tags: string[]` (optional, schema-trimmed/deduped). localStorage v1→v2; legacy data dropped per the no-compat-shims policy.
- **New shared schema**: `ModalityCategorySchema` extracted from `e2e-test.ts` so Connection + probes share one source of truth.
- **Playground area** under `/playground/*`: 1 live page (Chat) + 4 ComingSoon stubs (Image / Audio / Embeddings / Rerank). Sidebar gains a top-level "Playground" group above "Performance".
- **Shell primitives** (Phase 2/3-ready): `PlaygroundShell` (header + main + collapsible right `ParamsPanel` + optional tabs), `CategoryEndpointSelector` (filter + show-all toggle + mismatch warn).
- **Chat sub-page**: zustand store (no persist; pre-loaded with OpenAI default params), `MessageList` / `MessageComposer` / `ChatParams`. Five sliderable params (Temperature / Max Tokens / Top P / Frequency Penalty / Presence Penalty) use a new `Slider` shadcn primitive backed by `@radix-ui/react-slider`. Seed and Stop Sequence stay as plain inputs.
- **Backend**: `chat.service.ts` builds OpenAI-compatible body (camelCase → snake_case mapping), handles trailing-slash collapse, queryParams append, custom headers merge, Bearer auth, error truncation. 8 service tests covering URL edge cases + error paths.

**2. E2E Smoke matrix** (this branch's pre-existing work)

- Per-probe path override + category dropdown UI
- 10 probes across 5 categories
- Surface upstream response body + toast on probe failure

**Phase 1 deliberate omissions** (Phase 2 will cover): streaming SSE chat, multimodal attachments, ViewCodeDialog, HistoryStore, openai-client extraction, the 4 non-chat modalities.

**Spec**: `docs/superpowers/specs/2026-04-29-playground-design.md`
**Plan**: `docs/superpowers/plans/2026-04-29-playground-phase-1-foundation.md`

## Test Plan

- [x] `pnpm -r test --run` — 420 tests pass (contracts 43 / api 195 / web 182)
- [x] `pnpm -r lint` — exit 0 (4 pre-existing warnings in benchmark files unchanged)
- [x] `pnpm -r type-check` — exit 0
- [x] Manual smoke: create chat connection → /playground/chat → pick → multi-turn message → see assistant reply
- [x] Manual smoke: connection category filter (default + show-all)
- [x] Manual smoke: error injection (closed port) → red inline error block + sonner toast
- [x] Manual smoke: ConnectionDialog scrolls cleanly on a 13" laptop viewport

## Notes for the Reviewer

- The chat `onSend` relies on stale-closure semantics for the messages array — currently correct (verified by a multi-turn integration test) but flagged as fragile by the cross-branch review. **Phase 2's first commit will refactor this** alongside the streaming SSE work, since both touch `onSend` anyway.
- `endpoint.newConnection` i18n key is currently dead (no "+ New connection" button in `CategoryEndpointSelector` yet) — Phase 2 will add the button or remove the key.
- New top-level dependency: `@radix-ui/react-slider` (only new package; user-approved per CLAUDE.md gate).
- jsdom `ResizeObserver` stub added to `apps/web/src/test/setup.ts` (radix slider needs it; same file already stubs other browser APIs for radix primitives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)