### PR TITLE
fix(playground): issue #34 smoke-test fixes (3 items)

### DIFF
--- a/apps/web/src/features/playground/chat-compare/ChatComparePage.tsx
+++ b/apps/web/src/features/playground/chat-compare/ChatComparePage.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
 import { ApiError, api } from "@/lib/api-client";
 import { playgroundFetchStream } from "@/lib/playground-stream";
 import { useConnectionsStore } from "@/stores/connections-store";
@@ -125,22 +124,8 @@ export function ChatComparePage() {
       historySlot={<CompareHistoryControls />}
       toolbarRightSlot={<PanelCountSwitcher />}
     >
-      <div className="px-6 pb-3">
-        <details>
-          <summary className="cursor-pointer text-xs text-muted-foreground">
-            {t("chat.system.label")}
-          </summary>
-          <Textarea
-            rows={2}
-            value={sharedSystemMessage}
-            onChange={(e) => useCompareStore.getState().setSharedSystemMessage(e.target.value)}
-            placeholder={t("chat.system.placeholder")}
-            className="mt-2 font-mono text-xs"
-          />
-        </details>
-      </div>
       <div
-        className="grid min-h-0 flex-1 gap-3 overflow-x-auto px-6"
+        className="grid min-h-0 flex-1 gap-3 overflow-x-auto px-6 pt-3"
         style={{ gridTemplateColumns: "repeat(auto-fit, minmax(360px, 1fr))" }}
       >
         {panels.map((_, i) => (

--- a/apps/web/src/features/playground/embeddings/EmbeddingsPage.tsx
+++ b/apps/web/src/features/playground/embeddings/EmbeddingsPage.tsx
@@ -156,7 +156,7 @@ export function EmbeddingsPage() {
         </div>
       }
     >
-      <div className="flex min-h-0 flex-1 flex-col gap-4 px-6 py-4">
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-4">
         <div>
           <div className="mb-2 flex items-center justify-between">
             <label className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -219,8 +219,8 @@ export function EmbeddingsPage() {
             <span className="ml-3 text-xs text-destructive">{slice.error}</span>
           ) : null}
         </div>
-        <div className="flex-1 overflow-hidden">
-          <Tabs defaultValue="chart" className="h-full">
+        <div>
+          <Tabs defaultValue="chart">
             <TabsList>
               <TabsTrigger value="chart">{t("embeddings.tabs.chart")}</TabsTrigger>
               <TabsTrigger value="json">{t("embeddings.tabs.json")}</TabsTrigger>

--- a/apps/web/src/features/playground/embeddings/EmbeddingsPage.tsx
+++ b/apps/web/src/features/playground/embeddings/EmbeddingsPage.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { ApiError, api } from "@/lib/api-client";
@@ -159,15 +160,16 @@ export function EmbeddingsPage() {
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-4">
         <div>
           <div className="mb-2 flex items-center justify-between">
-            <label className="flex items-center gap-2 text-xs text-muted-foreground">
-              <input
-                type="checkbox"
-                checked={slice.batchMode}
-                onChange={(e) => slice.setBatchMode(e.target.checked)}
-              />
-              {t("embeddings.batchMode")}
-            </label>
-            <div className="flex gap-2">
+            <Label className="text-xs text-muted-foreground">{t("embeddings.inputs")}</Label>
+            <div className="flex items-center gap-3">
+              <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                <input
+                  type="checkbox"
+                  checked={slice.batchMode}
+                  onChange={(e) => slice.setBatchMode(e.target.checked)}
+                />
+                {t("embeddings.batchMode")}
+              </label>
               {!slice.batchMode ? (
                 <Button size="sm" variant="outline" onClick={slice.addInput}>
                   {t("embeddings.addInput")}

--- a/apps/web/src/features/playground/rerank/RerankPage.tsx
+++ b/apps/web/src/features/playground/rerank/RerankPage.tsx
@@ -175,7 +175,7 @@ export function RerankPage() {
         <div>
           <div className="mb-2 flex items-center justify-between">
             <Label className="text-xs text-muted-foreground">{t("rerank.documents")}</Label>
-            <div className="flex gap-2">
+            <div className="flex items-center gap-3">
               <label className="flex items-center gap-2 text-xs text-muted-foreground">
                 <input
                   type="checkbox"
@@ -189,6 +189,9 @@ export function RerankPage() {
                   {t("rerank.addDoc")}
                 </Button>
               ) : null}
+              <Button size="sm" variant="outline" onClick={slice.clearDocuments}>
+                {t("rerank.clear")}
+              </Button>
             </div>
           </div>
           {slice.batchMode ? (

--- a/apps/web/src/features/playground/rerank/store.test.ts
+++ b/apps/web/src/features/playground/rerank/store.test.ts
@@ -19,6 +19,14 @@ describe("useRerankStore", () => {
     expect(useRerankStore.getState().documents).toEqual(["b"]);
   });
 
+  it("clearDocuments resets to a single empty doc", () => {
+    useRerankStore.getState().setDocAt(0, "a");
+    useRerankStore.getState().addDocument();
+    useRerankStore.getState().setDocAt(1, "b");
+    useRerankStore.getState().clearDocuments();
+    expect(useRerankStore.getState().documents).toEqual([""]);
+  });
+
   it("setBatchText splits on newline", () => {
     useRerankStore.getState().setBatchText("a\nb\n\nc");
     expect(useRerankStore.getState().documents).toEqual(["a", "b", "c"]);

--- a/apps/web/src/features/playground/rerank/store.ts
+++ b/apps/web/src/features/playground/rerank/store.ts
@@ -25,6 +25,7 @@ export interface RerankStoreState {
   addDocument: () => void;
   removeDocument: (i: number) => void;
   setDocAt: (i: number, text: string) => void;
+  clearDocuments: () => void;
   setBatchMode: (b: boolean) => void;
   setBatchText: (s: string) => void;
   patchParams: (p: Partial<RerankParams>) => void;
@@ -61,6 +62,7 @@ export const useRerankStore = create<RerankStoreState>((set) => ({
       next[i] = text;
       return { documents: next };
     }),
+  clearDocuments: () => set({ documents: [""] }),
   setBatchMode: (b) => set({ batchMode: b }),
   setBatchText: (s) =>
     set({

--- a/apps/web/src/locales/en-US/playground.json
+++ b/apps/web/src/locales/en-US/playground.json
@@ -136,6 +136,7 @@
   "embeddings": {
     "title": "Embeddings",
     "subtitle": "Generate embedding vectors and visualise them in 2D.",
+    "inputs": "Inputs",
     "addInput": "+ Add input",
     "clear": "Clear",
     "batchMode": "Batch input",
@@ -212,6 +213,7 @@
     "queryPlaceholder": "Type the query…",
     "documents": "Documents",
     "addDoc": "+ Doc",
+    "clear": "Clear",
     "batchMode": "Batch input",
     "batchPlaceholder": "One document per line.",
     "send": "Send",

--- a/apps/web/src/locales/zh-CN/playground.json
+++ b/apps/web/src/locales/zh-CN/playground.json
@@ -136,6 +136,7 @@
   "embeddings": {
     "title": "嵌入",
     "subtitle": "生成嵌入向量并在 2D 中可视化。",
+    "inputs": "输入",
     "addInput": "+ 添加输入",
     "clear": "清空",
     "batchMode": "批量输入",
@@ -212,6 +213,7 @@
     "queryPlaceholder": "输入查询…",
     "documents": "文档",
     "addDoc": "+ 文档",
+    "clear": "清空",
     "batchMode": "批量输入",
     "batchPlaceholder": "每行一条文档。",
     "send": "发送",


### PR DESCRIPTION
Closes #34.

## Summary

Three small UI fixes uncovered by self-test on issue #34. Each gets its own commit so they can be reviewed independently.

- **Embeddings page can't scroll, chart cut off.** The body wrapper sat inside `PlaygroundShell`'s `overflow-hidden` `<main>` and the chart container had its own `flex-1 overflow-hidden`, so a tall input list silently clipped the 60vh chart. Body now uses `overflow-y-auto` and the chart container drops `flex-1 overflow-hidden` — the page scrolls naturally when content exceeds the viewport.
- **Rerank vs Embeddings input toolbar inconsistent.** Rerank had no Clear button and its batch checkbox sat opposite Embeddings'. Both pages now follow the same canonical layout: `[Label] … [Batch] [+ Add] [Clear]`. Adds `clearDocuments` to the rerank store (with a unit test), `rerank.clear` and `embeddings.inputs` locales (en/zh).
- **Compare page rendered two System editors.** `ChatComparePage` had its own top-of-page `<details>` system block while also passing `systemMessage` props to `MessageComposer`, which renders an identical inline editor. Drop the page-level block — composer-embedded one is single source of truth, matching single-mode `ChatPage`. Shared system message still wired into outgoing requests.

## Test plan

- [x] `pnpm -F @modeldoctor/web exec vitest run` — 67 files / 405 tests pass
- [x] `pnpm -F @modeldoctor/web exec tsc --noEmit` — clean
- [ ] Manual: open `/playground/embeddings`, add many input rows, confirm whole page scrolls and chart is fully visible
- [ ] Manual: confirm Rerank and Embeddings toolbars now look identical (label left, batch+add+clear right)
- [ ] Manual: open `/playground/chat/compare`, confirm only one System editor exists (inside the composer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)