### PR TITLE
fix(#53): PR #74 review follow-ups

### DIFF
--- a/apps/api/src/modules/run/run.controller.spec.ts
+++ b/apps/api/src/modules/run/run.controller.spec.ts
@@ -30,6 +30,7 @@ vi.mock("@modeldoctor/tool-adapters", async (orig) => {
       }),
       parseProgress: () => null,
       parseFinalReport: () => ({ tool: "guidellm", data: {} }),
+      getMaxDurationSeconds: () => 1800,
     }),
   };
 });

--- a/apps/benchmark-runner/runner/main.py
+++ b/apps/benchmark-runner/runner/main.py
@@ -15,12 +15,20 @@ import subprocess
 import sys
 import threading
 import time
+from collections import deque
 from pathlib import Path
 
 from runner.callback import post_finish, post_log_batch, post_state_running
 
 LOG_BATCH_INTERVAL_SEC = 0.25
 LOG_LINE_MAX_BYTES = 64 * 1024
+# Bounds the /finish POST body and runner RSS for long-running benchmarks.
+# /finish's stdout/stderr role is post-mortem only (/log already streamed
+# everything live), so 64 KB per stream is sufficient for triage.
+LOG_TAIL_MAX_BYTES = 64 * 1024  # per stream
+# vegeta attack.bin for a long load test can exceed 100 MB; base64-encoding
+# that entirely in memory would OOM the runner process.
+OUTPUT_FILE_MAX_BYTES = 50 * 1024 * 1024  # per output file
 
 logging.basicConfig(level=logging.INFO, format="[runner] %(message)s")
 log = logging.getLogger("runner")
@@ -36,7 +44,8 @@ class StreamPump:
         self.token = token
         self.run_id = run_id
         self.buffer: list[str] = []
-        self.full: list[str] = []
+        self.full: deque[str] = deque()
+        self.full_bytes: int = 0
         self._stop = threading.Event()
 
     def run(self) -> None:
@@ -51,6 +60,14 @@ class StreamPump:
                 line = repr(line_bytes)
             line = line.rstrip("\n")[:LOG_LINE_MAX_BYTES]
             self.full.append(line)
+            # +1 accounts for the \n that "\n".join(...) will reinsert on
+            # read — keeps the byte accounting consistent with the output size.
+            self.full_bytes += len(line.encode("utf-8")) + 1
+            # Evict oldest lines until we are within the tail-byte cap so that
+            # a 30-min benchmark's worth of progress output cannot exhaust RSS.
+            while self.full_bytes > LOG_TAIL_MAX_BYTES and self.full:
+                evicted = self.full.popleft()
+                self.full_bytes -= len(evicted.encode("utf-8")) + 1
             self.buffer.append(line)
             now = time.monotonic()
             if now - last_flush >= LOG_BATCH_INTERVAL_SEC:
@@ -142,12 +159,25 @@ def main() -> int:
     files_b64: dict[str, str] = {}
     for alias, rel_path in output_files.items():
         full = Path.cwd() / rel_path
-        if full.exists():
-            files_b64[alias] = base64.b64encode(full.read_bytes()).decode("ascii")
+        if not full.exists():
+            continue
+        size = full.stat().st_size
+        if size > OUTPUT_FILE_MAX_BYTES:
+            log.warning(
+                "output file %s (%d bytes) exceeds %d byte cap; skipping",
+                alias,
+                size,
+                OUTPUT_FILE_MAX_BYTES,
+            )
+            continue
+        files_b64[alias] = base64.b64encode(full.read_bytes()).decode("ascii")
 
     state = "completed" if proc.returncode == 0 else "failed"
     message = None if state == "completed" else f"tool exited with code {proc.returncode}"
 
+    # Snapshot deques into lists in case a daemon pump thread is still
+    # alive after join(timeout=5) — protects against "deque mutated
+    # during iteration" RuntimeError under unusual EOF behavior.
     try:
         post_finish(
             callback_url=callback_url,
@@ -155,8 +185,8 @@ def main() -> int:
             run_id=run_id,
             state=state,
             exit_code=proc.returncode,
-            stdout="\n".join(out_pump.full),
-            stderr="\n".join(err_pump.full),
+            stdout="\n".join(list(out_pump.full)),
+            stderr="\n".join(list(err_pump.full)),
             files=files_b64,
             message=message,
         )

--- a/apps/benchmark-runner/tests/test_main.py
+++ b/apps/benchmark-runner/tests/test_main.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import base64
 import io
 import json
