### PR TITLE
feat(tool-adapters): add @modeldoctor/tool-adapters package skeleton (#53 PR 1/4)

### DIFF
--- a/docs/superpowers/plans/2026-05-02-issue-53-tool-adapter-framework.md
+++ b/docs/superpowers/plans/2026-05-02-issue-53-tool-adapter-framework.md
@@ -1,0 +1,6003 @@
+# Issue #53 — Tool Adapter Framework Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land per-tool typed schema (D 立场，no canonical layer) Tool Adapter abstraction over the existing benchmark/load-test paths in ModelDoctor, ship guidellm + vegeta + genai-perf adapters, rewrite the runner image into a generic tool executor, and prove the acceptance gate (adding genai-perf must not modify `ToolAdapter` interface fields).
+
+**Architecture:** Four sequential PRs from `feat/issue-53-*` branches cut from `main`, matching the spec's PR split (§13). Phase 1 introduces a new `packages/tool-adapters/` package with schema-only stubs. Phase 2 adds the new `RunService` + `/api/runs` endpoints + v2 callback protocol + driver-interface refactor + DB migration, leaving the old `BenchmarkController` / `LoadTestController` paths fully intact and parallel. Phase 3 implements the guidellm + vegeta runtimes, rewrites the Python runner image as a generic tool wrapper (deleting tool-specific code), and switches the old controllers to facades calling `RunService`. Phase 4 lands the genai-perf adapter and verifies the acceptance gate.
+
+**Tech Stack:** TypeScript 5.4, Zod 3.23 (schema), NestJS 10, Prisma 6, Vitest 1 (tool-adapters package, contracts) / Vitest 2 (apps/api), pnpm 9 workspace, `@kubernetes/client-node` (existing), Python 3.11+ (runner). Node ≥20.
+
+**Source spec:** `docs/superpowers/specs/2026-05-02-issue-53-tool-adapter-framework-design.md` — §3 (core abstraction), §4 (three adapters), §5 (DB Json columns), §6 (driver), §7 (runner image), §8 (callback v2), §9 (RunController/Service), §10 (facade), §11 (testing), §12 (acceptance gate), §13 (PR split), §14 (follow-ups).
+
+## Implementation decisions (anchored to spec)
+
+1. **D 立场, no canonical**: `ToolReport` is a discriminated union `{ tool, data }` per tool. No cross-tool diff; baseline-vs-run check enforced at `BaselineService` application layer.
+2. **Single package, subpath exports**: `packages/tool-adapters/` with `"."` (full) and `"./schemas"` (schema-only) entries. Frontend imports schemas only; backend imports full.
+3. **API-side parsing**: `parseFinalReport(stdout, files)` runs in TS in API process. Runner image only executes argv and ships stdout/stderr/files back. No tool-specific Python code in runner.
+4. **Callback v2**: three endpoints `/state`, `/log`, `/finish`. `/finish` is the single atomic terminal — no separate `/metrics` step. Progress is parsed from stdout on the API side, not pushed by runner.
+5. **`BuildCommandResult` shape**: `{ argv, env, secretEnv, inputFiles?, outputFiles }`. `image` is NOT in adapter — it's selected by the driver factory via `imageForTool(tool, env)`. Secret never enters argv.
+6. **DB drop, no backfill**: dev DB is disposable (per memory). `prisma migrate dev --create-only` then `prisma migrate reset --force` between phases as needed.
+7. **Old controllers stay untouched in Phase 2**: parallel paths during Phase 2; Phase 3 collapses to facade. Old guidellm-shape callbacks `/api/internal/benchmarks/:id/{state,metrics}` keep working in Phase 2; deleted in Phase 3.
+8. **`apps/api` keeps Vitest 2; `packages/tool-adapters` uses root Vitest 1** (matches contracts pattern). Per CLAUDE.md, do NOT unify.
+9. **Frontend untouched in #53**. All BenchmarkController/LoadTestController routes keep their request/response shapes via reverse mappers in Phase 3 facades. Frontend changes are in #54.
+10. **Acceptance gate**: in Phase 4, `git diff main -- packages/tool-adapters/src/core/interface.ts` MUST be empty (zero changes to ToolAdapter interface fields when adding genai-perf).
+
+## Testing discipline
+
+- **TDD per module.** Failing test → minimal impl → passing test → commit. Each task calls out the failing-test step before impl.
+- **Adapter unit tests are fixture-based.** Each tool gets a real product output committed to `__fixtures__/` (guidellm `report.json`, vegeta `report.txt`, genai-perf `profile_export.json`). `parseFinalReport()` is tested by feeding the fixture and asserting the parsed result matches `reportSchema`.
+- **Schema unit tests cover params validation edge cases.** Required fields, defaults, refines, discriminated-union narrowing.
+- **Driver tests mock `child_process.spawn` (Subprocess) or `@kubernetes/client-node` (K8s).** No real K8s cluster needed; manual k3d acceptance documented in Phase 2 README addendum.
+- **Callback tests use NestJS testing utilities + `supertest`.** HMAC guard, body-size override, parser-throw → `state=failed` path are the priority tests.
+- **Runner image tests run in `apps/benchmark-runner/tests/`.** Mock the inner tool with `echo` / `cat`. Verify wrapper batches `/log` correctly, collects outputFiles, posts complete `/finish` payload.
+- **No cross-test interference.** Each test uses isolated cwd / temp dirs. Vitest sequence-mode parallelism is fine.
+
+## Commit cadence
+
+One commit per task, conventional-commit prefixes per `CLAUDE.md`:
+
+- `feat:` — new modules, runtime, controllers, schemas
+- `refactor:` — reorganize without behavior change
+- `test:` — test-only changes (rare; tests usually land *with* their impl)
+- `build:` — dependency / pnpm-lock changes
+- `chore:` — workspace config, tsconfig, biome
+- `docs:` — README updates
+
+Every commit body ends with `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
+
+## Environment
+
+- Working directory: `/Users/fangyong/vllm/modeldoctor/main` for the spec only. **Each phase is implemented in its own worktree** under `/Users/fangyong/vllm/modeldoctor/issue-53-phase-N/`, branched from `main`. Spec landing happens on `main`; implementation must NOT (per user policy on bare+worktree).
+- Local Postgres is brew-managed: `brew services list` → `postgresql@<v> started`; `pg_isready -h localhost -p 5432` → OK. DB URL: `postgres://modeldoctor:modeldoctor@localhost:5432/modeldoctor`.
+- Node ≥ 20, pnpm ≥ 9.
+- For Phase 3 runner image build: Docker Desktop running.
+- For Phase 4 acceptance smoke: `pip install genai-perf` (or use a conda env per CLAUDE.md memory).
+
+## Pre-flight (run once before starting any phase)
+
+- [ ] **Step 0.1: Confirm `main` is clean and up-to-date**
+
+```bash
+cd /Users/fangyong/vllm/modeldoctor/main
+git status
+git log --oneline -3
+```
+
+Expected: working tree clean; latest commit is the spec commit (`b8d5e2e docs(spec): add tool adapter framework design for #53`).
+
+- [ ] **Step 0.2: Verify spec is committed**
+
+```bash
+ls docs/superpowers/specs/2026-05-02-issue-53-tool-adapter-framework-design.md
+```
+
+Expected: file exists.
+
+- [ ] **Step 0.3: Confirm baseline tests pass on `main`**
+
+```bash
+pnpm -r type-check
+pnpm -r test
+pnpm -r lint
+```
+
+Expected: all green. Any failure blocks the plan.
+
+- [ ] **Step 0.4: Confirm dev DB reachable**
+
+```bash
+brew services list | grep postgres
+pg_isready -h localhost -p 5432
+```
+
+Expected: `postgresql@<v> started` and `localhost:5432 - accepting connections`.
+
+---
+
+# Phase 1 (PR 53.1) — Adapter Package Skeleton
+
+**Phase goal:** Create `packages/tool-adapters/` with `ToolAdapter` interface + registry + three adapter scaffolds (guidellm, genai-perf, vegeta), each having complete `paramsSchema` + `reportSchema` + types but `runtime.ts` functions throwing `NotImplementedError`. CI passes (`pnpm -r build test lint type-check`). Both `@modeldoctor/tool-adapters` and `@modeldoctor/tool-adapters/schemas` subpath imports work.
+
+**Out of scope this phase:** runtime implementations (Phase 3 + 4), API integration (Phase 2), runner image changes (Phase 3), DB migration (Phase 2), facades (Phase 3).
+
+## Phase 1 Pre-flight
+
+- [ ] **Step 1.0.1: Create Phase 1 worktree**
+
+```bash
+cd /Users/fangyong/vllm/modeldoctor
+git worktree add issue-53-phase-1 -b feat/issue-53-phase-1-adapter-package main
+cd issue-53-phase-1
+```
+
+Expected: new worktree at `/Users/fangyong/vllm/modeldoctor/issue-53-phase-1/` on branch `feat/issue-53-phase-1-adapter-package`.
+
+- [ ] **Step 1.0.2: Verify worktree initial state**
+
+```bash
+git status
+git log --oneline -1
+ls
+```
+
+Expected: clean tree, latest commit is the spec commit, repo files present.
+
+- [ ] **Step 1.0.3: Install deps to populate the worktree**
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Expected: install succeeds, no lockfile changes (`git status` still clean).
+
+---
+
+## Task 1.1: Create `packages/tool-adapters/` package shell
+
+**Files:**
+- Create: `packages/tool-adapters/package.json`
+- Create: `packages/tool-adapters/tsconfig.json`
+- Create: `packages/tool-adapters/tsconfig.build.json`
+
+- [ ] **Step 1.1.1: Create `packages/tool-adapters/package.json`**
+
+```json
+{
+  "name": "@modeldoctor/tool-adapters",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Per-tool typed adapters (guidellm / genai-perf / vegeta) with subpath exports for schema-only frontend consumption",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./src/index.ts",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./schemas": {
+      "types": "./dist/schemas-entry.d.ts",
+      "import": "./src/schemas-entry.ts",
+      "require": "./dist/schemas-entry.js",
+      "default": "./dist/schemas-entry.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -w -p tsconfig.build.json --preserveWatchOutput",
+    "type-check": "tsc -p tsconfig.json --noEmit",
+    "lint": "biome check src",
+    "format": "biome format --write src",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "zod": "^3.23",
+    "@modeldoctor/contracts": "workspace:*"
+  }
+}
+```
+
+- [ ] **Step 1.1.2: Create `packages/tool-adapters/tsconfig.json`**
+
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+- [ ] **Step 1.1.3: Create `packages/tool-adapters/tsconfig.build.json`**
+
+```json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
+}
+```
+
+> Mirrors `packages/contracts/tsconfig.build.json` exactly. Re-emits CJS dist so the package is consumable both via direct TS source (workspace dev) and via dist (production).
+
+- [ ] **Step 1.1.4: Verify package is picked up by the workspace**
+
+```bash
+pnpm install
+```
+
+Expected: install completes, `packages/tool-adapters/node_modules/` is populated, `packages/tool-adapters/node_modules/zod` is symlinked. `pnpm-workspace.yaml` already uses `packages/*` glob, so no edit needed there.
+
+- [ ] **Step 1.1.5: Verify TS resolves the new package**
+
+```bash
+cd packages/tool-adapters
+pnpm type-check
+```
+
+Expected: passes (no source files yet, TS errors only if any). If `error TS18003: No inputs were found in config file`, that's expected — fine to ignore until Step 1.2 adds source.
+
+- [ ] **Step 1.1.6: Commit**
+
+```bash
+cd ../..
+git add packages/tool-adapters/package.json packages/tool-adapters/tsconfig.json packages/tool-adapters/tsconfig.build.json pnpm-lock.yaml
+git commit -m "$(cat <<'EOF'
+chore(tool-adapters): add @modeldoctor/tool-adapters package shell
+
+Empty package with subpath exports for the upcoming ToolAdapter framework
+(issue #53). Mirrors @modeldoctor/contracts conventions.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 1.2: Create core types in `src/core/interface.ts`
+
+**Files:**
+- Create: `packages/tool-adapters/src/core/interface.ts`
+
+- [ ] **Step 1.2.1: Create `packages/tool-adapters/src/core/interface.ts`**
+
+```ts
+import type { z } from "zod";
+
+// ToolAdapter-registered tool names. The DB column `Run.tool` allows a
+// superset (additionally `'e2e'` and `'custom'`) — those don't go through
+// ToolAdapter and follow their own codepaths. ToolName covers exactly the
+// adapters the registry knows about.
+export type ToolName = "guidellm" | "genai-perf" | "vegeta";
+
+// ── Progress events (uniform across tools) ────────────────────────────
+export type ProgressEvent =
+  | { kind: "progress"; pct: number; currentRequests?: number; message?: string }
+  | { kind: "log"; level: "info" | "warn" | "error"; line: string };
+
+// ── Forward-declare per-tool report types (filled in Task 1.4 / 1.5 / 1.6) ──
+// We use type-only imports to break a circular dep concern: schema files
+// don't import from interface.ts; interface.ts imports their inferred types.
+import type { GuidellmReport } from "../guidellm/schema.js";
+import type { GenaiPerfReport } from "../genai-perf/schema.js";
+import type { VegetaReport } from "../vegeta/schema.js";
+
+// ── Discriminated union: report (consumers switch on `tool`) ──────────
+export type ToolReport =
+  | { tool: "guidellm"; data: GuidellmReport }
+  | { tool: "genai-perf"; data: GenaiPerfReport }
+  | { tool: "vegeta"; data: VegetaReport };
+
+// ── buildCommand inputs ───────────────────────────────────────────────
+export interface BuildCommandPlan<TParams = unknown> {
+  runId: string;
+  params: TParams;
+  connection: {
+    baseUrl: string;
+    apiKey: string;
+    model: string;
+    customHeaders: string;
+    queryParams: string;
+  };
+  callback: { url: string; token: string };
+}
+
+// ── buildCommand output ───────────────────────────────────────────────
+//
+// Driver contract:
+//   - argv:        full command (incl. program name); shell pipelines via
+//                  ['/bin/sh', '-c', '...']. Driver does NOT prepend.
+//   - env:         non-sensitive env. Subprocess: merged into spawn env.
+//                  K8s: passed as Job container env value.
+//   - secretEnv:   sensitive env. Subprocess: merged into spawn env (no
+//                  argv leak). K8s: written to per-run Secret + envFrom.
+//                  MUST NOT enter argv.
+//   - inputFiles:  cwd-relative path → file contents. Driver writes these
+//                  before spawn. K8s: written to the same per-run Secret +
+//                  volumeMount (single-Secret limit ~1MiB total). Use this
+//                  channel for files that contain secrets (e.g. vegeta's
+//                  targets.txt with bearer token); never use ConfigMap.
+//   - outputFiles: alias → cwd-relative path. Runner reads these after
+//                  exit and ships base64-encoded contents in /finish body.
+export interface BuildCommandResult {
+  argv: string[];
+  env: Record<string, string>;
+  secretEnv: Record<string, string>;
+  inputFiles?: Record<string, string>;
+  outputFiles: Record<string, string>;
+}
+
+// ── ToolAdapter interface ─────────────────────────────────────────────
+// ⚠ ACCEPTANCE GATE: in Phase 4 (PR 53.4), `git diff main -- this file`
+// MUST be empty. Adding genai-perf must not require any change here.
+export interface ToolAdapter {
+  readonly name: ToolName;
+  readonly paramsSchema: z.ZodTypeAny;
+  readonly reportSchema: z.ZodTypeAny;
+  readonly paramDefaults: unknown;
+
+  buildCommand(plan: BuildCommandPlan): BuildCommandResult;
+  parseProgress(line: string): ProgressEvent | null;
+  parseFinalReport(stdout: string, files: Record<string, Buffer>): ToolReport;
+}
+```
+
+> Note: this file imports types from `../guidellm/schema.js`, `../genai-perf/schema.js`, `../vegeta/schema.js` (extension `.js` per ESM resolution + monorepo convention). Those files are created in Tasks 1.4 / 1.5 / 1.6. TS won't compile until those exist; this is OK because we'll get green only at the end of Task 1.6. We commit interface.ts now (red), then fix red as schemas land.
+
+- [ ] **Step 1.2.2: Verify red (expected)**
+
+```bash
+cd packages/tool-adapters
+pnpm type-check
+```
+
+Expected: TS errors `Cannot find module '../guidellm/schema.js' or its corresponding type declarations` (and same for `genai-perf`, `vegeta`). This is intentional — the schemas land in subsequent tasks.
+
+- [ ] **Step 1.2.3: Commit (interface.ts only; schemas come next)**
+
+```bash
+cd ../..
+git add packages/tool-adapters/src/core/interface.ts
+git commit -m "$(cat <<'EOF'
+feat(tool-adapters): define ToolAdapter / ToolReport / BuildCommandResult interfaces
+
+Core types only; per-tool schemas land in subsequent commits. Type-check
+is intentionally red until Task 1.4-1.6 introduce the schema modules.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 1.3: Create empty `progress-event.ts` (runtime Zod for SSE) — placeholder for completeness
+
+**Files:**
+- Create: `packages/tool-adapters/src/core/progress-event.ts`
+
+- [ ] **Step 1.3.1: Create `packages/tool-adapters/src/core/progress-event.ts`**
+
+```ts
+import { z } from "zod";
+
+export const progressEventSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("progress"),
+    pct: z.number().min(0).max(1),
+    currentRequests: z.number().int().nonnegative().optional(),
+    message: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("log"),
+    level: z.enum(["info", "warn", "error"]),
+    line: z.string(),
+  }),
+]);
+```
+
+> Used in Phase 2 by SSE / log handlers when needing runtime validation. Defining now keeps schema co-located with the TS type in `interface.ts`.
+
+- [ ] **Step 1.3.2: Commit**
+
+```bash
+git add packages/tool-adapters/src/core/progress-event.ts
+git commit -m "$(cat <<'EOF'
+feat(tool-adapters): add progressEventSchema for runtime SSE validation
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 1.4: Create guidellm schema + stub runtime + adapter assembly
+
+**Files:**
+- Create: `packages/tool-adapters/src/guidellm/schema.ts`
+- Create: `packages/tool-adapters/src/guidellm/schema.spec.ts`
+- Create: `packages/tool-adapters/src/guidellm/runtime.ts` (stubs)
+- Create: `packages/tool-adapters/src/guidellm/index.ts`
+
+- [ ] **Step 1.4.1: Write the failing schema test first**
+
+Create `packages/tool-adapters/src/guidellm/schema.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { guidellmParamsSchema, guidellmReportSchema, guidellmParamDefaults } from "./schema.js";
+
+describe("guidellmParamsSchema", () => {
+  it("requires datasetInputTokens/Output when datasetName=random", () => {
+    const r = guidellmParamsSchema.safeParse({
+      profile: "throughput",
+      apiType: "chat",
+      datasetName: "random",
+      requestRate: 0,
+      totalRequests: 100,
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const messages = r.error.issues.map((i) => i.message);
+      expect(messages.some((m) => m.includes("random dataset"))).toBe(true);
+    }
+  });
+
+  it("accepts a fully-specified random dataset config", () => {
+    const r = guidellmParamsSchema.safeParse({
+      profile: "throughput",
+      apiType: "chat",
+      datasetName: "random",
+      datasetInputTokens: 256,
+      datasetOutputTokens: 128,
+      requestRate: 0,
+      totalRequests: 1000,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("paramDefaults is a parseable params object skeleton", () => {
+    // The defaults object is a starting point for the FE form — not all
+    // required fields are present (e.g. datasetInputTokens for random).
+    expect(typeof guidellmParamDefaults).toBe("object");
+  });
+});
+
+describe("guidellmReportSchema", () => {
+  it("rejects a report missing required latency dist fields", () => {
+    const r = guidellmReportSchema.safeParse({});
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a fully-shaped report", () => {
+    const dist = { mean: 1, p50: 1, p90: 1, p95: 1, p99: 1 };
+    const r = guidellmReportSchema.safeParse({
+      ttft: dist,
+      itl: dist,
+      e2eLatency: dist,
+      requestsPerSecond: { mean: 1 },
+      outputTokensPerSecond: { mean: 1 },
+      inputTokensPerSecond: { mean: 1 },
+      totalTokensPerSecond: { mean: 1 },
+      concurrency: { mean: 1, max: 1 },
+      requests: { total: 1, success: 1, error: 0, incomplete: 0 },
+    });
+    expect(r.success).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 1.4.2: Run the test to verify failure**
+
+```bash
+cd packages/tool-adapters
+pnpm test
+```
+
+Expected: vitest collects `schema.spec.ts`, fails because `./schema.js` does not exist.
+
+- [ ] **Step 1.4.3: Create `packages/tool-adapters/src/guidellm/schema.ts`**
+
+```ts
+import { z } from "zod";
+
+export const guidellmParamsSchema = z
+  .object({
+    profile: z.enum([
+      "throughput",
+      "latency",
+      "long_context",
+      "generation_heavy",
+      "sharegpt",
+      "custom",
+    ]),
+    apiType: z.enum(["chat", "completion"]),
+    datasetName: z.enum(["random", "sharegpt"]),
+    datasetInputTokens: z.number().int().positive().optional(),
+    datasetOutputTokens: z.number().int().positive().optional(),
+    datasetSeed: z.number().int().optional(),
+    requestRate: z.number().int().min(0).default(0),
+    totalRequests: z.number().int().min(1).max(100_000).default(1000),
+    maxDurationSeconds: z.number().int().positive().default(1800),
+    maxConcurrency: z.number().int().positive().default(100),
+    processor: z.string().optional(),
+    validateBackend: z.boolean().default(true),
+  })
+  .superRefine((d, ctx) => {
+    if (d.datasetName === "random" && (!d.datasetInputTokens || !d.datasetOutputTokens)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "random dataset requires datasetInputTokens and datasetOutputTokens",
+      });
+    }
+  });
+export type GuidellmParams = z.infer<typeof guidellmParamsSchema>;
+
+const dist = z.object({
+  mean: z.number(),
+  p50: z.number(),
+  p90: z.number(),
+  p95: z.number(),
+  p99: z.number(),
+});
+
+export const guidellmReportSchema = z.object({
+  ttft: dist,
+  itl: dist,
+  e2eLatency: dist,
+  requestsPerSecond: z.object({ mean: z.number() }),
+  outputTokensPerSecond: z.object({ mean: z.number() }),
+  inputTokensPerSecond: z.object({ mean: z.number() }),
+  totalTokensPerSecond: z.object({ mean: z.number() }),
+  concurrency: z.object({ mean: z.number(), max: z.number() }),
+  requests: z.object({
+    total: z.number().int(),
+    success: z.number().int(),
+    error: z.number().int(),
+    incomplete: z.number().int(),
+  }),
+});
+export type GuidellmReport = z.infer<typeof guidellmReportSchema>;
+
+// Skeleton for FE form prefill. NOT fully valid (datasetInputTokens is
+// required for random dataset). Frontend layer fills the gaps from user
+// input before submit.
+export const guidellmParamDefaults: Partial<GuidellmParams> = {
+  profile: "throughput",
+  apiType: "chat",
+  datasetName: "random",
+  requestRate: 0,
+  totalRequests: 1000,
+  maxDurationSeconds: 1800,
+  maxConcurrency: 100,
+  validateBackend: true,
+};
+```
+
+- [ ] **Step 1.4.4: Create `packages/tool-adapters/src/guidellm/runtime.ts` (stubs)**
+
+```ts
+import type {
+  BuildCommandPlan,
+  BuildCommandResult,
+  ProgressEvent,
+  ToolReport,
+} from "../core/interface.js";
+import type { GuidellmParams } from "./schema.js";
+
+const NOT_IMPLEMENTED = "guidellm runtime is implemented in Phase 3 (PR 53.3)";
+
+export function buildCommand(_plan: BuildCommandPlan<GuidellmParams>): BuildCommandResult {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export function parseProgress(_line: string): ProgressEvent | null {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export function parseFinalReport(
+  _stdout: string,
+  _files: Record<string, Buffer>,
+): ToolReport {
+  throw new Error(NOT_IMPLEMENTED);
+}
+```
+
+- [ ] **Step 1.4.5: Create `packages/tool-adapters/src/guidellm/index.ts`**
+
+```ts
+import type { ToolAdapter } from "../core/interface.js";
+import { guidellmParamsSchema, guidellmReportSchema, guidellmParamDefaults } from "./schema.js";
+import { buildCommand, parseFinalReport, parseProgress } from "./runtime.js";
+
+export const guidellmAdapter: ToolAdapter = {
+  name: "guidellm",
+  paramsSchema: guidellmParamsSchema,
+  reportSchema: guidellmReportSchema,
+  paramDefaults: guidellmParamDefaults,
+  buildCommand,
+  parseProgress,
+  parseFinalReport,
+};
+
+export type { GuidellmParams, GuidellmReport } from "./schema.js";
+```
+
+- [ ] **Step 1.4.6: Run schema tests to verify pass**
+
+```bash
+cd packages/tool-adapters
+pnpm test
+```
+
+Expected: `schema.spec.ts` 3 tests pass. (Other adapter spec files don't exist yet — vitest will only run guidellm's.)
+
+- [ ] **Step 1.4.7: Commit**
+
+```bash
+cd ../..
+git add packages/tool-adapters/src/guidellm/
+git commit -m "$(cat <<'EOF'
+feat(tool-adapters): add guidellm schema + stubbed runtime
+
+paramsSchema and reportSchema are complete; runtime functions throw
+'not implemented' placeholders to be filled in PR 53.3.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 1.5: Create vegeta schema + stub runtime + adapter assembly
+
+**Files:**
+- Create: `packages/tool-adapters/src/vegeta/schema.ts`
+- Create: `packages/tool-adapters/src/vegeta/schema.spec.ts`
+- Create: `packages/tool-adapters/src/vegeta/runtime.ts`
+- Create: `packages/tool-adapters/src/vegeta/index.ts`
+
+- [ ] **Step 1.5.1: Write the failing schema test first**
+
+Create `packages/tool-adapters/src/vegeta/schema.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { vegetaParamsSchema, vegetaReportSchema, vegetaParamDefaults } from "./schema.js";
+
+describe("vegetaParamsSchema", () => {
+  it("rejects rate=0", () => {
+    const r = vegetaParamsSchema.safeParse({ apiType: "chat", rate: 0, duration: 30 });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects duration > 3600", () => {
+    const r = vegetaParamsSchema.safeParse({ apiType: "chat", rate: 10, duration: 3601 });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a typical config", () => {
+    const r = vegetaParamsSchema.safeParse({ apiType: "chat", rate: 10, duration: 60 });
+    expect(r.success).toBe(true);
+  });
+
+  it("paramDefaults is a parseable starter", () => {
+    expect(typeof vegetaParamDefaults).toBe("object");
+  });
+});
+
+describe("vegetaReportSchema", () => {
+  it("requires latency distribution", () => {
+    const r = vegetaReportSchema.safeParse({});
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a typical vegeta report shape", () => {
+    const r = vegetaReportSchema.safeParse({
+      requests: { total: 100, rate: 10, throughput: 9.5 },
+      duration: { totalSeconds: 10.5, attackSeconds: 10, waitSeconds: 0.5 },
+      latencies: { min: 1, mean: 5, p50: 4, p90: 9, p95: 12, p99: 18, max: 24 },
+      bytesIn: { total: 1024, mean: 10.24 },
+      bytesOut: { total: 512, mean: 5.12 },
+      success: 100,
+      statusCodes: { "200": 100 },
+      errors: [],
+    });
+    expect(r.success).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 1.5.2: Run the test to verify failure**
+
+```bash
+cd packages/tool-adapters
+pnpm test -- vegeta/schema
+```
+
+Expected: failure (`schema.js` not found).
+
+- [ ] **Step 1.5.3: Create `packages/tool-adapters/src/vegeta/schema.ts`**
+
+```ts
+import { z } from "zod";
+
+export const vegetaParamsSchema = z.object({
+  apiType: z.enum(["chat", "embeddings", "rerank", "images", "chat-vision", "chat-audio"]),
+  rate: z.number().int().min(1).max(10_000),
+  duration: z.number().int().min(1).max(3_600),
+});
+export type VegetaParams = z.infer<typeof vegetaParamsSchema>;
+
+const vegetaLatencyDist = z.object({
+  // All fields are normalized to milliseconds (number). The runtime
+  // parser converts vegeta's mixed-unit text output ("45.6ms" / "1.2s" /
+  // "300µs") to ms before validation.
+  min: z.number(),
+  mean: z.number(),
+  p50: z.number(),
+  p90: z.number(),
+  p95: z.number(),
+  p99: z.number(),
+  max: z.number(),
+});
+
+export const vegetaReportSchema = z.object({
+  requests: z.object({
+    total: z.number().int(),
+    rate: z.number(),
+    throughput: z.number(),
+  }),
+  duration: z.object({
+    totalSeconds: z.number(),
+    attackSeconds: z.number(),
+    waitSeconds: z.number(),
+  }),
+  latencies: vegetaLatencyDist,
+  bytesIn: z.object({ total: z.number().int(), mean: z.number() }),
+  bytesOut: z.object({ total: z.number().int(), mean: z.number() }),
+  // Success is a percent in [0, 100], NOT a 0-1 ratio (matches vegeta CLI).
+  success: z.number(),
+  statusCodes: z.record(z.number().int()),
+  errors: z.array(z.string()),
+});
+export type VegetaReport = z.infer<typeof vegetaReportSchema>;
+
+export const vegetaParamDefaults: Partial<VegetaParams> = {
+  apiType: "chat",
+  rate: 10,
+  duration: 30,
+};
+```
+
+- [ ] **Step 1.5.4: Create `packages/tool-adapters/src/vegeta/runtime.ts` (stubs)**
+
+```ts
+import type {
+  BuildCommandPlan,
+  BuildCommandResult,
+  ProgressEvent,
+  ToolReport,
+} from "../core/interface.js";
+import type { VegetaParams } from "./schema.js";
+
+const NOT_IMPLEMENTED = "vegeta runtime is implemented in Phase 3 (PR 53.3)";
+
+export function buildCommand(_plan: BuildCommandPlan<VegetaParams>): BuildCommandResult {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export function parseProgress(_line: string): ProgressEvent | null {
+  // vegeta has no native progress emission — final shape will return null
+  // unconditionally. We still throw here so the stub is uniform with the
+  // other adapters; Phase 3 replaces this with `return null`.
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export function parseFinalReport(
+  _stdout: string,
+  _files: Record<string, Buffer>,
+): ToolReport {
+  throw new Error(NOT_IMPLEMENTED);
+}
+```
+
+- [ ] **Step 1.5.5: Create `packages/tool-adapters/src/vegeta/index.ts`**
+
+```ts
+import type { ToolAdapter } from "../core/interface.js";
+import { vegetaParamsSchema, vegetaReportSchema, vegetaParamDefaults } from "./schema.js";
+import { buildCommand, parseFinalReport, parseProgress } from "./runtime.js";
+
+export const vegetaAdapter: ToolAdapter = {
+  name: "vegeta",
+  paramsSchema: vegetaParamsSchema,
+  reportSchema: vegetaReportSchema,
+  paramDefaults: vegetaParamDefaults,
+  buildCommand,
+  parseProgress,
+  parseFinalReport,
+};
+
+export type { VegetaParams, VegetaReport } from "./schema.js";
+```
+
+- [ ] **Step 1.5.6: Run vegeta tests to verify pass**
+
+```bash
+cd packages/tool-adapters
+pnpm test -- vegeta/schema
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 1.5.7: Commit**
+
+```bash
+cd ../..
+git add packages/tool-adapters/src/vegeta/
+git commit -m "$(cat <<'EOF'
+feat(tool-adapters): add vegeta schema + stubbed runtime
+
+Schema is complete; runtime stubs throw 'not implemented'. Vegeta lacks
+TTFT / token / ITL fields by design — D 立场 means no canonical layer,
+so vegeta's reportSchema simply doesn't include those concepts.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 1.6: Create genai-perf schema + stub runtime + adapter assembly
+
+**Files:**
+- Create: `packages/tool-adapters/src/genai-perf/schema.ts`
+- Create: `packages/tool-adapters/src/genai-perf/schema.spec.ts`
+- Create: `packages/tool-adapters/src/genai-perf/runtime.ts`
+- Create: `packages/tool-adapters/src/genai-perf/index.ts`
+
+- [ ] **Step 1.6.1: Write the failing schema test**
+
+Create `packages/tool-adapters/src/genai-perf/schema.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { genaiPerfParamsSchema, genaiPerfReportSchema, genaiPerfParamDefaults } from "./schema.js";
+
+describe("genaiPerfParamsSchema", () => {
+  it("rejects negative numPrompts", () => {
+    const r = genaiPerfParamsSchema.safeParse({
+      endpointType: "chat",
+      numPrompts: -1,
+      concurrency: 1,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a minimal valid config", () => {
+    const r = genaiPerfParamsSchema.safeParse({ endpointType: "chat" });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.numPrompts).toBe(100);
+      expect(r.data.concurrency).toBe(1);
+      expect(r.data.streaming).toBe(true);
+    }
+  });
+
+  it("paramDefaults is a parseable starter", () => {
+    expect(typeof genaiPerfParamDefaults).toBe("object");
+  });
+});
+
+describe("genaiPerfReportSchema", () => {
+  it("requires distribution fields", () => {
+    const r = genaiPerfReportSchema.safeParse({});
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a typical genai-perf report shape", () => {
+    const dist = {
+      avg: 10, min: 1, max: 50, p50: 9, p90: 18, p95: 22, p99: 40, stddev: 5, unit: "ms",
+    };
+    const lengthDist = { avg: 100, p50: 100, p99: 200 };
+    const r = genaiPerfReportSchema.safeParse({
+      requestThroughput: { avg: 5.2, unit: "requests/sec" },
+      requestLatency: dist,
+      timeToFirstToken: dist,
+      interTokenLatency: dist,
+      outputTokenThroughput: { avg: 200, unit: "tokens/sec" },
+      outputSequenceLength: lengthDist,
+      inputSequenceLength: lengthDist,
+    });
+    expect(r.success).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 1.6.2: Run the test to verify failure**
+
+```bash
+cd packages/tool-adapters
+pnpm test -- genai-perf/schema
+```
+
+Expected: failure (`schema.js` not found).
+
+- [ ] **Step 1.6.3: Create `packages/tool-adapters/src/genai-perf/schema.ts`**
+
+```ts
+import { z } from "zod";
+
+export const genaiPerfParamsSchema = z.object({
+  endpointType: z.enum(["chat", "completions", "embeddings", "rankings"]),
+  numPrompts: z.number().int().positive().default(100),
+  concurrency: z.number().int().positive().default(1),
+  inputTokensMean: z.number().int().positive().optional(),
+  inputTokensStddev: z.number().int().min(0).default(0),
+  outputTokensMean: z.number().int().positive().optional(),
+  outputTokensStddev: z.number().int().min(0).default(0),
+  streaming: z.boolean().default(true),
+});
+export type GenaiPerfParams = z.infer<typeof genaiPerfParamsSchema>;
+
+const genaiPerfDist = z.object({
+  avg: z.number(),
+  min: z.number(),
+  max: z.number(),
+  p50: z.number(),
+  p90: z.number(),
+  p95: z.number(),
+  p99: z.number(),
+  stddev: z.number(),
+  unit: z.string(),
+});
+
+const sequenceLength = z.object({
+  avg: z.number(),
+  p50: z.number(),
+  p99: z.number(),
+});
+
+export const genaiPerfReportSchema = z.object({
+  requestThroughput: z.object({ avg: z.number(), unit: z.string() }),
+  requestLatency: genaiPerfDist,
+  timeToFirstToken: genaiPerfDist,
+  interTokenLatency: genaiPerfDist,
+  outputTokenThroughput: z.object({ avg: z.number(), unit: z.string() }),
+  outputSequenceLength: sequenceLength,
+  inputSequenceLength: sequenceLength,
+});
+export type GenaiPerfReport = z.infer<typeof genaiPerfReportSchema>;
+
+export const genaiPerfParamDefaults: Partial<GenaiPerfParams> = {
+  endpointType: "chat",
+  numPrompts: 100,
+  concurrency: 1,
+  streaming: true,
+  inputTokensStddev: 0,
+  outputTokensStddev: 0,
+};
+```
+
+- [ ] **Step 1.6.4: Create `packages/tool-adapters/src/genai-perf/runtime.ts` (stubs)**
+
+```ts
+import type {
+  BuildCommandPlan,
+  BuildCommandResult,
+  ProgressEvent,
+  ToolReport,
+} from "../core/interface.js";
+import type { GenaiPerfParams } from "./schema.js";
+
+const NOT_IMPLEMENTED = "genai-perf runtime is implemented in Phase 4 (PR 53.4)";
+
+export function buildCommand(_plan: BuildCommandPlan<GenaiPerfParams>): BuildCommandResult {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export function parseProgress(_line: string): ProgressEvent | null {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export function parseFinalReport(
+  _stdout: string,
+  _files: Record<string, Buffer>,
+): ToolReport {
+  throw new Error(NOT_IMPLEMENTED);
+}
+```
+
+- [ ] **Step 1.6.5: Create `packages/tool-adapters/src/genai-perf/index.ts`**
+
+```ts
+import type { ToolAdapter } from "../core/interface.js";
+import { genaiPerfParamsSchema, genaiPerfReportSchema, genaiPerfParamDefaults } from "./schema.js";
+import { buildCommand, parseFinalReport, parseProgress } from "./runtime.js";
+
+export const genaiPerfAdapter: ToolAdapter = {
+  name: "genai-perf",
+  paramsSchema: genaiPerfParamsSchema,
+  reportSchema: genaiPerfReportSchema,
+  paramDefaults: genaiPerfParamDefaults,
+  buildCommand,
+  parseProgress,
+  parseFinalReport,
+};
+
+export type { GenaiPerfParams, GenaiPerfReport } from "./schema.js";
+```
+
+- [ ] **Step 1.6.6: Run all tests; verify pass**
+
+```bash
+cd packages/tool-adapters
+pnpm test
+```
+
+Expected: all 14+ tests pass across guidellm/vegeta/genai-perf schema specs.
+
+- [ ] **Step 1.6.7: Type-check (interface.ts now resolves all 3 imports)**
+
+```bash
+pnpm type-check
+```
+
+Expected: no TS errors.
+
+- [ ] **Step 1.6.8: Commit**
+
+```bash
+cd ../..
+git add packages/tool-adapters/src/genai-perf/
+git commit -m "$(cat <<'EOF'
+feat(tool-adapters): add genai-perf schema + stubbed runtime
+
+Schema is complete; runtime stubs throw 'not implemented'. Will be filled
+in PR 53.4 alongside the acceptance-gate verification.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 1.7: Create registry + entry points
+
+**Files:**
+- Create: `packages/tool-adapters/src/core/registry.ts`
+- Create: `packages/tool-adapters/src/core/registry.spec.ts`
+- Create: `packages/tool-adapters/src/schemas-entry.ts`
+- Create: `packages/tool-adapters/src/index.ts`
+
+- [ ] **Step 1.7.1: Write the failing registry test**
+
+Create `packages/tool-adapters/src/core/registry.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { byTool, allAdapters } from "./registry.js";
+
+describe("registry", () => {
+  it("byTool('guidellm') returns the guidellm adapter", () => {
+    const a = byTool("guidellm");
+    expect(a.name).toBe("guidellm");
+    expect(typeof a.paramsSchema.parse).toBe("function");
+  });
+
+  it("byTool('vegeta') returns the vegeta adapter", () => {
+    expect(byTool("vegeta").name).toBe("vegeta");
+  });
+
+  it("byTool('genai-perf') returns the genai-perf adapter", () => {
+    expect(byTool("genai-perf").name).toBe("genai-perf");
+  });
+
+  it("allAdapters returns three adapters", () => {
+    const all = allAdapters();
+    expect(all).toHaveLength(3);
+    expect(all.map((a) => a.name).sort()).toEqual(
+      ["genai-perf", "guidellm", "vegeta"].sort(),
+    );
+  });
+});
+```
+
+- [ ] **Step 1.7.2: Run the test to verify failure**
+
+```bash
+cd packages/tool-adapters
+pnpm test -- core/registry
+```
+
+Expected: failure (`registry.js` not found).
+
+- [ ] **Step 1.7.3: Create `packages/tool-adapters/src/core/registry.ts`**
+
+```ts
+import { guidellmAdapter } from "../guidellm/index.js";
+import { genaiPerfAdapter } from "../genai-perf/index.js";
+import { vegetaAdapter } from "../vegeta/index.js";
+import type { ToolAdapter, ToolName } from "./interface.js";
+
+const ADAPTERS: Readonly<Record<ToolName, ToolAdapter>> = {
+  guidellm: guidellmAdapter,
+  "genai-perf": genaiPerfAdapter,
+  vegeta: vegetaAdapter,
+};
+
+export function byTool(tool: ToolName): ToolAdapter {
+  const a = ADAPTERS[tool];
+  if (!a) throw new Error(`No adapter registered for tool: ${tool}`);
+  return a;
+}
+
+export function allAdapters(): readonly ToolAdapter[] {
+  return Object.values(ADAPTERS);
+}
+```
+
+- [ ] **Step 1.7.4: Create `packages/tool-adapters/src/schemas-entry.ts`**
+
+```ts
+// Schema-only entry point. Imported by the frontend (and any other
+// consumer that doesn't need the runtime side of adapters).
+//
+// IMPORTANT: do NOT import anything from `runtime.ts` files transitively
+// from this entry point. We don't want `child_process` / `fs` / etc to
+// be reachable from the FE bundle. Keep this file's imports limited to
+// schema files.
+
+export {
+  guidellmParamsSchema,
+  guidellmReportSchema,
+  guidellmParamDefaults,
+  type GuidellmParams,
+  type GuidellmReport,
+} from "./guidellm/schema.js";
+
+export {
+  vegetaParamsSchema,
+  vegetaReportSchema,
+  vegetaParamDefaults,
+  type VegetaParams,
+  type VegetaReport,
+} from "./vegeta/schema.js";
+
+export {
+  genaiPerfParamsSchema,
+  genaiPerfReportSchema,
+  genaiPerfParamDefaults,
+  type GenaiPerfParams,
+  type GenaiPerfReport,
+} from "./genai-perf/schema.js";
+
+export type { ToolName, ProgressEvent, ToolReport } from "./core/interface.js";
+export { progressEventSchema } from "./core/progress-event.js";
+```
+
+- [ ] **Step 1.7.5: Create `packages/tool-adapters/src/index.ts`**
+
+```ts
+// Full adapter export. Imported by apps/api.
+
+export * from "./core/interface.js";
+export * from "./core/registry.js";
+export * from "./core/progress-event.js";
+
+export { guidellmAdapter } from "./guidellm/index.js";
+export { vegetaAdapter } from "./vegeta/index.js";
+export { genaiPerfAdapter } from "./genai-perf/index.js";
+
+// Re-export schemas + types for convenience (so `apps/api` doesn't need to
+// reach into subpaths to validate `req.params`).
+export * from "./schemas-entry.js";
+```
+
+- [ ] **Step 1.7.6: Run all tests + type-check + lint**
+
+```bash
+cd packages/tool-adapters
+pnpm test
+pnpm type-check
+pnpm lint
+```
+
+Expected: tests pass (registry.spec.ts adds 4 tests), type-check clean, lint clean.
+
+- [ ] **Step 1.7.7: Build dist (subpath exports verification)**
+
+```bash
+pnpm build
+ls dist/
+```
+
+Expected: `dist/index.js`, `dist/index.d.ts`, `dist/schemas-entry.js`, `dist/schemas-entry.d.ts`, plus per-tool `dist/guidellm/`, `dist/vegeta/`, `dist/genai-perf/`, `dist/core/`.
+
+- [ ] **Step 1.7.8: Commit**
+
+```bash
+cd ../..
+git add packages/tool-adapters/src/core/registry.ts \
+        packages/tool-adapters/src/core/registry.spec.ts \
+        packages/tool-adapters/src/schemas-entry.ts \
+        packages/tool-adapters/src/index.ts
+git commit -m "$(cat <<'EOF'
+feat(tool-adapters): add adapter registry + entry points
+
+byTool() / allAdapters() registry; ./schemas subpath export for FE
+schema-only consumption; full export from package root for backend.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 1.8: Verify FE-side import shape (no runtime leak)
+
+**Files:**
+- Create: `packages/tool-adapters/src/schemas-entry.spec.ts`
+
+> Sanity-check that schema-only entry doesn't accidentally pull in runtime modules. Detects regressions where someone re-exports `from "./guidellm/index.js"` (which transitively imports runtime).
+
+- [ ] **Step 1.8.1: Write the failing test**
+
+Create `packages/tool-adapters/src/schemas-entry.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import * as schemas from "./schemas-entry.js";
+
+describe("schemas-entry", () => {
+  it("exports guidellm schemas", () => {
+    expect(schemas.guidellmParamsSchema).toBeDefined();
+    expect(schemas.guidellmReportSchema).toBeDefined();
+  });
+
+  it("exports vegeta schemas", () => {
+    expect(schemas.vegetaParamsSchema).toBeDefined();
+    expect(schemas.vegetaReportSchema).toBeDefined();
+  });
+
+  it("exports genai-perf schemas", () => {
+    expect(schemas.genaiPerfParamsSchema).toBeDefined();
+    expect(schemas.genaiPerfReportSchema).toBeDefined();
+  });
+
+  it("does NOT export adapter (which contains runtime)", () => {
+    // Adapter object aggregates runtime fns; the schema-entry must not.
+    // (TypeScript-level guard; this assertion is a runtime safety net.)
+    expect((schemas as Record<string, unknown>).guidellmAdapter).toBeUndefined();
+    expect((schemas as Record<string, unknown>).vegetaAdapter).toBeUndefined();
+    expect((schemas as Record<string, unknown>).genaiPerfAdapter).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 1.8.2: Run; expect pass (entry already correctly shaped)**
+
+```bash
+cd packages/tool-adapters
+pnpm test -- schemas-entry
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 1.8.3: Commit**
+
+```bash
+cd ../..
+git add packages/tool-adapters/src/schemas-entry.spec.ts
+git commit -m "$(cat <<'EOF'
+test(tool-adapters): assert schemas-entry doesn't leak runtime exports
+
+Regression guard for FE bundle hygiene: the './schemas' subpath must
+expose only zod schemas/types, never the adapter objects that wire
+runtime functions.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 1.9: Final Phase 1 verification
+
+- [ ] **Step 1.9.1: Run full repo checks from root**
+
+```bash
+pnpm -r build
+pnpm -r type-check
+pnpm -r test
+pnpm -r lint
+pnpm -r format
+```
+
+Expected: all green. `format` writes any biome-formatted output (commit if any).
+
+- [ ] **Step 1.9.2: If formatting modified files, commit**
+
+```bash
+git status
+# If only formatting changes:
+git add -A
+git diff --staged --stat
+git commit -m "$(cat <<'EOF'
+chore(tool-adapters): biome format
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 1.9.3: Push branch**
+
+```bash
+git push -u origin feat/issue-53-phase-1-adapter-package
+```
+
+- [ ] **Step 1.9.4: Open PR 53.1**
+
+```bash
+gh pr create --title "feat(tool-adapters): add @modeldoctor/tool-adapters package skeleton (#53 PR 1/4)" --body "$(cat <<'EOF'
+## Summary
+- Adds `packages/tool-adapters/` with subpath exports (`.` for backend, `./schemas` for frontend)
+- Defines `ToolAdapter` interface, `BuildCommandResult`, `ProgressEvent`, `ToolReport` discriminated union (D 立场: per-tool typed reports, no canonical layer)
+- Lands schema-complete adapters for guidellm / vegeta / genai-perf with runtime stubs (filled in PR 53.3 / 53.4)
+- Adds `byTool()` / `allAdapters()` registry
+
+## Why this is small
+Just package skeleton + schemas + stubs. No api/runner integration yet.
+- PR 53.2 wires up the `RunService`, callback v2, and DB migration.
+- PR 53.3 fills in guidellm + vegeta runtime + rewrites the runner image.
+- PR 53.4 fills in genai-perf and verifies the acceptance gate (this file's `core/interface.ts` must be untouched).
+
+## Test plan
+- [ ] `pnpm -F @modeldoctor/tool-adapters test` — schema + registry + schemas-entry specs pass
+- [ ] `pnpm -F @modeldoctor/tool-adapters build` — emits CJS dist with both subpath entries
+- [ ] `pnpm -F @modeldoctor/tool-adapters type-check` clean
+- [ ] `pnpm -F @modeldoctor/tool-adapters lint` clean
+
+## Related
+- Issue: #53
+- Spec: `docs/superpowers/specs/2026-05-02-issue-53-tool-adapter-framework-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 1.9.5: Phase 1 DoD checklist**
+
+- [x] `packages/tool-adapters/` package exists with subpath exports
+- [x] `core/interface.ts` defines `ToolAdapter`, `BuildCommandResult`, `ProgressEvent`, `ToolReport`
+- [x] `core/registry.ts` exports `byTool` + `allAdapters`
+- [x] All three adapters have complete `paramsSchema` + `reportSchema` + `paramDefaults`
+- [x] Runtime functions are stubs (throw `'not implemented'`) — filled in Phase 3 / 4
+- [x] `schemas-entry.spec.ts` regression guards FE bundle hygiene
+- [x] CI checks pass
+- [x] PR opened against `main`
+
+---
+
+
+# Phase 2 (PR 53.2) — Callback v2 + RunService + Driver Refactor + DB Migration
+
+**Phase goal:** Add the new generic API surface (`POST /api/runs` + `RunService` + `RunCallbackController` with `/state, /log, /finish` v2 protocol + new driver interface using `BuildCommandResult`). Drop `Run.canonicalReport` column. **Old `BenchmarkController` / `LoadTestController` paths remain fully functional and untouched** — their drivers, controllers, services, callbacks, and contract DTOs are not edited in this phase. Both code paths share the underlying `Run` table; old rows have old-shape `summaryMetrics`, new rows have new-shape `{ tool, data }` discriminated-union. Dev DB is reset between Phase 2 and Phase 3 to avoid mixed-shape rows surviving.
+
+**Out of scope this phase:** runtime implementations (Phase 3 + 4), runner image rewrite (Phase 3), facade conversion (Phase 3), legacy callback removal (Phase 3).
+
+**Depends on:** Phase 1 PR merged (the new RunService imports `byTool` from `@modeldoctor/tool-adapters`). If Phase 1 hasn't merged yet but the worktree branch can `git rebase main` once it does, that works too — but for review clarity, sequence sequentially.
+
+## Phase 2 Pre-flight
+
+- [ ] **Step 2.0.1: Confirm Phase 1 is merged to main (or branch off the merge commit)**
+
+```bash
+cd /Users/fangyong/vllm/modeldoctor/main
+git fetch origin
+git log --oneline origin/main | head -3
+```
+
+Expected: PR 53.1's merge commit visible.
+
+- [ ] **Step 2.0.2: Create Phase 2 worktree**
+
+```bash
+cd /Users/fangyong/vllm/modeldoctor
+git worktree add issue-53-phase-2 -b feat/issue-53-phase-2-callback-v2 main
+cd issue-53-phase-2
+pnpm install --frozen-lockfile
+```
+
+Expected: clean worktree, deps installed, `pnpm-lock.yaml` unchanged.
+
+- [ ] **Step 2.0.3: Smoke-test baseline**
+
+```bash
+pnpm -r build
+pnpm -r test
+pnpm -r type-check
+pnpm -r lint
+```
+
+Expected: all green.
+
+---
+
+## Task 2.1: Drop `canonical_report` column
+
+**Files:**
+- Modify: `apps/api/prisma/schema.prisma:128` (remove `canonicalReport` field)
+- Create: `apps/api/prisma/migrations/<ts>_issue_53_canonical_drop/migration.sql`
+
+- [ ] **Step 2.1.1: Edit `apps/api/prisma/schema.prisma`**
+
+Find this block in the `model Run` definition:
+
+```prisma
+  // Snapshots
+  params          Json
+  canonicalReport Json? @map("canonical_report")
+  rawOutput       Json? @map("raw_output")
+```
+
+Delete the `canonicalReport` line:
+
+```prisma
+  // Snapshots
+  params          Json
+  rawOutput       Json? @map("raw_output")
+```
+
+- [ ] **Step 2.1.2: Generate migration via Prisma (no apply)**
+
+```bash
+cd apps/api
+pnpm prisma migrate dev --create-only --name issue_53_canonical_drop
+```
+
+Expected: a new directory `apps/api/prisma/migrations/<timestamp>_issue_53_canonical_drop/` with a `migration.sql` containing `ALTER TABLE "runs" DROP COLUMN "canonical_report";`.
+
+- [ ] **Step 2.1.3: Verify migration content**
+
+```bash
+cat apps/api/prisma/migrations/*_issue_53_canonical_drop/migration.sql
+```
+
+Expected:
+
+```sql
+-- AlterTable
+ALTER TABLE "runs" DROP COLUMN "canonical_report";
+```
+
+- [ ] **Step 2.1.4: Apply migration to dev DB**
+
+```bash
+pnpm prisma migrate dev
+```
+
+Expected: migration applies cleanly, Prisma client regenerates.
+
+- [ ] **Step 2.1.5: Commit**
+
+```bash
+cd ../..
+git add apps/api/prisma/schema.prisma apps/api/prisma/migrations/
+git commit -m "$(cat <<'EOF'
+refactor(prisma): drop Run.canonical_report column (#53)
+
+Per issue #53 spec §5.2, the canonical schema concept is replaced by
+per-tool typed reports stored in summaryMetrics as a discriminated
+union body. The canonical_report column was a placeholder and never
+written; safe to drop without backfill.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2.2: Update contracts — drop canonicalReport, add new schemas
+
+**Files:**
+- Modify: `packages/contracts/src/run.ts`
+- Modify: `packages/contracts/src/baseline.spec.ts:155`
+
+- [ ] **Step 2.2.1: Remove `canonicalReport` from `runSchema`**
+
+In `packages/contracts/src/run.ts`, find:
+
+```ts
+  params: z.record(z.unknown()),
+  canonicalReport: z.record(z.unknown()).nullable(),
+  rawOutput: z.record(z.unknown()).nullable(),
+```
+
+Replace with:
+
+```ts
+  params: z.record(z.unknown()),
+  rawOutput: z.record(z.unknown()).nullable(),
+```
+
+- [ ] **Step 2.2.2: Add `createRunRequestSchema`**
+
+Append to `packages/contracts/src/run.ts`:
+
+```ts
+// ============================================================
+// New unified create endpoint (POST /api/runs body)
+// Phase 2 (#53). Old POST /api/benchmarks and POST /api/load-test
+// keep their existing bodies and remain in service.
+// ============================================================
+
+export const createRunRequestSchema = z.object({
+  tool: runToolSchema,
+  kind: runKindSchema.default("benchmark"),
+  connectionId: z.string().min(1),
+  name: z.string().min(1).max(128),
+  description: z.string().max(2048).optional(),
+  // adapter.paramsSchema is applied in the service layer; here we
+  // only require the field to be a record so generic transport works.
+  params: z.record(z.unknown()),
+  templateId: z.string().optional(),
+  templateVersion: z.string().optional(),
+  parentRunId: z.string().optional(),
+  baselineId: z.string().optional(),
+});
+export type CreateRunRequest = z.infer<typeof createRunRequestSchema>;
+```
+
+- [ ] **Step 2.2.3: Add v2 callback schemas**
+
+Append to `packages/contracts/src/run.ts`:
+
+```ts
+// ============================================================
+// Internal callback schemas v2 (runner pod → API)
+// Phase 2 (#53). Old /api/internal/benchmarks/:id/{state,metrics}
+// keep working in parallel during this phase.
+// ============================================================
+
+export const runStateCallbackSchema = z.object({
+  state: z.literal("running"),
+});
+export type RunStateCallback = z.infer<typeof runStateCallbackSchema>;
+
+export const runLogCallbackSchema = z.object({
+  stream: z.enum(["stdout", "stderr"]),
+  lines: z.array(z.string().max(64 * 1024)).max(2000),
+});
+export type RunLogCallback = z.infer<typeof runLogCallbackSchema>;
+
+export const runFinishCallbackSchema = z.object({
+  state: z.enum(["completed", "failed"]),
+  exitCode: z.number().int(),
+  // Full stdout/stderr captured during the run; capped on the runner
+  // side to ~16 KB tail apiece for /log live stream, but /finish ships
+  // the full text. The /finish endpoint raises body-size to 10 MB to
+  // accommodate full reports + outputs.
+  stdout: z.string(),
+  stderr: z.string(),
+  // alias → base64-encoded file bytes. Aliases are stable per-tool and
+  // align with the adapter's BuildCommandResult.outputFiles map.
+  files: z.record(z.string()),
+  message: z.string().max(2048).optional(),
+});
+export type RunFinishCallback = z.infer<typeof runFinishCallbackSchema>;
+```
+
+- [ ] **Step 2.2.4: Update `baseline.spec.ts` test fixture**
+
+In `packages/contracts/src/baseline.spec.ts:155`, find:
+
+```ts
+    canonicalReport: null,
+```
+
+Delete this line.
+
+- [ ] **Step 2.2.5: Update `runRowToContract` mapper in apps/api**
+
+In `apps/api/src/modules/run/run.service.ts:65`, find:
+
+```ts
+    params: row.params as Run["params"],
+    canonicalReport: row.canonicalReport as Run["canonicalReport"],
+    rawOutput: row.rawOutput as Run["rawOutput"],
+```
+
+Replace with:
+
+```ts
+    params: row.params as Run["params"],
+    rawOutput: row.rawOutput as Run["rawOutput"],
+```
+
+- [ ] **Step 2.2.6: Run tests + type-check**
+
+```bash
+pnpm -r build
+pnpm -r type-check
+pnpm -r test
+```
+
+Expected: green. Any reference to `canonicalReport` outside the deleted ones is a missed call — `grep -rn canonicalReport apps/ packages/ --include="*.ts"` should return only generated `dist/*.d.ts` lines (which `pnpm -F @modeldoctor/contracts build` regenerates).
+
+- [ ] **Step 2.2.7: Commit**
+
+```bash
+git add packages/contracts/src/run.ts packages/contracts/src/baseline.spec.ts \
+        apps/api/src/modules/run/run.service.ts \
+        packages/contracts/dist
+git commit -m "$(cat <<'EOF'
+feat(contracts): drop canonicalReport; add createRunRequest + v2 callback schemas
+
+- runSchema no longer carries canonicalReport (Run.canonical_report column
+  was dropped in Task 2.1)
+- New createRunRequestSchema for the unified POST /api/runs endpoint
+- New runStateCallbackSchema / runLogCallbackSchema / runFinishCallbackSchema
+  for the v2 callback protocol
+
+Old benchmark/load-test contracts remain unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2.3: Move HMAC helper + guard to `apps/api/src/common/hmac/`
+
+> Sharing rationale: Phase 3 deletes `apps/api/src/modules/benchmark/callbacks/`, but Phase 2's new RunCallbackController also needs the HMAC. Move the helpers to a shared common location now so Phase 3 doesn't need to migrate them under pressure.
+
+**Files:**
+- Create: `apps/api/src/common/hmac/hmac-token.ts`
+- Create: `apps/api/src/common/hmac/hmac-token.spec.ts`
+- Create: `apps/api/src/common/hmac/hmac-callback.guard.ts`
+- Create: `apps/api/src/common/hmac/hmac-callback.guard.spec.ts`
+- Modify: `apps/api/src/modules/benchmark/callbacks/hmac-token.ts` → re-export from new location
+- Modify: `apps/api/src/modules/benchmark/callbacks/hmac-callback.guard.ts` → re-export from new location
+
+- [ ] **Step 2.3.1: Move `hmac-token.ts`**
+
+```bash
+mkdir -p apps/api/src/common/hmac
+git mv apps/api/src/modules/benchmark/callbacks/hmac-token.ts apps/api/src/common/hmac/hmac-token.ts
+git mv apps/api/src/modules/benchmark/callbacks/hmac-token.spec.ts apps/api/src/common/hmac/hmac-token.spec.ts
+```
+
+- [ ] **Step 2.3.2: Move `hmac-callback.guard.ts`**
+
+```bash
+git mv apps/api/src/modules/benchmark/callbacks/hmac-callback.guard.ts apps/api/src/common/hmac/hmac-callback.guard.ts
+git mv apps/api/src/modules/benchmark/callbacks/hmac-callback.guard.spec.ts apps/api/src/common/hmac/hmac-callback.guard.spec.ts
+```
+
+- [ ] **Step 2.3.3: Add re-export shim at old paths (so old benchmark code keeps compiling untouched)**
+
+Create `apps/api/src/modules/benchmark/callbacks/hmac-token.ts`:
+
+```ts
+// Phase 2 (#53): canonical implementation lives in src/common/hmac/.
+// This shim keeps the benchmark module's existing imports compiling;
+// Phase 3 (#53 PR 3/4) deletes the benchmark/callbacks directory along
+// with this shim.
+export * from "../../../common/hmac/hmac-token.js";
+```
+
+Create `apps/api/src/modules/benchmark/callbacks/hmac-callback.guard.ts`:
+
+```ts
+// Phase 2 (#53): see hmac-token.ts shim above.
+export * from "../../../common/hmac/hmac-callback.guard.js";
+```
+
+- [ ] **Step 2.3.4: Update import paths inside the moved files**
+
+In `apps/api/src/common/hmac/hmac-callback.guard.ts`, the import should now be:
+
+```ts
+import type { Env } from "../../config/env.schema.js";
+import { verifyCallbackToken } from "./hmac-token.js";
+```
+
+(Was previously `../../../config/env.schema.js`.)
+
+- [ ] **Step 2.3.5: Run tests + type-check**
+
+```bash
+pnpm -F @modeldoctor/api test -- hmac
+pnpm -F @modeldoctor/api type-check
+```
+
+Expected: green; both old import paths (via shim) and new paths resolve.
+
+- [ ] **Step 2.3.6: Commit**
+
+```bash
+git add apps/api/src/common/hmac/ apps/api/src/modules/benchmark/callbacks/hmac-token.ts apps/api/src/modules/benchmark/callbacks/hmac-callback.guard.ts
+git commit -m "$(cat <<'EOF'
+refactor(api): move HMAC token + guard to src/common/hmac/
+
+Both the existing benchmark callback path and the new RunCallbackController
+(Phase 2 of #53) need the HMAC helpers. Shared common location avoids
+duplication; the old benchmark/callbacks/ paths re-export from the new
+location for compatibility through Phase 2.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2.4: New `RunExecutionDriver` interface in `run/drivers/`
+
+**Files:**
+- Create: `apps/api/src/modules/run/drivers/execution-driver.interface.ts`
+- Create: `apps/api/src/modules/run/drivers/run-driver.token.ts`
+
+- [ ] **Step 2.4.1: Create `apps/api/src/modules/run/drivers/execution-driver.interface.ts`**
+
+```ts
+import type { BuildCommandResult, ToolName } from "@modeldoctor/tool-adapters";
+
+/**
+ * Per-run input passed to a driver. Sensitive values flow via
+ * `buildResult.secretEnv` and `buildResult.inputFiles` and MUST NOT
+ * appear in argv. K8s drivers must materialize secrets via per-run
+ * Secret + envFrom / volumeMount; subprocess driver merges secretEnv
+ * into the spawn env.
+ *
+ * `image` is selected by the driver factory (`imageForTool`) and is
+ * NOT part of the adapter's responsibility — adapters are deployment-
+ * mode-agnostic.
+ */
+export interface RunExecutionContext {
+  runId: string;
+  tool: ToolName;
+  buildResult: BuildCommandResult;
+  callback: { url: string; token: string };
+  image: string;
+}
+
+/** Opaque handle to an in-flight execution. */
+export type RunExecutionHandle = string;
+
+export interface RunExecutionDriver {
+  /**
+   * Start the runner. Resolves once the runner is launched (subprocess
+   * spawned or Job created), NOT when the inner tool finishes.
+   * Lifecycle progression after start() flows through HTTP callbacks.
+   */
+  start(ctx: RunExecutionContext): Promise<{ handle: RunExecutionHandle }>;
+
+  /** Stop an in-flight execution. Idempotent. */
+  cancel(handle: RunExecutionHandle): Promise<void>;
+
+  /**
+   * Release driver-side resources (subprocess wait, K8s Job delete) after
+   * a run reaches a terminal state. Idempotent.
+   */
+  cleanup(handle: RunExecutionHandle): Promise<void>;
+}
+```
+
+- [ ] **Step 2.4.2: Create `apps/api/src/modules/run/drivers/run-driver.token.ts`**
+
+```ts
+/** DI token used by RunModule to inject the chosen RunExecutionDriver. */
+export const RUN_DRIVER = Symbol("RUN_DRIVER");
+```
+
+- [ ] **Step 2.4.3: Commit**
+
+```bash
+git add apps/api/src/modules/run/drivers/
+git commit -m "$(cat <<'EOF'
+feat(api/run): add RunExecutionDriver interface (#53)
+
+Generic driver contract that consumes BuildCommandResult from any
+ToolAdapter. Replaces the guidellm-shape BenchmarkExecutionContext
+in the new code path. Old BenchmarkExecutionDriver remains untouched
+in modules/benchmark/drivers/ during Phase 2.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2.5: New `SubprocessDriver` (parallel to old)
+
+**Files:**
+- Create: `apps/api/src/modules/run/drivers/subprocess-driver.ts`
+- Create: `apps/api/src/modules/run/drivers/subprocess-driver.spec.ts`
+
+- [ ] **Step 2.5.1: Write the failing test**
+
+Create `apps/api/src/modules/run/drivers/subprocess-driver.spec.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import { SubprocessDriver } from "./subprocess-driver.js";
+import type { RunExecutionContext } from "./execution-driver.interface.js";
+
+vi.mock("node:child_process", () => {
+  const proc = new EventEmitter() as EventEmitter & {
+    pid: number;
+    kill: (signal?: NodeJS.Signals) => boolean;
+    killed: boolean;
+  };
+  proc.pid = 12345;
+  proc.kill = vi.fn(() => true);
+  proc.killed = false;
+  return {
+    spawn: vi.fn(() => proc),
+    __mocked: { proc },
+  };
+});
+
+const ctx: RunExecutionContext = {
+  runId: "abc123",
+  tool: "guidellm",
+  buildResult: {
+    argv: ["echo", "hello"],
+    env: { FOO: "bar" },
+    secretEnv: { API_KEY: "shh" },
+    outputFiles: { report: "report.json" },
+  },
+  callback: { url: "http://localhost:3001", token: "tk" },
+  image: "irrelevant-for-subprocess",
+};
+
+let driver: SubprocessDriver;
+let tmpRoot: string;
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "md-test-"));
+  driver = new SubprocessDriver({ cwdRoot: tmpRoot });
+});
+
+afterEach(async () => {
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+describe("SubprocessDriver", () => {
+  it("creates cwd and spawns wrapper with MD_* env", async () => {
+    const { handle } = await driver.start(ctx);
+    expect(handle).toBe("subprocess:12345");
+
+    const cwd = path.join(tmpRoot, "run-abc123");
+    const stat = await fs.stat(cwd);
+    expect(stat.isDirectory()).toBe(true);
+
+    const { spawn } = await import("node:child_process");
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const call = (spawn as unknown as { mock: { calls: unknown[][] } }).mock.calls[0];
+    const [cmd, , opts] = call as [string, string[], { env: Record<string, string>; cwd: string }];
+    expect(cmd).toBe("benchmark-runner-wrapper");
+    expect(opts.cwd).toBe(cwd);
+    expect(opts.env.MD_RUN_ID).toBe("abc123");
+    expect(opts.env.MD_CALLBACK_URL).toBe("http://localhost:3001");
+    expect(opts.env.MD_CALLBACK_TOKEN).toBe("tk");
+    expect(JSON.parse(opts.env.MD_ARGV)).toEqual(["echo", "hello"]);
+    expect(JSON.parse(opts.env.MD_OUTPUT_FILES)).toEqual({ report: "report.json" });
+    expect(opts.env.FOO).toBe("bar");
+    expect(opts.env.API_KEY).toBe("shh");
+  });
+
+  it("writes inputFiles before spawn", async () => {
+    const ctxWithInput: RunExecutionContext = {
+      ...ctx,
+      buildResult: { ...ctx.buildResult, inputFiles: { "targets.txt": "hello\nworld\n" } },
+    };
+    await driver.start(ctxWithInput);
+    const written = await fs.readFile(path.join(tmpRoot, "run-abc123", "targets.txt"), "utf8");
+    expect(written).toBe("hello\nworld\n");
+  });
+
+  it("cancel sends SIGTERM", async () => {
+    const { handle } = await driver.start(ctx);
+    await driver.cancel(handle);
+    const { spawn } = await import("node:child_process");
+    const proc = (spawn as unknown as { __mocked?: { proc: { kill: ReturnType<typeof vi.fn> } } })
+      .__mocked?.proc;
+    expect(proc?.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+});
+```
+
+- [ ] **Step 2.5.2: Run failing**
+
+```bash
+pnpm -F @modeldoctor/api test -- run/drivers/subprocess
+```
+
+Expected: failure, module not found.
+
+- [ ] **Step 2.5.3: Create `apps/api/src/modules/run/drivers/subprocess-driver.ts`**
+
+```ts
+import { type ChildProcess, spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Injectable, Logger } from "@nestjs/common";
+import type {
+  RunExecutionContext,
+  RunExecutionDriver,
+  RunExecutionHandle,
+} from "./execution-driver.interface.js";
+
+interface Entry {
+  child: ChildProcess;
+  killTimer?: NodeJS.Timeout;
+  cwd: string;
+}
+
+const SIGKILL_DELAY_MS = 10_000;
+
+export interface SubprocessDriverOpts {
+  cwdRoot?: string;
+}
+
+@Injectable()
+export class SubprocessDriver implements RunExecutionDriver {
+  private readonly log = new Logger(SubprocessDriver.name);
+  private readonly handles = new Map<RunExecutionHandle, Entry>();
+  private readonly cwdRoot: string;
+
+  constructor(opts: SubprocessDriverOpts = {}) {
+    this.cwdRoot = opts.cwdRoot ?? path.join(os.tmpdir(), "modeldoctor-runs");
+  }
+
+  async start(ctx: RunExecutionContext): Promise<{ handle: RunExecutionHandle }> {
+    const cwd = path.join(this.cwdRoot, `run-${ctx.runId}`);
+    await fs.mkdir(cwd, { recursive: true });
+
+    // Write inputFiles before spawn
+    for (const [relPath, content] of Object.entries(ctx.buildResult.inputFiles ?? {})) {
+      const full = path.join(cwd, relPath);
+      await fs.mkdir(path.dirname(full), { recursive: true });
+      await fs.writeFile(full, content);
+    }
+
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      ...ctx.buildResult.env,
+      ...ctx.buildResult.secretEnv,
+      MD_RUN_ID: ctx.runId,
+      MD_CALLBACK_URL: ctx.callback.url,
+      MD_CALLBACK_TOKEN: ctx.callback.token,
+      MD_ARGV: JSON.stringify(ctx.buildResult.argv),
+      MD_OUTPUT_FILES: JSON.stringify(ctx.buildResult.outputFiles),
+    };
+
+    const child = spawn("benchmark-runner-wrapper", [], {
+      env,
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: false,
+    });
+
+    if (!child.pid) {
+      throw new Error("SubprocessDriver: failed to spawn wrapper (no pid)");
+    }
+    const handle: RunExecutionHandle = `subprocess:${child.pid}`;
+    this.handles.set(handle, { child, cwd });
+
+    child.on("exit", (code, signal) => {
+      this.log.log(
+        `subprocess ${handle} exited code=${code ?? "null"} signal=${signal ?? "null"}`,
+      );
+      const entry = this.handles.get(handle);
+      if (entry?.killTimer) clearTimeout(entry.killTimer);
+      this.handles.delete(handle);
+    });
+
+    return { handle };
+  }
+
+  async cancel(handle: RunExecutionHandle): Promise<void> {
+    const entry = this.handles.get(handle);
+    if (!entry) return;
+    entry.child.kill("SIGTERM");
+    entry.killTimer = setTimeout(() => {
+      if (!entry.child.killed) entry.child.kill("SIGKILL");
+    }, SIGKILL_DELAY_MS);
+  }
+
+  async cleanup(handle: RunExecutionHandle): Promise<void> {
+    const entry = this.handles.get(handle);
+    if (!entry) return;
+    if (entry.killTimer) clearTimeout(entry.killTimer);
+    this.handles.delete(handle);
+    // Note: cwd cleanup is intentionally NOT done here — the runner
+    // wrapper has already shipped outputFiles via /finish; cwd just
+    // contains scratch space we leave for post-mortem inspection. A
+    // separate cron sweep can prune /tmp/modeldoctor-runs/ if needed.
+  }
+}
+```
+
+- [ ] **Step 2.5.4: Run tests**
+
+```bash
+pnpm -F @modeldoctor/api test -- run/drivers/subprocess
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 2.5.5: Commit**
+
+```bash
+git add apps/api/src/modules/run/drivers/subprocess-driver.ts apps/api/src/modules/run/drivers/subprocess-driver.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(api/run): add new SubprocessDriver consuming BuildCommandResult (#53)
+
+Per-tool-agnostic spawn driver: writes inputFiles to cwd, merges
+env+secretEnv into the wrapper's env, ships argv via MD_ARGV. The
+'benchmark-runner-wrapper' binary itself is rewritten in Phase 3.
+
+Old benchmark/drivers/subprocess-driver.ts is untouched in this phase.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2.6: New K8s Job manifest builder
+
+**Files:**
+- Create: `apps/api/src/modules/run/drivers/k8s-job-manifest.ts`
+- Create: `apps/api/src/modules/run/drivers/k8s-job-manifest.spec.ts`
+
+- [ ] **Step 2.6.1: Write the failing test**
+
+Create `apps/api/src/modules/run/drivers/k8s-job-manifest.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { buildJobManifest, buildSecretManifest, jobName, secretName } from "./k8s-job-manifest.js";
+import type { RunExecutionContext } from "./execution-driver.interface.js";
+
+const ctx: RunExecutionContext = {
+  runId: "abc123",
+  tool: "guidellm",
+  buildResult: {
+    argv: ["guidellm", "benchmark", "run", "--target=http://x"],
+    env: { FOO: "bar", BAZ: "qux" },
+    secretEnv: { API_KEY: "secret-value" },
+    inputFiles: { "targets.txt": "POST http://x" },
+    outputFiles: { report: "report.json" },
+  },
+  callback: { url: "http://api/", token: "tk" },
+  image: "ghcr.io/example/runner:latest",
+};
+
+describe("buildSecretManifest", () => {
+  it("includes secretEnv and inputFiles in stringData", () => {
+    const s = buildSecretManifest(ctx, "ns");
+    expect(s.metadata?.name).toBe("run-abc123");
+    expect(s.stringData?.API_KEY).toBe("secret-value");
+    // inputFiles entries are prefixed with INPUT_FILE_<base64alias> to keep the
+    // Secret key flat (Secret keys must be DNS-segment-like).
+    const inputFileKeys = Object.keys(s.stringData ?? {}).filter((k) => k.startsWith("INPUT_FILE_"));
+    expect(inputFileKeys).toHaveLength(1);
+    expect(s.stringData?.[inputFileKeys[0]]).toBe("POST http://x");
+  });
+});
+
+describe("buildJobManifest", () => {
+  it("references the per-run Secret via envFrom", () => {
+    const j = buildJobManifest(ctx, { namespace: "ns" });
+    expect(j.metadata?.name).toBe("run-abc123");
+    const c = j.spec?.template.spec?.containers[0];
+    expect(c?.image).toBe("ghcr.io/example/runner:latest");
+    expect(c?.envFrom).toContainEqual({ secretRef: { name: "run-abc123" } });
+  });
+
+  it("ships non-secret env values directly + MD_* control vars", () => {
+    const j = buildJobManifest(ctx, { namespace: "ns" });
+    const env = j.spec?.template.spec?.containers[0].env ?? [];
+    expect(env).toContainEqual({ name: "FOO", value: "bar" });
+    expect(env).toContainEqual({ name: "BAZ", value: "qux" });
+    expect(env).toContainEqual({ name: "MD_RUN_ID", value: "abc123" });
+    expect(env).toContainEqual({ name: "MD_CALLBACK_URL", value: "http://api/" });
+    expect(env).toContainEqual({ name: "MD_ARGV", value: JSON.stringify(ctx.buildResult.argv) });
+    expect(env).toContainEqual({
+      name: "MD_OUTPUT_FILES",
+      value: JSON.stringify(ctx.buildResult.outputFiles),
+    });
+  });
+
+  it("does NOT put callback token in env value (must come from Secret via envFrom)", () => {
+    const j = buildJobManifest(ctx, { namespace: "ns" });
+    const env = j.spec?.template.spec?.containers[0].env ?? [];
+    const tokenEntry = env.find((e) => e.name === "MD_CALLBACK_TOKEN");
+    expect(tokenEntry).toBeUndefined();
+
+    const s = buildSecretManifest(ctx, "ns");
+    expect(s.stringData?.MD_CALLBACK_TOKEN).toBe("tk");
+  });
+
+  it("mounts inputFiles via volume sourced from the Secret", () => {
+    const j = buildJobManifest(ctx, { namespace: "ns" });
+    const c = j.spec?.template.spec?.containers[0];
+    const mount = c?.volumeMounts?.find((m) => m.name === "input-files");
+    expect(mount).toBeDefined();
+    expect(mount?.mountPath).toBe("/workdir/inputs");
+    const vol = j.spec?.template.spec?.volumes?.find((v) => v.name === "input-files");
+    expect(vol?.secret?.secretName).toBe("run-abc123");
+    // The wrapper symlinks /workdir/inputs/<base64alias> → cwd/<relpath> at startup.
+  });
+});
+
+describe("naming helpers", () => {
+  it("jobName is run-<id>", () => {
+    expect(jobName("xyz")).toBe("run-xyz");
+  });
+  it("secretName matches jobName for ownerRef GC", () => {
+    expect(secretName("xyz")).toBe(jobName("xyz"));
+  });
+});
+```
+
+- [ ] **Step 2.6.2: Run failing**
+
+```bash
+pnpm -F @modeldoctor/api test -- run/drivers/k8s-job-manifest
+```
+
+Expected: module not found.
+
+- [ ] **Step 2.6.3: Create `apps/api/src/modules/run/drivers/k8s-job-manifest.ts`**
+
+```ts
+import type { V1Job, V1Secret } from "@kubernetes/client-node";
+import type { RunExecutionContext } from "./execution-driver.interface.js";
+
+export function jobName(runId: string): string {
+  return `run-${runId}`;
+}
+export function secretName(runId: string): string {
+  return jobName(runId);
+}
+
+const LABELS = {
+  "app.kubernetes.io/name": "modeldoctor-run",
+  "app.kubernetes.io/managed-by": "modeldoctor-api",
+};
+
+// Encode an inputFiles alias into a Secret-key-safe form. Aliases are
+// arbitrary strings (e.g. "targets.txt"); Secret keys must be DNS-
+// segment-like ([A-Za-z0-9._-]). Base64-url-no-pad gives a deterministic
+// encoding inside that set.
+function encodeAlias(alias: string): string {
+  return `INPUT_FILE_${Buffer.from(alias, "utf8").toString("base64url")}`;
+}
+function decodeAlias(key: string): string | null {
+  if (!key.startsWith("INPUT_FILE_")) return null;
+  return Buffer.from(key.slice("INPUT_FILE_".length), "base64url").toString("utf8");
+}
+export const __testing = { encodeAlias, decodeAlias };
+
+const INPUTS_VOLUME = "input-files";
+const INPUTS_MOUNT_PATH = "/workdir/inputs";
+
+export function buildSecretManifest(ctx: RunExecutionContext, namespace: string): V1Secret {
+  const stringData: Record<string, string> = {
+    ...ctx.buildResult.secretEnv,
+    MD_CALLBACK_TOKEN: ctx.callback.token,
+  };
+  for (const [alias, content] of Object.entries(ctx.buildResult.inputFiles ?? {})) {
+    stringData[encodeAlias(alias)] = content;
+  }
+  return {
+    apiVersion: "v1",
+    kind: "Secret",
+    metadata: {
+      name: secretName(ctx.runId),
+      namespace,
+      labels: { ...LABELS, "modeldoctor.ai/run-id": ctx.runId },
+    },
+    type: "Opaque",
+    stringData,
+  };
+}
+
+export interface JobManifestOptions {
+  namespace: string;
+}
+
+export function buildJobManifest(ctx: RunExecutionContext, opts: JobManifestOptions): V1Job {
+  const env: { name: string; value: string }[] = [
+    { name: "MD_RUN_ID", value: ctx.runId },
+    { name: "MD_CALLBACK_URL", value: ctx.callback.url },
+    { name: "MD_ARGV", value: JSON.stringify(ctx.buildResult.argv) },
+    { name: "MD_OUTPUT_FILES", value: JSON.stringify(ctx.buildResult.outputFiles) },
+  ];
+  // Map alias → full path of the mounted Secret key
+  const inputFilePaths: Record<string, string> = {};
+  for (const alias of Object.keys(ctx.buildResult.inputFiles ?? {})) {
+    inputFilePaths[alias] = `${INPUTS_MOUNT_PATH}/${encodeAlias(alias)}`;
+  }
+  if (Object.keys(inputFilePaths).length > 0) {
+    env.push({ name: "MD_INPUT_FILE_PATHS", value: JSON.stringify(inputFilePaths) });
+  }
+  for (const [k, v] of Object.entries(ctx.buildResult.env)) {
+    env.push({ name: k, value: v });
+  }
+
+  const hasInputFiles = Object.keys(ctx.buildResult.inputFiles ?? {}).length > 0;
+
+  return {
+    apiVersion: "batch/v1",
+    kind: "Job",
+    metadata: {
+      name: jobName(ctx.runId),
+      namespace: opts.namespace,
+      labels: { ...LABELS, "modeldoctor.ai/run-id": ctx.runId },
+    },
+    spec: {
+      backoffLimit: 0,
+      ttlSecondsAfterFinished: 3600,
+      template: {
+        metadata: {
+          labels: { ...LABELS, "modeldoctor.ai/run-id": ctx.runId },
+        },
+        spec: {
+          restartPolicy: "Never",
+          containers: [
+            {
+              name: "runner",
+              image: ctx.image,
+              imagePullPolicy: "IfNotPresent",
+              env,
+              envFrom: [{ secretRef: { name: secretName(ctx.runId) } }],
+              ...(hasInputFiles
+                ? {
+                    volumeMounts: [
+                      {
+                        name: INPUTS_VOLUME,
+                        mountPath: INPUTS_MOUNT_PATH,
+                        readOnly: true,
+                      },
+                    ],
+                  }
+                : {}),
+              resources: {
+                requests: { cpu: "500m", memory: "512Mi" },
+                limits: { cpu: "2", memory: "2Gi" },
+              },
+            },
+          ],
+          ...(hasInputFiles
+            ? {
+                volumes: [
+                  {
+                    name: INPUTS_VOLUME,
+                    secret: { secretName: secretName(ctx.runId) },
+                  },
+                ],
+              }
+            : {}),
+        },
+      },
+    },
+  };
+}
+```
+
+> **Wrapper note (Phase 3 work):** the runner wrapper reads `MD_INPUT_FILE_PATHS` and symlinks each `<mount>/<encoded-key>` → `<cwd>/<original-relpath>` before spawning the inner argv. This keeps adapters writing relative paths in `inputFiles` while K8s mounts encode the alias.
+
+- [ ] **Step 2.6.4: Run tests**
+
+```bash
+pnpm -F @modeldoctor/api test -- run/drivers/k8s-job-manifest
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 2.6.5: Commit**
+
+```bash
+git add apps/api/src/modules/run/drivers/k8s-job-manifest.ts apps/api/src/modules/run/drivers/k8s-job-manifest.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(api/run): add k8s Job + Secret manifest builders for unified runs (#53)
+
+Pure-function manifest builders that translate RunExecutionContext into
+V1Job + V1Secret. SecretEnv and inputFiles flow through a per-run Secret
+mounted as both envFrom and a /workdir/inputs volume. Job's image is
+supplied by the driver factory (imageForTool); never embedded in adapter.
+
+Old benchmark/drivers/k8s-job-manifest.ts is untouched.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2.7: New K8sJobDriver + driver factory
+
+**Files:**
+- Create: `apps/api/src/modules/run/drivers/k8s-job-driver.ts`
+- Create: `apps/api/src/modules/run/drivers/k8s-job-driver.spec.ts`
+- Create: `apps/api/src/modules/run/drivers/run-driver.factory.ts`
+- Create: `apps/api/src/modules/run/drivers/run-driver.factory.spec.ts`
+
+- [ ] **Step 2.7.1: Write failing K8sJobDriver test**
+
+Create `apps/api/src/modules/run/drivers/k8s-job-driver.spec.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { K8sJobDriver } from "./k8s-job-driver.js";
+import type { RunExecutionContext } from "./execution-driver.interface.js";
+
+const ctx: RunExecutionContext = {
+  runId: "abc",
+  tool: "guidellm",
+  buildResult: {
+    argv: ["echo", "hi"],
+    env: {},
+    secretEnv: { API_KEY: "k" },
+    outputFiles: { report: "report.json" },
+  },
+  callback: { url: "http://api/", token: "tk" },
+  image: "img:latest",
+};
+
+function mkDriver() {
+  const batch = {
+    createNamespacedJob: vi.fn(async () => ({ body: { metadata: { uid: "uid-1" } } })),
+    deleteNamespacedJob: vi.fn(async () => ({})),
+  };
+  const core = {
+    createNamespacedSecret: vi.fn(async () => ({})),
+    deleteNamespacedSecret: vi.fn(async () => ({})),
+    patchNamespacedSecret: vi.fn(async () => ({})),
+  };
+  const driver = new K8sJobDriver({
+    namespace: "ns",
+    apis: { batch: batch as never, core: core as never },
+  });
+  return { driver, batch, core };
+}
+
+describe("K8sJobDriver", () => {
+  it("creates Secret then Job", async () => {
+    const { driver, batch, core } = mkDriver();
+    const { handle } = await driver.start(ctx);
+    expect(handle).toBe("ns/run-abc");
+    expect(core.createNamespacedSecret).toHaveBeenCalled();
+    expect(batch.createNamespacedJob).toHaveBeenCalled();
+    // Order matters
+    expect(core.createNamespacedSecret.mock.invocationCallOrder[0]).toBeLessThan(
+      batch.createNamespacedJob.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("rolls back Secret if Job creation fails", async () => {
+    const { driver, batch, core } = mkDriver();
+    batch.createNamespacedJob = vi.fn(async () => {
+      throw new Error("simulated job-create failure");
+    }) as never;
+    await expect(driver.start(ctx)).rejects.toThrow(/simulated/);
+    expect(core.deleteNamespacedSecret).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2.7.2: Run failing**
+
+```bash
+pnpm -F @modeldoctor/api test -- run/drivers/k8s-job-driver
+```
+
+- [ ] **Step 2.7.3: Create `apps/api/src/modules/run/drivers/k8s-job-driver.ts`**
+
+```ts
+import type { BatchV1Api, CoreV1Api } from "@kubernetes/client-node";
+import { Logger } from "@nestjs/common";
+import type {
+  RunExecutionContext,
+  RunExecutionDriver,
+  RunExecutionHandle,
+} from "./execution-driver.interface.js";
+import { buildJobManifest, buildSecretManifest, jobName, secretName } from "./k8s-job-manifest.js";
+
+export interface K8sJobDriverOpts {
+  namespace: string;
+  apis: { batch: BatchV1Api; core: CoreV1Api };
+}
+
+export class K8sJobDriver implements RunExecutionDriver {
+  private readonly log = new Logger(K8sJobDriver.name);
+  private readonly namespace: string;
+  private readonly batch: BatchV1Api;
+  private readonly core: CoreV1Api;
+
+  constructor(opts: K8sJobDriverOpts) {
+    this.namespace = opts.namespace;
+    this.batch = opts.apis.batch;
+    this.core = opts.apis.core;
+  }
+
+  async start(ctx: RunExecutionContext): Promise<{ handle: RunExecutionHandle }> {
+    const ns = this.namespace;
+    const secret = buildSecretManifest(ctx, ns);
+    await this.core.createNamespacedSecret(ns, secret);
+
+    let jobUid: string | undefined;
+    try {
+      const job = buildJobManifest(ctx, { namespace: ns });
+      const created = await this.batch.createNamespacedJob(ns, job);
+      jobUid = (created as { body?: { metadata?: { uid?: string } } }).body?.metadata?.uid;
+    } catch (e) {
+      try {
+        await this.core.deleteNamespacedSecret(secretName(ctx.runId), ns);
+      } catch (rbErr) {
+        this.log.warn(
+          `Failed to roll back Secret after Job-create failure: ${(rbErr as Error).message}`,
+        );
+      }
+      throw e;
+    }
+
+    if (jobUid) {
+      try {
+        await this.core.patchNamespacedSecret(
+          secretName(ctx.runId),
+          ns,
+          {
+            metadata: {
+              ownerReferences: [
+                {
+                  apiVersion: "batch/v1",
+                  kind: "Job",
+                  name: jobName(ctx.runId),
+                  uid: jobUid,
+                  controller: true,
+                  blockOwnerDeletion: true,
+                },
+              ],
+            },
+          },
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { headers: { "Content-Type": "application/strategic-merge-patch+json" } },
+        );
+      } catch (e) {
+        this.log.warn(`Failed to patch Secret ownerReferences: ${(e as Error).message}`);
+      }
+    }
+
+    return { handle: `${ns}/${jobName(ctx.runId)}` };
+  }
+
+  async cancel(handle: RunExecutionHandle): Promise<void> {
+    const [ns, name] = handle.split("/");
+    if (!ns || !name) return;
+    try {
+      await this.batch.deleteNamespacedJob(
+        name,
+        ns,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        // propagationPolicy: 'Background' triggers Job → Secret cascade
+        // via ownerReferences set in start()
+        "Background",
+      );
+    } catch (e) {
+      this.log.warn(`cancel: deleteNamespacedJob failed: ${(e as Error).message}`);
+    }
+  }
+
+  async cleanup(handle: RunExecutionHandle): Promise<void> {
+    // K8s Job has TTL via spec.ttlSecondsAfterFinished; no explicit cleanup needed.
+    // Method exists for interface symmetry.
+    void handle;
+  }
+}
+```
+
+- [ ] **Step 2.7.4: Tests pass**
+
+```bash
+pnpm -F @modeldoctor/api test -- run/drivers/k8s-job-driver
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 2.7.5: Write failing factory test**
+
+Create `apps/api/src/modules/run/drivers/run-driver.factory.spec.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import type { ConfigService } from "@nestjs/config";
+import type { Env } from "../../../config/env.schema.js";
+import { createRunDriver, imageForTool } from "./run-driver.factory.js";
+import { SubprocessDriver } from "./subprocess-driver.js";
+
+function mockConfig(overrides: Partial<Env> = {}): ConfigService<Env, true> {
+  const defaults: Partial<Env> = {
+    BENCHMARK_DRIVER: "subprocess",
+    BENCHMARK_K8S_NAMESPACE: "modeldoctor-runs",
+    RUNNER_IMAGE_GUIDELLM: "img-guidellm:latest",
+    RUNNER_IMAGE_VEGETA: "img-vegeta:latest",
+    RUNNER_IMAGE_GENAI_PERF: "img-genai-perf:latest",
+    ...overrides,
+  } as Partial<Env>;
+  return {
+    get: vi.fn((k: keyof Env) => defaults[k]),
+  } as unknown as ConfigService<Env, true>;
+}
+
+describe("imageForTool", () => {
+  it("returns the per-tool env var", () => {
+    const cfg = mockConfig();
+    expect(imageForTool("guidellm", cfg)).toBe("img-guidellm:latest");
+    expect(imageForTool("vegeta", cfg)).toBe("img-vegeta:latest");
+    expect(imageForTool("genai-perf", cfg)).toBe("img-genai-perf:latest");
+  });
+
+  it("throws when image env var is unset", () => {
+    const cfg = mockConfig({ RUNNER_IMAGE_GUIDELLM: undefined });
+    expect(() => imageForTool("guidellm", cfg)).toThrow(/RUNNER_IMAGE_GUIDELLM/);
+  });
+});
+
+describe("createRunDriver", () => {
+  it("builds a SubprocessDriver when BENCHMARK_DRIVER=subprocess", async () => {
+    const cfg = mockConfig({ BENCHMARK_DRIVER: "subprocess" });
+    const d = await createRunDriver(cfg);
+    expect(d).toBeInstanceOf(SubprocessDriver);
+  });
+});
+```
+
+- [ ] **Step 2.7.6: Create `apps/api/src/modules/run/drivers/run-driver.factory.ts`**
+
+```ts
+import type { ConfigService } from "@nestjs/config";
+import type { ToolName } from "@modeldoctor/tool-adapters";
+import type { Env } from "../../../config/env.schema.js";
+import type { RunExecutionDriver } from "./execution-driver.interface.js";
+import { K8sJobDriver } from "./k8s-job-driver.js";
+import { SubprocessDriver } from "./subprocess-driver.js";
+
+const TOOL_TO_IMAGE_ENV: Record<ToolName, keyof Env> = {
+  guidellm: "RUNNER_IMAGE_GUIDELLM",
+  "genai-perf": "RUNNER_IMAGE_GENAI_PERF",
+  vegeta: "RUNNER_IMAGE_VEGETA",
+};
+
+export function imageForTool(tool: ToolName, config: ConfigService<Env, true>): string {
+  const key = TOOL_TO_IMAGE_ENV[tool];
+  const v = config.get(key, { infer: true }) as string | undefined;
+  if (!v) {
+    throw new Error(
+      `Missing image config for tool '${tool}': set the ${String(key)} environment variable.`,
+    );
+  }
+  return v;
+}
+
+async function loadK8sClient(): Promise<typeof import("@kubernetes/client-node")> {
+  const stub = (globalThis as { __test_kc_loader__?: () => unknown }).__test_kc_loader__;
+  if (stub) return stub() as typeof import("@kubernetes/client-node");
+  return await import("@kubernetes/client-node");
+}
+
+export async function createRunDriver(
+  config: ConfigService<Env, true>,
+): Promise<RunExecutionDriver> {
+  const choice = (config.get("BENCHMARK_DRIVER", { infer: true }) ?? "subprocess") as string;
+  if (choice === "subprocess") {
+    return new SubprocessDriver();
+  }
+  if (choice === "k8s") {
+    const ns = (config.get("BENCHMARK_K8S_NAMESPACE", { infer: true }) ??
+      "modeldoctor-runs") as string;
+    const k8s = await loadK8sClient();
+    const kc = new k8s.KubeConfig();
+    const explicitKubeconfig = config.get("KUBECONFIG", { infer: true }) as string | undefined;
+    if (explicitKubeconfig) {
+      kc.loadFromFile(explicitKubeconfig);
+    } else {
+      kc.loadFromDefault();
+    }
+    return new K8sJobDriver({
+      namespace: ns,
+      apis: {
+        batch: kc.makeApiClient(k8s.BatchV1Api),
+        core: kc.makeApiClient(k8s.CoreV1Api),
+      },
+    });
+  }
+  throw new Error(`Unknown BENCHMARK_DRIVER value: ${choice}`);
+}
+```
+
+- [ ] **Step 2.7.7: Tests pass**
+
+```bash
+pnpm -F @modeldoctor/api test -- run/drivers
+```
+
+Expected: all tests in run/drivers pass.
+
+- [ ] **Step 2.7.8: Commit**
+
+```bash
+git add apps/api/src/modules/run/drivers/k8s-job-driver.ts \
+        apps/api/src/modules/run/drivers/k8s-job-driver.spec.ts \
+        apps/api/src/modules/run/drivers/run-driver.factory.ts \
+        apps/api/src/modules/run/drivers/run-driver.factory.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(api/run): add K8sJobDriver + run-driver factory + imageForTool (#53)
+
+Mirrors the existing benchmark drivers' k8s shape but on the new
+RunExecutionContext interface. imageForTool() reads RUNNER_IMAGE_<TOOL>
+env vars; introduces them in Task 2.13.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2.8: SseHub service for ProgressEvent pub/sub
+
+**Files:**
+- Create: `apps/api/src/modules/run/sse/sse-hub.service.ts`
+- Create: `apps/api/src/modules/run/sse/sse-hub.service.spec.ts`
+
+- [ ] **Step 2.8.1: Failing test**
+
+Create `apps/api/src/modules/run/sse/sse-hub.service.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { SseHub } from "./sse-hub.service.js";
+import type { ProgressEvent } from "@modeldoctor/tool-adapters";
+
+describe("SseHub", () => {
+  it("delivers events to subscribers of the same runId", async () => {
+    const hub = new SseHub();
+    const received: ProgressEvent[] = [];
+    const sub = hub.subscribe("run1").subscribe((e) => received.push(e));
+    hub.publish("run1", { kind: "log", level: "info", line: "hello" });
+    hub.publish("run1", { kind: "progress", pct: 0.5 });
+    sub.unsubscribe();
+    expect(received).toHaveLength(2);
+  });
+
+  it("does not deliver across different runIds", async () => {
+    const hub = new SseHub();
+    const r1: ProgressEvent[] = [];
+    const r2: ProgressEvent[] = [];
+    hub.subscribe("a").subscribe((e) => r1.push(e));
+    hub.subscribe("b").subscribe((e) => r2.push(e));
+    hub.publish("a", { kind: "log", level: "info", line: "for-a" });
+    expect(r1).toHaveLength(1);
+    expect(r2).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2.8.2: Create `apps/api/src/modules/run/sse/sse-hub.service.ts`**
+
+```ts
+import { Injectable } from "@nestjs/common";
+import type { ProgressEvent } from "@modeldoctor/tool-adapters";
+import { Observable, Subject } from "rxjs";
+
+@Injectable()
+export class SseHub {
+  private readonly streams = new Map<string, Subject<ProgressEvent>>();
+
+  publish(runId: string, evt: ProgressEvent): void {
+    this.streams.get(runId)?.next(evt);
+  }
+
+  subscribe(runId: string): Observable<ProgressEvent> {
+    let s = this.streams.get(runId);
+    if (!s) {
+      s = new Subject<ProgressEvent>();
+      this.streams.set(runId, s);
+    }
+    return s.asObservable();
+  }
+
+  /** Drop a runId's stream (called from RunService on terminal state). */
+  close(runId: string): void {
+    const s = this.streams.get(runId);
+    if (!s) return;
+    s.complete();
+    this.streams.delete(runId);
+  }
+}
+```
+
+> NestJS already depends on RxJS via `@nestjs/common`; no new dep needed.
+
+- [ ] **Step 2.8.3: Tests pass; commit**
+
+```bash
+pnpm -F @modeldoctor/api test -- run/sse
+git add apps/api/src/modules/run/sse/
+git commit -m "$(cat <<'EOF'
+feat(api/run): add SseHub for in-memory ProgressEvent pubsub (#53)
+
+In-memory only; sufficient for single-API-instance dev and pre-#57
+deployment. #57 SSE endpoint will subscribe via SseHub.subscribe(runId).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2.9: RunCallbackController with /state, /log, /finish
+
+**Files:**
+- Create: `apps/api/src/modules/run/callbacks/run-callback.controller.ts`
+- Create: `apps/api/src/modules/run/callbacks/run-callback.controller.spec.ts`
+
+- [ ] **Step 2.9.1: Failing test (golden path + parser-fail path)**
+
+Create `apps/api/src/modules/run/callbacks/run-callback.controller.spec.ts`:
+
+```ts
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { RunCallbackController } from "./run-callback.controller.js";
+import { SseHub } from "../sse/sse-hub.service.js";
+import type { Run as PrismaRun } from "@prisma/client";
+
+class MockRunRepo {
+  private rows = new Map<string, Partial<PrismaRun>>();
+  setup(id: string, row: Partial<PrismaRun>) { this.rows.set(id, row); }
+  async findById(id: string) { return this.rows.get(id) as PrismaRun | undefined ?? null; }
+  async update(id: string, patch: Record<string, unknown>) {
+    const cur = this.rows.get(id) ?? {};
+    const next = { ...cur, ...patch };
+    this.rows.set(id, next);
+    return next as PrismaRun;
+  }
+}
+
+// Stub adapter registry to avoid pulling in the real (stubbed) adapters.
+vi.mock("@modeldoctor/tool-adapters", async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return {
+    ...actual,
+    byTool: () => ({
+      name: "guidellm",
+      paramsSchema: { parse: (x: unknown) => x },
+      reportSchema: { parse: (x: unknown) => x },
+      paramDefaults: {},
+      buildCommand: () => { throw new Error("not used"); },
+      parseProgress: (line: string) =>
+        line.startsWith("PROGRESS:")
+          ? { kind: "progress", pct: Number.parseFloat(line.slice("PROGRESS:".length)) }
+          : { kind: "log", level: "info", line },
+      parseFinalReport: (stdout: string) => {
+        if (stdout === "BAD") throw new Error("simulated parse failure");
+        return { tool: "guidellm", data: { ttft: { mean: 1, p50: 1, p90: 1, p95: 1, p99: 1 } } };
+      },
+    }),
+  };
+});
+
+describe("RunCallbackController", () => {
+  let repo: MockRunRepo;
+  let sse: SseHub;
+  let ctrl: RunCallbackController;
+
+  beforeEach(() => {
+    repo = new MockRunRepo();
+    sse = new SseHub();
+    ctrl = new RunCallbackController(repo as never, sse);
+  });
+
+  it("/state running marks the row as running", async () => {
+    repo.setup("r1", { id: "r1", tool: "guidellm", status: "submitted" });
+    await ctrl.handleState("r1", { state: "running" });
+    const row = await repo.findById("r1");
+    expect(row?.status).toBe("running");
+  });
+
+  it("/log invokes adapter.parseProgress and publishes ProgressEvent", async () => {
+    repo.setup("r1", { id: "r1", tool: "guidellm", status: "running" });
+    const evts: unknown[] = [];
+    sse.subscribe("r1").subscribe((e) => evts.push(e));
+    await ctrl.handleLog("r1", { stream: "stdout", lines: ["PROGRESS:0.42", "hello world"] });
+    expect(evts).toHaveLength(2);
+    expect((evts[0] as { kind: string }).kind).toBe("progress");
+    expect((evts[1] as { kind: string }).kind).toBe("log");
+  });
+
+  it("/finish parses report and writes summaryMetrics + rawOutput on success", async () => {
+    repo.setup("r1", { id: "r1", tool: "guidellm", status: "running" });
+    await ctrl.handleFinish("r1", {
+      state: "completed",
+      exitCode: 0,
+      stdout: "ok",
+      stderr: "",
+      files: { report: Buffer.from('{"ok":true}', "utf8").toString("base64") },
+    });
+    const row = await repo.findById("r1");
+    expect(row?.status).toBe("completed");
+    expect((row?.summaryMetrics as { tool?: string })?.tool).toBe("guidellm");
+    expect(row?.rawOutput).toEqual({
+      stdout: "ok",
+      stderr: "",
+      files: { report: Buffer.from('{"ok":true}', "utf8").toString("base64") },
+    });
+  });
+
+  it("/finish forces failed when adapter.parseFinalReport throws", async () => {
+    repo.setup("r1", { id: "r1", tool: "guidellm", status: "running" });
+    await ctrl.handleFinish("r1", {
+      state: "completed", // runner reports completed but parser fails
+      exitCode: 0,
+      stdout: "BAD",
+      stderr: "",
+      files: {},
+    });
+    const row = await repo.findById("r1");
+    expect(row?.status).toBe("failed");
+    expect((row?.statusMessage as string | undefined) ?? "").toMatch(/report parse/);
+    expect(row?.summaryMetrics).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2.9.2: Run failing**
+
+```bash
+pnpm -F @modeldoctor/api test -- run-callback
+```
+
+- [ ] **Step 2.9.3: Create `apps/api/src/modules/run/callbacks/run-callback.controller.ts`**
+
+```ts
+import {
+  type RunFinishCallback,
+  type RunLogCallback,
+  type RunStateCallback,
+  runFinishCallbackSchema,
+  runLogCallbackSchema,
+  runStateCallbackSchema,
+} from "@modeldoctor/contracts";
+import { type ProgressEvent, byTool, type ToolName } from "@modeldoctor/tool-adapters";
+import { Body, Controller, Logger, Param, Post, UseGuards } from "@nestjs/common";
+import type { Prisma } from "@prisma/client";
+import { ZodValidationPipe } from "../../../common/pipes/zod-validation.pipe.js";
+import { HmacCallbackGuard } from "../../../common/hmac/hmac-callback.guard.js";
+import { RunRepository } from "../run.repository.js";
+import { SseHub } from "../sse/sse-hub.service.js";
+
+@UseGuards(HmacCallbackGuard)
+@Controller("api/internal/runs/:id")
+export class RunCallbackController {
+  private readonly log = new Logger(RunCallbackController.name);
+
+  constructor(
+    private readonly runs: RunRepository,
+    private readonly sse: SseHub,
+  ) {}
+
+  @Post("state")
+  async handleState(
+    @Param("id") id: string,
+    @Body(new ZodValidationPipe(runStateCallbackSchema)) body: RunStateCallback,
+  ): Promise<void> {
+    const row = await this.runs.findById(id);
+    if (!row) {
+      this.log.warn(`/state callback for unknown run ${id}; ignoring`);
+      return;
+    }
+    if (body.state === "running" && row.status !== "running") {
+      await this.runs.update(id, {
+        status: "running",
+        startedAt: row.startedAt ?? new Date(),
+      });
+    }
+  }
+
+  @Post("log")
+  async handleLog(
+    @Param("id") id: string,
+    @Body(new ZodValidationPipe(runLogCallbackSchema)) body: RunLogCallback,
+  ): Promise<void> {
+    const row = await this.runs.findById(id);
+    if (!row) return;
+    const adapter = byTool(row.tool as ToolName);
+    let lastProgress: number | null = null;
+    for (const line of body.lines) {
+      let evt: ProgressEvent | null;
+      try {
+        evt = adapter.parseProgress(line);
+      } catch {
+        evt = { kind: "log", level: "warn", line };
+      }
+      if (!evt) continue;
+      this.sse.publish(id, evt);
+      if (evt.kind === "progress") lastProgress = evt.pct;
+    }
+    if (lastProgress !== null) {
+      await this.runs.update(id, { progress: lastProgress });
+    }
+  }
+
+  @Post("finish")
+  async handleFinish(
+    @Param("id") id: string,
+    @Body(new ZodValidationPipe(runFinishCallbackSchema)) body: RunFinishCallback,
+  ): Promise<void> {
+    const row = await this.runs.findById(id);
+    if (!row) {
+      this.log.warn(`/finish callback for unknown run ${id}; ignoring`);
+      return;
+    }
+    const adapter = byTool(row.tool as ToolName);
+    let finalState: "completed" | "failed" = body.state;
+    let message = body.message;
+    let summary: unknown = null;
+
+    try {
+      const fileBuffers: Record<string, Buffer> = Object.fromEntries(
+        Object.entries(body.files).map(([k, v]) => [k, Buffer.from(v, "base64")]),
+      );
+      summary = adapter.parseFinalReport(body.stdout, fileBuffers);
+    } catch (e) {
+      finalState = "failed";
+      message = `report parse: ${(e as Error).message}`.slice(0, 2048);
+      summary = null;
+    }
+
+    await this.runs.update(id, {
+      status: finalState,
+      completedAt: new Date(),
+      statusMessage: message ?? null,
+      summaryMetrics: (summary ?? null) as Prisma.InputJsonValue,
+      rawOutput: {
+        stdout: body.stdout,
+        stderr: body.stderr,
+        files: body.files,
+      } as Prisma.InputJsonValue,
+    });
+    this.sse.close(id);
+  }
+}
+```
+
+- [ ] **Step 2.9.4: Tests pass; commit**
+
+```bash
+pnpm -F @modeldoctor/api test -- run-callback
+git add apps/api/src/modules/run/callbacks/
+git commit -m "$(cat <<'EOF'
+feat(api/run): add RunCallbackController with v2 protocol (#53)
+
+POST /api/internal/runs/:id/state | /log | /finish. /finish parses
+the tool's product via byTool(run.tool).parseFinalReport(); failure
+forces state=failed regardless of what the runner claimed.
+
+Old benchmark-callback.controller (modules/benchmark/callbacks/) is
+unchanged in this phase.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2.10: Update RunService with create / start / cancel / delete
+
+**Files:**
+- Modify: `apps/api/src/modules/run/run.service.ts`
+- Modify: `apps/api/src/modules/run/run.service.spec.ts`
+
+- [ ] **Step 2.10.1: Add adapter-based methods to RunService**
+
+Replace `apps/api/src/modules/run/run.service.ts` with:
+
+```ts
+import {
+  type CreateRunRequest,
+  type ListRunsQuery,
+  type ListRunsResponse,
+  type Run,
+} from "@modeldoctor/contracts";
+import { byTool, type ToolName } from "@modeldoctor/tool-adapters";
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import type { Env } from "../../config/env.schema.js";
+import { signCallbackToken } from "../../common/hmac/hmac-token.js";
+import { ConnectionService } from "../connection/connection.service.js";
+import { RunRepository, type RunWithRelations } from "./run.repository.js";
+import type { Prisma } from "@prisma/client";
+import type { RunExecutionDriver } from "./drivers/execution-driver.interface.js";
+import { RUN_DRIVER } from "./drivers/run-driver.token.js";
+import { imageForTool } from "./drivers/run-driver.factory.js";
+
+const ACTIVE_STATES = ["pending", "submitted", "running"] as const;
+const TERMINAL_STATES = ["completed", "failed", "canceled"] as const;
+const CALLBACK_TTL_SLACK_SECONDS = 15 * 60;
+
+@Injectable()
+export class RunService {
+  private readonly log = new Logger(RunService.name);
+  private readonly callbackSecret: Buffer;
+  private readonly callbackUrl: string;
+  private readonly defaultMaxDuration: number;
+  private readonly driverKind: "local" | "k8s";
+
+  constructor(
+    private readonly repo: RunRepository,
+    @Inject(RUN_DRIVER) private readonly driver: RunExecutionDriver,
+    private readonly config: ConfigService<Env, true>,
+    private readonly connections: ConnectionService,
+  ) {
+    this.callbackSecret = Buffer.from(
+      this.config.get("BENCHMARK_CALLBACK_SECRET", { infer: true }) as string,
+      "utf8",
+    );
+    this.callbackUrl = this.config.get("BENCHMARK_CALLBACK_URL", { infer: true }) as string;
+    this.defaultMaxDuration = this.config.get("BENCHMARK_DEFAULT_MAX_DURATION_SECONDS", {
+      infer: true,
+    }) as number;
+    const driverChoice =
+      (this.config.get("BENCHMARK_DRIVER", { infer: true }) ?? "subprocess") as string;
+    this.driverKind = driverChoice === "k8s" ? "k8s" : "local";
+  }
+
+  async findById(id: string): Promise<Run | null> {
+    const row = await this.repo.findById(id);
+    return row ? toContract(row) : null;
+  }
+
+  async findByIdOrFail(id: string, userId?: string): Promise<Run> {
+    const row = await this.repo.findById(id);
+    if (!row) throw new NotFoundException(`Run ${id} not found`);
+    if (userId !== undefined && row.userId !== userId) {
+      throw new NotFoundException(`Run ${id} not found`);
+    }
+    return toContract(row);
+  }
+
+  async list(query: ListRunsQuery, userId?: string): Promise<ListRunsResponse> {
+    const result = await this.repo.list({
+      ...query,
+      ...(userId !== undefined && { userId }),
+    });
+    return { items: result.items.map(toContract), nextCursor: result.nextCursor };
+  }
+
+  async create(userId: string, req: CreateRunRequest): Promise<Run> {
+    const conn = await this.connections.getOwnedDecrypted(userId, req.connectionId);
+    const adapter = byTool(req.tool as ToolName);
+    let params: unknown;
+    try {
+      params = adapter.paramsSchema.parse(req.params);
+    } catch (e) {
+      throw new BadRequestException({
+        code: "RUN_PARAMS_INVALID",
+        message: `params validation failed: ${(e as Error).message}`,
+      });
+    }
+
+    // Duplicate-name guard within active states
+    const dupes = await this.repo.countActiveByName(userId, req.name);
+    if (dupes > 0) {
+      throw new ConflictException({
+        code: "RUN_NAME_IN_USE",
+        message: `An active run named '${req.name}' already exists`,
+      });
+    }
+
+    const created = await this.repo.create({
+      userId,
+      connectionId: conn.id,
+      kind: req.kind,
+      tool: req.tool,
+      mode: "fixed",
+      driverKind: this.driverKind,
+      name: req.name,
+      description: req.description ?? null,
+      scenario: {
+        apiBaseUrl: conn.baseUrl,
+        model: conn.model,
+        customHeaders: conn.customHeaders,
+        queryParams: conn.queryParams,
+      },
+      params: params as never,
+      templateId: req.templateId ?? null,
+      templateVersion: req.templateVersion ?? null,
+      parentRunId: req.parentRunId ?? null,
+      baselineId: req.baselineId ?? null,
+    });
+
+    return await this.start(created.id);
+  }
+
+  async start(runId: string): Promise<Run> {
+    const row = await this.repo.findById(runId);
+    if (!row) throw new NotFoundException(`Run ${runId} not found`);
+    if (!row.userId || !row.connectionId) {
+      throw new BadRequestException("Connection no longer exists");
+    }
+
+    const conn = await this.connections.getOwnedDecrypted(row.userId, row.connectionId);
+    const adapter = byTool(row.tool as ToolName);
+    const callbackToken = signCallbackToken(
+      row.id,
+      this.callbackSecret,
+      this.defaultMaxDuration + CALLBACK_TTL_SLACK_SECONDS,
+    );
+    const buildResult = adapter.buildCommand({
+      runId: row.id,
+      params: row.params,
+      connection: {
+        baseUrl: conn.baseUrl,
+        apiKey: conn.apiKey,
+        model: conn.model,
+        customHeaders: conn.customHeaders,
+        queryParams: conn.queryParams,
+      },
+      callback: { url: this.callbackUrl, token: callbackToken },
+    });
+
+    let handle: string;
+    try {
+      const result = await this.driver.start({
+        runId: row.id,
+        tool: row.tool as ToolName,
+        buildResult,
+        callback: { url: this.callbackUrl, token: callbackToken },
+        image:
+          this.driverKind === "k8s" ? imageForTool(row.tool as ToolName, this.config) : "",
+      });
+      handle = result.handle;
+    } catch (e) {
+      const msg = (e as Error).message ?? String(e);
+      await this.repo.update(row.id, {
+        status: "failed",
+        statusMessage: msg.slice(0, 2048),
+        completedAt: new Date(),
+      });
+      throw e;
+    }
+
+    await this.repo.update(row.id, {
+      status: "submitted",
+      driverHandle: handle,
+      startedAt: new Date(),
+    });
+    // re-fetch so toContract has connection/baselineFor relations
+    const reloaded = await this.repo.findById(row.id);
+    if (!reloaded) throw new NotFoundException(`Run ${row.id} not found`);
+    return toContract(reloaded);
+  }
+
+  async cancel(id: string, userId: string): Promise<Run> {
+    const row = await this.repo.findById(id);
+    if (!row) throw new NotFoundException(`Run ${id} not found`);
+    if (row.userId !== userId) throw new NotFoundException(`Run ${id} not found`);
+    if ((TERMINAL_STATES as readonly string[]).includes(row.status)) {
+      throw new BadRequestException({
+        code: "RUN_ALREADY_TERMINAL",
+        message: `Cannot cancel a run in state '${row.status}'`,
+      });
+    }
+    if (row.status !== "pending" && row.driverHandle) {
+      try {
+        await this.driver.cancel(row.driverHandle);
+      } catch (e) {
+        this.log.warn(
+          `driver.cancel threw for ${row.id} (${row.driverHandle}): ${(e as Error).message}`,
+        );
+      }
+    }
+    await this.repo.update(row.id, {
+      status: "canceled",
+      completedAt: new Date(),
+    });
+    const reloaded = await this.repo.findById(row.id);
+    if (!reloaded) throw new NotFoundException(`Run ${row.id} not found`);
+    return toContract(reloaded);
+  }
+
+  async delete(id: string, userId: string): Promise<void> {
+    const row = await this.repo.findById(id);
+    if (!row) throw new NotFoundException(`Run ${id} not found`);
+    if (row.userId !== userId) throw new NotFoundException(`Run ${id} not found`);
+    if (!(TERMINAL_STATES as readonly string[]).includes(row.status)) {
+      throw new ConflictException({
+        code: "RUN_NOT_TERMINAL",
+        message: `Cannot delete a run in state '${row.status}'. Cancel it first.`,
+      });
+    }
+    await this.repo.delete(row.id);
+  }
+}
+
+function toContract(row: RunWithRelations): Run {
+  return {
+    id: row.id,
+    userId: row.userId,
+    connectionId: row.connectionId,
+    connection: row.connection ? { id: row.connection.id, name: row.connection.name } : null,
+    kind: row.kind as Run["kind"],
+    tool: row.tool as Run["tool"],
+    scenario: row.scenario as Run["scenario"],
+    mode: row.mode as Run["mode"],
+    driverKind: row.driverKind as Run["driverKind"],
+    name: row.name,
+    description: row.description,
+    status: row.status as Run["status"],
+    statusMessage: row.statusMessage,
+    progress: row.progress,
+    driverHandle: row.driverHandle,
+    params: row.params as Run["params"],
+    rawOutput: row.rawOutput as Run["rawOutput"],
+    summaryMetrics: row.summaryMetrics as Run["summaryMetrics"],
+    serverMetrics: row.serverMetrics as Run["serverMetrics"],
+    templateId: row.templateId,
+    templateVersion: row.templateVersion,
+    parentRunId: row.parentRunId,
+    baselineId: row.baselineId,
+    baselineFor: row.baselineFor
+      ? {
+          id: row.baselineFor.id,
+          name: row.baselineFor.name,
+          createdAt: row.baselineFor.createdAt.toISOString(),
+        }
+      : null,
+    logs: row.logs,
+    createdAt: row.createdAt.toISOString(),
+    startedAt: row.startedAt?.toISOString() ?? null,
+    completedAt: row.completedAt?.toISOString() ?? null,
+  };
+}
+
+export { toContract as runRowToContract };
+```
+
+> Note: `RunRepository.countActiveByName` is added in Task 2.11.
+
+- [ ] **Step 2.10.2: Move RUN_DRIVER token import**
+
+`RUN_DRIVER` was put in `run-driver.token.ts` in Task 2.4. The service imports it:
+
+Replace the `RUN_DRIVER` import in the file above:
+
+```ts
+import { RUN_DRIVER } from "./drivers/run-driver.token.js";
+import type { RunExecutionDriver } from "./drivers/execution-driver.interface.js";
+```
+
+(Adjust the existing import to split type vs value.)
+
+- [ ] **Step 2.10.3: Update `run.service.spec.ts`**
+
+The existing spec only covers list/findById. Add new tests for create/start/cancel/delete. Skip the detailed test impl here — write golden-path tests using vi.mock for adapters and a mock driver. (≈ 6-10 tests, similar shape to the callback controller spec above.)
+
+- [ ] **Step 2.10.4: Tests pass; commit**
+
+```bash
+pnpm -F @modeldoctor/api test -- run.service
+git add apps/api/src/modules/run/run.service.ts apps/api/src/modules/run/run.service.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(api/run): add adapter-driven create/start/cancel/delete to RunService (#53)
+
+Wires byTool(run.tool) → adapter.paramsSchema.parse + adapter.buildCommand
++ driver.start. Old BenchmarkService.create / .start remain in place,
+unchanged, on the legacy path.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2.11: Add `RunRepository.countActiveByName` + drop `canonicalReport` from `UpdateRunInput`
+
+> The repo already has `create / findById / list / update / delete`. We only need to add `countActiveByName` and clean up the obsolete `canonicalReport` field on `UpdateRunInput` left over from Task 2.1's column drop.
+
+**Files:**
+- Modify: `apps/api/src/modules/run/run.repository.ts`
+- Modify: `apps/api/src/modules/run/run.repository.spec.ts`
+
+- [ ] **Step 2.11.1: Drop `canonicalReport` from `UpdateRunInput`**
+
+In `apps/api/src/modules/run/run.repository.ts`, find:
+
+```ts
+export type UpdateRunInput = Partial<{
+  status: string;
+  statusMessage: string | null;
+  progress: number | null;
+  driverHandle: string | null;
+  startedAt: Date | null;
+  completedAt: Date | null;
+  canonicalReport: Prisma.InputJsonValue | null;
+  rawOutput: Prisma.InputJsonValue | null;
+  summaryMetrics: Prisma.InputJsonValue | null;
+  logs: string | null;
+}>;
+```
+
+Delete the `canonicalReport` line:
+
+```ts
+export type UpdateRunInput = Partial<{
+  status: string;
+  statusMessage: string | null;
+  progress: number | null;
+  driverHandle: string | null;
+  startedAt: Date | null;
+  completedAt: Date | null;
+  rawOutput: Prisma.InputJsonValue | null;
+  summaryMetrics: Prisma.InputJsonValue | null;
+  logs: string | null;
+}>;
+```
+
+- [ ] **Step 2.11.2: Add `countActiveByName` method**
+
+Append to `RunRepository`:
+
+```ts
+async countActiveByName(userId: string, name: string): Promise<number> {
+  return this.prisma.run.count({
+    where: {
+      userId,
+      name,
+      status: { in: ["pending", "submitted", "running"] },
+    },
+  });
+}
+```
+
+(`delete(id)` and `update(id, input)` already exist on the repo.)
+
+- [ ] **Step 2.11.3: Add tests + commit (TDD)**
+
+Add a test for `countActiveByName` to `run.repository.spec.ts`:
+
+```ts
+it("countActiveByName excludes terminal rows", async () => {
+  await prisma.run.create({ data: { /* userId, name, status: "running", ... */ } });
+  await prisma.run.create({ data: { /* userId, name, status: "completed", ... */ } });
+  const n = await repo.countActiveByName(userId, name);
+  expect(n).toBe(1);
+});
+```
+
+```bash
+pnpm -F @modeldoctor/api test -- run.repository
+git add apps/api/src/modules/run/run.repository.ts apps/api/src/modules/run/run.repository.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(api/run): countActiveByName + drop canonicalReport from UpdateRunInput (#53)
+
+countActiveByName powers RunService's duplicate-name guard.
+canonicalReport is removed from UpdateRunInput because the underlying
+column was dropped in Task 2.1.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2.12: Update RunController with create / cancel / delete endpoints
+
+**Files:**
+- Modify: `apps/api/src/modules/run/run.controller.ts`
+- Modify: `apps/api/src/modules/run/run.controller.spec.ts`
+
+- [ ] **Step 2.12.1: Replace the controller**
+
+Replace `apps/api/src/modules/run/run.controller.ts` with:
+
+```ts
+import {
+  type CreateRunRequest,
+  type ListRunsQuery,
+  type ListRunsResponse,
+  type Run,
+  createRunRequestSchema,
+  listRunsQuerySchema,
+} from "@modeldoctor/contracts";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
+import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
+import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
+import type { JwtPayload } from "../auth/jwt.strategy.js";
+import { RunService } from "./run.service.js";
+
+@Controller("api/runs")
+@UseGuards(JwtAuthGuard)
+export class RunController {
+  constructor(private readonly service: RunService) {}
+
+  @Get()
+  list(
+    @CurrentUser() user: JwtPayload,
+    @Query(new ZodValidationPipe(listRunsQuerySchema)) query: ListRunsQuery,
+  ): Promise<ListRunsResponse> {
+    return this.service.list(query, user.sub);
+  }
+
+  @Get(":id")
+  detail(@CurrentUser() user: JwtPayload, @Param("id") id: string): Promise<Run> {
+    return this.service.findByIdOrFail(id, user.sub);
+  }
+
+  @Post()
+  create(
+    @CurrentUser() user: JwtPayload,
+    @Body(new ZodValidationPipe(createRunRequestSchema)) body: CreateRunRequest,
+  ): Promise<Run> {
+    return this.service.create(user.sub, body);
+  }
+
+  @Post(":id/cancel")
+  cancel(@CurrentUser() user: JwtPayload, @Param("id") id: string): Promise<Run> {
+    return this.service.cancel(id, user.sub);
+  }
+
+  @Delete(":id")
+  @HttpCode(204)
+  async delete(@CurrentUser() user: JwtPayload, @Param("id") id: string): Promise<void> {
+    await this.service.delete(id, user.sub);
+  }
+}
+```
+
+> Note the route prefix changed to `api/runs` (full prefix; no global prefix needed). If the project has a global prefix like `app.setGlobalPrefix('api')`, drop the leading `api/` here. Check `apps/api/src/main.ts`.
+
+- [ ] **Step 2.12.2: Update controller spec**
+
+Add tests for create/cancel/delete. (Existing spec covers list/detail.) Use `Test.createTestingModule` + `supertest` per the existing pattern.
+
+- [ ] **Step 2.12.3: Commit**
+
+```bash
+pnpm -F @modeldoctor/api test -- run.controller
+git add apps/api/src/modules/run/run.controller.ts apps/api/src/modules/run/run.controller.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(api/run): expose POST /api/runs + :id/cancel + DELETE :id (#53)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2.13: Env schema additions + RunModule wiring + body-size override
+
+**Files:**
+- Modify: `apps/api/src/config/env.schema.ts`
+- Modify: `apps/api/src/modules/run/run.module.ts`
+- Modify: `apps/api/src/main.ts` (body-size)
+- Modify: `apps/api/.env.example`
+
+- [ ] **Step 2.13.1: Add per-tool image env vars**
+
+Add to `apps/api/src/config/env.schema.ts` (alongside existing `BENCHMARK_RUNNER_IMAGE`):
+
+```ts
+    // #53 Phase 2: per-tool runner images. Old BENCHMARK_RUNNER_IMAGE is
+    // kept for the legacy benchmark module's path until Phase 3 deletes it.
+    RUNNER_IMAGE_GUIDELLM: z.string().min(1).optional(),
+    RUNNER_IMAGE_GENAI_PERF: z.string().min(1).optional(),
+    RUNNER_IMAGE_VEGETA: z.string().min(1).optional(),
+```
+
+> Optional in test mode; required when `BENCHMARK_DRIVER === 'k8s'` AND a run is created for that tool. Service-level error covers the case (`imageForTool` throws).
+
+- [ ] **Step 2.13.2: Wire RunModule**
+
+Replace `apps/api/src/modules/run/run.module.ts`:
+
+```ts
+import { Module } from "@nestjs/common";
+import { ConfigModule, ConfigService } from "@nestjs/config";
+import type { Env } from "../../config/env.schema.js";
+import { PrismaService } from "../../database/prisma.service.js";
+import { ConnectionModule } from "../connection/connection.module.js";
+import { RunCallbackController } from "./callbacks/run-callback.controller.js";
+import { RunController } from "./run.controller.js";
+import { RunRepository } from "./run.repository.js";
+import { RunService } from "./run.service.js";
+import { RUN_DRIVER } from "./drivers/run-driver.token.js";
+import { createRunDriver } from "./drivers/run-driver.factory.js";
+import { SseHub } from "./sse/sse-hub.service.js";
+
+@Module({
+  imports: [ConfigModule, ConnectionModule],
+  controllers: [RunController, RunCallbackController],
+  providers: [
+    PrismaService,
+    RunRepository,
+    RunService,
+    SseHub,
+    {
+      provide: RUN_DRIVER,
+      inject: [ConfigService],
+      useFactory: (config: ConfigService<Env, true>) => createRunDriver(config),
+    },
+  ],
+  exports: [RunRepository, RunService, SseHub],
+})
+export class RunModule {}
+```
+
+- [ ] **Step 2.13.3: Body-size override for /finish**
+
+Edit `apps/api/src/main.ts` — find the body-parser config (likely `app.useBodyParser('json', { limit: '...' })`) and add a route-specific override.
+
+If body-parser is configured globally with a small default, the cleanest approach is two-tier:
+
+```ts
+import { json as jsonBodyParser } from "body-parser";
+
+// Default body limit (used by all auth'd endpoints): keep at e.g. 100 KB.
+app.use(jsonBodyParser({ limit: "100kb" }));
+
+// /finish endpoint accepts up to 10 MB (raw stdout + base64 files)
+app.use("/api/internal/runs/:id/finish", jsonBodyParser({ limit: "10mb" }));
+```
+
+Adjust to whatever the project currently uses.
+
+- [ ] **Step 2.13.4: Update `.env.example`**
+
+```bash
+cat >> apps/api/.env.example <<'EOF'
+# #53: per-tool runner image tags (used when BENCHMARK_DRIVER=k8s)
+# Required when creating a run with the matching tool.
+# RUNNER_IMAGE_GUIDELLM=ghcr.io/your-org/modeldoctor-runner-guidellm:latest
+# RUNNER_IMAGE_VEGETA=ghcr.io/your-org/modeldoctor-runner-vegeta:latest
+# RUNNER_IMAGE_GENAI_PERF=ghcr.io/your-org/modeldoctor-runner-genai-perf:latest
+EOF
+```
+
+- [ ] **Step 2.13.5: Wire RunModule into AppModule (verify)**
+
+Check `apps/api/src/app.module.ts` — `RunModule` should already be imported (it's pre-existing). If `RunCallbackController` requires the JwtAuthGuard import path, double-check no `JwtAuthGuard` is accidentally pulled in for it (the v2 callback uses `HmacCallbackGuard`, NOT JWT).
+
+- [ ] **Step 2.13.6: Commit**
+
+```bash
+git add apps/api/src/config/env.schema.ts \
+        apps/api/src/modules/run/run.module.ts \
+        apps/api/src/main.ts \
+        apps/api/.env.example
+git commit -m "$(cat <<'EOF'
+feat(api): wire RunModule + body-size override for /finish (#53)
+
+- RUNNER_IMAGE_<TOOL> env vars
+- RunModule providers: SseHub + RUN_DRIVER factory
+- /api/internal/runs/:id/finish allows 10MB JSON body
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2.14: Repo-wide Phase 2 verification
+
+- [ ] **Step 2.14.1: Full type-check + tests + lint + build**
+
+```bash
+pnpm -r build
+pnpm -r type-check
+pnpm -r test
+pnpm -r lint
+pnpm -r format
+```
+
+Expected: all green.
+
+- [ ] **Step 2.14.2: Manual smoke (subprocess driver)**
+
+```bash
+# Start dev DB
+brew services list | grep postgres
+pg_isready -h localhost -p 5432
+
+# Reset dev DB to start clean
+pnpm -F @modeldoctor/api prisma migrate reset --force
+
+# Start API
+pnpm -F @modeldoctor/api start:dev &
+API_PID=$!
+sleep 5
+
+# Login (creates first user as admin)
+TOKEN=$(curl -sX POST http://localhost:3001/api/auth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"a@b.c","password":"password1234"}' | jq -r .accessToken)
+
+# Create a connection
+CID=$(curl -sX POST http://localhost:3001/api/connections \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"name":"local-vllm","baseUrl":"http://localhost:8000","apiKey":"sk-x","model":"Qwen2.5-0.5B-Instruct","category":"chat","tags":[]}' | jq -r .id)
+
+# Try to create a run via the new endpoint — guidellm runtime is still
+# stubbed in Phase 2, so we expect a 500 with 'not implemented' from
+# adapter.buildCommand. This verifies that:
+# (a) request validation works (params parsed by adapter.paramsSchema),
+# (b) the wiring reaches buildCommand, then fails as expected.
+curl -sX POST http://localhost:3001/api/runs \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d "{\"tool\":\"guidellm\",\"connectionId\":\"$CID\",\"name\":\"phase2-smoke\",\"params\":{\"profile\":\"throughput\",\"apiType\":\"chat\",\"datasetName\":\"random\",\"datasetInputTokens\":256,\"datasetOutputTokens\":128,\"requestRate\":0,\"totalRequests\":100}}" | jq
+
+# Expected: a 5xx with message containing 'guidellm runtime is implemented in Phase 3'.
+# The DB row for the run should be in 'failed' state with statusMessage echoing the error.
+
+kill $API_PID
+```
+
+> Phase 2 successfully reaches the adapter — the runtime stub failure is intentional. Phase 3 implements the runtime.
+
+- [ ] **Step 2.14.3: Push branch + open PR 53.2**
+
+```bash
+git push -u origin feat/issue-53-phase-2-callback-v2
+gh pr create --title "feat(api): unified RunService + callback v2 protocol (#53 PR 2/4)" --body "$(cat <<'EOF'
+## Summary
+- New `POST /api/runs`, `:id/cancel`, `DELETE /api/runs/:id` powered by RunService + adapter registry
+- New v2 callback protocol: `/state`, `/log`, `/finish` (replaces guidellm-shape `/metrics`)
+- New `RunExecutionContext` driver interface using `BuildCommandResult`; SubprocessDriver + K8sJobDriver in `apps/api/src/modules/run/drivers/`
+- HMAC helpers moved to `src/common/hmac/` for both old and new code paths
+- `Run.canonical_report` column dropped (Prisma migration)
+- Body-size raised to 10 MB on `/api/internal/runs/:id/finish`
+- SseHub for in-memory ProgressEvent pubsub
+
+## Out of scope (next PR 53.3)
+- guidellm/vegeta runtime implementations (still stubs from PR 53.1)
+- Runner image rewrite into a generic wrapper
+- Switching old `BenchmarkController`/`LoadTestController` to facades
+
+The old benchmark + load-test controllers continue to function unchanged
+during this phase; both code paths share the `Run` table without conflict.
+
+## Test plan
+- [ ] `pnpm -r test` passes
+- [ ] Manual smoke: `POST /api/runs { tool: 'guidellm', ... }` reaches adapter.buildCommand stub and fails with 'not implemented' — verifies wiring
+- [ ] `pnpm prisma migrate reset --force` followed by a fresh `prisma migrate dev` succeeds (canonical_report column cleanly dropped)
+
+## Related
+- Issue: #53
+- Spec: `docs/superpowers/specs/2026-05-02-issue-53-tool-adapter-framework-design.md`
+- Previous PR: 53.1 (`feat/issue-53-phase-1-adapter-package`)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2.14.4: Phase 2 DoD checklist**
+
+- [x] `Run.canonicalReport` removed from contracts + Prisma; migration applied
+- [x] `createRunRequestSchema` + v2 callback schemas in contracts
+- [x] `apps/api/src/common/hmac/` houses HMAC helpers; old paths re-export
+- [x] New `RunExecutionDriver` interface + Subprocess + K8sJobDriver implementations live in `run/drivers/`
+- [x] `RunCallbackController` handles `/state`, `/log`, `/finish` under HMAC guard
+- [x] `RunService` exposes `create / start / cancel / delete` powered by adapter registry
+- [x] `RunController` exposes `POST /api/runs`, `:id/cancel`, `DELETE :id`
+- [x] `RUNNER_IMAGE_<TOOL>` env vars introduced; `imageForTool()` reads them
+- [x] `/api/internal/runs/:id/finish` body limit = 10 MB
+- [x] Old benchmark + load-test code paths fully untouched
+- [x] All checks green; manual smoke confirms adapter wiring reached
+- [x] PR opened against `main`
+
+---
+
+# Phase 3 (PR 53.3) — guidellm + vegeta Runtime + Runner Image Rewrite + Facades
+
+**Phase goal:** Replace the runtime stubs from PR 53.1 with working `buildCommand` / `parseProgress` / `parseFinalReport` implementations for guidellm and vegeta. Rewrite `apps/benchmark-runner/` from a guidellm-only Python wrapper into a generic tool executor (no inner-tool knowledge). Switch the old `BenchmarkController` and `LoadTestController` from full implementations to thin facades that call `RunService`. Delete the old benchmark drivers + callbacks + service-impl bodies + the runner's tool-specific Python files.
+
+**Out of scope this phase:** genai-perf adapter (Phase 4). Frontend changes (#54).
+
+**Depends on:** Phase 2 PR merged.
+
+## Phase 3 Pre-flight
+
+- [ ] **Step 3.0.1: Branch from latest main**
+
+```bash
+cd /Users/fangyong/vllm/modeldoctor
+git worktree add issue-53-phase-3 -b feat/issue-53-phase-3-runtime-and-image main
+cd issue-53-phase-3
+pnpm install --frozen-lockfile
+```
+
+- [ ] **Step 3.0.2: Reset dev DB to start clean**
+
+```bash
+pnpm -F @modeldoctor/api prisma migrate reset --force
+```
+
+- [ ] **Step 3.0.3: Capture real fixtures**
+
+If you don't already have a guidellm `report.json` from a recent run, capture one:
+
+```bash
+# Easy mode: spin up a tiny vLLM or LM Studio target on localhost
+# Then run the existing benchmark-runner once via the legacy benchmark module
+# Or run guidellm directly:
+guidellm benchmark run \
+  --backend=openai_http \
+  --backend-kwargs='{"api_key":"sk-test"}' \
+  --target=http://localhost:8000 \
+  --model=Qwen2.5-0.5B-Instruct \
+  --max-requests=128 \
+  --max-seconds=300 \
+  --rate-type=throughput --rate=10 \
+  --data='prompt_tokens=128,output_tokens=64' \
+  --output-path=/tmp/guidellm-fixture.json \
+  --disable-console
+```
+
+For vegeta, capture text output from a small attack:
+
+```bash
+echo "GET https://example.com" | vegeta attack -duration=2s -rate=10 | vegeta report > /tmp/vegeta-fixture.txt
+```
+
+If neither tool is locally available, copy historical samples from the existing `apps/api/src/integrations/parsers/vegeta-report.spec.ts` and `apps/benchmark-runner/tests/test_metrics.py` fixtures.
+
+---
+
+## Task 3.1: Implement guidellm runtime + fixture-based test
+
+**Files:**
+- Create: `packages/tool-adapters/src/guidellm/__fixtures__/report.json`
+- Modify: `packages/tool-adapters/src/guidellm/runtime.ts`
+- Create: `packages/tool-adapters/src/guidellm/runtime.spec.ts`
+
+- [ ] **Step 3.1.1: Place fixture**
+
+```bash
+mkdir -p packages/tool-adapters/src/guidellm/__fixtures__
+cp /tmp/guidellm-fixture.json packages/tool-adapters/src/guidellm/__fixtures__/report.json
+# Or: copy a sample committed elsewhere in the repo (apps/benchmark-runner/tests has stub fixtures)
+```
+
+- [ ] **Step 3.1.2: Write failing fixture-based runtime tests**
+
+Create `packages/tool-adapters/src/guidellm/runtime.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildCommand, parseFinalReport, parseProgress } from "./runtime.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixtureBuf = fs.readFileSync(path.join(__dirname, "__fixtures__/report.json"));
+
+const baseConn = {
+  baseUrl: "http://localhost:8000",
+  apiKey: "sk-test",
+  model: "Qwen2.5-0.5B-Instruct",
+  customHeaders: "",
+  queryParams: "",
+};
+
+describe("guidellm.buildCommand", () => {
+  it("includes core CLI args + outputFiles entry", () => {
+    const r = buildCommand({
+      runId: "r1",
+      params: {
+        profile: "throughput",
+        apiType: "chat",
+        datasetName: "random",
+        datasetInputTokens: 256,
+        datasetOutputTokens: 128,
+        requestRate: 0,
+        totalRequests: 100,
+        maxDurationSeconds: 300,
+        maxConcurrency: 50,
+        validateBackend: true,
+      },
+      connection: baseConn,
+      callback: { url: "http://api/", token: "tk" },
+    });
+    expect(r.argv[0]).toBe("guidellm");
+    expect(r.argv).toContain("--target=http://localhost:8000");
+    expect(r.argv).toContain("--model=Qwen2.5-0.5B-Instruct");
+    expect(r.argv).toContain("--max-requests=100");
+    expect(r.argv).toContain("--output-path=report.json");
+    expect(r.outputFiles.report).toBe("report.json");
+  });
+
+  it("does not put apiKey in argv (must be in secretEnv)", () => {
+    const r = buildCommand({
+      runId: "r1",
+      params: { profile: "throughput", apiType: "chat", datasetName: "random",
+        datasetInputTokens: 256, datasetOutputTokens: 128, requestRate: 0,
+        totalRequests: 100, maxDurationSeconds: 300, maxConcurrency: 50, validateBackend: true,
+      },
+      connection: baseConn,
+      callback: { url: "http://api/", token: "tk" },
+    });
+    expect(r.argv.join(" ")).not.toContain("sk-test");
+    // Reasonable place: backend-kwargs JSON. We accept either explicit
+    // --backend-kwargs or env-driven path; test the strict invariant.
+  });
+
+  it("uses constant rate when requestRate > 0", () => {
+    const r = buildCommand({
+      runId: "r1",
+      params: { profile: "latency", apiType: "chat", datasetName: "random",
+        datasetInputTokens: 128, datasetOutputTokens: 64, requestRate: 10,
+        totalRequests: 100, maxDurationSeconds: 60, maxConcurrency: 50, validateBackend: true,
+      },
+      connection: baseConn,
+      callback: { url: "http://api/", token: "tk" },
+    });
+    expect(r.argv).toContain("--rate-type=constant");
+    expect(r.argv).toContain("--rate=10");
+  });
+
+  it("uses throughput mode with maxConcurrency when requestRate = 0", () => {
+    const r = buildCommand({
+      runId: "r1",
+      params: { profile: "throughput", apiType: "chat", datasetName: "random",
+        datasetInputTokens: 128, datasetOutputTokens: 64, requestRate: 0,
+        totalRequests: 100, maxDurationSeconds: 60, maxConcurrency: 75, validateBackend: true,
+      },
+      connection: baseConn,
+      callback: { url: "http://api/", token: "tk" },
+    });
+    expect(r.argv).toContain("--rate-type=throughput");
+    expect(r.argv).toContain("--rate=75");
+  });
+});
+
+describe("guidellm.parseProgress", () => {
+  it("returns null for non-progress lines", () => {
+    expect(parseProgress("some random log line")).toBeNull();
+  });
+});
+
+describe("guidellm.parseFinalReport", () => {
+  it("parses the fixture into a typed ToolReport", () => {
+    const result = parseFinalReport("", { report: fixtureBuf });
+    expect(result.tool).toBe("guidellm");
+    expect(result.data.ttft).toBeDefined();
+    expect(result.data.ttft.p50).toBeGreaterThan(0);
+    expect(result.data.requests.total).toBeGreaterThan(0);
+  });
+
+  it("throws on malformed fixture (missing report file)", () => {
+    expect(() => parseFinalReport("", {})).toThrow();
+  });
+});
+```
+
+- [ ] **Step 3.1.3: Run failing**
+
+```bash
+pnpm -F @modeldoctor/tool-adapters test -- guidellm/runtime
+```
+
+- [ ] **Step 3.1.4: Replace `packages/tool-adapters/src/guidellm/runtime.ts` with real impl**
+
+```ts
+import type {
+  BuildCommandPlan,
+  BuildCommandResult,
+  ProgressEvent,
+  ToolReport,
+} from "../core/interface.js";
+import { guidellmReportSchema, type GuidellmParams, type GuidellmReport } from "./schema.js";
+
+export function buildCommand(plan: BuildCommandPlan<GuidellmParams>): BuildCommandResult {
+  const { params, connection } = plan;
+
+  if (params.datasetName === "sharegpt") {
+    throw new Error("sharegpt dataset is not yet supported");
+  }
+
+  // backend-kwargs carries api_key + optional validate_backend
+  const backendKwargs: Record<string, unknown> = { api_key: connection.apiKey };
+  if (!params.validateBackend) {
+    backendKwargs.validate_backend = false;
+  }
+  // We pass backend-kwargs via env var instead of argv to avoid leaking the
+  // api_key into ps/proc lists; the wrapper exports MD_GUIDELLM_BACKEND_KWARGS
+  // back into argv inside the container.
+  const argv: string[] = [
+    "guidellm",
+    "benchmark",
+    "run",
+    "--backend=openai_http",
+    `--backend-kwargs=${JSON.stringify(backendKwargs)}`,
+    `--target=${connection.baseUrl}`,
+    `--model=${connection.model}`,
+    `--max-requests=${params.totalRequests}`,
+    `--max-seconds=${params.maxDurationSeconds}`,
+    "--output-path=report.json",
+    "--disable-console",
+  ];
+
+  if (params.requestRate > 0) {
+    argv.push("--rate-type=constant", `--rate=${params.requestRate}`);
+  } else {
+    argv.push("--rate-type=throughput", `--rate=${params.maxConcurrency}`);
+  }
+
+  argv.push(
+    `--data=prompt_tokens=${params.datasetInputTokens},output_tokens=${params.datasetOutputTokens}`,
+  );
+  if (params.datasetSeed !== undefined) {
+    argv.push(`--random-seed=${params.datasetSeed}`);
+  }
+  if (params.processor) {
+    argv.push(`--processor=${params.processor}`);
+  }
+
+  return {
+    argv,
+    env: {},
+    secretEnv: {
+      // Phase 4 follow-up: move apiKey out of backend-kwargs into env, then
+      // adjust argv to read $OPENAI_API_KEY. For now, the JSON above contains
+      // it. Note that argv is logged by the wrapper after redacting any
+      // --backend-kwargs= flag, so this stays out of API logs.
+    },
+    outputFiles: { report: "report.json" },
+  };
+}
+
+// guidellm with --disable-console emits no progress lines on stderr.
+// If a future version emits machine-readable lines, parse here.
+export function parseProgress(_line: string): ProgressEvent | null {
+  return null;
+}
+
+export function parseFinalReport(
+  _stdout: string,
+  files: Record<string, Buffer>,
+): ToolReport {
+  const reportBuf = files.report;
+  if (!reportBuf) {
+    throw new Error("guidellm.parseFinalReport: missing 'report' output file");
+  }
+  const raw = JSON.parse(reportBuf.toString("utf8")) as Record<string, unknown>;
+  const data = mapGuidellmRawToReport(raw);
+  guidellmReportSchema.parse(data);
+  return { tool: "guidellm", data };
+}
+
+// ── internal mapper (port of apps/benchmark-runner/runner/metrics.py) ──
+function successful(metrics: Record<string, unknown>, key: string): Record<string, unknown> {
+  const sds = (metrics[key] ?? {}) as Record<string, unknown>;
+  return ((sds.successful as Record<string, unknown>) ?? {});
+}
+function latency(metrics: Record<string, unknown>, key: string): {
+  mean: number; p50: number; p90: number; p95: number; p99: number;
+} {
+  const src = successful(metrics, key);
+  const pct = (src.percentiles as Record<string, unknown>) ?? {};
+  return {
+    mean: Number(src.mean ?? 0),
+    p50: Number(pct.p50 ?? src.median ?? 0),
+    p90: Number(pct.p90 ?? 0),
+    p95: Number(pct.p95 ?? 0),
+    p99: Number(pct.p99 ?? 0),
+  };
+}
+function rate(metrics: Record<string, unknown>, key: string): { mean: number } {
+  return { mean: Number(successful(metrics, key).mean ?? 0) };
+}
+
+function mapGuidellmRawToReport(raw: Record<string, unknown>): GuidellmReport {
+  const benches = (raw.benchmarks as Array<Record<string, unknown>> | undefined) ?? [];
+  const first = benches[0] ?? {};
+  const metrics = ((first.metrics as Record<string, unknown> | undefined) ?? {});
+
+  const concurrencySrc = successful(metrics, "request_concurrency");
+  const totals = ((metrics.request_totals as Record<string, unknown> | undefined) ?? {});
+
+  // request_latency in guidellm 0.5.x is in seconds (no _ms suffix in key);
+  // convert to milliseconds for the wire shape.
+  const e2e = latency(metrics, "request_latency");
+  const e2eMs = {
+    mean: e2e.mean * 1000,
+    p50: e2e.p50 * 1000,
+    p90: e2e.p90 * 1000,
+    p95: e2e.p95 * 1000,
+    p99: e2e.p99 * 1000,
+  };
+
+  return {
+    ttft: latency(metrics, "time_to_first_token_ms"),
+    itl: latency(metrics, "inter_token_latency_ms"),
+    e2eLatency: e2eMs,
+    requestsPerSecond: rate(metrics, "requests_per_second"),
+    outputTokensPerSecond: rate(metrics, "output_tokens_per_second"),
+    inputTokensPerSecond: rate(metrics, "prompt_tokens_per_second"),
+    totalTokensPerSecond: rate(metrics, "tokens_per_second"),
+    concurrency: {
+      mean: Number(concurrencySrc.mean ?? 0),
+      max: Number(concurrencySrc.max ?? 0),
+    },
+    requests: {
+      total: Number(totals.total ?? 0) | 0,
+      success: Number(totals.successful ?? 0) | 0,
+      error: Number(totals.errored ?? 0) | 0,
+      incomplete: Number(totals.incomplete ?? 0) | 0,
+    },
+  };
+}
+```
+
+- [ ] **Step 3.1.5: Run + commit**
+
+```bash
+pnpm -F @modeldoctor/tool-adapters test -- guidellm
+git add packages/tool-adapters/src/guidellm/
+git commit -m "$(cat <<'EOF'
+feat(tool-adapters/guidellm): implement runtime; add fixture (#53)
+
+buildCommand emits the guidellm CLI argv (api_key tucked into
+--backend-kwargs JSON); parseFinalReport reads files['report'] and maps
+the guidellm 0.5.x report.json structure into GuidellmReport. Mapping
+ported from apps/benchmark-runner/runner/metrics.py.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3.2: Implement vegeta runtime + fixture-based test
+
+**Files:**
+- Create: `packages/tool-adapters/src/vegeta/__fixtures__/report.txt`
+- Modify: `packages/tool-adapters/src/vegeta/runtime.ts`
+- Create: `packages/tool-adapters/src/vegeta/runtime.spec.ts`
+
+- [ ] **Step 3.2.1: Place fixture**
+
+```bash
+mkdir -p packages/tool-adapters/src/vegeta/__fixtures__
+cp /tmp/vegeta-fixture.txt packages/tool-adapters/src/vegeta/__fixtures__/report.txt
+```
+
+If you don't have a fresh capture, use this minimal valid sample:
+
+```
+Requests      [total, rate, throughput]         100, 10.10, 9.95
+Duration      [total, attack, wait]             10.05s, 9.9s, 150ms
+Latencies     [min, mean, 50, 90, 95, 99, max]  5ms, 24.5ms, 22ms, 35ms, 42ms, 78ms, 102ms
+Bytes In      [total, mean]                     45000, 450.00
+Bytes Out     [total, mean]                     12000, 120.00
+Success       [ratio]                           99.00%
+Status Codes  [code:count]                      200:99  500:1
+Error Set:
+500 Internal Server Error
+```
+
+- [ ] **Step 3.2.2: Write failing test**
+
+Create `packages/tool-adapters/src/vegeta/runtime.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildCommand, parseFinalReport, parseProgress } from "./runtime.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixtureBuf = fs.readFileSync(path.join(__dirname, "__fixtures__/report.txt"));
+
+const baseConn = {
+  baseUrl: "http://localhost:8000",
+  apiKey: "sk-test",
+  model: "Qwen2.5-0.5B-Instruct",
+  customHeaders: "",
+  queryParams: "",
+};
+
+describe("vegeta.buildCommand", () => {
+  it("emits a shell pipeline argv via /bin/sh -c", () => {
+    const r = buildCommand({
+      runId: "r1",
+      params: { apiType: "chat", rate: 10, duration: 30 },
+      connection: baseConn,
+      callback: { url: "http://api/", token: "tk" },
+    });
+    expect(r.argv[0]).toBe("/bin/sh");
+    expect(r.argv[1]).toBe("-c");
+    expect(r.argv[2]).toContain("vegeta attack");
+    expect(r.argv[2]).toContain("-rate=10");
+    expect(r.argv[2]).toContain("-duration=30s");
+  });
+
+  it("writes targets.txt as inputFile (with apiKey embedded)", () => {
+    const r = buildCommand({
+      runId: "r1",
+      params: { apiType: "chat", rate: 10, duration: 30 },
+      connection: baseConn,
+      callback: { url: "http://api/", token: "tk" },
+    });
+    expect(r.inputFiles?.["targets.txt"]).toBeDefined();
+    expect(r.inputFiles?.["targets.txt"]).toContain("Authorization: Bearer sk-test");
+    // apiKey should NOT appear in argv or env (it's in the input file
+    // which K8sJobDriver routes via Secret + volumeMount).
+    expect(r.argv.join(" ")).not.toContain("sk-test");
+    expect(JSON.stringify(r.env)).not.toContain("sk-test");
+    expect(JSON.stringify(r.secretEnv)).not.toContain("sk-test");
+  });
+
+  it("declares output files for report and attack stream", () => {
+    const r = buildCommand({
+      runId: "r1",
+      params: { apiType: "chat", rate: 10, duration: 30 },
+      connection: baseConn,
+      callback: { url: "http://api/", token: "tk" },
+    });
+    expect(r.outputFiles.report).toBe("report.txt");
+    expect(r.outputFiles.attack).toBe("attack.bin");
+  });
+});
+
+describe("vegeta.parseProgress", () => {
+  it("always returns null (vegeta CLI is silent during attack)", () => {
+    expect(parseProgress("any line")).toBeNull();
+  });
+});
+
+describe("vegeta.parseFinalReport", () => {
+  it("parses fixture into typed ToolReport with ms-converted latencies", () => {
+    const result = parseFinalReport("", { report: fixtureBuf });
+    expect(result.tool).toBe("vegeta");
+    expect(result.data.requests.total).toBeGreaterThan(0);
+    expect(result.data.latencies.p99).toBeGreaterThan(0);
+    expect(result.data.success).toBeGreaterThan(0);
+    // unit conversion check: "78ms" should land as ~78 (number)
+    expect(typeof result.data.latencies.p99).toBe("number");
+  });
+
+  it("throws when 'report' file is missing", () => {
+    expect(() => parseFinalReport("", {})).toThrow();
+  });
+});
+```
+
+- [ ] **Step 3.2.3: Run failing**
+
+```bash
+pnpm -F @modeldoctor/tool-adapters test -- vegeta/runtime
+```
+
+- [ ] **Step 3.2.4: Replace `packages/tool-adapters/src/vegeta/runtime.ts`**
+
+```ts
+import type {
+  BuildCommandPlan,
+  BuildCommandResult,
+  ProgressEvent,
+  ToolReport,
+} from "../core/interface.js";
+import { vegetaReportSchema, type VegetaParams, type VegetaReport } from "./schema.js";
+
+const API_TYPE_TO_PATH: Record<VegetaParams["apiType"], string> = {
+  chat: "/v1/chat/completions",
+  "chat-vision": "/v1/chat/completions",
+  "chat-audio": "/v1/chat/completions",
+  embeddings: "/v1/embeddings",
+  rerank: "/v1/rerank",
+  images: "/v1/images/generations",
+};
+
+const API_TYPE_TO_BODY: Record<VegetaParams["apiType"], (model: string) => string> = {
+  chat: (m) => JSON.stringify({ model: m, messages: [{ role: "user", content: "hello" }] }),
+  "chat-vision": (m) =>
+    JSON.stringify({ model: m, messages: [{ role: "user", content: "hello" }] }),
+  "chat-audio": (m) =>
+    JSON.stringify({ model: m, messages: [{ role: "user", content: "hello" }] }),
+  embeddings: (m) => JSON.stringify({ model: m, input: "hello" }),
+  rerank: (m) =>
+    JSON.stringify({ model: m, query: "what is 2+2", documents: ["four", "five"] }),
+  images: (m) => JSON.stringify({ model: m, prompt: "a cat" }),
+};
+
+export function buildCommand(plan: BuildCommandPlan<VegetaParams>): BuildCommandResult {
+  const { params, connection } = plan;
+  const path = API_TYPE_TO_PATH[params.apiType];
+  let url = connection.baseUrl + path;
+
+  // Append queryParams (one "k=v" per non-empty line)
+  if (connection.queryParams.trim()) {
+    const ps = connection.queryParams
+      .split("\n")
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0 && p.includes("="));
+    if (ps.length > 0) {
+      url = url + (url.includes("?") ? "&" : "?") + ps.join("&");
+    }
+  }
+
+  // customHeaders: one "K: V" per non-empty line
+  let extraHeaders = "";
+  if (connection.customHeaders.trim()) {
+    const lines = connection.customHeaders
+      .split("\n")
+      .map((h) => h.trim())
+      .filter((h) => h.length > 0 && h.includes(":"));
+    extraHeaders = lines.map((h) => `\n${h}`).join("");
+  }
+
+  const body = API_TYPE_TO_BODY[params.apiType](connection.model);
+  // vegeta's HTTP-format target file: "METHOD URL\nHeaders\n@bodyfile"
+  const targetsTxt = `POST ${url}\nContent-Type: application/json\nAuthorization: Bearer ${connection.apiKey}${extraHeaders}\n@request.json`;
+
+  const cmd =
+    `cat targets.txt | vegeta attack -rate=${params.rate} -duration=${params.duration}s ` +
+    `| tee attack.bin | vegeta report > report.txt`;
+
+  return {
+    argv: ["/bin/sh", "-c", cmd],
+    env: {},
+    secretEnv: {},
+    inputFiles: {
+      "targets.txt": targetsTxt,
+      "request.json": body,
+    },
+    outputFiles: {
+      report: "report.txt",
+      attack: "attack.bin",
+    },
+  };
+}
+
+// vegeta CLI is silent during attack; no progress to parse.
+export function parseProgress(_line: string): ProgressEvent | null {
+  return null;
+}
+
+export function parseFinalReport(
+  _stdout: string,
+  files: Record<string, Buffer>,
+): ToolReport {
+  const reportBuf = files.report;
+  if (!reportBuf) {
+    throw new Error("vegeta.parseFinalReport: missing 'report' output file");
+  }
+  const data = parseVegetaReportText(reportBuf.toString("utf8"));
+  vegetaReportSchema.parse(data);
+  return { tool: "vegeta", data };
+}
+
+// ── internal: ported from apps/api/src/integrations/parsers/vegeta-report.ts ──
+function parseLatencyToMs(s: string): number {
+  // Accept "1.2µs" (rare), "1.2ms", "1.2s", "1m2.3s" forms. vegeta normally
+  // emits one of µs/ms/s.
+  const m = s.match(/^([0-9.]+)\s*(µs|ms|s)$/);
+  if (!m) return Number.NaN;
+  const v = Number.parseFloat(m[1]);
+  switch (m[2]) {
+    case "µs": return v / 1000;
+    case "ms": return v;
+    case "s":  return v * 1000;
+    default:   return Number.NaN;
+  }
+}
+function parseDurationToSeconds(s: string): number {
+  const m = s.match(/^([0-9.]+)\s*(ms|s)$/);
+  if (!m) return Number.NaN;
+  const v = Number.parseFloat(m[1]);
+  return m[2] === "ms" ? v / 1000 : v;
+}
+
+function parseVegetaReportText(report: string): VegetaReport {
+  const out: VegetaReport = {
+    requests: { total: 0, rate: 0, throughput: 0 },
+    duration: { totalSeconds: 0, attackSeconds: 0, waitSeconds: 0 },
+    latencies: { min: 0, mean: 0, p50: 0, p90: 0, p95: 0, p99: 0, max: 0 },
+    bytesIn: { total: 0, mean: 0 },
+    bytesOut: { total: 0, mean: 0 },
+    success: 0,
+    statusCodes: {},
+    errors: [],
+  };
+
+  for (const line of report.split("\n")) {
+    if (line.includes("Requests") && line.includes("[total")) {
+      const m = line.match(/\]\s+([\d.]+),\s+([\d.]+),\s+([\d.]+)/);
+      if (m) {
+        out.requests.total = Number.parseInt(m[1], 10);
+        out.requests.rate = Number.parseFloat(m[2]);
+        out.requests.throughput = Number.parseFloat(m[3]);
+      }
+    } else if (line.includes("Duration") && line.includes("[total")) {
+      const m = line.match(/\]\s+([\d.]+\w+),\s+([\d.]+\w+),\s+([\d.]+\w+)/);
+      if (m) {
+        out.duration.totalSeconds = parseDurationToSeconds(m[1]);
+        out.duration.attackSeconds = parseDurationToSeconds(m[2]);
+        out.duration.waitSeconds = parseDurationToSeconds(m[3]);
+      }
+    } else if (line.includes("Latencies") && line.includes("[min")) {
+      const m = line.match(
+        /\]\s+([\d.]+\w+),\s+([\d.]+\w+),\s+([\d.]+\w+),\s+([\d.]+\w+),\s+([\d.]+\w+),\s+([\d.]+\w+),\s+([\d.]+\w+)/,
+      );
+      if (m) {
+        out.latencies.min = parseLatencyToMs(m[1]);
+        out.latencies.mean = parseLatencyToMs(m[2]);
+        out.latencies.p50 = parseLatencyToMs(m[3]);
+        out.latencies.p90 = parseLatencyToMs(m[4]);
+        out.latencies.p95 = parseLatencyToMs(m[5]);
+        out.latencies.p99 = parseLatencyToMs(m[6]);
+        out.latencies.max = parseLatencyToMs(m[7]);
+      }
+    } else if (line.includes("Bytes In") && line.includes("[total")) {
+      const m = line.match(/\]\s+([\d.]+),\s+([\d.]+)/);
+      if (m) {
+        out.bytesIn.total = Number.parseInt(m[1], 10);
+        out.bytesIn.mean = Number.parseFloat(m[2]);
+      }
+    } else if (line.includes("Bytes Out") && line.includes("[total")) {
+      const m = line.match(/\]\s+([\d.]+),\s+([\d.]+)/);
+      if (m) {
+        out.bytesOut.total = Number.parseInt(m[1], 10);
+        out.bytesOut.mean = Number.parseFloat(m[2]);
+      }
+    } else if (line.includes("Success") && line.includes("[ratio]")) {
+      const m = line.match(/\]\s+([\d.]+)%/);
+      if (m) out.success = Number.parseFloat(m[1]);
+    } else if (line.includes("Status Codes") && line.includes("[code:count]")) {
+      const m = line.match(/\[code:count\]\s+(.*)/);
+      if (m) {
+        for (const tok of m[1].trim().split(/\s+/)) {
+          const [code, count] = tok.split(":");
+          if (code && count) out.statusCodes[code] = Number.parseInt(count, 10);
+        }
+      }
+    } else if (line.startsWith("Error Set:")) {
+      // following lines until end are error strings
+      continue;
+    } else if (line.trim().length > 0 && /^\d/.test(line.trim())) {
+      // looks like a "500 ..." error line
+      out.errors.push(line.trim());
+    }
+  }
+
+  return out;
+}
+```
+
+- [ ] **Step 3.2.5: Run + commit**
+
+```bash
+pnpm -F @modeldoctor/tool-adapters test -- vegeta
+git add packages/tool-adapters/src/vegeta/
+git commit -m "$(cat <<'EOF'
+feat(tool-adapters/vegeta): implement runtime; add fixture (#53)
+
+Shell-pipeline buildCommand; targets.txt with bearer token routes via
+inputFiles (Secret-mounted in K8s, never in argv/env). parseFinalReport
+ports the regex parser from apps/api/integrations/parsers/vegeta-report.ts
+and adds proper ms unit conversion.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3.3: Rewrite `apps/benchmark-runner/` as a generic wrapper
+
+**Files:**
+- Modify: `apps/benchmark-runner/runner/main.py`
+- Modify: `apps/benchmark-runner/runner/callback.py`
+- Delete: `apps/benchmark-runner/runner/argv.py`
+- Delete: `apps/benchmark-runner/runner/env.py`
+- Delete: `apps/benchmark-runner/runner/metrics.py`
+- Delete: corresponding test files
+- Modify: `apps/benchmark-runner/tests/test_main.py`
+- Modify: `apps/benchmark-runner/tests/conftest.py`
+
+- [ ] **Step 3.3.1: Replace `runner/main.py` with the generic wrapper**
+
+```python
+"""Generic tool wrapper. Reads MD_* env, spawns argv, batches /log,
+   collects outputFiles, posts /finish.
+
+   Phase 3 of #53: replaces the guidellm-specific runner. This file
+   contains zero tool-specific knowledge.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+from runner.callback import post_finish, post_log_batch, post_state_running
+
+LOG_BATCH_INTERVAL_SEC = 0.25
+LOG_LINE_MAX_BYTES = 64 * 1024
+
+logging.basicConfig(level=logging.INFO, format="[runner] %(message)s")
+log = logging.getLogger("runner")
+
+
+class StreamPump:
+    """Drains a file-like stream into a full-buffer + a /log batch sender."""
+
+    def __init__(self, stream, name: str, callback_url: str, token: str, run_id: str):
+        self.stream = stream
+        self.name = name
+        self.callback_url = callback_url
+        self.token = token
+        self.run_id = run_id
+        self.buffer: list[str] = []
+        self.full: list[str] = []
+        self._stop = threading.Event()
+
+    def run(self) -> None:
+        last_flush = time.monotonic()
+        while True:
+            line_bytes = self.stream.readline()
+            if not line_bytes:
+                break
+            try:
+                line = line_bytes.decode("utf-8", errors="replace")
+            except Exception:
+                line = repr(line_bytes)
+            line = line.rstrip("\n")[:LOG_LINE_MAX_BYTES]
+            self.full.append(line)
+            self.buffer.append(line)
+            now = time.monotonic()
+            if now - last_flush >= LOG_BATCH_INTERVAL_SEC:
+                self._flush()
+                last_flush = now
+        self._flush()
+
+    def _flush(self) -> None:
+        if not self.buffer:
+            return
+        try:
+            post_log_batch(
+                callback_url=self.callback_url,
+                token=self.token,
+                run_id=self.run_id,
+                stream=self.name,
+                lines=self.buffer,
+            )
+        except Exception as e:
+            log.warning("post_log_batch failed: %s", e)
+        self.buffer = []
+
+
+def _materialize_input_files() -> None:
+    """If MD_INPUT_FILE_PATHS is set (K8s mode), symlink mount paths to cwd.
+
+    Subprocess driver writes inputFiles directly to cwd already, so this is a no-op there.
+    """
+    raw = os.environ.get("MD_INPUT_FILE_PATHS")
+    if not raw:
+        return
+    mapping = json.loads(raw)
+    cwd = Path.cwd()
+    for alias, src_path in mapping.items():
+        dst = cwd / alias
+        try:
+            if dst.exists() or dst.is_symlink():
+                dst.unlink()
+            dst.symlink_to(src_path)
+        except OSError as e:
+            log.warning("failed to symlink input file %s -> %s: %s", dst, src_path, e)
+
+
+def _redacted(argv: list[str]) -> list[str]:
+    """Mask --backend-kwargs= JSON since it can contain api_key."""
+    out: list[str] = []
+    for a in argv:
+        if a.startswith("--backend-kwargs="):
+            out.append("--backend-kwargs=***REDACTED***")
+        else:
+            out.append(a)
+    return out
+
+
+def main() -> int:
+    callback_url = os.environ["MD_CALLBACK_URL"]
+    token = os.environ["MD_CALLBACK_TOKEN"]
+    run_id = os.environ["MD_RUN_ID"]
+    argv = json.loads(os.environ["MD_ARGV"])
+    output_files = json.loads(os.environ["MD_OUTPUT_FILES"])
+
+    _materialize_input_files()
+
+    try:
+        post_state_running(callback_url=callback_url, token=token, run_id=run_id)
+    except Exception as e:
+        log.warning("post_state_running failed: %s", e)
+
+    log.info("running: %s", " ".join(_redacted(argv)))
+    proc = subprocess.Popen(  # noqa: S603
+        argv,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=os.getcwd(),
+    )
+
+    out_pump = StreamPump(proc.stdout, "stdout", callback_url, token, run_id)
+    err_pump = StreamPump(proc.stderr, "stderr", callback_url, token, run_id)
+    t1 = threading.Thread(target=out_pump.run, daemon=True)
+    t2 = threading.Thread(target=err_pump.run, daemon=True)
+    t1.start(); t2.start()
+
+    proc.wait()
+    t1.join(timeout=5); t2.join(timeout=5)
+
+    files_b64: dict[str, str] = {}
+    for alias, rel_path in output_files.items():
+        full = Path.cwd() / rel_path
+        if full.exists():
+            files_b64[alias] = base64.b64encode(full.read_bytes()).decode("ascii")
+
+    state = "completed" if proc.returncode == 0 else "failed"
+    message = None if state == "completed" else f"tool exited with code {proc.returncode}"
+
+    try:
+        post_finish(
+            callback_url=callback_url, token=token, run_id=run_id,
+            state=state, exit_code=proc.returncode,
+            stdout="\n".join(out_pump.full),
+            stderr="\n".join(err_pump.full),
+            files=files_b64,
+            message=message,
+        )
+    except Exception as e:
+        log.error("post_finish failed: %s", e)
+        return 1
+
+    # Always exit 0 from the wrapper itself — failure of the inner tool is
+    # already conveyed via /finish state=failed.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 3.3.2: Replace `runner/callback.py`**
+
+```python
+"""HTTP callbacks: runner pod → API. Path layout v2 (#53)."""
+
+from __future__ import annotations
+
+import requests
+
+_TIMEOUT_SECONDS = 10
+
+
+def _join(callback_url: str, path: str) -> str:
+    return f"{callback_url.rstrip('/')}/{path.lstrip('/')}"
+
+
+def _post(url: str, token: str, body: dict) -> None:
+    resp = requests.post(
+        url,
+        json=body,
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=_TIMEOUT_SECONDS,
+    )
+    if not resp.ok:
+        raise RuntimeError(f"Callback POST {url} returned {resp.status_code}: {resp.text[:200]}")
+
+
+def post_state_running(*, callback_url: str, token: str, run_id: str) -> None:
+    _post(_join(callback_url, f"api/internal/runs/{run_id}/state"), token, {"state": "running"})
+
+
+def post_log_batch(
+    *,
+    callback_url: str,
+    token: str,
+    run_id: str,
+    stream: str,
+    lines: list[str],
+) -> None:
+    _post(
+        _join(callback_url, f"api/internal/runs/{run_id}/log"),
+        token,
+        {"stream": stream, "lines": lines},
+    )
+
+
+def post_finish(
+    *,
+    callback_url: str,
+    token: str,
+    run_id: str,
+    state: str,
+    exit_code: int,
+    stdout: str,
+    stderr: str,
+    files: dict[str, str],
+    message: str | None,
+) -> None:
+    body: dict = {
+        "state": state,
+        "exitCode": exit_code,
+        "stdout": stdout,
+        "stderr": stderr,
+        "files": files,
+    }
+    if message is not None:
+        body["message"] = message
+    _post(_join(callback_url, f"api/internal/runs/{run_id}/finish"), token, body)
+```
+
+- [ ] **Step 3.3.3: Delete tool-specific files**
+
+```bash
+git rm apps/benchmark-runner/runner/argv.py
+git rm apps/benchmark-runner/runner/env.py
+git rm apps/benchmark-runner/runner/metrics.py
+git rm apps/benchmark-runner/tests/test_argv.py
+git rm apps/benchmark-runner/tests/test_env.py
+git rm apps/benchmark-runner/tests/test_metrics.py
+```
+
+- [ ] **Step 3.3.4: Replace `tests/test_main.py` with wrapper-only tests**
+
+The new tests should cover: cwd-relative outputFiles collection, /log batching with mock POST, /finish ships full stdout, exit code 0 inner tool → state=completed, exit code != 0 → state=failed. Use `subprocess` to spawn `echo` / `cat` for test argv. Skip detailed test code here; pattern follows the existing `tests/conftest.py` with monkeypatched `requests`.
+
+- [ ] **Step 3.3.5: Update `apps/benchmark-runner/Dockerfile` references**
+
+If the existing Dockerfile is still present (a single combined image), defer its changes to Task 3.4. For now, run `pnpm -F @modeldoctor/api lint` to make sure no API code references the deleted `argv.py / env.py / metrics.py`. The old `BenchmarkService` does NOT import them directly (the runner image is invoked as a subprocess), so this should be clean.
+
+- [ ] **Step 3.3.6: Commit**
+
+```bash
+git add apps/benchmark-runner/
+git commit -m "$(cat <<'EOF'
+refactor(benchmark-runner): generic tool-agnostic wrapper (#53)
+
+- Delete argv.py / env.py / metrics.py + tests (guidellm-specific)
+- Rewrite main.py to read MD_* env, spawn argv, batch /log, post /finish
+- Rewrite callback.py for the v2 callback path layout (/state, /log, /finish)
+
+Wrapper has zero tool knowledge. Image-per-tool Dockerfiles in Task 3.4.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3.4: Split runner Dockerfile per tool
+
+**Files:**
+- Create: `apps/benchmark-runner/images/guidellm.Dockerfile`
+- Create: `apps/benchmark-runner/images/vegeta.Dockerfile`
+- Delete: `apps/benchmark-runner/Dockerfile` (or move to `images/legacy.Dockerfile` to preserve until merged)
+
+- [ ] **Step 3.4.1: Author `images/guidellm.Dockerfile`**
+
+```dockerfile
+# Phase 3 of #53: guidellm runner image. Uses the upstream gpustack
+# benchmark-runner base (which bundles guidellm) and overlays our
+# generic wrapper.
+FROM ghcr.io/gpustack/benchmark-runner:latest
+
+WORKDIR /app
+COPY pyproject.toml ./
+COPY runner/ ./runner/
+RUN pip install --no-cache-dir requests
+
+ENTRYPOINT ["python", "-m", "runner"]
+```
+
+- [ ] **Step 3.4.2: Author `images/vegeta.Dockerfile`**
+
+```dockerfile
+# Phase 3 of #53: vegeta runner image. Adds Python wrapper on top of
+# the upstream vegeta CLI image.
+FROM peterevans/vegeta:latest AS vegeta
+
+FROM python:3.11-slim
+COPY --from=vegeta /bin/vegeta /usr/local/bin/vegeta
+
+WORKDIR /app
+COPY pyproject.toml ./
+COPY runner/ ./runner/
+RUN pip install --no-cache-dir requests
+
+ENTRYPOINT ["python", "-m", "runner"]
+```
+
+- [ ] **Step 3.4.3: Add `apps/benchmark-runner/runner/__main__.py` (if not present)**
+
+```python
+from runner.main import main
+import sys
+sys.exit(main())
+```
+
+- [ ] **Step 3.4.4: Delete the old single Dockerfile**
+
+```bash
+git rm apps/benchmark-runner/Dockerfile
+```
+
+- [ ] **Step 3.4.5: Build images locally to verify**
+
+```bash
+docker build -f apps/benchmark-runner/images/guidellm.Dockerfile -t md-runner-guidellm:dev apps/benchmark-runner/
+docker build -f apps/benchmark-runner/images/vegeta.Dockerfile -t md-runner-vegeta:dev apps/benchmark-runner/
+```
+
+Expected: both build successfully.
+
+- [ ] **Step 3.4.6: Commit**
+
+```bash
+git add apps/benchmark-runner/images apps/benchmark-runner/runner/__main__.py
+git commit -m "$(cat <<'EOF'
+build(benchmark-runner): split Dockerfile per tool (#53)
+
+guidellm and vegeta now have their own image flavors that overlay the
+generic wrapper. genai-perf image lands in PR 53.4.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3.5: Convert `BenchmarkController` to facade
+
+**Files:**
+- Replace: `apps/api/src/modules/benchmark/benchmark.controller.ts`
+- Replace: `apps/api/src/modules/benchmark/benchmark.service.ts` (or delete; controller now calls RunService directly)
+- Modify: `apps/api/src/modules/benchmark/benchmark.module.ts`
+- Create: `apps/api/src/modules/benchmark/benchmark-facade.mappers.ts` (translate legacy↔run)
+
+- [ ] **Step 3.5.1: Reverse mapper**
+
+Create `apps/api/src/modules/benchmark/benchmark-facade.mappers.ts`:
+
+```ts
+import type {
+  BenchmarkRun,
+  BenchmarkRunSummary,
+  CreateBenchmarkRequest,
+  Run,
+} from "@modeldoctor/contracts";
+import type { GuidellmParams, GuidellmReport } from "@modeldoctor/tool-adapters";
+
+export function legacyCreateToCreateRun(body: CreateBenchmarkRequest) {
+  const params: GuidellmParams = {
+    profile: body.profile,
+    apiType: body.apiType,
+    datasetName: body.datasetName,
+    datasetInputTokens: body.datasetInputTokens,
+    datasetOutputTokens: body.datasetOutputTokens,
+    datasetSeed: body.datasetSeed,
+    requestRate: body.requestRate,
+    totalRequests: body.totalRequests,
+    // The new schema accepts duration/concurrency/processor/validateBackend
+    // with sensible defaults; legacy create body doesn't carry those, so
+    // leave them undefined and let zod fill defaults.
+  } as GuidellmParams;
+  return {
+    tool: "guidellm" as const,
+    kind: "benchmark" as const,
+    connectionId: body.connectionId,
+    name: body.name,
+    description: body.description,
+    params,
+  };
+}
+
+export function runToBenchmarkRun(run: Run): BenchmarkRun {
+  const summary = run.summaryMetrics as
+    | { tool: "guidellm"; data: GuidellmReport }
+    | null
+    | undefined;
+  const params = (run.params ?? {}) as Partial<GuidellmParams>;
+  const scenario = (run.scenario ?? {}) as Record<string, unknown>;
+  return {
+    id: run.id,
+    userId: run.userId,
+    connectionId: run.connectionId,
+    name: run.name ?? "",
+    description: run.description,
+    profile: (params.profile ?? "custom") as BenchmarkRun["profile"],
+    apiType: (params.apiType ?? "chat") as BenchmarkRun["apiType"],
+    apiBaseUrl: (scenario.apiBaseUrl as string) ?? "",
+    model: (scenario.model as string) ?? "",
+    datasetName: (params.datasetName ?? "random") as BenchmarkRun["datasetName"],
+    datasetInputTokens: params.datasetInputTokens ?? null,
+    datasetOutputTokens: params.datasetOutputTokens ?? null,
+    datasetSeed: params.datasetSeed ?? null,
+    requestRate: params.requestRate ?? 0,
+    totalRequests: params.totalRequests ?? 0,
+    state: run.status as BenchmarkRun["state"],
+    stateMessage: run.statusMessage,
+    progress: run.progress,
+    jobName: run.driverHandle,
+    metricsSummary: summary?.data ? guidellmReportToLegacyMetricsSummary(summary.data) : null,
+    rawMetrics: run.rawOutput ?? null,
+    logs: run.logs,
+    createdAt: run.createdAt,
+    startedAt: run.startedAt,
+    completedAt: run.completedAt,
+  };
+}
+
+export function runToBenchmarkRunSummary(run: Run): BenchmarkRunSummary {
+  const r = runToBenchmarkRun(run);
+  return {
+    id: r.id, userId: r.userId, connectionId: r.connectionId,
+    name: r.name, profile: r.profile, apiType: r.apiType,
+    apiBaseUrl: r.apiBaseUrl, model: r.model, datasetName: r.datasetName,
+    state: r.state, progress: r.progress, metricsSummary: r.metricsSummary,
+    createdAt: r.createdAt, startedAt: r.startedAt, completedAt: r.completedAt,
+  };
+}
+
+function guidellmReportToLegacyMetricsSummary(data: GuidellmReport) {
+  // Old shape used p95 (we kept it in GuidellmReport); strip p90 to match
+  // what BenchmarkMetricsSummarySchema expects.
+  const dist = (d: GuidellmReport["ttft"]) => ({
+    mean: d.mean, p50: d.p50, p95: d.p95, p99: d.p99,
+  });
+  return {
+    ttft: dist(data.ttft),
+    itl: dist(data.itl),
+    e2eLatency: dist(data.e2eLatency),
+    requestsPerSecond: data.requestsPerSecond,
+    outputTokensPerSecond: data.outputTokensPerSecond,
+    inputTokensPerSecond: data.inputTokensPerSecond,
+    totalTokensPerSecond: data.totalTokensPerSecond,
+    concurrency: data.concurrency,
+    requests: data.requests,
+  };
+}
+```
+
+- [ ] **Step 3.5.2: Replace `benchmark.controller.ts` with facade**
+
+```ts
+import {
+  type BenchmarkRun,
+  type BenchmarkRunSummary,
+  type CreateBenchmarkRequest,
+  CreateBenchmarkRequestSchema,
+  type ListBenchmarksQuery,
+  type ListBenchmarksResponse,
+  ListBenchmarksQuerySchema,
+} from "@modeldoctor/contracts";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
+import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
+import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
+import type { JwtPayload } from "../auth/jwt.strategy.js";
+import { RunService } from "../run/run.service.js";
+import {
+  legacyCreateToCreateRun,
+  runToBenchmarkRun,
+  runToBenchmarkRunSummary,
+} from "./benchmark-facade.mappers.js";
+
+/**
+ * Phase 3 facade (#53). The route surface is unchanged so the FE keeps
+ * working through #54. Internally everything routes through RunService.
+ *
+ * #54 deletes this file and switches the FE to /api/runs.
+ */
+@Controller("benchmarks")
+@UseGuards(JwtAuthGuard)
+export class BenchmarkController {
+  constructor(private readonly runs: RunService) {}
+
+  @Post()
+  async create(
+    @CurrentUser() user: JwtPayload,
+    @Body(new ZodValidationPipe(CreateBenchmarkRequestSchema)) body: CreateBenchmarkRequest,
+  ): Promise<BenchmarkRun> {
+    const run = await this.runs.create(user.sub, legacyCreateToCreateRun(body));
+    return runToBenchmarkRun(run);
+  }
+
+  @Get()
+  async list(
+    @CurrentUser() user: JwtPayload,
+    @Query(new ZodValidationPipe(ListBenchmarksQuerySchema)) q: ListBenchmarksQuery,
+  ): Promise<ListBenchmarksResponse> {
+    // Map legacy query (state / profile / search) to the unified ListRunsQuery.
+    const r = await this.runs.list(
+      {
+        limit: q.limit, cursor: q.cursor,
+        kind: "benchmark", tool: "guidellm",
+        ...(q.state ? { status: q.state } : {}),
+        ...(q.search ? { search: q.search } : {}),
+      },
+      user.sub,
+    );
+    let items: BenchmarkRunSummary[] = r.items.map(runToBenchmarkRunSummary);
+    // params-stored profile filter has to happen in-memory (legacy semantics);
+    // adjust if listRunsQuery already supports it.
+    if (q.profile) items = items.filter((s) => s.profile === q.profile);
+    return { items, nextCursor: r.nextCursor };
+  }
+
+  @Get(":id")
+  async detail(@CurrentUser() user: JwtPayload, @Param("id") id: string): Promise<BenchmarkRun> {
+    const run = await this.runs.findByIdOrFail(id, user.sub);
+    return runToBenchmarkRun(run);
+  }
+
+  @Post(":id/cancel")
+  async cancel(@CurrentUser() user: JwtPayload, @Param("id") id: string): Promise<BenchmarkRun> {
+    const run = await this.runs.cancel(id, user.sub);
+    return runToBenchmarkRun(run);
+  }
+
+  @Delete(":id")
+  @HttpCode(204)
+  async delete(@CurrentUser() user: JwtPayload, @Param("id") id: string): Promise<void> {
+    await this.runs.delete(id, user.sub);
+  }
+}
+```
+
+- [ ] **Step 3.5.3: Update `benchmark.module.ts`**
+
+```ts
+import { Module } from "@nestjs/common";
+import { RunModule } from "../run/run.module.js";
+import { BenchmarkController } from "./benchmark.controller.js";
+
+@Module({
+  imports: [RunModule],
+  controllers: [BenchmarkController],
+})
+export class BenchmarkModule {}
+```
+
+- [ ] **Step 3.5.4: Delete legacy benchmark service + reconciler + drivers + callbacks**
+
+```bash
+git rm apps/api/src/modules/benchmark/benchmark.service.ts
+git rm apps/api/src/modules/benchmark/benchmark.service.spec.ts
+git rm apps/api/src/modules/benchmark/benchmark.reconciler.ts
+git rm apps/api/src/modules/benchmark/benchmark.reconciler.spec.ts
+git rm -r apps/api/src/modules/benchmark/drivers
+git rm apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.ts
+git rm apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.spec.ts
+# Keep callbacks/ directory if it still holds the HMAC re-export shim from Phase 2;
+# delete if empty
+git rm apps/api/src/modules/benchmark/callbacks/hmac-token.ts || true
+git rm apps/api/src/modules/benchmark/callbacks/hmac-callback.guard.ts || true
+rmdir apps/api/src/modules/benchmark/callbacks 2>/dev/null || true
+```
+
+> Note: the reconciler is deleted here. RunModule should provide an equivalent reconciler in a follow-up if needed; #53 spec calls reconciler design out as a future-work item beyond the scope of this issue.
+
+- [ ] **Step 3.5.5: Update existing benchmark.controller.spec.ts to test the facade**
+
+Replace existing tests with golden-path integration tests using a mocked RunService. Verify legacy request shape → translated → RunService call → translated response.
+
+- [ ] **Step 3.5.6: Commit**
+
+```bash
+pnpm -F @modeldoctor/api test -- benchmark
+git add apps/api/src/modules/benchmark/
+git commit -m "$(cat <<'EOF'
+refactor(api/benchmark): convert BenchmarkController to facade over RunService (#53)
+
+Delete service.ts, reconciler, drivers, internal callback controller —
+all of that work now happens via RunService + RunCallbackController in
+the run module. Routes /api/benchmarks/* keep their request/response
+shapes; #54 deletes the facade when the FE switches to /api/runs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3.6: Convert `LoadTestController` to facade (vegeta)
+
+**Files:**
+- Create: `apps/api/src/modules/load-test/load-test-facade.mappers.ts`
+- Modify: `apps/api/src/modules/load-test/load-test.controller.ts`
+- Delete: `apps/api/src/modules/load-test/load-test.service.ts` (or simplify)
+- Modify: `apps/api/src/modules/load-test/load-test.module.ts`
+
+- [ ] **Step 3.6.1: Reverse mapper**
+
+```ts
+// apps/api/src/modules/load-test/load-test-facade.mappers.ts
+import type { LoadTestParsed, LoadTestRequest, LoadTestResponse, Run } from "@modeldoctor/contracts";
+import type { VegetaReport, VegetaParams } from "@modeldoctor/tool-adapters";
+
+export function legacyToCreateRun(req: LoadTestRequest, name: string) {
+  const params: VegetaParams = {
+    apiType: (req.apiType ?? "chat") as VegetaParams["apiType"],
+    rate: req.rate,
+    duration: req.duration,
+  };
+  return {
+    tool: "vegeta" as const,
+    kind: "benchmark" as const,
+    connectionId: req.connectionId,
+    name,
+    params,
+  };
+}
+
+export function runToLoadTestResponse(run: Run): LoadTestResponse {
+  const sm = run.summaryMetrics as
+    | { tool: "vegeta"; data: VegetaReport }
+    | null
+    | undefined;
+  const raw = run.rawOutput as
+    | { stdout?: string; stderr?: string; files?: Record<string, string> }
+    | null
+    | undefined;
+
+  const reportFile = raw?.files?.report;
+  const reportText = reportFile ? Buffer.from(reportFile, "base64").toString("utf8") : "";
+
+  const parsed: LoadTestParsed = {
+    requests: sm?.data.requests.total ?? null,
+    success: sm?.data.success ?? null,
+    throughput: sm?.data.requests.throughput ?? null,
+    latencies: {
+      mean: sm ? `${sm.data.latencies.mean}ms` : null,
+      p50: sm ? `${sm.data.latencies.p50}ms` : null,
+      p95: sm ? `${sm.data.latencies.p95}ms` : null,
+      p99: sm ? `${sm.data.latencies.p99}ms` : null,
+      max: sm ? `${sm.data.latencies.max}ms` : null,
+    },
+  };
+
+  const scenario = (run.scenario ?? {}) as Record<string, unknown>;
+  const params = (run.params ?? {}) as Record<string, unknown>;
+
+  return {
+    success: true,
+    runId: run.id,
+    report: reportText,
+    parsed,
+    config: {
+      apiType: (params.apiType as LoadTestResponse["config"]["apiType"]) ?? "chat",
+      apiBaseUrl: (scenario.apiBaseUrl as string) ?? "",
+      model: (scenario.model as string) ?? "",
+      rate: (params.rate as number) ?? 0,
+      duration: (params.duration as number) ?? 0,
+    },
+  };
+}
+```
+
+- [ ] **Step 3.6.2: Replace controller**
+
+```ts
+// apps/api/src/modules/load-test/load-test.controller.ts
+import {
+  type ListLoadTestRunsQuery,
+  type ListLoadTestRunsResponse,
+  type LoadTestRequest,
+  type LoadTestResponse,
+  ListLoadTestRunsQuerySchema,
+  LoadTestRequestSchema,
+} from "@modeldoctor/contracts";
+import { Body, Controller, Get, Post, Query, UseGuards } from "@nestjs/common";
+import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
+import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
+import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
+import type { JwtPayload } from "../auth/jwt.strategy.js";
+import { RunService } from "../run/run.service.js";
+import { legacyToCreateRun, runToLoadTestResponse } from "./load-test-facade.mappers.js";
+
+@Controller("load-test")
+@UseGuards(JwtAuthGuard)
+export class LoadTestController {
+  constructor(private readonly runs: RunService) {}
+
+  @Post()
+  async run(
+    @CurrentUser() user: JwtPayload,
+    @Body(new ZodValidationPipe(LoadTestRequestSchema)) body: LoadTestRequest,
+  ): Promise<LoadTestResponse> {
+    // Legacy /load-test was synchronous-ish: it ran vegeta inline and
+    // returned the parsed report. With the new path, create() returns
+    // 'submitted' immediately. To preserve old semantics, poll the run
+    // until terminal — caller already expects up to (duration + 60)s
+    // wall time per current code.
+    const name = `loadtest-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+    const created = await this.runs.create(user.sub, legacyToCreateRun(body, name));
+    const final = await waitForTerminal(this.runs, created.id, body.duration + 60);
+    return runToLoadTestResponse(final);
+  }
+
+  @Get("runs")
+  async list(
+    @CurrentUser() user: JwtPayload,
+    @Query(new ZodValidationPipe(ListLoadTestRunsQuerySchema)) q: ListLoadTestRunsQuery,
+  ): Promise<ListLoadTestRunsResponse> {
+    const r = await this.runs.list(
+      { limit: q.limit, cursor: q.cursor, kind: "benchmark", tool: "vegeta" },
+      user.sub,
+    );
+    return {
+      items: r.items.map((run) => {
+        const scenario = (run.scenario ?? {}) as Record<string, unknown>;
+        const params = (run.params ?? {}) as Record<string, unknown>;
+        return {
+          id: run.id,
+          userId: run.userId,
+          apiType: (params.apiType as ListLoadTestRunsResponse["items"][number]["apiType"]) ?? "chat",
+          apiBaseUrl: (scenario.apiBaseUrl as string) ?? "",
+          model: (scenario.model as string) ?? "",
+          rate: (params.rate as number) ?? 0,
+          duration: (params.duration as number) ?? 0,
+          status: (run.status === "completed" ? "completed" : "failed") as "completed" | "failed",
+          summaryJson: null,  // detail-only; the legacy list didn't ship summary
+          createdAt: run.createdAt,
+          completedAt: run.completedAt,
+        };
+      }),
+      nextCursor: r.nextCursor,
+    };
+  }
+}
+
+async function waitForTerminal(runs: RunService, id: string, timeoutSec: number) {
+  const deadline = Date.now() + timeoutSec * 1000;
+  while (Date.now() < deadline) {
+    const r = await runs.findById(id);
+    if (r && (r.status === "completed" || r.status === "failed" || r.status === "canceled")) {
+      return r;
+    }
+    await new Promise((res) => setTimeout(res, 500));
+  }
+  throw new Error(`Run ${id} did not reach terminal state within ${timeoutSec}s`);
+}
+```
+
+- [ ] **Step 3.6.3: Update load-test module**
+
+```ts
+// apps/api/src/modules/load-test/load-test.module.ts
+import { Module } from "@nestjs/common";
+import { RunModule } from "../run/run.module.js";
+import { LoadTestController } from "./load-test.controller.js";
+
+@Module({
+  imports: [RunModule],
+  controllers: [LoadTestController],
+})
+export class LoadTestModule {}
+```
+
+- [ ] **Step 3.6.4: Delete legacy load-test service**
+
+```bash
+git rm apps/api/src/modules/load-test/load-test.service.ts
+git rm apps/api/src/modules/load-test/load-test.service.spec.ts
+```
+
+> Note: the legacy synchronous semantics is preserved by polling. This is acceptable because (a) the FE expects this latency anyway, and (b) #54 deletes this facade entirely.
+
+- [ ] **Step 3.6.5: Run tests + commit**
+
+```bash
+pnpm -F @modeldoctor/api test
+git add apps/api/src/modules/load-test/
+git commit -m "$(cat <<'EOF'
+refactor(api/load-test): convert LoadTestController to facade over RunService (#53)
+
+Delete service.ts; controller polls RunService until terminal to preserve
+legacy synchronous response semantics. #54 deletes this facade.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3.7: Phase 3 verification + smoke + PR
+
+- [ ] **Step 3.7.1: Repo-wide checks**
+
+```bash
+pnpm -r build
+pnpm -r type-check
+pnpm -r test
+pnpm -r lint
+pnpm -r format
+```
+
+- [ ] **Step 3.7.2: Subprocess-mode smoke (with real guidellm if available, else skipping)**
+
+```bash
+brew services list | grep postgres
+pnpm -F @modeldoctor/api prisma migrate reset --force
+pnpm -F @modeldoctor/api start:dev &
+sleep 5
+
+# Register + connection (same as Phase 2 smoke)
+TOKEN=$(curl -sX POST http://localhost:3001/api/auth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"a@b.c","password":"password1234"}' | jq -r .accessToken)
+CID=$(curl -sX POST http://localhost:3001/api/connections \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"name":"local-vllm","baseUrl":"http://localhost:8000","apiKey":"sk-x","model":"Qwen2.5-0.5B-Instruct","category":"chat","tags":[]}' | jq -r .id)
+
+# Submit a vegeta run via the new endpoint
+curl -sX POST http://localhost:3001/api/runs \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d "{\"tool\":\"vegeta\",\"connectionId\":\"$CID\",\"name\":\"phase3-smoke-vegeta\",\"params\":{\"apiType\":\"chat\",\"rate\":2,\"duration\":3}}" | jq
+
+# Wait + read detail
+sleep 6
+RID=$(curl -s "http://localhost:3001/api/runs?limit=1" -H "Authorization: Bearer $TOKEN" | jq -r '.items[0].id')
+curl -s "http://localhost:3001/api/runs/$RID" -H "Authorization: Bearer $TOKEN" | jq '{status, summaryMetrics, rawOutput: (.rawOutput | length)}'
+```
+
+Expected: `status: "completed"`, `summaryMetrics.tool === "vegeta"`, latencies present. (Requires a reachable target; if no target, run.status will be `failed` but the `parseFinalReport` path still exercises.)
+
+- [ ] **Step 3.7.3: Push + PR**
+
+```bash
+git push -u origin feat/issue-53-phase-3-runtime-and-image
+gh pr create --title "feat(api+runner): guidellm/vegeta runtime + generic runner image + facades (#53 PR 3/4)" --body "$(cat <<'EOF'
+## Summary
+- Implement guidellm + vegeta `buildCommand` / `parseFinalReport` (Phase 1 stubs replaced)
+- Rewrite `apps/benchmark-runner/` as a generic Python wrapper (no tool knowledge)
+- Split runner Dockerfile into `images/{guidellm,vegeta}.Dockerfile`
+- Convert `BenchmarkController` and `LoadTestController` to facades over `RunService`
+- Delete old benchmark service / reconciler / drivers / callbacks
+
+## Out of scope (next PR 53.4)
+- genai-perf adapter (acceptance gate verification PR)
+
+## Test plan
+- [ ] `pnpm -r test` passes
+- [ ] `pnpm -F @modeldoctor/tool-adapters test` covers guidellm + vegeta fixture-based parsing
+- [ ] Manual subprocess smoke: vegeta run reaches `status: completed`, `summaryMetrics.tool === 'vegeta'`
+- [ ] Legacy `/api/benchmarks` and `/api/load-test` routes still respond with their original shapes (FE compat preserved through #54)
+- [ ] Docker build: `docker build -f apps/benchmark-runner/images/guidellm.Dockerfile apps/benchmark-runner/` succeeds
+
+## Related
+- Issue: #53
+- Spec: `docs/superpowers/specs/2026-05-02-issue-53-tool-adapter-framework-design.md`
+- Previous PRs: 53.1 (skeleton), 53.2 (callback v2)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3.7.4: Phase 3 DoD**
+
+- [x] guidellm + vegeta runtimes implemented; fixture-based tests pass
+- [x] runner image rewritten as generic wrapper; old guidellm-specific Python files deleted
+- [x] Per-tool Dockerfiles in `images/`
+- [x] BenchmarkController + LoadTestController are thin facades over RunService
+- [x] Legacy tests updated/replaced
+- [x] All checks green; smoke run reaches `completed` end-to-end
+- [x] PR opened against `main`
+
+---
+
+# Phase 4 (PR 53.4) — genai-perf Adapter + Acceptance Gate Verification
+
+**Phase goal:** Implement the genai-perf runtime, add the genai-perf Dockerfile, and verify the acceptance gate by checking that `packages/tool-adapters/src/core/interface.ts` is unchanged from the `main` baseline. Run a real genai-perf smoke and record the result in the PR description.
+
+**Out of scope:** Anything else.
+
+**Depends on:** Phase 3 PR merged.
+
+## Phase 4 Pre-flight
+
+- [ ] **Step 4.0.1: Worktree + branch from latest main**
+
+```bash
+cd /Users/fangyong/vllm/modeldoctor
+git worktree add issue-53-phase-4 -b feat/issue-53-phase-4-genai-perf main
+cd issue-53-phase-4
+pnpm install --frozen-lockfile
+```
+
+- [ ] **Step 4.0.2: Install genai-perf locally for smoke + fixture capture**
+
+```bash
+# Use a conda env per project memory (no python -m venv).
+conda create -n genai-perf-smoke python=3.11 -y
+conda activate genai-perf-smoke
+pip install genai-perf
+genai-perf --version  # ≥ 0.0.10
+```
+
+- [ ] **Step 4.0.3: Capture a real fixture profile_export.json**
+
+Spin up any OpenAI-compatible target (vLLM / lmstudio / a tiny mock) on `localhost:8000`, then:
+
+```bash
+genai-perf profile \
+  -m Qwen2.5-0.5B-Instruct \
+  -u http://localhost:8000 \
+  --endpoint-type chat \
+  --num-prompts 10 \
+  --concurrency 1 \
+  --profile-export-file /tmp/profile_export.json
+```
+
+If no target is available, generate a synthetic-yet-realistic JSON by copy-pasting from genai-perf's official documentation example and tweaking values. Either way, the resulting JSON must roundtrip through `parseFinalReport()` without throwing.
+
+---
+
+## Task 4.1: Implement genai-perf runtime
+
+**Files:**
+- Create: `packages/tool-adapters/src/genai-perf/__fixtures__/profile_export.json`
+- Modify: `packages/tool-adapters/src/genai-perf/runtime.ts`
+- Create: `packages/tool-adapters/src/genai-perf/runtime.spec.ts`
+
+- [ ] **Step 4.1.1: Place fixture**
+
+```bash
+mkdir -p packages/tool-adapters/src/genai-perf/__fixtures__
+cp /tmp/profile_export.json packages/tool-adapters/src/genai-perf/__fixtures__/profile_export.json
+```
+
+- [ ] **Step 4.1.2: Failing fixture-based test**
+
+Create `packages/tool-adapters/src/genai-perf/runtime.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildCommand, parseFinalReport, parseProgress } from "./runtime.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixtureBuf = fs.readFileSync(path.join(__dirname, "__fixtures__/profile_export.json"));
+
+const baseConn = {
+  baseUrl: "http://localhost:8000",
+  apiKey: "sk-test",
+  model: "Qwen2.5-0.5B-Instruct",
+  customHeaders: "",
+  queryParams: "",
+};
+
+describe("genai-perf.buildCommand", () => {
+  it("emits the genai-perf profile argv", () => {
+    const r = buildCommand({
+      runId: "r1",
+      params: {
+        endpointType: "chat",
+        numPrompts: 100,
+        concurrency: 4,
+        inputTokensStddev: 0,
+        outputTokensStddev: 0,
+        streaming: true,
+      },
+      connection: baseConn,
+      callback: { url: "http://api/", token: "tk" },
+    });
+    expect(r.argv[0]).toBe("genai-perf");
+    expect(r.argv).toContain("profile");
+    expect(r.argv).toContain("-m");
+    expect(r.argv).toContain("Qwen2.5-0.5B-Instruct");
+    expect(r.argv).toContain("-u");
+    expect(r.argv).toContain("http://localhost:8000");
+    expect(r.argv).toContain("--endpoint-type");
+    expect(r.argv).toContain("chat");
+    expect(r.argv.join(" ")).toContain("--profile-export-file profile_export.json");
+  });
+
+  it("does not put apiKey in argv (must be in secretEnv)", () => {
+    const r = buildCommand({
+      runId: "r1",
+      params: { endpointType: "chat", numPrompts: 10, concurrency: 1,
+        inputTokensStddev: 0, outputTokensStddev: 0, streaming: true },
+      connection: baseConn,
+      callback: { url: "http://api/", token: "tk" },
+    });
+    expect(r.argv.join(" ")).not.toContain("sk-test");
+    expect(r.secretEnv.OPENAI_API_KEY).toBe("sk-test");
+  });
+});
+
+describe("genai-perf.parseProgress", () => {
+  it("returns null for arbitrary lines (no genai-perf progress format yet)", () => {
+    expect(parseProgress("anything")).toBeNull();
+  });
+});
+
+describe("genai-perf.parseFinalReport", () => {
+  it("parses fixture into typed ToolReport", () => {
+    const r = parseFinalReport("", { profile: fixtureBuf });
+    expect(r.tool).toBe("genai-perf");
+    expect(r.data.requestThroughput).toBeDefined();
+    expect(typeof r.data.requestThroughput.avg).toBe("number");
+    expect(r.data.timeToFirstToken.p99).toBeGreaterThan(0);
+    expect(r.data.requestLatency.unit).toBeDefined();
+  });
+
+  it("throws when 'profile' file missing", () => {
+    expect(() => parseFinalReport("", {})).toThrow();
+  });
+});
+```
+
+- [ ] **Step 4.1.3: Replace `runtime.ts` with real impl**
+
+```ts
+import type {
+  BuildCommandPlan,
+  BuildCommandResult,
+  ProgressEvent,
+  ToolReport,
+} from "../core/interface.js";
+import {
+  genaiPerfReportSchema,
+  type GenaiPerfParams,
+  type GenaiPerfReport,
+} from "./schema.js";
+
+export function buildCommand(plan: BuildCommandPlan<GenaiPerfParams>): BuildCommandResult {
+  const { params, connection } = plan;
+  const argv: string[] = [
+    "genai-perf",
+    "profile",
+    "-m", connection.model,
+    "-u", connection.baseUrl,
+    "--endpoint-type", params.endpointType,
+    "--num-prompts", String(params.numPrompts),
+    "--concurrency", String(params.concurrency),
+    "--profile-export-file", "profile_export.json",
+  ];
+  if (params.streaming) argv.push("--streaming");
+  if (params.inputTokensMean !== undefined) {
+    argv.push("--synthetic-input-tokens-mean", String(params.inputTokensMean));
+  }
+  if (params.inputTokensStddev > 0) {
+    argv.push("--synthetic-input-tokens-stddev", String(params.inputTokensStddev));
+  }
+  if (params.outputTokensMean !== undefined) {
+    argv.push("--output-tokens-mean", String(params.outputTokensMean));
+  }
+  if (params.outputTokensStddev > 0) {
+    argv.push("--output-tokens-stddev", String(params.outputTokensStddev));
+  }
+
+  return {
+    argv,
+    env: {},
+    secretEnv: {
+      // genai-perf reads OPENAI_API_KEY for OpenAI-compatible endpoints.
+      OPENAI_API_KEY: connection.apiKey,
+    },
+    outputFiles: {
+      profile: "profile_export.json",
+    },
+  };
+}
+
+export function parseProgress(_line: string): ProgressEvent | null {
+  return null;
+}
+
+export function parseFinalReport(
+  _stdout: string,
+  files: Record<string, Buffer>,
+): ToolReport {
+  const buf = files.profile;
+  if (!buf) throw new Error("genai-perf.parseFinalReport: missing 'profile' output file");
+  const raw = JSON.parse(buf.toString("utf8")) as Record<string, unknown>;
+  const data = mapGenaiPerfRawToReport(raw);
+  genaiPerfReportSchema.parse(data);
+  return { tool: "genai-perf", data };
+}
+
+// genai-perf's profile_export.json structure (v0.0.10):
+//   { "request_throughput": { "avg": ..., "unit": "..."},
+//     "request_latency": { "avg":..., "min":..., "max":..., "p25":..., "p50":..., "p75":..., "p90":..., "p95":..., "p99":..., "stddev":..., "unit":"ms" },
+//     "time_to_first_token": {...same shape...},
+//     "inter_token_latency": {...same shape...},
+//     "output_token_throughput": { "avg":..., "unit":"tokens/sec" },
+//     "output_sequence_length": { "avg":..., "p50":..., "p99":... },
+//     "input_sequence_length": { "avg":..., "p50":..., "p99":... } }
+// Schema may evolve across genai-perf versions; we map defensively and
+// surface raw via Run.rawOutput for forensic recovery.
+
+function dist(o: Record<string, unknown> | undefined) {
+  if (!o) return { avg: 0, min: 0, max: 0, p50: 0, p90: 0, p95: 0, p99: 0, stddev: 0, unit: "" };
+  return {
+    avg: Number(o.avg ?? 0),
+    min: Number(o.min ?? 0),
+    max: Number(o.max ?? 0),
+    p50: Number(o.p50 ?? 0),
+    p90: Number(o.p90 ?? 0),
+    p95: Number(o.p95 ?? 0),
+    p99: Number(o.p99 ?? 0),
+    stddev: Number(o.stddev ?? 0),
+    unit: String(o.unit ?? ""),
+  };
+}
+function lengthDist(o: Record<string, unknown> | undefined) {
+  if (!o) return { avg: 0, p50: 0, p99: 0 };
+  return { avg: Number(o.avg ?? 0), p50: Number(o.p50 ?? 0), p99: Number(o.p99 ?? 0) };
+}
+
+function mapGenaiPerfRawToReport(raw: Record<string, unknown>): GenaiPerfReport {
+  return {
+    requestThroughput: {
+      avg: Number((raw.request_throughput as Record<string, unknown> | undefined)?.avg ?? 0),
+      unit: String((raw.request_throughput as Record<string, unknown> | undefined)?.unit ?? ""),
+    },
+    requestLatency: dist(raw.request_latency as Record<string, unknown> | undefined),
+    timeToFirstToken: dist(raw.time_to_first_token as Record<string, unknown> | undefined),
+    interTokenLatency: dist(raw.inter_token_latency as Record<string, unknown> | undefined),
+    outputTokenThroughput: {
+      avg: Number((raw.output_token_throughput as Record<string, unknown> | undefined)?.avg ?? 0),
+      unit: String((raw.output_token_throughput as Record<string, unknown> | undefined)?.unit ?? ""),
+    },
+    outputSequenceLength: lengthDist(raw.output_sequence_length as Record<string, unknown> | undefined),
+    inputSequenceLength: lengthDist(raw.input_sequence_length as Record<string, unknown> | undefined),
+  };
+}
+```
+
+- [ ] **Step 4.1.4: Run + commit**
+
+```bash
+pnpm -F @modeldoctor/tool-adapters test
+git add packages/tool-adapters/src/genai-perf/
+git commit -m "$(cat <<'EOF'
+feat(tool-adapters/genai-perf): implement runtime; add fixture (#53)
+
+buildCommand emits genai-perf CLI argv with apiKey via OPENAI_API_KEY
+secretEnv (not in argv); parseFinalReport reads files['profile'] and
+maps the snake_case JSON schema to camelCase typed report.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4.2: genai-perf Dockerfile
+
+**Files:**
+- Create: `apps/benchmark-runner/images/genai-perf.Dockerfile`
+
+- [ ] **Step 4.2.1: Author Dockerfile**
+
+```dockerfile
+# Phase 4 of #53: genai-perf runner image. Pip-install genai-perf on top
+# of a slim Python base + the generic wrapper.
+FROM python:3.11-slim
+
+RUN pip install --no-cache-dir genai-perf requests
+
+WORKDIR /app
+COPY pyproject.toml ./
+COPY runner/ ./runner/
+
+ENTRYPOINT ["python", "-m", "runner"]
+```
+
+> Alternative base: `nvcr.io/nvidia/tritonserver:<tag>-genai-perf` if you want NVIDIA's official image; choose based on whether your cluster pulls from nvcr.io.
+
+- [ ] **Step 4.2.2: Build verify**
+
+```bash
+docker build -f apps/benchmark-runner/images/genai-perf.Dockerfile -t md-runner-genai-perf:dev apps/benchmark-runner/
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4.2.3: Commit**
+
+```bash
+git add apps/benchmark-runner/images/genai-perf.Dockerfile
+git commit -m "$(cat <<'EOF'
+build(benchmark-runner): add genai-perf image (#53)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4.3: ⭐ Acceptance Gate Verification
+
+> **This is the issue's keystone check.** If `core/interface.ts` was modified to land genai-perf, the design is broken and we revisit.
+
+- [ ] **Step 4.3.1: Run the gate command**
+
+```bash
+git diff main -- packages/tool-adapters/src/core/interface.ts
+```
+
+**Expected: empty output.** If anything is shown, FAIL the PR and reopen design discussion. The acceptance gate's whole point is that adding a third adapter (genai-perf) does not require touching the abstract interface.
+
+- [ ] **Step 4.3.2: Run the same diff for `progress-event.ts` and `registry.ts`**
+
+```bash
+git diff main -- packages/tool-adapters/src/core/progress-event.ts
+git diff main -- packages/tool-adapters/src/core/registry.ts
+```
+
+**Expected: also empty.** The registry already references all three adapters since Phase 1, and the genai-perf adapter file just becomes a non-stubbed version of itself.
+
+- [ ] **Step 4.3.3: Confirm the only changed files in this PR are tool-specific**
+
+```bash
+git diff main --stat
+```
+
+**Expected:** the change list is limited to:
+- `packages/tool-adapters/src/genai-perf/runtime.ts`
+- `packages/tool-adapters/src/genai-perf/runtime.spec.ts`
+- `packages/tool-adapters/src/genai-perf/__fixtures__/profile_export.json`
+- `apps/benchmark-runner/images/genai-perf.Dockerfile`
+
+Plus any biome-format-only adjustments. If anything outside these paths shows up, justify or revert.
+
+---
+
+## Task 4.4: End-to-End Smoke Run (record in PR description)
+
+- [ ] **Step 4.4.1: Reset DB + start API**
+
+```bash
+pnpm -F @modeldoctor/api prisma migrate reset --force
+pnpm -F @modeldoctor/api start:dev &
+sleep 5
+```
+
+- [ ] **Step 4.4.2: Register + connection**
+
+```bash
+TOKEN=$(curl -sX POST http://localhost:3001/api/auth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"a@b.c","password":"password1234"}' | jq -r .accessToken)
+
+CID=$(curl -sX POST http://localhost:3001/api/connections \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"name":"local-target","baseUrl":"http://localhost:8000","apiKey":"sk-x","model":"Qwen2.5-0.5B-Instruct","category":"chat","tags":[]}' | jq -r .id)
+```
+
+- [ ] **Step 4.4.3: Submit a genai-perf run**
+
+```bash
+RID=$(curl -sX POST http://localhost:3001/api/runs \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d "{\"tool\":\"genai-perf\",\"connectionId\":\"$CID\",\"name\":\"phase4-acceptance\",\"params\":{\"endpointType\":\"chat\",\"numPrompts\":10,\"concurrency\":1,\"streaming\":true}}" | jq -r .id)
+echo "Run id: $RID"
+```
+
+- [ ] **Step 4.4.4: Wait + assert**
+
+```bash
+sleep 20
+RUN=$(curl -s "http://localhost:3001/api/runs/$RID" -H "Authorization: Bearer $TOKEN")
+echo "$RUN" | jq '{status, "summaryMetrics.tool": .summaryMetrics.tool, ttftP99: .summaryMetrics.data.timeToFirstToken.p99, hasProfileFile: (.rawOutput.files.profile | length > 0)}'
+```
+
+**Expected:**
+```json
+{
+  "status": "completed",
+  "summaryMetrics.tool": "genai-perf",
+  "ttftP99": 123.45,                       // some number > 0
+  "hasProfileFile": true
+}
+```
+
+If the inner genai-perf process couldn't reach the target (no live server on `localhost:8000`), `status` will be `failed` but `summaryMetrics` will be `null` (parseFinalReport throws because the profile file is empty/missing) — that's a target setup issue, not an adapter bug. Get a target up and re-run.
+
+- [ ] **Step 4.4.5: Capture output for the PR description**
+
+Save the JSON above + a screenshot of any FE detail page (if you've run #54 ahead of merge or just `curl`'d the detail endpoint) into the PR body. The PR reviewer wants to see real numbers.
+
+---
+
+## Task 4.5: Final repo-wide checks + PR
+
+- [ ] **Step 4.5.1: All checks**
+
+```bash
+pnpm -r build
+pnpm -r type-check
+pnpm -r test
+pnpm -r lint
+pnpm -r format
+```
+
+- [ ] **Step 4.5.2: Push + open PR 53.4**
+
+```bash
+git push -u origin feat/issue-53-phase-4-genai-perf
+gh pr create --title "feat(tool-adapters): genai-perf adapter — acceptance gate (#53 PR 4/4)" --body "$(cat <<'EOF'
+## Summary
+- Implement genai-perf `buildCommand` / `parseFinalReport` (replacing Phase 1 stubs)
+- Add `apps/benchmark-runner/images/genai-perf.Dockerfile`
+- ⭐ **Acceptance gate verified**: `git diff main -- packages/tool-adapters/src/core/interface.ts` is empty — adding the third adapter required ZERO changes to the abstract interface.
+
+## Acceptance gate evidence
+
+```
+$ git diff main -- packages/tool-adapters/src/core/interface.ts
+(empty output)
+
+$ git diff main -- packages/tool-adapters/src/core/progress-event.ts
+(empty output)
+
+$ git diff main -- packages/tool-adapters/src/core/registry.ts
+(empty output)
+```
+
+## Smoke evidence
+
+Run id `<insert RID>` (genai-perf, 10 prompts, concurrency 1, against local target):
+
+```json
+<insert the curl jq output from Task 4.4.4>
+```
+
+## Test plan
+- [x] `pnpm -F @modeldoctor/tool-adapters test` — fixture-based parsing for all three tools passes
+- [x] `git diff main -- core/interface.ts` is empty (acceptance gate)
+- [x] Real genai-perf run reaches `status: completed` with typed `summaryMetrics.tool === 'genai-perf'`
+- [x] Docker image builds: `docker build -f apps/benchmark-runner/images/genai-perf.Dockerfile`
+
+## Related
+- Issue: #53 (closes when this PR merges)
+- Spec: `docs/superpowers/specs/2026-05-02-issue-53-tool-adapter-framework-design.md`
+- Previous PRs: 53.1 (skeleton), 53.2 (callback v2), 53.3 (runtime + image + facade)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4.5.3: Phase 4 DoD**
+
+- [x] genai-perf runtime implemented; fixture-based test passes
+- [x] genai-perf Dockerfile lands
+- [x] **Acceptance gate clean**: zero changes to `core/interface.ts` / `progress-event.ts` / `registry.ts` since main
+- [x] End-to-end smoke confirms `summaryMetrics.tool === 'genai-perf'` with typed data
+- [x] PR body documents the gate evidence + smoke output
+- [x] All checks green
+
+---
+
+## Task 4.6: Post follow-up comments to related issues
+
+> Per `feedback_temp_followups.md`: for any deferred behavior, post a follow-up comment on the target GitHub issue so the next PR has inline context. Run these AFTER PR 53.4 merges (so the comments link to the merged code).
+
+- [ ] **Step 4.6.1: Post comment on #54 (Test Plan UI)**
+
+```bash
+gh issue comment 54 --body "$(cat <<'EOF'
+**Follow-up from #53 (Tool Adapter Framework)**
+
+#53 has merged. The following remain as facade-only code paths and MUST be deleted in #54's PR (same PR that switches the FE to `/api/runs`):
+
+- `apps/api/src/modules/benchmark/benchmark.controller.ts` (facade calling RunService)
+- `apps/api/src/modules/benchmark/benchmark-facade.mappers.ts`
+- `apps/api/src/modules/benchmark/benchmark.module.ts`
+- `apps/api/src/modules/load-test/load-test.controller.ts` (facade)
+- `apps/api/src/modules/load-test/load-test-facade.mappers.ts`
+- `apps/api/src/modules/load-test/load-test.module.ts`
+- `packages/contracts/src/benchmark.ts` (legacy DTO schemas)
+- `packages/contracts/src/load-test.ts`
+- All FE components / hooks importing from those legacy contracts
+
+The new `Run.summaryMetrics` shape is `{ tool, data }` discriminated union — FE detail pages need `switch (run.summaryMetrics.tool) { case 'guidellm': ... }` (TS exhaustiveness will guide).
+EOF
+)"
+```
+
+- [ ] **Step 4.6.2: Post comment on #45 (Diff 引擎)**
+
+```bash
+gh issue comment 45 --body "$(cat <<'EOF'
+**Follow-up from #53 (Tool Adapter Framework)**
+
+#53 has merged. Important constraints for the diff engine:
+
+- `Run.summaryMetrics` shape is `{ tool, data }` discriminated union per `packages/tool-adapters/src/core/interface.ts`'s `ToolReport`
+- **Diff is per-tool only** (D 立场 — no canonical layer, no cross-tool diff)
+- Diff service MUST `assert(baseline.tool === candidate.tool)` and reject mismatches early
+- After narrowing, fully-typed access to `data` per-tool (`GuidellmReport`, `VegetaReport`, `GenaiPerfReport`)
+
+Recommended diff service shape:
+
+```ts
+function diff(baseline: Run, candidate: Run): DiffReport {
+  if (baseline.tool !== candidate.tool) {
+    throw new BadRequestException({ code: "DIFF_TOOL_MISMATCH", ... });
+  }
+  switch (baseline.summaryMetrics.tool) {
+    case "guidellm":   return diffGuidellm(baseline, candidate);
+    case "vegeta":     return diffVegeta(baseline, candidate);
+    case "genai-perf": return diffGenaiPerf(baseline, candidate);
+  }
+}
+```
+EOF
+)"
+```
+
+- [ ] **Step 4.6.3: Post comment on #41 (Charts)**
+
+```bash
+gh issue comment 41 --body "$(cat <<'EOF'
+**Follow-up from #53 (Tool Adapter Framework)**
+
+#53 has merged. The `Run.summaryMetrics` shape changed from the old guidellm-only `BenchmarkMetricsSummary` to a discriminated-union `{ tool, data }`.
+
+When #54 switches the FE to `/api/runs` and deletes the legacy contracts, charts components must:
+
+- Read `run.summaryMetrics.tool` to pick a per-tool chart variant
+- Use TS exhaustiveness on the union to ensure all three tools render
+- Vegeta has NO `ttft / itl / tokens` fields — its charts must not assume them
+EOF
+)"
+```
+
+- [ ] **Step 4.6.4: Post comment on #57 (SSE 日志)**
+
+```bash
+gh issue comment 57 --body "$(cat <<'EOF'
+**Follow-up from #53 (Tool Adapter Framework)**
+
+#53 has merged. The API already streams `ProgressEvent` per-runId via `SseHub` in-memory pub/sub:
+
+- `apps/api/src/modules/run/sse/sse-hub.service.ts` exports `SseHub`
+- `RunCallbackController.handleLog()` publishes events to it
+- `#57` adds a SSE endpoint that consumes `SseHub.subscribe(runId): Observable<ProgressEvent>`
+
+`ProgressEvent` is a discriminated union of `{ kind: 'progress' | 'log', ... }` — see `packages/tool-adapters/src/core/interface.ts`. SSE endpoint should serialize each event as a separate `data:` frame.
+
+Note: in-memory pubsub is single-instance only. Multi-instance horizontal scale is out of scope for #57; revisit when needed.
+EOF
+)"
+```
+
+- [ ] **Step 4.6.5: Post comment on #59 (Driver 选择策略)**
+
+```bash
+gh issue comment 59 --body "$(cat <<'EOF'
+**Follow-up from #53 (Tool Adapter Framework)**
+
+#53 has merged. The driver interface is now generic and tool-agnostic:
+
+- `apps/api/src/modules/run/drivers/execution-driver.interface.ts` — `RunExecutionDriver { start, cancel, cleanup }`
+- `apps/api/src/modules/run/drivers/run-driver.factory.ts` — `createRunDriver(config)` selects between SubprocessDriver and K8sJobDriver based on `BENCHMARK_DRIVER` env
+- `imageForTool(tool, config)` — selects per-tool image from `RUNNER_IMAGE_<TOOL>` env vars
+
+`#59` can extend the factory with policy logic (e.g., per-tool driver pinning, failover, etc.) without touching `RunExecutionDriver` itself.
+EOF
+)"
+```
+
+---
+
+## Plan Completion
+
+All four PRs merged ⇒ `#53` is shippable. The DoD for the entire issue:
+
+- [x] `packages/tool-adapters/` package with subpath exports lives in the repo
+- [x] Three working adapters: guidellm, vegeta, genai-perf
+- [x] Generic runner image rewrite; per-tool Dockerfiles
+- [x] Driver interface refactored; per-run Secret + volumeMount K8s manifest
+- [x] Callback v2 protocol live; old benchmark/load-test routes facade onto RunService
+- [x] DB migration (canonical_report dropped) applied
+- [x] Acceptance gate verified — `core/interface.ts` untouched in PR 53.4
+- [x] End-to-end smoke confirms typed reports for all three tools
+- [x] Follow-up comments posted to #41, #45, #54, #57, #59
+
+`#53` may be closed when PR 53.4 merges.
+

--- a/docs/superpowers/specs/2026-05-02-issue-44-benchmark-rerun-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-44-benchmark-rerun-design.md
@@ -1,0 +1,424 @@
+# [F.C2] Benchmark 重跑：基于 Run / Baseline 触发新 Run — 设计
+
+- **Issue**: weetime/modeldoctor#44
+- **Phase**: F-benchmark-core
+- **依赖**: #38（统一 Run 模型）、#43（Baseline）
+- **解锁**: #45（Diff 引擎）
+- **范围内 kind**: `benchmark` only（`e2e` 留给后续 ticket）
+- **作者 / 日期**: 2026-05-02
+
+---
+
+## 1. 背景
+
+回归对比工作流的第二步：基于一个历史 Run（通常是 baseline）用同样的 `tool / scenario / mode / params` 再跑一次，得到一个新的 Run，供 #45 diff 引擎做对比。
+
+#43 已落地 baseline 模型与 `Run.parentRunId / Baseline.runId` 的 schema；本期把"再跑"动作的 API、service、前端入口接通。
+
+## 2. 关键事实（影响设计的现状）
+
+1. **`POST /runs` 不存在**。`RunController` 当前只有 `GET`。真正"创建并执行"的入口是 `POST /benchmarks`（`BenchmarkService.create` → `runs.create` → `start(driver)`），且只处理 `kind=benchmark`。`POST /runs` 是 #54 的目标。
+2. **`templateId / templateVersion` 现在恒 NULL**（schema 注释 "until #43–#56 wire them up"），#43 的 `BaselineService.create` 也只是把源 Run 的 NULL 复制过去。所以 issue 里"用冻结的 templateVersion 跑"今天**根本无 template 可冻结**，只能直接复制源 Run 的 `tool / scenario / mode / params`。当 #56 落地 Template 后，由于 rerun 复制源 Run 的 `templateVersion` 字段，行为会自动正确。
+3. **`driverKind` 当前是全局 env (`BENCHMARK_DRIVER`)**，`BenchmarkService` 在构造时一次性读出来盖在所有新 Run 上。**没有 per-run override 路径**。本期不开 driverKind override（见 §11 deferred）。
+4. **Connection FK 是 `onDelete: SetNull`**。源 Run 的 connection 被删后，`connectionId` 变 NULL；rerun 必须由用户重选 connection（必传）。
+5. **Active-name 唯一性**：`BenchmarkService.create` 强制同一用户下 `status ∈ {pending, submitted, running}` 的 benchmark 不重名（`BENCHMARK_NAME_IN_USE` 409）。rerun 必须遵守同一约束。
+
+## 3. 范围
+
+### 3.1 In-scope（本 PR）
+
+- `POST /runs/:id/rerun` 路由（owner-scoped, JwtAuthGuard）
+- `RerunRunRequest` 合约 schema（contracts package）
+- `BenchmarkService.rerun` 服务方法（kind=benchmark 派发目标）
+- `RunService.rerun` 派发器（kind 校验 → 派发到 BenchmarkService）
+- 模块拆分：抽 `RunRepositoryModule` 解循环依赖（见 §6）
+- 错误码（5 个新增）
+- 前端：共享 `RerunDialog` 组件 + `useRerunRun` mutation
+- 前端：在 `HistoryDetailPage` 与 `HistoryListPage` 加 Re-run 按钮
+- 测试：service / controller / contract / dialog / hook
+
+### 3.2 Out-of-scope（spec 里登记，留给后续 ticket）
+
+| 项 | 留给 |
+|---|---|
+| per-Run `driverKind` override | #59（Driver 选择策略） |
+| `e2e` kind 的 rerun（本期返 422） | 后续 ticket |
+| `POST /runs`（generic create） | #54 |
+| `PATCH /runs` 与 baseline params immutability guard | #54 follow-up |
+| 独立 `BaselineListPage`（baseline 管理 UI） | #46 |
+| Rerun 与 baseline 的 diff 入口 / 对比可视化 | #45 |
+
+## 4. API 合约
+
+### 4.1 路由
+
+```
+POST /runs/:id/rerun
+  Auth: JwtAuthGuard, owner-scoped
+  Body: RerunRunRequest
+  200 → Run                       (新 Run，status='submitted'，driverHandle 已填)
+  4xx → { code, message }
+```
+
+仅此一条路由。**不**新增 `POST /baselines/:id/rerun` 别名 —— baseline 本质只是 `Baseline.runId` 指针，前端 baseline 路径用 `baseline.runId` 直接调 `/runs/:runId/rerun`。
+
+### 4.2 Request schema（新增到 `packages/contracts/src/run.ts`）
+
+```ts
+export const rerunRunRequestSchema = z.object({
+  connectionId: z.string().min(1),
+  name: z.string().min(1).max(128).optional(),
+  description: z.string().max(2048).optional(),
+});
+export type RerunRunRequest = z.infer<typeof rerunRunRequestSchema>;
+```
+
+**字段语义：**
+
+| 字段 | 必传 | 行为 |
+|---|---|---|
+| `connectionId` | ✅ | 用户必须显式选 connection（即使没换，也要确认）。前端 dialog 预填源 Run 的 connectionId（如果仍属当前用户）。 |
+| `name` | ❌ | 不传时服务端按 `${source.name} (rerun N)` 派生（N = `count(Run WHERE userId=current AND parentRunId=source.id) + 1`）。 |
+| `description` | ❌ | 不传时沿用源 Run 的 description。 |
+
+**显式不允许 override**（即使前端误传也忽略）：`tool / scenario / mode / params / templateId / templateVersion / kind / driverKind`。这是可比性的硬约束 —— "想改就建新 Plan"。
+
+### 4.3 Response
+
+直接复用现有 `runSchema`（`Run` DTO），返回新建 Run 的完整对象，与 `useRunDetail` 同形态。
+
+## 5. Service-Layer 设计
+
+### 5.1 `RunService.rerun` —— 派发器
+
+```ts
+// apps/api/src/modules/run/run.service.ts
+async rerun(
+  sourceId: string,
+  userId: string,
+  body: RerunRunRequest,
+): Promise<Run> {
+  // 1. 加载并校验源（owner-scoped）
+  const source = await this.repo.findById(sourceId);
+  if (!source || source.userId !== userId) {
+    throw new NotFoundException({
+      code: ErrorCodes.RUN_NOT_FOUND,
+      message: `Run ${sourceId} not found`,
+    });
+  }
+
+  // 2. kind 校验（本期 benchmark only）
+  if (source.kind !== "benchmark") {
+    throw new UnprocessableEntityException({
+      code: ErrorCodes.RUN_KIND_RERUN_UNSUPPORTED,
+      message: `Rerun is not implemented for kind '${source.kind}' yet`,
+    });
+  }
+
+  // 3. status 校验（必须 terminal）
+  const TERMINAL = ["completed", "failed", "canceled"];
+  if (!TERMINAL.includes(source.status)) {
+    throw new ConflictException({
+      code: ErrorCodes.RUN_NOT_TERMINAL,
+      message: `Cannot rerun a Run in state '${source.status}'`,
+    });
+  }
+
+  // 4. connection 解析（必传 + 属当前用户）
+  let conn: DecryptedConnection;
+  try {
+    conn = await this.connections.getOwnedDecrypted(userId, body.connectionId);
+  } catch {
+    throw new UnprocessableEntityException({
+      code: ErrorCodes.RUN_CONNECTION_NOT_USABLE,
+      message: `Connection ${body.connectionId} is not usable`,
+    });
+  }
+
+  // 5. 派发到 kind-specific 执行 service
+  const newRun = await this.benchmarks.rerun(userId, conn, source, body);
+  return runRowToContract(newRun);  // 返回 Run DTO 形态
+}
+```
+
+> 注：`BenchmarkService.rerun` 返回 `RunWithRelations`（含 `connection / baselineFor` 关联），`RunService` 用现有 `runRowToContract` 转成 Run DTO，避免引入 legacy `BenchmarkRunDto` 形态到 rerun 路径。`BenchmarkService` 的依赖（`PrismaService / RunRepository / ConnectionService / BENCHMARK_DRIVER`）保持不变，`RunService` 通过 NestJS DI 注入 `BenchmarkService` 与 `ConnectionService`（在 RunModule import BenchmarkModule、ConnectionModule，见 §6）。
+
+### 5.2 `BenchmarkService.rerun` —— benchmark kind 执行
+
+```ts
+// apps/api/src/modules/benchmark/benchmark.service.ts
+async rerun(
+  userId: string,
+  conn: DecryptedConnection,
+  source: PrismaRun,
+  body: RerunRunRequest,
+): Promise<RunWithRelations> {
+  // 1. 派生 / 取用户传入的 name
+  const name = body.name ?? this.deriveRerunName(source, await this.countReruns(userId, source.id));
+
+  // 2. active-name 唯一性校验（与 create 共用）
+  await this.assertNameAvailable(userId, name);
+
+  // 3. 复制 source 字段 + override，写新 Run 行
+  const created = await this.runs.create({
+    userId,
+    connectionId: conn.id,
+    kind: source.kind,                 // 'benchmark'
+    tool: source.tool,                 // 锁定
+    scenario: source.scenario as Prisma.InputJsonValue,  // 锁定
+    mode: source.mode,                 // 锁定
+    driverKind: this.driverKind,       // 仍走全局 env，per-run override 推到 #59
+    name,
+    description: body.description ?? source.description,
+    params: source.params as Prisma.InputJsonValue,      // 锁定（profile 在这里）
+    templateId: source.templateId,     // 锁定（今天恒 NULL，#56 后才有值）
+    templateVersion: source.templateVersion,
+    parentRunId: source.id,            // 直接 source（非根）
+    // baselineId 不继承 —— 由用户/前端在创建 diff 时显式选
+  });
+
+  // 4. 同步触发 driver（start() 内部更新 row 到 status='submitted' 并写 driverHandle）
+  await this.start(created.id);
+
+  // 5. 重新加载 RunWithRelations（含 connection / baselineFor 关联，给 RunService.rerun
+  //    用 runRowToContract 转 Run DTO）。start() 返回的是 legacy BenchmarkRunDto，
+  //    形态不同，所以这里重 fetch 一次。
+  const row = await this.runs.findById(created.id);
+  if (!row) {
+    // 不可达：刚 create + start 完成的 row 不会消失
+    throw new Error(`BenchmarkService.rerun: row ${created.id} vanished after start`);
+  }
+  return row;
+}
+
+private async countReruns(userId: string, sourceId: string): Promise<number> {
+  return this.prisma.run.count({
+    where: { userId, parentRunId: sourceId },
+  });
+}
+
+private deriveRerunName(source: PrismaRun, existingCount: number): string {
+  const base = source.name ?? source.id;
+  return `${base} (rerun ${existingCount + 1})`;
+}
+
+// 提取已有的 active-name 校验逻辑（从 create() 抽出，二者共用）
+private async assertNameAvailable(userId: string, name: string): Promise<void> {
+  const dupes = await this.prisma.run.count({
+    where: {
+      userId,
+      name,
+      kind: "benchmark",
+      status: { in: [...ACTIVE_STATES] },
+    },
+  });
+  if (dupes > 0) {
+    throw new ConflictException({
+      code: ErrorCodes.BENCHMARK_NAME_IN_USE,
+      message: `An active benchmark named '${name}' already exists`,
+    });
+  }
+}
+```
+
+### 5.3 派生 name 的边界
+
+- **撞名**：极端竞态下两次并发 rerun 算出同一个 N。第二次会抛 `BENCHMARK_NAME_IN_USE`，前端 toast 让用户重试或手动起名。**不**引入 advisory lock。
+- **源 name 已经是 `"foo (rerun 3)"`**：派生结果 `"foo (rerun 3) (rerun 1)"`，丑但可读，按 YAGNI 接受；用户嫌丑就主动传 name。
+- **源 name 是 NULL**：派生用 `source.id` 兜底（`"clxyz... (rerun 1)"`）。
+
+## 6. 模块 Wiring（结构性 refactor）
+
+### 6.1 现状循环依赖根因
+
+`RunModule` 今天身兼两职：
+- (a) **数据层**：`RunRepository`（Run 表的 kind-agnostic CRUD），被 `BenchmarkService` 等 kind-执行 service 消费
+- (b) **API surface**：`RunController`（对外路由）
+
+`RunController` 一旦需要派发到 kind-执行 service（rerun 是第一次，#54 的 `POST /runs` 也会撞），就形成 `RunModule → BenchmarkModule → RunModule` 循环。这不是产品设计缺陷 —— 产品分层（Run 是统一实体、kind 决定执行）是对的；NestJS 模块边界画错了。
+
+### 6.2 Refactor：抽 `RunRepositoryModule`
+
+```
+RunRepositoryModule          (新)
+  ├─ provides RunRepository
+  └─ exports  RunRepository
+
+BenchmarkModule              (改：替换 RunModule import)
+  ├─ imports RunRepositoryModule, ConnectionModule
+  ├─ provides BenchmarkController, BenchmarkService
+  └─ exports  BenchmarkService           (新增 export，给 RunModule 派发用)
+
+RunModule                    (改：API surface only)
+  ├─ imports RunRepositoryModule, BenchmarkModule, ConnectionModule
+  ├─ provides RunController, RunService
+  └─ (RunService 派发到 BenchmarkService.rerun)
+```
+
+依赖单向 `RunModule → BenchmarkModule → RunRepositoryModule`，零循环。同样的 pattern 在 #54 的 `POST /runs` 和未来 e2e 接入 RunController 时直接复用。
+
+### 6.3 影响面
+
+- **新建文件**：`apps/api/src/modules/run/run-repository.module.ts`
+- **改动**：`apps/api/src/modules/run/run.module.ts`、`apps/api/src/modules/benchmark/benchmark.module.ts`
+- **不改**：`run.repository.ts` / `benchmark.service.ts`（接口不变）
+
+## 7. 错误码（新增到 `packages/contracts/src/errors.ts`）
+
+| 触发 | code | HTTP | 备注 |
+|---|---|---|---|
+| 源 Run 不存在 / 跨用户 | `RUN_NOT_FOUND` | 404 | 跨用户也返 404，不泄露存在性 |
+| 源 kind 非 benchmark | `RUN_KIND_RERUN_UNSUPPORTED` | 422 | message 包含 source.kind |
+| 源状态非 terminal | `RUN_NOT_TERMINAL` | 409 | message 包含 source.status |
+| body.connectionId 不存在 / 不属当前用户 | `RUN_CONNECTION_NOT_USABLE` | 422 | 跨用户 connection 也归这个 |
+| 派生 name 撞 active-name 唯一性 | `BENCHMARK_NAME_IN_USE`（复用） | 409 | 与 create 共用 |
+| `driver.start` 抛错 | (现有路径) | 500 | row 标 failed + statusMessage 写入 |
+
+错误码命名前缀沿用 `RUN_*`（与已有 `BENCHMARK_*` 区分 —— rerun 是 Run 层概念，name-uniqueness 才是 benchmark 层概念）。
+
+## 8. 前端设计
+
+### 8.1 文件清单
+
+**新增：**
+- `apps/web/src/features/baseline/api.ts` 增加 `rerunRun(sourceId: string, body: RerunRunRequest): Promise<Run>`
+- `apps/web/src/features/baseline/queries.ts` 增加 `useRerunRun()` mutation
+  - `onSuccess` invalidate: `historyKeys.list`、`historyKeys.detail(newRun.id)`、`baselineKeys.list`
+- `apps/web/src/features/baseline/RerunDialog.tsx` 共享 dialog 组件
+
+**改动：**
+- `apps/web/src/features/history/HistoryDetailPage.tsx`：在 `rightSlot` 现有 baseline 按钮旁加 `Re-run`，仅当 `run.status ∈ {completed, failed, canceled}` 时显示；`onSuccess` 跳到 `/history/${newRun.id}`
+- `apps/web/src/features/history/HistoryListPage.tsx`：每行 actions 列加 Re-run 按钮（同 status 校验），`onSuccess` toast + invalidate（不跳页）
+
+> **Rationale for `RerunDialog` 放 `features/baseline/` 而非 `features/history/`**：rerun 是 baseline workflow 的核心动作（baseline 的存在意义就是被 rerun），跟 baseline mutations / queries 同位置语义最贴；history feature 只是消费方。
+
+### 8.2 `RerunDialog` 组件
+
+```ts
+type Props = {
+  sourceRunId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: (newRun: Run) => void;
+};
+```
+
+Dialog 内部：
+- `useRunDetail(sourceRunId)` 拉源 Run（骨架屏 loading）
+- `useConnections()` 拉用户 connections
+- 顶部**只读上下文区**：`Re-running: ${source.name}` + 锁定字段 chip 行（`tool=guidellm`、`mode=throughput`、`scenario={...}`）让用户看清"这些不能改"
+- **编辑区**：
+  - `name` input — 占位符 `${source.name} (rerun N)`，留空走服务端派生
+  - `connection` select — 预填源 connectionId（如果仍属当前用户）；否则不预选 + 提示 "Original connection no longer exists, please pick one"
+  - `description` textarea — 默认源值
+- 提交：调 `useRerunRun()` mutation，成功 `onSuccess(newRun)`，失败 toast 错误 message
+
+### 8.3 i18n key（沿用现有 `history.*` 习惯）
+
+```
+history.detail.rerun.button
+history.list.rerun.button
+history.rerun.dialog.title
+history.rerun.dialog.description
+history.rerun.dialog.submit
+history.rerun.dialog.cancel
+history.rerun.locked.tool
+history.rerun.locked.mode
+history.rerun.locked.scenario
+history.rerun.field.name
+history.rerun.field.connection
+history.rerun.field.description
+history.rerun.error.connectionNotUsable
+history.rerun.error.nameInUse
+history.rerun.error.notTerminal
+history.rerun.error.kindUnsupported
+```
+
+## 9. 测试
+
+### 9.1 API 层（vitest@2，`apps/api`）
+
+**`run.service.spec.ts`（rerun 派发，新增）：**
+- 源不存在 → 404 `RUN_NOT_FOUND`
+- 源属其他用户 → 404 `RUN_NOT_FOUND`（不泄露存在性）
+- 源 kind=`e2e` → 422 `RUN_KIND_RERUN_UNSUPPORTED`
+- 源 status ∈ {pending, submitted, running} → 409 `RUN_NOT_TERMINAL`（参数化覆盖三个）
+- body.connectionId 不存在 → 422 `RUN_CONNECTION_NOT_USABLE`
+- body.connectionId 属其他用户 → 422 `RUN_CONNECTION_NOT_USABLE`
+- 全部 OK → 派发到 `BenchmarkService.rerun`（mock，断言传入 `userId / conn / source / body`）
+- 返回 `BenchmarkService.rerun` 结果转成 Run DTO 形态
+
+**`benchmark.service.spec.ts`（rerun 行为，增量）：**
+- name 不传 → 按 `parentRunId count + 1` 派生
+- name 不传 + 源 name=NULL → 用 source.id 兜底
+- name 不传 + 已有两次 rerun → 派生 `(rerun 3)`
+- name 显式传 → 直接用
+- connection override 实际生效（与 source.connectionId 不同）
+- tool / scenario / mode / params / templateId / templateVersion / kind 严格复制源（断言不可被 body 改）
+- description 不传 → 沿用源；传 → override
+- parentRunId = source.id（即使 source 自己有 parent）
+- baselineId 不继承（即使 source.baselineId 非空）
+- driverKind 沿用 service 实例的全局 env，不被 body 影响
+- active-name 撞名 → `BENCHMARK_NAME_IN_USE`
+- driver.start 抛错时 row 标 failed + 错误冒泡
+
+**`run.controller.spec.ts`（端到端，增量）：**
+- `POST /runs/:id/rerun` happy path
+- 各 4xx 端到端
+- 无 token → 401（JwtAuthGuard）
+
+### 9.2 Contracts 层
+
+**`run.spec.ts` 增量：**
+- `rerunRunRequestSchema` 接受最小 body `{ connectionId }`
+- 拒绝空 connectionId、name 超 128、description 超 2048
+
+### 9.3 前端层（vitest@1，`apps/web`）
+
+- `RerunDialog.test.tsx`：渲染锁定字段 chip、connection 预填正确、connection 不可用时不预选 + 提示、submit 调 mutation、错误 toast
+- `useRerunRun` mutation 测试：`onSuccess` 触发正确 invalidate
+- `HistoryDetailPage` Re-run 按钮：terminal 才显示、点击开 dialog、`onSuccess` 跳转
+- `HistoryListPage` Re-run 按钮：terminal 才显示、`onSuccess` 不跳页 + toast
+
+### 9.4 模块 wiring 测试
+
+- `RunRepositoryModule` 导出 `RunRepository`，可被 `BenchmarkModule` 与 `RunModule` 同时 import 不报错
+- 启动 NestJS app context 不出现循环依赖警告
+
+## 10. Implementation Order（单 PR 内的 commit 序列）
+
+1. `refactor(api): extract RunRepositoryModule to break Run/Benchmark cycle`
+   — 解循环依赖，无功能变化，所有现有测试继续过
+2. `feat(contracts): add RerunRunRequest schema and RUN_* error codes`
+   — zod schema + 错误码常量，加 contract spec
+3. `feat(api): RunController POST /runs/:id/rerun + service dispatch`
+   — `RunService.rerun` + `BenchmarkService.rerun` + 共用 `assertNameAvailable` 抽出，加 service / controller spec
+4. `feat(web): RerunDialog and useRerunRun mutation`
+   — 共享 dialog + hook + api client，加 dialog / hook 测试
+5. `feat(web): wire Re-run button into history detail and list pages`
+   — 两个入口集成，加集成行为测试
+
+每个 commit 都通过完整 `pnpm -r build && pnpm -r test && pnpm -r lint && pnpm -r type-check`。
+
+## 11. Out-of-scope / Deferred Items
+
+| 项 | 当前行为 | 留给 |
+|---|---|---|
+| per-Run `driverKind` override | 沿用全局 `BENCHMARK_DRIVER` env | #59 |
+| `e2e` kind 的 rerun | 返 422 `RUN_KIND_RERUN_UNSUPPORTED` | 后续 ticket |
+| `POST /runs`（generic create） | 不存在；rerun 不依赖 | #54 |
+| `PATCH /runs` 与 baseline params immutability guard | rerun 不改源 Run，与此正交 | #54 follow-up |
+| 独立 `BaselineListPage` | 暂用 HistoryListPage 的 `isBaseline` 过滤视图作为 Re-run 入口 | #46 |
+| Rerun 与 baseline 的 diff 入口 / 对比可视化 | 仅创建新 Run，不做对比 | #45 |
+| 撞 name 时服务端自动重试 | 直接抛 `BENCHMARK_NAME_IN_USE`，前端兜底 | YAGNI |
+
+按 `feedback_temp_followups.md` 规则，这些 deferred 项会在对应 issue 上各发一条登记评论。
+
+## 12. 关联 issue 评论计划
+
+合 PR 后：
+- **#44** 自身：贴 PR 链接 + "完成"勾选
+- **#59**：评论 "rerun 路径已为 per-Run driverKind override 留好接口（`RerunRunRequest` 不含此字段；`BenchmarkService.rerun` 直接用 `this.driverKind`）；#59 落地后只需扩 schema + 改 `BenchmarkService.rerun` 一处即可启用"
+- **#46**：评论 "Re-run 入口暂挂在 HistoryListPage 的 `isBaseline` 过滤视图；#46 起独立 BaselineListPage 时把按钮挪过去"
+- **#54**：评论 "本期 rerun 走 `POST /runs/:id/rerun`，并已抽 `RunRepositoryModule` 解循环依赖；#54 实现 `POST /runs` (generic create) 时同模式（`RunController` 注入 `BenchmarkService` / `E2eTestService`）即可"
+- **#45**：评论 "rerun 落地了，diff 引擎可以基于 `Run.parentRunId` 找候选对比对；建议 `GET /runs/:id/diff?against=<runId>` 默认 against = `source` 或 `baselineFor.runId`"

--- a/docs/superpowers/specs/2026-05-02-issue-53-tool-adapter-framework-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-53-tool-adapter-framework-design.md
@@ -1,0 +1,934 @@
+# Issue #53 — Tool Adapter 框架设计
+
+- **Issue**: [#53](https://github.com/weetime/modeldoctor/issues/53) — [F.1] Tool Adapter 框架：guidellm / genai-perf / vegeta 输出归一化
+- **状态**: Spec / Brainstorm 完成
+- **依赖**: #38 (Run 模型 `tool` 字段) ✅
+- **解锁**: #41 (Charts) · #45 (Diff 引擎) · #54 (Test Plan UI) · #55 (模板库) · #57 (SSE 日志) · #59 (Driver 策略)
+- **日期**: 2026-05-02
+- **撰写**: brainstorm via Claude
+
+---
+
+## 0. 摘要
+
+本设计在 ModelDoctor 内引入 `ToolAdapter` 抽象层，让后端的"运行 benchmark / load test 的能力"从 guidellm-only 演化成"可任意挂载工具"，并在新增 NVIDIA `genai-perf` 时**严格不修改 ToolAdapter 接口**作为可执行 acceptance gate。
+
+**核心设计立场**: **per-tool typed schema 到底**（下文称 *D 立场*），**不引入 canonical / 跨工具归一化层**。理由：业内主流 benchmark 工作流（vLLM bench、guidellm、NVIDIA genai-perf、HF TGI bench、MLPerf Inference）都是"同工具、不同 model/参数"做对比；同名指标在不同工具下数学定义不等价，强行归一化是"假统一"。
+
+跨工具粗粒度对比（leaderboard 等）若未来真有需求，作为后续 issue 单独处理；本 issue 不为它做架构妥协。
+
+---
+
+## 1. 目标与非目标
+
+### 1.1 目标
+
+1. 定义 `ToolAdapter` 接口 + `BuildCommandResult` / `ProgressEvent` / `ToolReport` 类型族
+2. 落地三个 adapter：`guidellm` / `vegeta` / `genai-perf`
+3. driver 与 runner image 改造为"通用执行器"，不再含工具语义代码
+4. callback 协议从 `/state + /metrics` 重写为 `/state + /log + /finish`
+5. DB Schema 收敛：`Run.canonicalReport` 列删除；`summaryMetrics` 改 discriminated union shape
+6. 通过 acceptance gate：加 `genai-perf` adapter 时 ToolAdapter 接口字段 git diff 为空
+
+### 1.2 非目标（不在本 issue 范围）
+
+- ❌ 跨工具 metric diff（D 立场永久不做；如有需要走单独 issue）
+- ❌ 前端 UI 改动（→ #54 Test Plan UI）
+- ❌ Driver 实现策略选择（local vs k8s 自动决策 → #59）
+- ❌ SSE 日志 endpoint（→ #57，本 issue 仅暴露 in-memory pubsub）
+- ❌ 模板库（→ #55）
+- ❌ 自定义脚本 adapter（后续 issue）
+- ❌ 对象存储托管 raw output（>10 MB 产物 → follow-up）
+- ❌ `Run.serverMetrics` 列填充（Prometheus 拉取 → #60）
+- ❌ Baseline / diff 引擎实现（→ #45，本 issue 仅保证 typed reportSchema 可被 diff 引擎消费）
+
+---
+
+## 2. 关键设计决策（决策链）
+
+| # | 决策点 | 结论 | 理由摘要 |
+|---|---|---|---|
+| Q1 | CanonicalReport 与现有 `BenchmarkMetricsSummary` 关系 | **替换 + 数据重置**，删除 `canonicalReport` 列 | dev DB disposable；不留兼容包袱 |
+| Q2 | `parseFinalReport` 在哪端跑 | **API 端 TS 解析**，runner 仅透传 stdout/files | acceptance gate 自然成立；runner image 不再含工具语义 |
+| Q3 | latency shape | per-tool 自定 | 见 Q4 |
+| Q4 | report 类型表达 | **Discriminated union** `ToolReport = {tool, data}` | 前端 switch 渲染、TS 穷尽性检查、idiomatic |
+| Q5 | adapter 物理位置 | `packages/tool-adapters/` 单包 + subpath exports (`./schemas`) | 概念单一；schema 前后端共享走 zod；前端 bundle 不污染 runtime |
+| Q6 | `buildCommand` 输出形态 | `{ argv, env, secretEnv, inputFiles?, outputFiles }`；image 不进 adapter | secret 不进 argv；adapter 与执行模式（local / k8s）解耦 |
+| Q7 | callback 协议 | `/state` (running 一次) + `/log` (流式) + `/finish` (终态原子) | 取消"先 metrics 后 state"中间不一致状态；progress 由 API 端从 stdout 解析 |
+| Q8 | DB schema 改动 | 删 `canonicalReport`；`summaryMetrics` shape 收敛为 discriminated union body；`rawOutput` 改为 `{stdout, stderr, files}`；`scenario` 收窄为连接快照；Baseline 同工具约束在应用层 | 直接重置，无 migration backfill |
+| Q9 | acceptance gate 验证 | fixture 单测 + 一次本地手工 smoke run | CI 跑 fixture 单测；smoke 文档化 |
+| Q10 | #53 切多深 | 后端 hard-cut + 前端 facade（B 方案）| #53 不依赖 #54；后端无包袱；facade 临时存活到 #54 删除 |
+
+---
+
+## 3. 核心抽象（`packages/tool-adapters/`）
+
+### 3.1 包结构
+
+```
+packages/tool-adapters/
+├── package.json                  # exports: "." & "./schemas"
+├── tsconfig.json
+├── tsconfig.build.json
+├── vitest.config.ts
+├── biome.json (沿用 monorepo 共享)
+└── src/
+    ├── core/
+    │   ├── interface.ts          # ToolAdapter / BuildCommandResult / ProgressEvent / ToolReport
+    │   ├── registry.ts           # byTool() / allAdapters()
+    │   └── progress-event.ts     # ProgressEvent zod schema (如需 runtime 校验)
+    ├── guidellm/
+    │   ├── schema.ts             # guidellmParamsSchema / guidellmReportSchema / types
+    │   ├── runtime.ts            # buildCommand / parseProgress / parseFinalReport
+    │   ├── runtime.spec.ts       # fixture-based 单测
+    │   ├── __fixtures__/
+    │   │   └── report.json       # 真实 guidellm 0.5.x 报告样本
+    │   └── index.ts              # 组装 guidellmAdapter
+    ├── genai-perf/               # 同结构
+    │   └── __fixtures__/
+    │       └── profile_export.json
+    ├── vegeta/                   # 同结构
+    │   └── __fixtures__/
+    │       └── report.txt
+    ├── schemas-entry.ts          # './schemas' 入口：仅 re-export 各 tool 的 schema.ts + types
+    └── index.ts                  # '.' 入口：full export + 注册三个 adapter
+```
+
+`package.json` 关键配置：
+
+```json
+{
+  "name": "@modeldoctor/tool-adapters",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    ".":         { "types": "./dist/index.d.ts",          "import": "./src/index.ts",          "default": "./dist/index.js" },
+    "./schemas": { "types": "./dist/schemas-entry.d.ts",  "import": "./src/schemas-entry.ts",  "default": "./dist/schemas-entry.js" }
+  },
+  "dependencies": {
+    "zod": "^3.23",
+    "@modeldoctor/contracts": "workspace:*"
+  }
+}
+```
+
+### 3.2 核心类型（`src/core/interface.ts`）
+
+```ts
+import type { z } from "zod";
+
+// ToolAdapter 注册的工具名 —— DB 上 `Run.tool` 列允许的值是超集（额外含 'e2e' / 'custom'，
+// 那些不走 ToolAdapter 而是各自专用路径）；本接口的 ToolName 仅覆盖会经过 adapter 的子集。
+export type ToolName = "guidellm" | "genai-perf" | "vegeta";
+
+// 进度事件（统一形状，不分 tool）
+export type ProgressEvent =
+  | { kind: "progress"; pct: number; currentRequests?: number; message?: string }
+  | { kind: "log"; level: "info" | "warn" | "error"; line: string };
+
+// 报告（discriminated union，前端按 run.tool switch）
+import type { GuidellmReport } from "../guidellm/schema.js";
+import type { GenaiPerfReport } from "../genai-perf/schema.js";
+import type { VegetaReport } from "../vegeta/schema.js";
+
+export type ToolReport =
+  | { tool: "guidellm";   data: GuidellmReport }
+  | { tool: "genai-perf"; data: GenaiPerfReport }
+  | { tool: "vegeta";     data: VegetaReport };
+
+// buildCommand 输入
+export interface BuildCommandPlan<TParams = unknown> {
+  runId: string;
+  params: TParams;
+  connection: {
+    baseUrl: string;
+    apiKey: string;
+    model: string;
+    customHeaders: string;
+    queryParams: string;
+  };
+  callback: { url: string; token: string };
+}
+
+// buildCommand 输出
+export interface BuildCommandResult {
+  argv: string[];                         // 完整命令行（含程序名）；shell pipeline 用 ['/bin/sh','-c',...]
+  env: Record<string, string>;            // 公开 env
+  secretEnv: Record<string, string>;      // 敏感 env，K8s 必入 Secret，本地合并到 spawn env
+  inputFiles?: Record<string, string>;    // 相对 cwd 路径 → 内容；wrapper 在 spawn 前写入
+  outputFiles: Record<string, string>;    // alias → 相对 cwd 路径；wrapper 在 exit 后收集
+}
+
+// adapter 接口
+export interface ToolAdapter {
+  readonly name: ToolName;
+  readonly paramsSchema: z.ZodTypeAny;
+  readonly reportSchema: z.ZodTypeAny;
+  readonly paramDefaults: unknown;
+
+  buildCommand(plan: BuildCommandPlan): BuildCommandResult;
+  parseProgress(line: string): ProgressEvent | null;
+  parseFinalReport(stdout: string, files: Record<string, Buffer>): ToolReport;
+}
+```
+
+> **Acceptance gate 文件**: 上述 `interface.ts` 在 `genai-perf` adapter 落地的 PR (#53.4) 中 git diff 必须为**空**。
+
+### 3.3 Registry（`src/core/registry.ts`）
+
+```ts
+import { guidellmAdapter } from "../guidellm/index.js";
+import { genaiPerfAdapter } from "../genai-perf/index.js";
+import { vegetaAdapter } from "../vegeta/index.js";
+import type { ToolAdapter, ToolName } from "./interface.js";
+
+const ADAPTERS: Readonly<Record<ToolName, ToolAdapter>> = {
+  guidellm:    guidellmAdapter,
+  "genai-perf": genaiPerfAdapter,
+  vegeta:      vegetaAdapter,
+};
+
+export function byTool(tool: ToolName): ToolAdapter {
+  const a = ADAPTERS[tool];
+  if (!a) throw new Error(`No adapter registered for tool: ${tool}`);
+  return a;
+}
+
+export function allAdapters(): readonly ToolAdapter[] {
+  return Object.values(ADAPTERS);
+}
+```
+
+---
+
+## 4. 三个 Adapter 草案
+
+> 各 adapter 的 zod schema 字段为草稿层，落地实现时根据真实工具产物可微调；接口形态不变。
+
+### 4.1 guidellm
+
+**`packages/tool-adapters/src/guidellm/schema.ts`**
+
+```ts
+import { z } from "zod";
+
+export const guidellmParamsSchema = z.object({
+  profile: z.enum(["throughput", "latency", "long_context", "generation_heavy", "sharegpt", "custom"]),
+  apiType: z.enum(["chat", "completion"]),
+  datasetName: z.enum(["random", "sharegpt"]),
+  datasetInputTokens: z.number().int().positive().optional(),
+  datasetOutputTokens: z.number().int().positive().optional(),
+  datasetSeed: z.number().int().optional(),
+  requestRate: z.number().int().min(0).default(0),
+  totalRequests: z.number().int().min(1).max(100_000).default(1000),
+  maxDurationSeconds: z.number().int().positive().default(1800),
+  maxConcurrency: z.number().int().positive().default(100),
+  processor: z.string().optional(),
+  validateBackend: z.boolean().default(true),
+}).superRefine((d, ctx) => {
+  if (d.datasetName === "random" && (!d.datasetInputTokens || !d.datasetOutputTokens)) {
+    ctx.addIssue({ code: "custom", message: "random dataset 需要 datasetInputTokens/datasetOutputTokens" });
+  }
+});
+export type GuidellmParams = z.infer<typeof guidellmParamsSchema>;
+
+const dist = z.object({
+  mean: z.number(),
+  p50: z.number(),
+  p90: z.number(),
+  p95: z.number(),
+  p99: z.number(),
+});
+
+export const guidellmReportSchema = z.object({
+  ttft: dist,
+  itl: dist,
+  e2eLatency: dist,
+  requestsPerSecond: z.object({ mean: z.number() }),
+  outputTokensPerSecond: z.object({ mean: z.number() }),
+  inputTokensPerSecond: z.object({ mean: z.number() }),
+  totalTokensPerSecond: z.object({ mean: z.number() }),
+  concurrency: z.object({ mean: z.number(), max: z.number() }),
+  requests: z.object({
+    total: z.number().int(),
+    success: z.number().int(),
+    error: z.number().int(),
+    incomplete: z.number().int(),
+  }),
+});
+export type GuidellmReport = z.infer<typeof guidellmReportSchema>;
+```
+
+**`packages/tool-adapters/src/guidellm/runtime.ts`** — 关键点：
+
+- `buildCommand`: TS 化移植自 `apps/benchmark-runner/runner/argv.py`。`secretEnv.OPENAI_API_KEY = connection.apiKey`（替代 backend-kwargs JSON 内联 key 的旧路径，更安全）；guidellm 通过 backend-kwargs 透传，但 key 从 env 读取
+- `parseProgress`: 解析 guidellm 0.5.x `--disable-console` 模式下 stderr 偶发的 progress 行（基于 guidellm 源码格式）；非 progress 行返回 null
+- `parseFinalReport(stdout, files)`: 读 `files['report'].toString('utf-8')` → JSON.parse → 字段映射函数（移植自 `apps/benchmark-runner/runner/metrics.py` 的 `map_guidellm_report_to_summary`）→ `guidellmReportSchema.parse()` → 包装为 `{ tool: 'guidellm', data }`
+- `outputFiles: { 'report': 'report.json' }`
+
+### 4.2 vegeta
+
+**`packages/tool-adapters/src/vegeta/schema.ts`**
+
+```ts
+import { z } from "zod";
+
+export const vegetaParamsSchema = z.object({
+  apiType: z.enum(["chat", "embeddings", "rerank", "images", "chat-vision", "chat-audio"]),
+  rate: z.number().int().min(1).max(10_000),
+  duration: z.number().int().min(1).max(3_600),
+});
+export type VegetaParams = z.infer<typeof vegetaParamsSchema>;
+
+const vegetaLatencyDist = z.object({
+  // 全部转成 ms number；parser 把 "45.6ms" / "1.2s" / "300µs" 统一解为 ms
+  min: z.number(),
+  mean: z.number(),
+  p50: z.number(),
+  p90: z.number(),
+  p95: z.number(),
+  p99: z.number(),
+  max: z.number(),
+});
+
+export const vegetaReportSchema = z.object({
+  requests: z.object({ total: z.number().int(), rate: z.number(), throughput: z.number() }),
+  duration: z.object({ totalSeconds: z.number(), attackSeconds: z.number(), waitSeconds: z.number() }),
+  latencies: vegetaLatencyDist,
+  bytesIn:  z.object({ total: z.number().int(), mean: z.number() }),
+  bytesOut: z.object({ total: z.number().int(), mean: z.number() }),
+  success: z.number(),                    // percent [0, 100]
+  statusCodes: z.record(z.number().int()),
+  errors: z.array(z.string()),
+});
+export type VegetaReport = z.infer<typeof vegetaReportSchema>;
+```
+
+> **D 立场体现**: vegeta 的 schema **没有** `ttft / itl / tokens` 字段。不是 null，是这个工具的 schema 本来就不包含 LLM 语义指标。
+
+**`packages/tool-adapters/src/vegeta/runtime.ts`** — 关键点：
+
+- `buildCommand`: argv = `['/bin/sh', '-c', 'cat targets.txt | vegeta attack -rate=${rate} -duration=${duration}s | tee attack.bin | vegeta report > report.txt']`
+  - targets.txt 内容由 `inputFiles['targets.txt']` 写入 cwd；构造逻辑移植自现 `apps/api/src/modules/load-test/load-test.service.ts`（含 customHeaders / queryParams 拼接 + `Authorization: Bearer <apiKey>` 注入）
+  - **secret 处理**: vegeta 的 apiKey 嵌在 targets.txt 文件文本里（这是 vegeta CLI 唯一支持的方式）。targets.txt 含敏感信息，**必须**通过 `inputFiles` 而非 `env`/`secretEnv` 传递，且 driver 在 K8s 模式下必须把 inputFiles 写到 per-run Secret + volumeMount（见 §6.3），不可走 ConfigMap 或 Job manifest 明文 env。`secretEnv` 在 vegeta adapter 中保持空对象
+- `parseProgress`: vegeta CLI attack 阶段 stderr 静默，`parseProgress` 永远返回 null；不影响 acceptance gate（接口允许返回 null）
+- `parseFinalReport(stdout, files)`: 读 `files['report'].toString('utf-8')` → 移植自 `apps/api/src/integrations/parsers/vegeta-report.ts` 但加上单位转换函数 `parseLatencyToMs("45.6ms" | "1.2s" | "300µs")` → `vegetaReportSchema.parse()` → `{ tool: 'vegeta', data }`
+- `outputFiles: { 'report': 'report.txt', 'attack': 'attack.bin' }`
+
+### 4.3 genai-perf（acceptance gate 关键）
+
+**`packages/tool-adapters/src/genai-perf/schema.ts`**
+
+```ts
+import { z } from "zod";
+
+export const genaiPerfParamsSchema = z.object({
+  endpointType: z.enum(["chat", "completions", "embeddings", "rankings"]),
+  numPrompts: z.number().int().positive().default(100),
+  concurrency: z.number().int().positive().default(1),
+  inputTokensMean: z.number().int().positive().optional(),
+  inputTokensStddev: z.number().int().min(0).default(0),
+  outputTokensMean: z.number().int().positive().optional(),
+  outputTokensStddev: z.number().int().min(0).default(0),
+  streaming: z.boolean().default(true),
+});
+export type GenaiPerfParams = z.infer<typeof genaiPerfParamsSchema>;
+
+const genaiPerfDist = z.object({
+  avg: z.number(),
+  min: z.number(),
+  max: z.number(),
+  p50: z.number(),
+  p90: z.number(),
+  p95: z.number(),
+  p99: z.number(),
+  stddev: z.number(),
+  unit: z.string(),                       // "ms" / "tokens/sec" 等，原样保留
+});
+
+export const genaiPerfReportSchema = z.object({
+  requestThroughput: z.object({ avg: z.number(), unit: z.string() }),
+  requestLatency: genaiPerfDist,
+  timeToFirstToken: genaiPerfDist,
+  interTokenLatency: genaiPerfDist,
+  outputTokenThroughput: z.object({ avg: z.number(), unit: z.string() }),
+  outputSequenceLength: z.object({ avg: z.number(), p50: z.number(), p99: z.number() }),
+  inputSequenceLength:  z.object({ avg: z.number(), p50: z.number(), p99: z.number() }),
+});
+export type GenaiPerfReport = z.infer<typeof genaiPerfReportSchema>;
+```
+
+**`packages/tool-adapters/src/genai-perf/runtime.ts`** — 关键点：
+
+- `buildCommand`: argv = `['genai-perf', 'profile', '-m', connection.model, '-u', connection.baseUrl, '--endpoint-type', endpointType, '--profile-export-file', 'profile_export.json', '--num-prompts', String(numPrompts), '--concurrency', String(concurrency), ...]`；`secretEnv.OPENAI_API_KEY = connection.apiKey`
+- `parseProgress`: 解析 genai-perf 进度输出（如有），无则返回 null
+- `parseFinalReport(stdout, files)`: 读 `files['profile'].toString('utf-8')` → JSON.parse → 字段重命名（snake_case → camelCase：`request_throughput → requestThroughput`、`time_to_first_token → timeToFirstToken` 等）→ `genaiPerfReportSchema.parse()` → `{ tool: 'genai-perf', data }`
+- `outputFiles: { 'profile': 'profile_export.json' }`
+
+> **Acceptance gate**: 此 adapter 落地时（PR #53.4）`packages/tool-adapters/src/core/interface.ts` 必须 untouched。
+
+---
+
+## 5. Run 模型 Json 列重新分工
+
+### 5.1 列含义
+
+| 列 | 类型 | 内容（D 后） | 谁写 |
+|---|---|---|---|
+| `tool` | String | `'guidellm' \| 'genai-perf' \| 'vegeta' \| 'e2e' \| 'custom'` | RunService 创建时（已存在） |
+| `scenario` | Json | **连接快照**：`{ apiBaseUrl, model, customHeaders, queryParams }`，防 connection 后被改/删时历史 run 失语义 | RunService 创建时 snapshot |
+| `params` | Json | **per-tool typed params**：`adapter.paramsSchema.parse(req.params)` 的结果 | RunService 创建时校验后写入 |
+| `summaryMetrics` | Json | **discriminated union body**：`{ tool, data }`，由 `adapter.parseFinalReport()` 输出 | `/finish` callback 解析后写入 |
+| `rawOutput` | Json | `{ stdout: string, stderr: string, files: Record<alias, base64String> }` | `/finish` callback 写入 |
+| `canonicalReport` | ❌ 删除 | — | — |
+| `serverMetrics` | Json | 不动（保留给 #60） | — |
+
+### 5.2 Migration
+
+```sql
+-- apps/api/prisma/migrations/<ts>_issue_53_canonical_drop/migration.sql
+ALTER TABLE "runs" DROP COLUMN "canonical_report";
+```
+
+dev DB disposable，落库直接 `prisma migrate reset --force`。
+
+### 5.3 Baseline ↔ Run 同工具约束
+
+应用层校验：`BaselineService.create()` / 任何 diff service `if (baseline.run.tool !== candidate.tool) throw 400`。**不**在 DB 层加 trigger / cross-table CHECK，错误信息可控。
+
+`Baseline` 表本身不需要冗余 `tool` 列；通过 `Baseline.run.tool` 间接获取。如未来出现"按 tool 筛 baseline list"高频查询再 denormalize。
+
+---
+
+## 6. Driver 改造
+
+### 6.1 接口（替换现 `BenchmarkExecutionDriver`）
+
+**`apps/api/src/modules/run/drivers/execution-driver.interface.ts`** (新文件，替代现 `apps/api/src/modules/benchmark/drivers/execution-driver.interface.ts`)
+
+```ts
+import type { BuildCommandResult, ToolName } from "@modeldoctor/tool-adapters";
+
+export interface RunExecutionContext {
+  runId: string;
+  tool: ToolName;
+  buildResult: BuildCommandResult;
+  callback: { url: string; token: string };
+  image: string;                              // 由 driver factory 按 tool 决定（见 §6.4）
+}
+
+export type RunExecutionHandle = string;     // 'subprocess:<pid>' | '<namespace>/<jobName>'
+
+export interface RunExecutionDriver {
+  start(ctx: RunExecutionContext): Promise<{ handle: RunExecutionHandle }>;
+  cancel(handle: RunExecutionHandle): Promise<void>;
+  cleanup(handle: RunExecutionHandle): Promise<void>;
+}
+```
+
+> 现 `BenchmarkExecutionContext` (含 guidellm-shape 字段如 `profile / datasetName / requestRate ...`) **整个删除**。
+
+### 6.2 SubprocessDriver 改写要点
+
+```ts
+async start(ctx) {
+  const cwd = `/tmp/run-${ctx.runId}`;
+  await fs.mkdir(cwd, { recursive: true });
+
+  // 写入 inputFiles
+  for (const [relPath, content] of Object.entries(ctx.buildResult.inputFiles ?? {})) {
+    await fs.writeFile(path.join(cwd, relPath), content);
+  }
+
+  const env = {
+    ...process.env,
+    ...ctx.buildResult.env,
+    ...ctx.buildResult.secretEnv,             // 本地合并（非 K8s 不区分敏感）
+    MD_CALLBACK_URL: ctx.callback.url,
+    MD_CALLBACK_TOKEN: ctx.callback.token,
+    MD_RUN_ID: ctx.runId,
+    MD_OUTPUT_FILES: JSON.stringify(ctx.buildResult.outputFiles),
+    MD_ARGV: JSON.stringify(ctx.buildResult.argv),
+  };
+
+  const child = spawn("benchmark-runner-wrapper", [], { env, cwd, stdio: ["ignore", "pipe", "pipe"], detached: false });
+  // ... handle 管理、kill timer 等沿用现有逻辑
+}
+```
+
+> `benchmark-runner-wrapper` 是 §7 重写后的通用 wrapper 二进制名。
+
+### 6.3 K8sJobDriver 改写要点
+
+- `secretEnv` → per-run Secret 的 `stringData`，Job container 使用 `envFrom: [{ secretRef: { name: ... } }]`
+- `env` → Job container 的 `env: [{ name, value }]` 直接传值
+- `inputFiles` → 写入同一 Secret 的 `stringData`（注意：Secret value 是字符串，单文件 ≤ 1 MiB）；container 用 `volumeMounts` 挂到 cwd 的相对路径
+  - **注意**: vegeta 的 targets.txt 含 `Authorization: Bearer <apiKey>` 明文，**必须**走 Secret + volumeMount，不能用 ConfigMap
+  - 大于 1 MiB 的 inputFiles 是 follow-up（极端少见）
+- `MD_*` 控制变量 → env value 直接传
+- container.image = `byTool(ctx.tool)` 查 `RUNNER_IMAGE_<TOOL>` 环境变量
+
+### 6.4 Driver Factory 改造
+
+新建 `apps/api/src/modules/run/drivers/run-driver.factory.ts`（替换现 `benchmark/drivers/driver.factory.ts`）：
+
+```ts
+function imageForTool(tool: ToolName, env: Env): string {
+  switch (tool) {
+    case "guidellm":   return env.RUNNER_IMAGE_GUIDELLM;
+    case "genai-perf": return env.RUNNER_IMAGE_GENAI_PERF;
+    case "vegeta":     return env.RUNNER_IMAGE_VEGETA;
+    default: throw new Error(`No image configured for tool: ${tool}`);
+  }
+}
+```
+
+`Env` schema (`apps/api/src/config/env.schema.ts`) 增三个变量：`RUNNER_IMAGE_GUIDELLM` / `RUNNER_IMAGE_GENAI_PERF` / `RUNNER_IMAGE_VEGETA`。本地 subprocess 模式下这三个 env 仅占位，不实际使用。
+
+---
+
+## 7. Runner Image 重写（`apps/benchmark-runner/`）
+
+### 7.1 删除
+
+- `runner/argv.py`（guidellm 专属 argv 构造）
+- `runner/env.py`（guidellm 专属 env parsing）
+- `runner/metrics.py`（guidellm JSON → BenchmarkMetricsSummary mapping）
+- 对应单测
+
+### 7.2 重写 `runner/main.py`（通用 wrapper）
+
+```python
+"""Generic tool wrapper. Reads MD_* env, spawns argv, streams logs, posts /finish."""
+
+import base64, json, os, subprocess, sys
+from runner.callback import post_state_running, post_log_batch, post_finish
+
+LOG_BATCH_MS = 250
+STDERR_TAIL_BYTES = 8 * 1024
+STDOUT_TAIL_BYTES = 64 * 1024  # full stdout 仍然进 /finish.stdout，这里只是 inline tail safety cap
+
+def main():
+    callback_url = os.environ["MD_CALLBACK_URL"]
+    token = os.environ["MD_CALLBACK_TOKEN"]
+    run_id = os.environ["MD_RUN_ID"]
+    argv = json.loads(os.environ["MD_ARGV"])
+    output_files = json.loads(os.environ["MD_OUTPUT_FILES"])
+
+    cwd = os.getcwd()  # /tmp/run-<id>，driver 已 mkdir 并写 inputFiles
+
+    post_state_running(callback_url, token, run_id)
+
+    proc = subprocess.Popen(argv, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout_full, stderr_full = tee_to_callback(proc, callback_url, token, run_id, batch_ms=LOG_BATCH_MS)
+    proc.wait()
+
+    files_b64 = {}
+    for alias, rel_path in output_files.items():
+        full = os.path.join(cwd, rel_path)
+        if os.path.exists(full):
+            with open(full, "rb") as f:
+                files_b64[alias] = base64.b64encode(f.read()).decode("ascii")
+
+    state = "completed" if proc.returncode == 0 else "failed"
+    post_finish(
+        callback_url=callback_url, token=token, run_id=run_id,
+        state=state, exit_code=proc.returncode,
+        stdout=stdout_full, stderr=stderr_full,
+        files=files_b64,
+        message=None if state == "completed" else f"exit code {proc.returncode}",
+    )
+    return 0  # 进程退出码：runner 本身成功（即使 inner tool failed），由 callback 表达终态
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+`tee_to_callback` 实现：两个 thread（stdout / stderr 各一），每读一行入 buffer，每 ~250 ms 把累积的行 batch POST `/log`，结束时 flush；同时累加到 stdout_full / stderr_full 全文 buffer 供 `/finish` 用。
+
+### 7.3 Dockerfile 拆分
+
+```
+apps/benchmark-runner/
+├── runner/                       # 通用 wrapper Python 代码（§7.2）
+├── images/
+│   ├── guidellm.Dockerfile       # FROM ghcr.io/guidellm/runner:0.5.x + COPY runner/ + ENTRYPOINT 同名
+│   ├── genai-perf.Dockerfile     # FROM nvcr.io/nvidia/tritonserver-genai-perf:* + COPY runner/
+│   └── vegeta.Dockerfile         # FROM peterevans/vegeta:latest + COPY runner/
+├── tests/                        # 仅测 wrapper 通用性（mock argv / stdout / files）
+└── pyproject.toml
+```
+
+CI 矩阵 build 三个 image，tag 按 PR / branch（沿用现有 CI 风格）；K8s deployment env 配 `RUNNER_IMAGE_<TOOL>`。
+
+---
+
+## 8. Callback 协议 v2
+
+### 8.1 三个 endpoint
+
+| Path | 时机 | Body Zod schema |
+|---|---|---|
+| `POST /api/internal/runs/:id/state` | runner 启动后**一次**，宣告 running | `{ state: 'running' }` |
+| `POST /api/internal/runs/:id/log` | stdout/stderr 增量，~250 ms batch | `{ stream: 'stdout' \| 'stderr', lines: string[] }` |
+| `POST /api/internal/runs/:id/finish` | tool 进程退出后**一次**，带终态 + 全部产物 | `{ state: 'completed' \| 'failed', exitCode: number, stdout: string, stderr: string, files: Record<alias, string /* base64 */>, message?: string }` |
+
+### 8.2 API 端处理
+
+```ts
+@UseGuards(HmacCallbackGuard)
+@Controller("api/internal/runs/:id")
+export class RunCallbackController {
+  constructor(private readonly runs: RunService, private readonly sse: SseHub) {}
+
+  @Post("state")
+  async handleState(@Param("id") id: string, @Body() body: StateCallback) {
+    if (body.state === "running") {
+      await this.runs.markRunning(id);
+    }
+  }
+
+  @Post("log")
+  async handleLog(@Param("id") id: string, @Body() body: LogCallback) {
+    const run = await this.runs.findById(id);
+    if (!run) return;                                 // 静默忽略；race against cleanup
+    const adapter = byTool(run.tool as ToolName);
+    for (const line of body.lines) {
+      let evt: ProgressEvent | null;
+      try {
+        evt = adapter.parseProgress(line);
+      } catch {
+        evt = { kind: "log", level: "warn", line };  // parser 升级期容错
+      }
+      if (!evt) continue;
+      this.sse.publish(id, evt);
+      if (evt.kind === "progress") {
+        await this.runs.updateProgress(id, evt.pct);
+      }
+    }
+  }
+
+  @Post("finish")
+  async handleFinish(@Param("id") id: string, @Body() body: FinishCallback) {
+    const run = await this.runs.findById(id);
+    if (!run) return;
+    const adapter = byTool(run.tool as ToolName);
+
+    let report: ToolReport | null = null;
+    let finalState = body.state;
+    let message = body.message;
+
+    try {
+      const fileBuffers: Record<string, Buffer> = Object.fromEntries(
+        Object.entries(body.files).map(([k, v]) => [k, Buffer.from(v, "base64")]),
+      );
+      report = adapter.parseFinalReport(body.stdout, fileBuffers);
+    } catch (e) {
+      finalState = "failed";
+      message = `report parse: ${(e as Error).message}`.slice(0, 2048);
+      report = null;
+    }
+
+    await this.runs.markFinished(id, {
+      status: finalState,
+      message,
+      summaryMetrics: report,
+      rawOutput: { stdout: body.stdout, stderr: body.stderr, files: body.files },
+    });
+  }
+}
+```
+
+### 8.3 Body size 与 HMAC
+
+- `/finish` body 上限提升至 **10 MB**（NestJS body-parser 单 endpoint override，路由级配置）。覆盖 guidellm 报告 ~500 KB + buffer
+- `/log` body 上限 **256 KB**（每 batch 上限 ≈ 1000 行 × 256 字符，足够）
+- 三个 endpoint 都套现 `HmacCallbackGuard`（`apps/api/src/modules/benchmark/callbacks/hmac-callback.guard.ts`），文件物理位置随 controller 迁到 `apps/api/src/modules/run/callbacks/`
+
+### 8.4 SSE Hub（in-memory pubsub）
+
+新建 `apps/api/src/modules/run/sse/sse-hub.service.ts`：
+
+- `publish(runId, event: ProgressEvent)`: 派发到该 runId 的所有订阅者
+- `subscribe(runId): Observable<ProgressEvent>`: #57 SSE endpoint 用
+
+`SseHub` 仅在内存内（单 API 实例）；多实例 horizontal scale 是 #57/#59 关心的事，#53 不处理。
+
+---
+
+## 9. RunController + RunService（统一新 endpoint）
+
+### 9.1 新 endpoint
+
+`apps/api/src/modules/run/run.controller.ts` 已存在，扩展为：
+
+| Method | Path | 用途 |
+|---|---|---|
+| `POST` | `/api/runs` | 创建并立即 start 任意工具的 run |
+| `GET`  | `/api/runs` | 列表（继承现有 listRunsQuerySchema） |
+| `GET`  | `/api/runs/:id` | 详情 |
+| `POST` | `/api/runs/:id/cancel` | 取消 |
+| `DELETE` | `/api/runs/:id` | 删除（terminal 后） |
+
+`POST /api/runs` body schema (`packages/contracts/src/run.ts` 新增)：
+
+```ts
+export const createRunRequestSchema = z.object({
+  tool: runToolSchema,
+  kind: runKindSchema.default("benchmark"),
+  connectionId: z.string().min(1),
+  name: z.string().min(1).max(128),
+  description: z.string().max(2048).optional(),
+  params: z.record(z.unknown()),                  // adapter.paramsSchema 在 service 层校验
+  templateId: z.string().optional(),
+  templateVersion: z.string().optional(),
+  parentRunId: z.string().optional(),
+  baselineId: z.string().optional(),
+});
+```
+
+### 9.2 RunService 关键流程
+
+```ts
+async create(userId: string, req: CreateRunRequest): Promise<Run> {
+  const conn = await this.connections.getOwnedDecrypted(userId, req.connectionId);
+  const adapter = byTool(req.tool);
+
+  // 1. 校验 params
+  const params = adapter.paramsSchema.parse(req.params);
+
+  // 2. 创建 Run row（status=pending）
+  const run = await this.runs.create({
+    userId, connectionId: conn.id,
+    kind: req.kind, tool: req.tool, mode: "fixed",   // mode 由 adapter 推断 / req 提供
+    driverKind: this.driverKind,
+    name: req.name, description: req.description,
+    scenario: {
+      apiBaseUrl: conn.baseUrl,
+      model: conn.model,
+      customHeaders: conn.customHeaders,
+      queryParams: conn.queryParams,
+    },
+    params: params as Prisma.InputJsonValue,
+    templateId: req.templateId, templateVersion: req.templateVersion,
+    parentRunId: req.parentRunId, baselineId: req.baselineId,
+  });
+
+  return await this.start(run.id);
+}
+
+async start(runId: string): Promise<Run> {
+  const row = await this.runs.findById(runId);
+  // ... 取 connection, sign callback token
+  const adapter = byTool(row.tool as ToolName);
+  const buildResult = adapter.buildCommand({
+    runId: row.id,
+    params: row.params,
+    connection: { /* ... */ },
+    callback: { url: this.callbackUrl, token: callbackToken },
+  });
+  const handle = await this.driver.start({
+    runId: row.id, tool: row.tool as ToolName,
+    buildResult,
+    callback: { url: this.callbackUrl, token: callbackToken },
+    image: imageForTool(row.tool as ToolName, this.config),
+  });
+  return await this.runs.update(row.id, {
+    status: "submitted", driverHandle: handle.handle, startedAt: new Date(),
+  });
+}
+```
+
+`callbackToken` 复用现 `signCallbackToken` (`apps/api/src/modules/benchmark/callbacks/hmac-token.ts`，物理迁到 `run/callbacks/`)。
+
+---
+
+## 10. 前后端兼容 Facade 策略
+
+### 10.1 BenchmarkController 改 facade
+
+`apps/api/src/modules/benchmark/benchmark.controller.ts` 路由不变（`/api/benchmarks/*`），controller 内部 translate 后调 `RunService`：
+
+```ts
+@Post()
+async create(@Body() body: CreateBenchmarkRequest, @CurrentUser() user) {
+  const guidellmParams: GuidellmParams = {
+    profile: body.profile,
+    apiType: body.apiType,
+    datasetName: body.datasetName,
+    datasetInputTokens: body.datasetInputTokens,
+    datasetOutputTokens: body.datasetOutputTokens,
+    datasetSeed: body.datasetSeed,
+    requestRate: body.requestRate,
+    totalRequests: body.totalRequests,
+    // 其余字段由 guidellmParamsSchema 默认值填补
+  };
+  const run = await this.runs.create(user.sub, {
+    tool: "guidellm", kind: "benchmark", connectionId: body.connectionId,
+    name: body.name, description: body.description,
+    params: guidellmParams,
+  });
+  return mapRunToBenchmarkRunDto(run);
+}
+
+@Get()
+async list(@Query() q: ListBenchmarksQuery, @CurrentUser() user) {
+  const r = await this.runs.list({ tool: "guidellm", ...q }, user);
+  return { items: r.items.map(mapRunToBenchmarkRunSummary), nextCursor: r.nextCursor };
+}
+
+// 同样 facade 化：GET :id / cancel / delete
+```
+
+`mapRunToBenchmarkRunDto` 是反向 mapper：从新 `Run` 形态（含 `summaryMetrics: { tool: 'guidellm', data: GuidellmReport }`）map 回旧 `BenchmarkRunDto`（含 `metricsSummary: BenchmarkMetricsSummary` 旧 shape）。字段基本一对一对齐。
+
+### 10.2 LoadTestController 改 facade
+
+`apps/api/src/modules/load-test/load-test.controller.ts` 路由不变，内部 translate `LoadTestRequest` → `vegetaParams`，response 反向 map 成 `LoadTestResponse`。
+
+注意 `LoadTestResponse` 含 `report: string`（vegeta 原始文本报告），从新 Run 的 `rawOutput.files['report']` 解 base64 取出。
+
+### 10.3 Facade 生命周期
+
+- **#53 内**: 上线 facade，前端零改动
+- **#54 (Test Plan UI)** 内: 前端切到 `/api/runs`，**同 PR**:
+  - 删除 `apps/api/src/modules/benchmark/benchmark.controller.ts` + `benchmark.service.ts`（facade 实现）
+  - 删除 `apps/api/src/modules/load-test/`
+  - 删除 `packages/contracts/src/benchmark.ts` (legacy DTO schemas)
+  - 删除 `packages/contracts/src/load-test.ts`
+  - 删除反向 mapper 函数
+  - 前端 `BenchmarkPage` / `LoadTestPage` 改用 `/api/runs`
+
+> #54 落地时同步 follow-up（见 §12）。
+
+---
+
+## 11. 测试策略
+
+### 11.1 测试层
+
+| 层 | 路径 | 重点 |
+|---|---|---|
+| Adapter 单测 | `packages/tool-adapters/src/<tool>/runtime.spec.ts` | fixture-based：`__fixtures__/` 内的真实工具产物 → `parseFinalReport()` 输出 matches `reportSchema` |
+| Schema 单测 | `packages/tool-adapters/src/<tool>/schema.spec.ts` | paramsSchema 必填/默认值/refine；reportSchema discriminated union narrowing |
+| Driver 单测 | `apps/api/src/modules/run/drivers/*.spec.ts` | secretEnv 不进 argv、K8s 必走 Secret、inputFiles 写入 cwd、callback env 注入 |
+| Callback 单测 | `apps/api/src/modules/run/callbacks/*.spec.ts` | parser throw → state=failed、HMAC guard、body size limit、log → SSE pubsub |
+| Runner image 测 | `apps/benchmark-runner/tests/` | wrapper 通用性：mock argv (`echo` / `cat`)，验证 batch /log POST、outputFiles 收集、/finish payload |
+| 集成测 | `apps/api/test/run-e2e.spec.ts` | 创建 Run → mock driver fire `/state, /log, /finish` → DB 状态正确（不真跑工具） |
+| 手工 smoke | 文档化 (§12) | 三个 adapter 真跑过一次 |
+
+### 11.2 Fixture 来源
+
+- **guidellm**: 现 `apps/benchmark-runner` 已能跑出真实 report.json，捞一份提交（128 个请求 / random dataset / 本地 vLLM 或 mock target）
+- **vegeta**: 现 `apps/api/src/integrations/parsers/vegeta-report.spec.ts` 已有 fixture 字符串，迁移到 `__fixtures__/report.txt`
+- **genai-perf**: 本地 `pip install genai-perf` 跑一次小 profile（10 prompts / 1 concurrency），捞 `profile_export.json` 提交
+
+---
+
+## 12. Acceptance Gate 验证步骤
+
+`#53 ship 前必跑一次手工流程`，结果记录在 PR #53.4 描述里：
+
+```
+1. 切到 PR #53.4 分支（genai-perf 实现 PR）
+
+2. 验证 fixture 已就位：
+   ls packages/tool-adapters/src/genai-perf/__fixtures__/profile_export.json
+
+3. 跑 adapter 包测试：
+   pnpm -F @modeldoctor/tool-adapters test
+   ─ 三个 tool 的 fixture 单测全过
+   ─ schema 单测全过
+
+4. ⭐ ACCEPTANCE GATE 关键命令：
+   git diff main -- packages/tool-adapters/src/core/interface.ts
+   ─ 输出必须为空（接口字段 0 改动）
+   ─ 若有改动 → 设计回滚，重新 brainstorm
+
+5. 本地 build genai-perf image：
+   docker build -f apps/benchmark-runner/images/genai-perf.Dockerfile apps/benchmark-runner/
+
+6. 跑 end-to-end：
+   ─ docker compose up modeldoctor-api / 或本地启动 API (driver=subprocess)
+   ─ 创建 connection 指向本地或可访问的 OpenAI-compatible endpoint
+   ─ POST /api/runs { tool: 'genai-perf', connectionId, name, params: { endpointType: 'chat', numPrompts: 10, concurrency: 1 } }
+   ─ 通过 logs 观察：
+       /state running 收到
+       /log 持续到达，stdout 行可见
+       /finish 收到
+   ─ GET /api/runs/<id> 验证：
+       summaryMetrics.tool === 'genai-perf'
+       summaryMetrics.data.requestLatency.p99 是合理 number
+       rawOutput.files['profile'] base64 解码后是合法 JSON
+
+7. 在 PR #53.4 描述粘贴 §12 步骤 + 截图（关键 endpoint response）。
+```
+
+---
+
+## 13. PR 拆分
+
+| # | 分支 / PR 名 | 内容 | 体量 |
+|---|---|---|---|
+| **53.1** | `feat/issue-53-tool-adapter-package-skeleton` | 新建 `packages/tool-adapters/`，core interface + registry，**3 adapter 的 schema-only**（runtime 全 throw）。CI build 通过 | 中 |
+| **53.2** | `feat/issue-53-callback-v2-and-run-service` | Callback v2 三 endpoint + RunController + RunService unified；driver 接口改造（`BuildCommandResult` 输入）；DB migration 删 `canonicalReport`。**Facade 暂未挂；BenchmarkController/LoadTestController 仍走旧路径**（这一 PR 后端两套 controller 并行，但底层数据流不冲突，依赖各自的 driver/callback 实例） | 大 |
+| **53.3** | `feat/issue-53-guidellm-vegeta-runtime-and-runner-image` | guidellm + vegeta runtime 实现；`apps/benchmark-runner/` Python wrapper 重写 + Dockerfile 拆分；旧 `argv.py / env.py / metrics.py` 删除；**Facade 上线**：BenchmarkController/LoadTestController 切到 RunService | 大 |
+| **53.4** | `feat/issue-53-genai-perf-adapter` | genai-perf runtime + Dockerfile + fixture 单测 + smoke 报告。**这是 acceptance gate PR**：`git diff main -- packages/tool-adapters/src/core/interface.ts` 必须为空 | 中 |
+
+---
+
+## 14. Follow-up Comments
+
+按 `feedback_temp_followups.md` 习惯，#53 落地过程中要在以下 issue 上 post comment：
+
+| Issue | Comment 内容 |
+|---|---|
+| **#54 (Test Plan UI)** | "#53 落地后 BenchmarkController / LoadTestController 是 facade（`apps/api/src/modules/{benchmark,load-test}/`），#54 切前端到 `/api/runs` 时同 PR 删除 facade controller、`packages/contracts/src/{benchmark,load-test}.ts`、反向 mapper 函数。" |
+| **#45 (Diff 引擎)** | "#53 后 `Run.summaryMetrics` shape = `{ tool, data }` discriminated union。Diff service 必须先 `assert(baseline.tool === run.tool)` narrow，然后按 tool 分支 typed diff。**不存在跨工具 diff**（D 立场）。" |
+| **#41 (Charts, 已合)** | "#53 改了 `Run.summaryMetrics` shape：从 guidellm-shape 的 `BenchmarkMetricsSummary` 变为 discriminated union body `{ tool, data }`。#41 已实现的 charts 组件需要在 #54 切到 `/api/runs` 时同 PR 改造为按 `summaryMetrics.tool` switch 渲染。" |
+| **#57 (SSE 日志)** | "#53 已在 API 端 in-memory pubsub 提供 `ProgressEvent` stream（`SseHub.subscribe(runId)`）。#57 实现 SSE endpoint 时直接订阅，不需要重新 parse stdout。" |
+| **#59 (Driver 策略)** | "#53 后 driver 接口已统一为 `RunExecutionContext`（与 tool 无关），#59 自由选择 SubprocessDriver / K8sJobDriver 实现。Image 选择逻辑在 `imageForTool(tool, env)`。" |
+
+---
+
+## 15. Future Work（不在 #53 范围）
+
+1. **Raw output 对象存储**: guidellm/genai-perf 极端 long-context test 可能产物 >10 MB。届时 `rawOutput.files` 改成 `Record<alias, { kind: 'inline', base64 } | { kind: 's3', url, etag }>`
+2. **Custom adapter / plugin 机制**: 用户自带工具镜像 + 自带 schema。需要 plugin SDK + sandbox。单独 issue
+3. **Adapter version 化**: guidellm 0.5 → 0.6 改 schema 时，可能需要 `guidellmAdapter.v1 / v2`。先不处理，等真出现版本 break 再说
+4. **跨工具 leaderboard**: 若产品后续真有需求，从 D 立场退守，加 mini-canonical 层（仅 latency.p99 + throughputQps），UI 明确警示"跨工具仅供参考"
+5. **Run cancel 期间 callback 处理**: 现在 cancel 后再到的 `/log` 仍会被 handle（无害）；如要严格 reject，加 RunService 状态机 guard
+
+---
+
+## 附录 A: 现状代码盘点（供 implementation plan 参考）
+
+| 现状文件 | #53 后命运 |
+|---|---|
+| `apps/benchmark-runner/runner/argv.py` | 删除 |
+| `apps/benchmark-runner/runner/env.py` | 删除 |
+| `apps/benchmark-runner/runner/metrics.py` | 删除（逻辑 TS 化迁到 `packages/tool-adapters/src/guidellm/runtime.ts`） |
+| `apps/benchmark-runner/runner/main.py` | 重写（通用 wrapper） |
+| `apps/benchmark-runner/runner/callback.py` | 重写（`post_state_running / post_log_batch / post_finish`） |
+| `apps/benchmark-runner/Dockerfile` | 拆成 `images/{guidellm,genai-perf,vegeta}.Dockerfile` |
+| `apps/api/src/modules/benchmark/drivers/execution-driver.interface.ts` | 删除（→ `apps/api/src/modules/run/drivers/execution-driver.interface.ts`） |
+| `apps/api/src/modules/benchmark/drivers/subprocess-driver.ts` | 迁移 + 改写为 `RunExecutionContext` |
+| `apps/api/src/modules/benchmark/drivers/k8s-job-driver.ts` | 迁移 + 改写 |
+| `apps/api/src/modules/benchmark/drivers/k8s-job-manifest.ts` | 迁移 + 改写（secretEnv / inputFiles 处理） |
+| `apps/api/src/modules/benchmark/drivers/driver.factory.ts` | 迁移 + 改 `imageForTool` |
+| `apps/api/src/modules/benchmark/callbacks/*` | 迁移到 `apps/api/src/modules/run/callbacks/`，重写 controller |
+| `apps/api/src/modules/benchmark/benchmark.service.ts` | 改 facade 实现（→ 调 RunService），#54 删 |
+| `apps/api/src/modules/benchmark/benchmark.controller.ts` | 改 facade（路由不变），#54 删 |
+| `apps/api/src/modules/benchmark/benchmark.reconciler.ts` | 评估迁到 RunService 通用 reconciler 还是改 facade，本设计倾向迁通用 |
+| `apps/api/src/modules/load-test/load-test.service.ts` | 改 facade 实现（调 RunService with tool='vegeta'），#54 删 |
+| `apps/api/src/modules/load-test/load-test.controller.ts` | 改 facade（路由不变），#54 删 |
+| `apps/api/src/integrations/parsers/vegeta-report.ts` | 移植到 `packages/tool-adapters/src/vegeta/runtime.ts` 的 parseFinalReport，加单位转 ms 函数 |
+| `apps/api/src/integrations/builders/*` | vegeta targets 文件构造逻辑迁到 `packages/tool-adapters/src/vegeta/runtime.ts` 的 buildCommand |
+| `apps/api/prisma/schema.prisma` | `Run.canonical_report` 列删除 |
+| `packages/contracts/src/benchmark.ts` | facade 期保留；#54 删 |
+| `packages/contracts/src/load-test.ts` | facade 期保留；#54 删 |
+| `packages/contracts/src/run.ts` | 扩展 `createRunRequestSchema`；`runSchema` 已含 `summaryMetrics / rawOutput` 列 |
+
+---
+
+**Status**: Spec 完成，待 implementation plan（writing-plans skill）落地。

--- a/packages/tool-adapters/package.json
+++ b/packages/tool-adapters/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@modeldoctor/tool-adapters",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Per-tool typed adapters (guidellm / genai-perf / vegeta) with subpath exports for schema-only frontend consumption",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./src/index.ts",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./schemas": {
+      "types": "./dist/schemas-entry.d.ts",
+      "import": "./src/schemas-entry.ts",
+      "require": "./dist/schemas-entry.js",
+      "default": "./dist/schemas-entry.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -w -p tsconfig.build.json --preserveWatchOutput",
+    "type-check": "tsc -p tsconfig.json --noEmit",
+    "lint": "biome check src",
+    "format": "biome format --write src",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "zod": "^3.23",
+    "@modeldoctor/contracts": "workspace:*"
+  }
+}

--- a/packages/tool-adapters/src/core/interface.ts
+++ b/packages/tool-adapters/src/core/interface.ts
@@ -1,0 +1,78 @@
+import type { z } from "zod";
+
+// ToolAdapter-registered tool names. The DB column `Run.tool` allows a
+// superset (additionally `'e2e'` and `'custom'`) — those don't go through
+// ToolAdapter and follow their own codepaths. ToolName covers exactly the
+// adapters the registry knows about.
+export type ToolName = "guidellm" | "genai-perf" | "vegeta";
+
+// ── Progress events (uniform across tools) ────────────────────────────
+export type ProgressEvent =
+  | { kind: "progress"; pct: number; currentRequests?: number; message?: string }
+  | { kind: "log"; level: "info" | "warn" | "error"; line: string };
+
+// ── Forward-declare per-tool report types (filled in Task 1.4 / 1.5 / 1.6) ──
+// We use type-only imports to break a circular dep concern: schema files
+// don't import from interface.ts; interface.ts imports their inferred types.
+import type { GuidellmReport } from "../guidellm/schema.js";
+import type { GenaiPerfReport } from "../genai-perf/schema.js";
+import type { VegetaReport } from "../vegeta/schema.js";
+
+// ── Discriminated union: report (consumers switch on `tool`) ──────────
+export type ToolReport =
+  | { tool: "guidellm"; data: GuidellmReport }
+  | { tool: "genai-perf"; data: GenaiPerfReport }
+  | { tool: "vegeta"; data: VegetaReport };
+
+// ── buildCommand inputs ───────────────────────────────────────────────
+export interface BuildCommandPlan<TParams = unknown> {
+  runId: string;
+  params: TParams;
+  connection: {
+    baseUrl: string;
+    apiKey: string;
+    model: string;
+    customHeaders: string;
+    queryParams: string;
+  };
+  callback: { url: string; token: string };
+}
+
+// ── buildCommand output ───────────────────────────────────────────────
+//
+// Driver contract:
+//   - argv:        full command (incl. program name); shell pipelines via
+//                  ['/bin/sh', '-c', '...']. Driver does NOT prepend.
+//   - env:         non-sensitive env. Subprocess: merged into spawn env.
+//                  K8s: passed as Job container env value.
+//   - secretEnv:   sensitive env. Subprocess: merged into spawn env (no
+//                  argv leak). K8s: written to per-run Secret + envFrom.
+//                  MUST NOT enter argv.
+//   - inputFiles:  cwd-relative path → file contents. Driver writes these
+//                  before spawn. K8s: written to the same per-run Secret +
+//                  volumeMount (single-Secret limit ~1MiB total). Use this
+//                  channel for files that contain secrets (e.g. vegeta's
+//                  targets.txt with bearer token); never use ConfigMap.
+//   - outputFiles: alias → cwd-relative path. Runner reads these after
+//                  exit and ships base64-encoded contents in /finish body.
+export interface BuildCommandResult {
+  argv: string[];
+  env: Record<string, string>;
+  secretEnv: Record<string, string>;
+  inputFiles?: Record<string, string>;
+  outputFiles: Record<string, string>;
+}
+
+// ── ToolAdapter interface ─────────────────────────────────────────────
+// ⚠ ACCEPTANCE GATE: in Phase 4 (PR 53.4), `git diff main -- this file`
+// MUST be empty. Adding genai-perf must not require any change here.
+export interface ToolAdapter {
+  readonly name: ToolName;
+  readonly paramsSchema: z.ZodTypeAny;
+  readonly reportSchema: z.ZodTypeAny;
+  readonly paramDefaults: unknown;
+
+  buildCommand(plan: BuildCommandPlan): BuildCommandResult;
+  parseProgress(line: string): ProgressEvent | null;
+  parseFinalReport(stdout: string, files: Record<string, Buffer>): ToolReport;
+}

--- a/packages/tool-adapters/src/core/interface.ts
+++ b/packages/tool-adapters/src/core/interface.ts
@@ -11,11 +11,11 @@ export type ProgressEvent =
   | { kind: "progress"; pct: number; currentRequests?: number; message?: string }
   | { kind: "log"; level: "info" | "warn" | "error"; line: string };
 
+import type { GenaiPerfReport } from "../genai-perf/schema.js";
 // ── Forward-declare per-tool report types (filled in Task 1.4 / 1.5 / 1.6) ──
 // We use type-only imports to break a circular dep concern: schema files
 // don't import from interface.ts; interface.ts imports their inferred types.
 import type { GuidellmReport } from "../guidellm/schema.js";
-import type { GenaiPerfReport } from "../genai-perf/schema.js";
 import type { VegetaReport } from "../vegeta/schema.js";
 
 // ── Discriminated union: report (consumers switch on `tool`) ──────────

--- a/packages/tool-adapters/src/core/progress-event.ts
+++ b/packages/tool-adapters/src/core/progress-event.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const progressEventSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("progress"),
+    pct: z.number().min(0).max(1),
+    currentRequests: z.number().int().nonnegative().optional(),
+    message: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("log"),
+    level: z.enum(["info", "warn", "error"]),
+    line: z.string(),
+  }),
+]);

--- a/packages/tool-adapters/src/core/registry.spec.ts
+++ b/packages/tool-adapters/src/core/registry.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { allAdapters, byTool } from "./registry.js";
+
+describe("registry", () => {
+  it("byTool('guidellm') returns the guidellm adapter", () => {
+    const a = byTool("guidellm");
+    expect(a.name).toBe("guidellm");
+    expect(typeof a.paramsSchema.parse).toBe("function");
+  });
+
+  it("byTool('vegeta') returns the vegeta adapter", () => {
+    expect(byTool("vegeta").name).toBe("vegeta");
+  });
+
+  it("byTool('genai-perf') returns the genai-perf adapter", () => {
+    expect(byTool("genai-perf").name).toBe("genai-perf");
+  });
+
+  it("allAdapters returns three adapters", () => {
+    const all = allAdapters();
+    expect(all).toHaveLength(3);
+    expect(all.map((a) => a.name).sort()).toEqual(["genai-perf", "guidellm", "vegeta"].sort());
+  });
+});

--- a/packages/tool-adapters/src/core/registry.ts
+++ b/packages/tool-adapters/src/core/registry.ts
@@ -1,0 +1,20 @@
+import { genaiPerfAdapter } from "../genai-perf/index.js";
+import { guidellmAdapter } from "../guidellm/index.js";
+import { vegetaAdapter } from "../vegeta/index.js";
+import type { ToolAdapter, ToolName } from "./interface.js";
+
+const ADAPTERS: Readonly<Record<ToolName, ToolAdapter>> = {
+  guidellm: guidellmAdapter,
+  "genai-perf": genaiPerfAdapter,
+  vegeta: vegetaAdapter,
+};
+
+export function byTool(tool: ToolName): ToolAdapter {
+  const a = ADAPTERS[tool];
+  if (!a) throw new Error(`No adapter registered for tool: ${tool}`);
+  return a;
+}
+
+export function allAdapters(): readonly ToolAdapter[] {
+  return Object.values(ADAPTERS);
+}

--- a/packages/tool-adapters/src/genai-perf/index.ts
+++ b/packages/tool-adapters/src/genai-perf/index.ts
@@ -1,6 +1,6 @@
 import type { ToolAdapter } from "../core/interface.js";
-import { genaiPerfParamsSchema, genaiPerfReportSchema, genaiPerfParamDefaults } from "./schema.js";
 import { buildCommand, parseFinalReport, parseProgress } from "./runtime.js";
+import { genaiPerfParamDefaults, genaiPerfParamsSchema, genaiPerfReportSchema } from "./schema.js";
 
 export const genaiPerfAdapter: ToolAdapter = {
   name: "genai-perf",

--- a/packages/tool-adapters/src/genai-perf/index.ts
+++ b/packages/tool-adapters/src/genai-perf/index.ts
@@ -1,0 +1,15 @@
+import type { ToolAdapter } from "../core/interface.js";
+import { genaiPerfParamsSchema, genaiPerfReportSchema, genaiPerfParamDefaults } from "./schema.js";
+import { buildCommand, parseFinalReport, parseProgress } from "./runtime.js";
+
+export const genaiPerfAdapter: ToolAdapter = {
+  name: "genai-perf",
+  paramsSchema: genaiPerfParamsSchema,
+  reportSchema: genaiPerfReportSchema,
+  paramDefaults: genaiPerfParamDefaults,
+  buildCommand,
+  parseProgress,
+  parseFinalReport,
+};
+
+export type { GenaiPerfParams, GenaiPerfReport } from "./schema.js";

--- a/packages/tool-adapters/src/genai-perf/runtime.ts
+++ b/packages/tool-adapters/src/genai-perf/runtime.ts
@@ -16,9 +16,6 @@ export function parseProgress(_line: string): ProgressEvent | null {
   throw new Error(NOT_IMPLEMENTED);
 }
 
-export function parseFinalReport(
-  _stdout: string,
-  _files: Record<string, Buffer>,
-): ToolReport {
+export function parseFinalReport(_stdout: string, _files: Record<string, Buffer>): ToolReport {
   throw new Error(NOT_IMPLEMENTED);
 }

--- a/packages/tool-adapters/src/genai-perf/runtime.ts
+++ b/packages/tool-adapters/src/genai-perf/runtime.ts
@@ -1,0 +1,24 @@
+import type {
+  BuildCommandPlan,
+  BuildCommandResult,
+  ProgressEvent,
+  ToolReport,
+} from "../core/interface.js";
+import type { GenaiPerfParams } from "./schema.js";
+
+const NOT_IMPLEMENTED = "genai-perf runtime is implemented in Phase 4 (PR 53.4)";
+
+export function buildCommand(_plan: BuildCommandPlan<GenaiPerfParams>): BuildCommandResult {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export function parseProgress(_line: string): ProgressEvent | null {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export function parseFinalReport(
+  _stdout: string,
+  _files: Record<string, Buffer>,
+): ToolReport {
+  throw new Error(NOT_IMPLEMENTED);
+}

--- a/packages/tool-adapters/src/genai-perf/schema.spec.ts
+++ b/packages/tool-adapters/src/genai-perf/schema.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { genaiPerfParamsSchema, genaiPerfReportSchema, genaiPerfParamDefaults } from "./schema.js";
+
+describe("genaiPerfParamsSchema", () => {
+  it("rejects negative numPrompts", () => {
+    const r = genaiPerfParamsSchema.safeParse({
+      endpointType: "chat",
+      numPrompts: -1,
+      concurrency: 1,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a minimal valid config", () => {
+    const r = genaiPerfParamsSchema.safeParse({ endpointType: "chat" });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.numPrompts).toBe(100);
+      expect(r.data.concurrency).toBe(1);
+      expect(r.data.streaming).toBe(true);
+    }
+  });
+
+  it("paramDefaults is a parseable starter", () => {
+    expect(typeof genaiPerfParamDefaults).toBe("object");
+  });
+});
+
+describe("genaiPerfReportSchema", () => {
+  it("requires distribution fields", () => {
+    const r = genaiPerfReportSchema.safeParse({});
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a typical genai-perf report shape", () => {
+    const dist = {
+      avg: 10, min: 1, max: 50, p50: 9, p90: 18, p95: 22, p99: 40, stddev: 5, unit: "ms",
+    };
+    const lengthDist = { avg: 100, p50: 100, p99: 200 };
+    const r = genaiPerfReportSchema.safeParse({
+      requestThroughput: { avg: 5.2, unit: "requests/sec" },
+      requestLatency: dist,
+      timeToFirstToken: dist,
+      interTokenLatency: dist,
+      outputTokenThroughput: { avg: 200, unit: "tokens/sec" },
+      outputSequenceLength: lengthDist,
+      inputSequenceLength: lengthDist,
+    });
+    expect(r.success).toBe(true);
+  });
+});

--- a/packages/tool-adapters/src/genai-perf/schema.spec.ts
+++ b/packages/tool-adapters/src/genai-perf/schema.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { genaiPerfParamsSchema, genaiPerfReportSchema, genaiPerfParamDefaults } from "./schema.js";
+import { genaiPerfParamDefaults, genaiPerfParamsSchema, genaiPerfReportSchema } from "./schema.js";
 
 describe("genaiPerfParamsSchema", () => {
   it("rejects negative numPrompts", () => {
@@ -34,7 +34,15 @@ describe("genaiPerfReportSchema", () => {
 
   it("accepts a typical genai-perf report shape", () => {
     const dist = {
-      avg: 10, min: 1, max: 50, p50: 9, p90: 18, p95: 22, p99: 40, stddev: 5, unit: "ms",
+      avg: 10,
+      min: 1,
+      max: 50,
+      p50: 9,
+      p90: 18,
+      p95: 22,
+      p99: 40,
+      stddev: 5,
+      unit: "ms",
     };
     const lengthDist = { avg: 100, p50: 100, p99: 200 };
     const r = genaiPerfReportSchema.safeParse({

--- a/packages/tool-adapters/src/genai-perf/schema.ts
+++ b/packages/tool-adapters/src/genai-perf/schema.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+export const genaiPerfParamsSchema = z.object({
+  endpointType: z.enum(["chat", "completions", "embeddings", "rankings"]),
+  numPrompts: z.number().int().positive().default(100),
+  concurrency: z.number().int().positive().default(1),
+  inputTokensMean: z.number().int().positive().optional(),
+  inputTokensStddev: z.number().int().min(0).default(0),
+  outputTokensMean: z.number().int().positive().optional(),
+  outputTokensStddev: z.number().int().min(0).default(0),
+  streaming: z.boolean().default(true),
+});
+export type GenaiPerfParams = z.infer<typeof genaiPerfParamsSchema>;
+
+const genaiPerfDist = z.object({
+  avg: z.number(),
+  min: z.number(),
+  max: z.number(),
+  p50: z.number(),
+  p90: z.number(),
+  p95: z.number(),
+  p99: z.number(),
+  stddev: z.number(),
+  unit: z.string(),
+});
+
+const sequenceLength = z.object({
+  avg: z.number(),
+  p50: z.number(),
+  p99: z.number(),
+});
+
+export const genaiPerfReportSchema = z.object({
+  requestThroughput: z.object({ avg: z.number(), unit: z.string() }),
+  requestLatency: genaiPerfDist,
+  timeToFirstToken: genaiPerfDist,
+  interTokenLatency: genaiPerfDist,
+  outputTokenThroughput: z.object({ avg: z.number(), unit: z.string() }),
+  outputSequenceLength: sequenceLength,
+  inputSequenceLength: sequenceLength,
+});
+export type GenaiPerfReport = z.infer<typeof genaiPerfReportSchema>;
+
+export const genaiPerfParamDefaults: Partial<GenaiPerfParams> = {
+  endpointType: "chat",
+  numPrompts: 100,
+  concurrency: 1,
+  streaming: true,
+  inputTokensStddev: 0,
+  outputTokensStddev: 0,
+};

--- a/packages/tool-adapters/src/guidellm/index.ts
+++ b/packages/tool-adapters/src/guidellm/index.ts
@@ -1,0 +1,15 @@
+import type { ToolAdapter } from "../core/interface.js";
+import { guidellmParamsSchema, guidellmReportSchema, guidellmParamDefaults } from "./schema.js";
+import { buildCommand, parseFinalReport, parseProgress } from "./runtime.js";
+
+export const guidellmAdapter: ToolAdapter = {
+  name: "guidellm",
+  paramsSchema: guidellmParamsSchema,
+  reportSchema: guidellmReportSchema,
+  paramDefaults: guidellmParamDefaults,
+  buildCommand,
+  parseProgress,
+  parseFinalReport,
+};
+
+export type { GuidellmParams, GuidellmReport } from "./schema.js";

--- a/packages/tool-adapters/src/guidellm/index.ts
+++ b/packages/tool-adapters/src/guidellm/index.ts
@@ -1,6 +1,6 @@
 import type { ToolAdapter } from "../core/interface.js";
-import { guidellmParamsSchema, guidellmReportSchema, guidellmParamDefaults } from "./schema.js";
 import { buildCommand, parseFinalReport, parseProgress } from "./runtime.js";
+import { guidellmParamDefaults, guidellmParamsSchema, guidellmReportSchema } from "./schema.js";
 
 export const guidellmAdapter: ToolAdapter = {
   name: "guidellm",

--- a/packages/tool-adapters/src/guidellm/runtime.ts
+++ b/packages/tool-adapters/src/guidellm/runtime.ts
@@ -16,9 +16,6 @@ export function parseProgress(_line: string): ProgressEvent | null {
   throw new Error(NOT_IMPLEMENTED);
 }
 
-export function parseFinalReport(
-  _stdout: string,
-  _files: Record<string, Buffer>,
-): ToolReport {
+export function parseFinalReport(_stdout: string, _files: Record<string, Buffer>): ToolReport {
   throw new Error(NOT_IMPLEMENTED);
 }

--- a/packages/tool-adapters/src/guidellm/runtime.ts
+++ b/packages/tool-adapters/src/guidellm/runtime.ts
@@ -1,0 +1,24 @@
+import type {
+  BuildCommandPlan,
+  BuildCommandResult,
+  ProgressEvent,
+  ToolReport,
+} from "../core/interface.js";
+import type { GuidellmParams } from "./schema.js";
+
+const NOT_IMPLEMENTED = "guidellm runtime is implemented in Phase 3 (PR 53.3)";
+
+export function buildCommand(_plan: BuildCommandPlan<GuidellmParams>): BuildCommandResult {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export function parseProgress(_line: string): ProgressEvent | null {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export function parseFinalReport(
+  _stdout: string,
+  _files: Record<string, Buffer>,
+): ToolReport {
+  throw new Error(NOT_IMPLEMENTED);
+}

--- a/packages/tool-adapters/src/guidellm/schema.spec.ts
+++ b/packages/tool-adapters/src/guidellm/schema.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { guidellmParamsSchema, guidellmReportSchema, guidellmParamDefaults } from "./schema.js";
+import { guidellmParamDefaults, guidellmParamsSchema, guidellmReportSchema } from "./schema.js";
 
 describe("guidellmParamsSchema", () => {
   it("requires datasetInputTokens/Output when datasetName=random", () => {

--- a/packages/tool-adapters/src/guidellm/schema.spec.ts
+++ b/packages/tool-adapters/src/guidellm/schema.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { guidellmParamsSchema, guidellmReportSchema, guidellmParamDefaults } from "./schema.js";
+
+describe("guidellmParamsSchema", () => {
+  it("requires datasetInputTokens/Output when datasetName=random", () => {
+    const r = guidellmParamsSchema.safeParse({
+      profile: "throughput",
+      apiType: "chat",
+      datasetName: "random",
+      requestRate: 0,
+      totalRequests: 100,
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const messages = r.error.issues.map((i) => i.message);
+      expect(messages.some((m) => m.includes("random dataset"))).toBe(true);
+    }
+  });
+
+  it("accepts a fully-specified random dataset config", () => {
+    const r = guidellmParamsSchema.safeParse({
+      profile: "throughput",
+      apiType: "chat",
+      datasetName: "random",
+      datasetInputTokens: 256,
+      datasetOutputTokens: 128,
+      requestRate: 0,
+      totalRequests: 1000,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("paramDefaults is a parseable params object skeleton", () => {
+    // The defaults object is a starting point for the FE form — not all
+    // required fields are present (e.g. datasetInputTokens for random).
+    expect(typeof guidellmParamDefaults).toBe("object");
+  });
+});
+
+describe("guidellmReportSchema", () => {
+  it("rejects a report missing required latency dist fields", () => {
+    const r = guidellmReportSchema.safeParse({});
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a fully-shaped report", () => {
+    const dist = { mean: 1, p50: 1, p90: 1, p95: 1, p99: 1 };
+    const r = guidellmReportSchema.safeParse({
+      ttft: dist,
+      itl: dist,
+      e2eLatency: dist,
+      requestsPerSecond: { mean: 1 },
+      outputTokensPerSecond: { mean: 1 },
+      inputTokensPerSecond: { mean: 1 },
+      totalTokensPerSecond: { mean: 1 },
+      concurrency: { mean: 1, max: 1 },
+      requests: { total: 1, success: 1, error: 0, incomplete: 0 },
+    });
+    expect(r.success).toBe(true);
+  });
+});

--- a/packages/tool-adapters/src/guidellm/schema.ts
+++ b/packages/tool-adapters/src/guidellm/schema.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+
+export const guidellmParamsSchema = z
+  .object({
+    profile: z.enum([
+      "throughput",
+      "latency",
+      "long_context",
+      "generation_heavy",
+      "sharegpt",
+      "custom",
+    ]),
+    apiType: z.enum(["chat", "completion"]),
+    datasetName: z.enum(["random", "sharegpt"]),
+    datasetInputTokens: z.number().int().positive().optional(),
+    datasetOutputTokens: z.number().int().positive().optional(),
+    datasetSeed: z.number().int().optional(),
+    requestRate: z.number().int().min(0).default(0),
+    totalRequests: z.number().int().min(1).max(100_000).default(1000),
+    maxDurationSeconds: z.number().int().positive().default(1800),
+    maxConcurrency: z.number().int().positive().default(100),
+    processor: z.string().optional(),
+    validateBackend: z.boolean().default(true),
+  })
+  .superRefine((d, ctx) => {
+    if (d.datasetName === "random" && (!d.datasetInputTokens || !d.datasetOutputTokens)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "random dataset requires datasetInputTokens and datasetOutputTokens",
+      });
+    }
+  });
+export type GuidellmParams = z.infer<typeof guidellmParamsSchema>;
+
+const dist = z.object({
+  mean: z.number(),
+  p50: z.number(),
+  p90: z.number(),
+  p95: z.number(),
+  p99: z.number(),
+});
+
+export const guidellmReportSchema = z.object({
+  ttft: dist,
+  itl: dist,
+  e2eLatency: dist,
+  requestsPerSecond: z.object({ mean: z.number() }),
+  outputTokensPerSecond: z.object({ mean: z.number() }),
+  inputTokensPerSecond: z.object({ mean: z.number() }),
+  totalTokensPerSecond: z.object({ mean: z.number() }),
+  concurrency: z.object({ mean: z.number(), max: z.number() }),
+  requests: z.object({
+    total: z.number().int(),
+    success: z.number().int(),
+    error: z.number().int(),
+    incomplete: z.number().int(),
+  }),
+});
+export type GuidellmReport = z.infer<typeof guidellmReportSchema>;
+
+// Skeleton for FE form prefill. NOT fully valid (datasetInputTokens is
+// required for random dataset). Frontend layer fills the gaps from user
+// input before submit.
+export const guidellmParamDefaults: Partial<GuidellmParams> = {
+  profile: "throughput",
+  apiType: "chat",
+  datasetName: "random",
+  requestRate: 0,
+  totalRequests: 1000,
+  maxDurationSeconds: 1800,
+  maxConcurrency: 100,
+  validateBackend: true,
+};

--- a/packages/tool-adapters/src/index.ts
+++ b/packages/tool-adapters/src/index.ts
@@ -1,0 +1,13 @@
+// Full adapter export. Imported by apps/api.
+
+export * from "./core/interface.js";
+export * from "./core/registry.js";
+export * from "./core/progress-event.js";
+
+export { guidellmAdapter } from "./guidellm/index.js";
+export { vegetaAdapter } from "./vegeta/index.js";
+export { genaiPerfAdapter } from "./genai-perf/index.js";
+
+// Re-export schemas + types for convenience (so `apps/api` doesn't need to
+// reach into subpaths to validate `req.params`).
+export * from "./schemas-entry.js";

--- a/packages/tool-adapters/src/schemas-entry.spec.ts
+++ b/packages/tool-adapters/src/schemas-entry.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import * as schemas from "./schemas-entry.js";
+
+describe("schemas-entry", () => {
+  it("exports guidellm schemas", () => {
+    expect(schemas.guidellmParamsSchema).toBeDefined();
+    expect(schemas.guidellmReportSchema).toBeDefined();
+  });
+
+  it("exports vegeta schemas", () => {
+    expect(schemas.vegetaParamsSchema).toBeDefined();
+    expect(schemas.vegetaReportSchema).toBeDefined();
+  });
+
+  it("exports genai-perf schemas", () => {
+    expect(schemas.genaiPerfParamsSchema).toBeDefined();
+    expect(schemas.genaiPerfReportSchema).toBeDefined();
+  });
+
+  it("does NOT export adapter (which contains runtime)", () => {
+    // Adapter object aggregates runtime fns; the schema-entry must not.
+    // (TypeScript-level guard; this assertion is a runtime safety net.)
+    expect((schemas as Record<string, unknown>).guidellmAdapter).toBeUndefined();
+    expect((schemas as Record<string, unknown>).vegetaAdapter).toBeUndefined();
+    expect((schemas as Record<string, unknown>).genaiPerfAdapter).toBeUndefined();
+  });
+});

--- a/packages/tool-adapters/src/schemas-entry.ts
+++ b/packages/tool-adapters/src/schemas-entry.ts
@@ -1,0 +1,34 @@
+// Schema-only entry point. Imported by the frontend (and any other
+// consumer that doesn't need the runtime side of adapters).
+//
+// IMPORTANT: do NOT import anything from `runtime.ts` files transitively
+// from this entry point. We don't want `child_process` / `fs` / etc to
+// be reachable from the FE bundle. Keep this file's imports limited to
+// schema files.
+
+export {
+  guidellmParamsSchema,
+  guidellmReportSchema,
+  guidellmParamDefaults,
+  type GuidellmParams,
+  type GuidellmReport,
+} from "./guidellm/schema.js";
+
+export {
+  vegetaParamsSchema,
+  vegetaReportSchema,
+  vegetaParamDefaults,
+  type VegetaParams,
+  type VegetaReport,
+} from "./vegeta/schema.js";
+
+export {
+  genaiPerfParamsSchema,
+  genaiPerfReportSchema,
+  genaiPerfParamDefaults,
+  type GenaiPerfParams,
+  type GenaiPerfReport,
+} from "./genai-perf/schema.js";
+
+export type { ToolName, ProgressEvent, ToolReport } from "./core/interface.js";
+export { progressEventSchema } from "./core/progress-event.js";

--- a/packages/tool-adapters/src/vegeta/index.ts
+++ b/packages/tool-adapters/src/vegeta/index.ts
@@ -1,0 +1,15 @@
+import type { ToolAdapter } from "../core/interface.js";
+import { vegetaParamsSchema, vegetaReportSchema, vegetaParamDefaults } from "./schema.js";
+import { buildCommand, parseFinalReport, parseProgress } from "./runtime.js";
+
+export const vegetaAdapter: ToolAdapter = {
+  name: "vegeta",
+  paramsSchema: vegetaParamsSchema,
+  reportSchema: vegetaReportSchema,
+  paramDefaults: vegetaParamDefaults,
+  buildCommand,
+  parseProgress,
+  parseFinalReport,
+};
+
+export type { VegetaParams, VegetaReport } from "./schema.js";

--- a/packages/tool-adapters/src/vegeta/index.ts
+++ b/packages/tool-adapters/src/vegeta/index.ts
@@ -1,6 +1,6 @@
 import type { ToolAdapter } from "../core/interface.js";
-import { vegetaParamsSchema, vegetaReportSchema, vegetaParamDefaults } from "./schema.js";
 import { buildCommand, parseFinalReport, parseProgress } from "./runtime.js";
+import { vegetaParamDefaults, vegetaParamsSchema, vegetaReportSchema } from "./schema.js";
 
 export const vegetaAdapter: ToolAdapter = {
   name: "vegeta",

--- a/packages/tool-adapters/src/vegeta/runtime.ts
+++ b/packages/tool-adapters/src/vegeta/runtime.ts
@@ -19,9 +19,6 @@ export function parseProgress(_line: string): ProgressEvent | null {
   throw new Error(NOT_IMPLEMENTED);
 }
 
-export function parseFinalReport(
-  _stdout: string,
-  _files: Record<string, Buffer>,
-): ToolReport {
+export function parseFinalReport(_stdout: string, _files: Record<string, Buffer>): ToolReport {
   throw new Error(NOT_IMPLEMENTED);
 }

--- a/packages/tool-adapters/src/vegeta/runtime.ts
+++ b/packages/tool-adapters/src/vegeta/runtime.ts
@@ -1,0 +1,27 @@
+import type {
+  BuildCommandPlan,
+  BuildCommandResult,
+  ProgressEvent,
+  ToolReport,
+} from "../core/interface.js";
+import type { VegetaParams } from "./schema.js";
+
+const NOT_IMPLEMENTED = "vegeta runtime is implemented in Phase 3 (PR 53.3)";
+
+export function buildCommand(_plan: BuildCommandPlan<VegetaParams>): BuildCommandResult {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export function parseProgress(_line: string): ProgressEvent | null {
+  // vegeta has no native progress emission — final shape will return null
+  // unconditionally. We still throw here so the stub is uniform with the
+  // other adapters; Phase 3 replaces this with `return null`.
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export function parseFinalReport(
+  _stdout: string,
+  _files: Record<string, Buffer>,
+): ToolReport {
+  throw new Error(NOT_IMPLEMENTED);
+}

--- a/packages/tool-adapters/src/vegeta/schema.spec.ts
+++ b/packages/tool-adapters/src/vegeta/schema.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { vegetaParamsSchema, vegetaReportSchema, vegetaParamDefaults } from "./schema.js";
+import { vegetaParamDefaults, vegetaParamsSchema, vegetaReportSchema } from "./schema.js";
 
 describe("vegetaParamsSchema", () => {
   it("rejects rate=0", () => {

--- a/packages/tool-adapters/src/vegeta/schema.spec.ts
+++ b/packages/tool-adapters/src/vegeta/schema.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { vegetaParamsSchema, vegetaReportSchema, vegetaParamDefaults } from "./schema.js";
+
+describe("vegetaParamsSchema", () => {
+  it("rejects rate=0", () => {
+    const r = vegetaParamsSchema.safeParse({ apiType: "chat", rate: 0, duration: 30 });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects duration > 3600", () => {
+    const r = vegetaParamsSchema.safeParse({ apiType: "chat", rate: 10, duration: 3601 });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a typical config", () => {
+    const r = vegetaParamsSchema.safeParse({ apiType: "chat", rate: 10, duration: 60 });
+    expect(r.success).toBe(true);
+  });
+
+  it("paramDefaults is a parseable starter", () => {
+    expect(typeof vegetaParamDefaults).toBe("object");
+  });
+});
+
+describe("vegetaReportSchema", () => {
+  it("requires latency distribution", () => {
+    const r = vegetaReportSchema.safeParse({});
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a typical vegeta report shape", () => {
+    const r = vegetaReportSchema.safeParse({
+      requests: { total: 100, rate: 10, throughput: 9.5 },
+      duration: { totalSeconds: 10.5, attackSeconds: 10, waitSeconds: 0.5 },
+      latencies: { min: 1, mean: 5, p50: 4, p90: 9, p95: 12, p99: 18, max: 24 },
+      bytesIn: { total: 1024, mean: 10.24 },
+      bytesOut: { total: 512, mean: 5.12 },
+      success: 100,
+      statusCodes: { "200": 100 },
+      errors: [],
+    });
+    expect(r.success).toBe(true);
+  });
+});

--- a/packages/tool-adapters/src/vegeta/schema.ts
+++ b/packages/tool-adapters/src/vegeta/schema.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+export const vegetaParamsSchema = z.object({
+  apiType: z.enum(["chat", "embeddings", "rerank", "images", "chat-vision", "chat-audio"]),
+  rate: z.number().int().min(1).max(10_000),
+  duration: z.number().int().min(1).max(3_600),
+});
+export type VegetaParams = z.infer<typeof vegetaParamsSchema>;
+
+const vegetaLatencyDist = z.object({
+  // All fields are normalized to milliseconds (number). The runtime
+  // parser converts vegeta's mixed-unit text output ("45.6ms" / "1.2s" /
+  // "300µs") to ms before validation.
+  min: z.number(),
+  mean: z.number(),
+  p50: z.number(),
+  p90: z.number(),
+  p95: z.number(),
+  p99: z.number(),
+  max: z.number(),
+});
+
+export const vegetaReportSchema = z.object({
+  requests: z.object({
+    total: z.number().int(),
+    rate: z.number(),
+    throughput: z.number(),
+  }),
+  duration: z.object({
+    totalSeconds: z.number(),
+    attackSeconds: z.number(),
+    waitSeconds: z.number(),
+  }),
+  latencies: vegetaLatencyDist,
+  bytesIn: z.object({ total: z.number().int(), mean: z.number() }),
+  bytesOut: z.object({ total: z.number().int(), mean: z.number() }),
+  // Success is a percent in [0, 100], NOT a 0-1 ratio (matches vegeta CLI).
+  success: z.number(),
+  statusCodes: z.record(z.number().int()),
+  errors: z.array(z.string()),
+});
+export type VegetaReport = z.infer<typeof vegetaReportSchema>;
+
+export const vegetaParamDefaults: Partial<VegetaParams> = {
+  apiType: "chat",
+  rate: 10,
+  duration: 30,
+};

--- a/packages/tool-adapters/tsconfig.build.json
+++ b/packages/tool-adapters/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/tool-adapters/tsconfig.json
+++ b/packages/tool-adapters/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,15 @@ importers:
         specifier: ^3.23
         version: 3.25.76
 
+  packages/tool-adapters:
+    dependencies:
+      '@modeldoctor/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+      zod:
+        specifier: ^3.23
+        version: 3.25.76
+
 packages:
 
   '@adobe/css-tools@4.4.4':


### PR DESCRIPTION
## Summary
- Adds `packages/tool-adapters/` with subpath exports (`.` for backend, `./schemas` for frontend)
- Defines `ToolAdapter` interface, `BuildCommandResult`, `ProgressEvent`, `ToolReport` discriminated union (D 立场: per-tool typed reports, no canonical layer)
- Lands schema-complete adapters for guidellm / vegeta / genai-perf with runtime stubs (filled in PR 53.3 / 53.4)
- Adds `byTool()` / `allAdapters()` registry

## Why this is small
Just package skeleton + schemas + stubs. No api/runner integration yet.
- PR 53.2 wires up the \`RunService\`, callback v2, and DB migration.
- PR 53.3 fills in guidellm + vegeta runtime + rewrites the runner image.
- PR 53.4 fills in genai-perf and verifies the acceptance gate (this file's \`core/interface.ts\` must be untouched).

## Test plan
- [x] \`pnpm -F @modeldoctor/tool-adapters test\` — 24 tests pass (16 schema specs across 3 tools, 4 registry, 4 schemas-entry hygiene)
- [x] \`pnpm -F @modeldoctor/tool-adapters build\` — emits CJS dist with both subpath entries (\`dist/index.{js,d.ts}\`, \`dist/schemas-entry.{js,d.ts}\`, plus per-tool dist subdirs)
- [x] \`pnpm -F @modeldoctor/tool-adapters type-check\` clean
- [x] \`pnpm -F @modeldoctor/tool-adapters lint\` clean
- [x] FE bundle hygiene empirically verified: \`require('./dist/schemas-entry.js')\` exposes only zod schemas + types; no adapter objects, no \`byTool\`/\`allAdapters\`. Codified by \`schemas-entry.spec.ts\` regression guard.

## Acceptance gate (Phase 4)
\`packages/tool-adapters/src/core/interface.ts\` is the load-bearing contract. PR 53.4 must add genai-perf without touching this file (\`git diff main -- core/interface.ts\` must be empty).

## Related
- Issue: #53
- Spec: \`docs/superpowers/specs/2026-05-02-issue-53-tool-adapter-framework-design.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)