+import logging
 import os
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -174,20 +175,22 @@ def test_log_batches_posted_with_correct_kwargs(
     assert "line two" in all_lines
     assert "line three" in all_lines
 
-    # And /finish should include the full uncapped stdout (no _STDOUT_TAIL_BYTES cap).
+    # And /finish should include the tail stdout (within LOG_TAIL_MAX_BYTES).
     finish_kwargs = patched_callbacks["post_finish"].call_args.kwargs
     assert finish_kwargs["stdout"] == "line one\nline two\nline three"
 
 
-def test_full_stdout_is_uncapped_on_finish(
+def test_stdout_tail_caps_at_64kb(
     patched_callbacks: dict[str, MagicMock],
     md_env_minimal: dict[str, str],
     mocker: MockerFixture,
 ) -> None:
-    """The new wrapper does NOT cap stdout/stderr; full buffers ship on /finish."""
+    """StreamPump.full is bounded at LOG_TAIL_MAX_BYTES; /finish receives the tail."""
     mocker.patch.dict("os.environ", md_env_minimal, clear=True)
-    # 100 KB of stdout — well beyond the legacy 16 KB cap.
-    big = (b"x" * 1023 + b"\n") * 100
+    # Build 200 distinguishable lines (~1 KB each) so we can prove FIFO
+    # eviction: the first lines must be dropped, the last must survive.
+    lines_in = [f"line-{i:04d}-" + "x" * (1023 - 11) for i in range(200)]
+    big = ("\n".join(lines_in) + "\n").encode("utf-8")
     proc = _fake_proc(stdout=big, stderr=b"", returncode=0)
     mocker.patch("runner.main.subprocess.Popen", return_value=proc)
 
@@ -195,10 +198,32 @@ def test_full_stdout_is_uncapped_on_finish(
 
     assert rc == 0
     finish_kwargs = patched_callbacks["post_finish"].call_args.kwargs
-    # The pump strips trailing \n per line and joins with \n, so length is
-    # very close to the input but not a perfect equality. Crucially: well
-    # over 16 KB.
-    assert len(finish_kwargs["stdout"].encode("utf-8")) > 16 * 1024
+    captured = finish_kwargs["stdout"]
+    captured_bytes = len(captured.encode("utf-8"))
+    # Upper bound: the join produces N-1 newlines, so the on-the-wire
+    # bytes are always strictly less than the cap. The +1 accounting in
+    # StreamPump charges +1 per line (for the join newline), so once we
+    # evict to fit the cap, the actual bytes are ≤ cap - 1.
+    assert captured_bytes <= main_mod.LOG_TAIL_MAX_BYTES, (
+        f"stdout {captured_bytes} bytes exceeded cap {main_mod.LOG_TAIL_MAX_BYTES}"
+    )
+    # Lower bound: the buffer should actually be near-full — fed 200 KB,
+    # expect the tail to be within 1 KB of the cap (room for the last
+    # partial line eviction).
+    assert captured_bytes >= main_mod.LOG_TAIL_MAX_BYTES - 1024, (
+        f"stdout {captured_bytes} bytes is suspiciously below cap {main_mod.LOG_TAIL_MAX_BYTES}"
+    )
+
+    captured_lines = captured.split("\n")
+
+    # Tail semantics: the very last input line must be present.
+    assert captured_lines[-1] == lines_in[-1], "last input line should be preserved"
+
+    # FIFO eviction: the very first input line must be evicted.
+    assert "line-0000" not in captured, "first input line should have been evicted from tail"
+
+    # Sanity: many lines were dropped overall.
+    assert len(captured_lines) < 200, "tail should have evicted most lines"
 
 
 def test_redaction_in_log_line(
@@ -248,6 +273,40 @@ def test_redacted_helper_redacts_backend_kwargs() -> None:
     out = main_mod._redacted(argv)
     assert out[0] == "guidellm"
     assert out[1] == "--backend-kwargs=***REDACTED***"
+
+
+def test_oversized_output_file_skipped_with_warning(
+    patched_callbacks: dict[str, MagicMock],
+    md_env_minimal: dict[str, str],
+    mocker: MockerFixture,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Output files over OUTPUT_FILE_MAX_BYTES are skipped rather than OOMing."""
+    md_env_minimal["MD_OUTPUT_FILES"] = json.dumps({"attack": "attack.bin"})
+    mocker.patch.dict("os.environ", md_env_minimal, clear=True)
+
+    # Write a small file but lower the cap to 1 KB so the test stays fast.
+    big_file = tmp_path / "attack.bin"
+    big_file.write_bytes(b"B" * 2048)  # 2 KB — over the patched 1 KB cap
+    mocker.patch("runner.main.os.getcwd", return_value=str(tmp_path))
+    mocker.patch("runner.main.Path.cwd", return_value=tmp_path)
+    mocker.patch("runner.main.OUTPUT_FILE_MAX_BYTES", 1024)
+
+    proc = _fake_proc(stdout=b"", stderr=b"", returncode=0)
+    mocker.patch("runner.main.subprocess.Popen", return_value=proc)
+
+    with caplog.at_level("WARNING", logger="runner"):
+        rc = main_mod.main()
+
+    assert rc == 0
+    files = patched_callbacks["post_finish"].call_args.kwargs["files"]
+    assert "attack" not in files, "oversized file must not appear in /finish files"
+
+    warning_messages = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("exceeds" in msg and "attack" in msg for msg in warning_messages), (
+        f"expected a warning about 'attack' exceeding cap; got: {warning_messages}"
+    )
 
 
 def test_materialize_input_files_symlinks_into_cwd(

--- a/packages/tool-adapters/src/vegeta/__fixtures__/report-composite.txt
+++ b/packages/tool-adapters/src/vegeta/__fixtures__/report-composite.txt
@@ -1,0 +1,8 @@
+Requests      [total, rate, throughput]         200, 10.10, 9.95
+Duration      [total, attack, wait]             5m12.3s, 5m10s, 2.3s
+Latencies     [min, mean, 50, 90, 95, 99, max]  100µs, 1m30s, 2m, 1h2m, 1h2m3s, 90s, 102ms
+Bytes In      [total, mean]                     90000, 450.00
+Bytes Out     [total, mean]                     24000, 120.00
+Success       [ratio]                           98.00%
+Status Codes  [code:count]                      200:196  500:4
+Error Set:

--- a/packages/tool-adapters/src/vegeta/runtime.spec.ts
+++ b/packages/tool-adapters/src/vegeta/runtime.spec.ts
@@ -6,6 +6,9 @@ import { buildCommand, parseFinalReport, parseProgress } from "./runtime.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const fixtureBuf = fs.readFileSync(path.join(__dirname, "__fixtures__/report.txt"));
+const compositeFixtureBuf = fs.readFileSync(
+  path.join(__dirname, "__fixtures__/report-composite.txt"),
+);
 
 const baseConn = {
   baseUrl: "http://localhost:8000",
@@ -79,5 +82,55 @@ describe("vegeta.parseFinalReport", () => {
 
   it("throws when 'report' file is missing", () => {
     expect(() => parseFinalReport("", {})).toThrow();
+  });
+});
+
+describe("vegeta.parseFinalReport — composite Go durations", () => {
+  it("parses composite latencies (1m30s, 2m, 1h2m) from fixture", () => {
+    const result = parseFinalReport("", { report: compositeFixtureBuf });
+    expect(result.tool).toBe("vegeta");
+    // 100µs → 0.1 ms
+    expect(result.data.latencies.min).toBeCloseTo(0.1, 6);
+    // 1m30s → 90000 ms
+    expect(result.data.latencies.mean).toBeCloseTo(90000, 0);
+    // 2m → 120000 ms
+    expect(result.data.latencies.p50).toBeCloseTo(120000, 0);
+    // 1h2m → 3720000 ms
+    expect(result.data.latencies.p90).toBeCloseTo(3720000, 0);
+    // 1h2m3s → 3723000 ms
+    expect(result.data.latencies.p95).toBeCloseTo(3723000, 0);
+    // 90s → 90000 ms
+    expect(result.data.latencies.p99).toBeCloseTo(90000, 0);
+    // 102ms → 102 ms
+    expect(result.data.latencies.max).toBeCloseTo(102, 0);
+  });
+
+  it("parses composite duration total (5m12.3s) correctly", () => {
+    const result = parseFinalReport("", { report: compositeFixtureBuf });
+    // 5m12.3s = 312.3 s
+    expect(result.data.duration.totalSeconds).toBeCloseTo(312.3, 3);
+    // 5m10s = 310 s
+    expect(result.data.duration.attackSeconds).toBeCloseTo(310, 3);
+    // 2.3s
+    expect(result.data.duration.waitSeconds).toBeCloseTo(2.3, 3);
+  });
+
+  it("parseDurationToSeconds handles µs input (was broken: returned NaN)", () => {
+    // This tests the previously-broken parseDurationToSeconds path via
+    // a report where the wait value is in µs (sub-millisecond wait).
+    const reportWithMicrosecondWait = [
+      "Requests      [total, rate, throughput]         10, 10.00, 9.90",
+      "Duration      [total, attack, wait]             1.005s, 1s, 500µs",
+      "Latencies     [min, mean, 50, 90, 95, 99, max]  1ms, 2ms, 2ms, 3ms, 4ms, 5ms, 6ms",
+      "Bytes In      [total, mean]                     1000, 100.00",
+      "Bytes Out     [total, mean]                     500, 50.00",
+      "Success       [ratio]                           100.00%",
+      "Status Codes  [code:count]                      200:10",
+    ].join("\n");
+    const result = parseFinalReport("", {
+      report: Buffer.from(reportWithMicrosecondWait),
+    });
+    // 500µs = 0.0005 s
+    expect(result.data.duration.waitSeconds).toBeCloseTo(0.0005, 6);
   });
 });

--- a/packages/tool-adapters/src/vegeta/runtime.ts
+++ b/packages/tool-adapters/src/vegeta/runtime.ts
@@ -88,28 +88,40 @@ export function parseFinalReport(_stdout: string, files: Record<string, Buffer>)
 }
 
 // ── internal: ported from apps/api/src/integrations/parsers/vegeta-report.ts ──
-function parseLatencyToMs(s: string): number {
-  // Accept "1.2µs" (rare), "1.2ms", "1.2s", "1m2.3s" forms. vegeta normally
-  // emits one of µs/ms/s.
-  const m = s.match(/^([0-9.]+)\s*(µs|ms|s)$/);
-  if (!m) return Number.NaN;
-  const v = Number.parseFloat(m[1]);
-  switch (m[2]) {
-    case "µs":
-      return v / 1000;
-    case "ms":
-      return v;
-    case "s":
-      return v * 1000;
-    default:
-      return Number.NaN;
+
+// Walks a Go time.Duration string (e.g. "1h2m3.5s", "500µs", "1m30s")
+// and returns the total in milliseconds.  Returns NaN for empty or malformed input.
+const GO_DURATION_SEGMENT = /([0-9.]+)\s*(µs|ms|s|m|h)/g;
+const UNIT_TO_MS: Record<string, number> = {
+  µs: 0.001,
+  ms: 1,
+  s: 1000,
+  m: 60_000,
+  h: 3_600_000,
+};
+
+function parseGoDurationToMs(s: string): number {
+  let totalMs = 0;
+  let lastEnd = 0;
+  let matched = false;
+  for (const seg of s.matchAll(GO_DURATION_SEGMENT)) {
+    // Reject any non-whitespace gap before this segment (malformed input).
+    if (s.slice(lastEnd, seg.index).trim() !== "") return Number.NaN;
+    totalMs += Number.parseFloat(seg[1]) * (UNIT_TO_MS[seg[2]] ?? Number.NaN);
+    lastEnd = seg.index + seg[0].length;
+    matched = true;
   }
+  // Reject trailing non-whitespace garbage.
+  if (s.slice(lastEnd).trim() !== "") return Number.NaN;
+  return matched ? totalMs : Number.NaN;
 }
+
+function parseLatencyToMs(s: string): number {
+  return parseGoDurationToMs(s.trim());
+}
+
 function parseDurationToSeconds(s: string): number {
-  const m = s.match(/^([0-9.]+)\s*(ms|s)$/);
-  if (!m) return Number.NaN;
-  const v = Number.parseFloat(m[1]);
-  return m[2] === "ms" ? v / 1000 : v;
+  return parseGoDurationToMs(s.trim()) / 1000;
 }
 
 function parseVegetaReportText(report: string): VegetaReport {
@@ -134,7 +146,7 @@ function parseVegetaReportText(report: string): VegetaReport {
       }
     } else if (line.includes("Duration") && line.includes("[total")) {
       const m = line.match(
-        /\]\s+([\d.]+(?:µs|ms|s|m|h)),\s+([\d.]+(?:µs|ms|s|m|h)),\s+([\d.]+(?:µs|ms|s|m|h))/,
+        /\]\s+((?:[\d.]+(?:µs|ms|s|m|h))+),\s+((?:[\d.]+(?:µs|ms|s|m|h))+),\s+((?:[\d.]+(?:µs|ms|s|m|h))+)/,
       );
       if (m) {
         out.duration.totalSeconds = parseDurationToSeconds(m[1]);
@@ -143,7 +155,7 @@ function parseVegetaReportText(report: string): VegetaReport {
       }
     } else if (line.includes("Latencies") && line.includes("[min")) {
       const m = line.match(
-        /\]\s+([\d.]+(?:µs|ms|s|m|h)),\s+([\d.]+(?:µs|ms|s|m|h)),\s+([\d.]+(?:µs|ms|s|m|h)),\s+([\d.]+(?:µs|ms|s|m|h)),\s+([\d.]+(?:µs|ms|s|m|h)),\s+([\d.]+(?:µs|ms|s|m|h)),\s+([\d.]+(?:µs|ms|s|m|h))/,
+        /\]\s+((?:[\d.]+(?:µs|ms|s|m|h))+),\s+((?:[\d.]+(?:µs|ms|s|m|h))+),\s+((?:[\d.]+(?:µs|ms|s|m|h))+),\s+((?:[\d.]+(?:µs|ms|s|m|h))+),\s+((?:[\d.]+(?:µs|ms|s|m|h))+),\s+((?:[\d.]+(?:µs|ms|s|m|h))+),\s+((?:[\d.]+(?:µs|ms|s|m|h))+)/,
       );
       if (m) {
         out.latencies.min = parseLatencyToMs(m[1]);


### PR DESCRIPTION
## Summary

Addresses the four actionable findings from gemini-code-assist[bot] on the merged PR #74 (Phase 3) plus one related test-mock gap surfaced while running the suite.

| Commit | Addresses | Severity |
|---|---|---|
| `7b7fce2` | gemini #5 + #6: vegeta latency / duration parsers silently returned `NaN` for Go-style composite durations (`1m30s`, `1h2m3s`) and for the `µs` / `m` / `h` units the aggregate regex already advertised. Replaces both with one `parseGoDurationToMs` helper that walks all `<num><unit>` segments; aggregate regexes widened to capture full composite tokens. | medium |
| `2017983` | gemini #2 + #4: `StreamPump.full` was unbounded (regression vs. pre-Phase-3 `_STDOUT_TAIL_BYTES = 16 KB`) → OOM on long benchmarks. Now uses `deque[str]` capped at `LOG_TAIL_MAX_BYTES = 64 KB` per stream. Output files larger than `OUTPUT_FILE_MAX_BYTES = 50 MB` (e.g. vegeta `attack.bin` from a 5-min × 100rps run) are now skipped with a warning instead of being base64-encoded into RAM. | high |
| `8a98533` | Pre-existing (Phase 3 missed it): `run.controller.spec.ts`'s `byTool` mock did not implement `getMaxDurationSeconds`, which `RunService.start` started calling in commit `05ab5c9`. Adds the method, unblocks `pnpm -r test`. | low |

**Deferred** (intentionally out of scope, will be retired by issue #54):
- gemini #1 / #3 — `LoadTestController.waitForTerminal` blocks worker thread up to 1h and doesn't cancel on disconnect or run-deletion. Per Phase 3 follow-up note, this whole code path goes away when #54 ships its proper SSE-based progress UI; a 1-line fix here would be wasted churn.

## Test plan

- [x] `pnpm -F @modeldoctor/tool-adapters test --run` — 50/50, including 3 new tests for composite durations + µs duration round-trip
- [x] `apps/benchmark-runner` `pytest -q` — 26/26, including new tail-cap FIFO test (asserts `line-0000` evicted, `line-0199` preserved, captured bytes ≤ 64 KB) and over-cap output-file skip test
- [x] `pnpm -F @modeldoctor/api test --run src/modules/run/run.controller.spec.ts` — 7/7 (was 1 failing pre-PR)
- [x] `pnpm -r test --run` workspace-wide: 932 tests pass (86 contracts + 50 tool-adapters + 458 web + 312 api + 26 runner)
- [x] `pnpm -r build`, `pnpm -r lint`, `pnpm -r format` — clean
- [x] `git diff main -- packages/tool-adapters/src/core/{interface,progress-event,registry}.ts` — empty (Phase 4 keystone preserved)

Closes part of the Phase 3 review thread on PR #74. Phase 4 (genai-perf adapter + acceptance gate) follows on a separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)