### PR TITLE
chore: bring PR #82 from feat/k8s-tools-end-to-end to main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,14 +51,17 @@ BENCHMARK_CALLBACK_SECRET=<replace with: openssl rand -base64 48>
 BENCHMARK_K8S_NAMESPACE=modeldoctor-benchmarks
 
 # Per-tool runner images. Required when BENCHMARK_DRIVER=k8s.
-# Build + import into k3d:
-#   docker build -f apps/benchmark-runner/images/guidellm.Dockerfile   -t md-runner-guidellm:dev3   apps/benchmark-runner/
-#   docker build -f apps/benchmark-runner/images/vegeta.Dockerfile     -t md-runner-vegeta:dev3     apps/benchmark-runner/
-#   docker build -f apps/benchmark-runner/images/genai-perf.Dockerfile -t md-runner-genai-perf:dev3 apps/benchmark-runner/
-#   k3d image import md-runner-guidellm:dev3 md-runner-vegeta:dev3 md-runner-genai-perf:dev3 -c modeldoctor
-RUNNER_IMAGE_GUIDELLM=md-runner-guidellm:dev3
-RUNNER_IMAGE_VEGETA=md-runner-vegeta:dev3
-RUNNER_IMAGE_GENAI_PERF=md-runner-genai-perf:dev3
+#
+# Build + import via the helper script (auto-computes content-addressed
+# tag from `git log -1 --format=%h -- apps/benchmark-runner/`):
+#   ./tools/build-runner-images.sh
+#
+# The script prints the resulting tag at the end. Copy the three
+# RUNNER_IMAGE_* lines it suggests into this .env, OR export
+# RUNNER_IMAGE_TAG=<tag> and use the parametrized form below.
+RUNNER_IMAGE_GUIDELLM=md-runner-guidellm:${RUNNER_IMAGE_TAG:-dev3}
+RUNNER_IMAGE_VEGETA=md-runner-vegeta:${RUNNER_IMAGE_TAG:-dev3}
+RUNNER_IMAGE_GENAI_PERF=md-runner-genai-perf:${RUNNER_IMAGE_TAG:-dev3}
 
 # Optional kubeconfig override for out-of-cluster local dev. Leave unset in
 # production (the API runs as a pod and uses its in-cluster ServiceAccount).

--- a/apps/benchmark-runner/README.md
+++ b/apps/benchmark-runner/README.md
@@ -28,7 +28,19 @@ ruff format --check .   # CI runs this too — `ruff format .` to auto-apply
 (Non-conda contributors can substitute `python3.11 -m venv .venv && source .venv/bin/activate` —
 the project itself is environment-manager-agnostic; only the dev workflow above prefers conda.)
 
-## Building the images
+## Quick build + import
+
+The standard workflow is the helper script at the repo root:
+
+```bash
+./tools/build-runner-images.sh
+```
+
+This computes a content-addressed tag from the runner source's git SHA, builds all three images, and imports them into the local k3d cluster. The script prints the tag and the matching `RUNNER_IMAGE_*` lines for `.env`.
+
+Manual build commands (below) are kept for reference but the script is preferred.
+
+## Building the images (manual, advanced)
 
 Prerequisite: Docker (or Podman with `alias docker=podman`) must be installed and running.
 

--- a/apps/web/src/features/connections/schema.test.ts
+++ b/apps/web/src/features/connections/schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { connectionInputSchema } from "./schema";
+import { connectionInputEditSchema, connectionInputSchema } from "./schema";
 
 describe("connectionInputSchema", () => {
   const valid = {
@@ -106,5 +106,50 @@ describe("connectionInputSchema (category + tags)", () => {
   it("defaults tags to an empty array when omitted", () => {
     const out = connectionInputSchema.parse({ ...baseInput, category: "chat" });
     expect(out.tags).toEqual([]);
+  });
+});
+
+describe("connectionInputEditSchema apiKey refine (edit-mode)", () => {
+  const validBaseInput = {
+    name: "prod-vllm",
+    apiBaseUrl: "http://10.0.0.1:8000",
+    apiKey: "sk-abc",
+    model: "qwen-2.5-7b",
+    customHeaders: "",
+    queryParams: "",
+    tokenizerHfId: "",
+    category: "chat" as const,
+  };
+
+  it("accepts empty apiKey (no-reset signal)", () => {
+    const result = connectionInputEditSchema.safeParse({
+      ...validBaseInput,
+      apiKey: "",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects edit-mode apiKey with control characters when non-empty", () => {
+    const result = connectionInputEditSchema.safeParse({
+      ...validBaseInput,
+      apiKey: "sk-test\nwith-newline",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects edit-mode apiKey with leading whitespace when non-empty", () => {
+    const result = connectionInputEditSchema.safeParse({
+      ...validBaseInput,
+      apiKey: " sk-test",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts edit-mode apiKey with shell metacharacters (POSIX expansion is safe)", () => {
+    const result = connectionInputEditSchema.safeParse({
+      ...validBaseInput,
+      apiKey: 'sk-test$(rm)`backtick`"quote',
+    });
+    expect(result.success).toBe(true);
   });
 });

--- a/apps/web/src/features/connections/schema.test.ts
+++ b/apps/web/src/features/connections/schema.test.ts
@@ -35,6 +35,29 @@ describe("connectionInputSchema", () => {
     expect(r.success).toBe(false);
   });
 
+  it("rejects apiKey with control characters (e.g. newline from paste)", () => {
+    const r = connectionInputSchema.safeParse({ ...valid, apiKey: "sk-test\nwith-newline" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects apiKey with leading whitespace", () => {
+    const r = connectionInputSchema.safeParse({ ...valid, apiKey: " sk-test" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects apiKey with trailing whitespace", () => {
+    const r = connectionInputSchema.safeParse({ ...valid, apiKey: "sk-test " });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts apiKey with shell metacharacters (POSIX-safe)", () => {
+    const r = connectionInputSchema.safeParse({
+      ...valid,
+      apiKey: 'sk-test$(rm)`backtick`"quote',
+    });
+    expect(r.success).toBe(true);
+  });
+
   it("rejects empty model", () => {
     const r = connectionInputSchema.safeParse({ ...valid, model: "" });
     expect(r.success).toBe(false);

--- a/apps/web/src/features/connections/schema.ts
+++ b/apps/web/src/features/connections/schema.ts
@@ -50,10 +50,19 @@ export const connectionInputCreateSchema = z.object({
 /**
  * Edit-mode form schema. apiKey is optional: when the user did NOT toggle
  * "Reset apiKey", the field is empty and the PATCH body must omit it.
+ * Empty string is the "no-reset" signal and must pass; non-empty values
+ * get the same control-char + edge-whitespace refines as create-mode.
  */
 export const connectionInputEditSchema = z.object({
   ...baseShape,
-  apiKey: z.string(),
+  apiKey: z
+    .string()
+    .refine((v) => v === "" || !/\p{Cc}/u.test(v), {
+      message: "apiKey must not contain control characters",
+    })
+    .refine((v) => v === "" || v === v.trim(), {
+      message: "apiKey must not have leading or trailing whitespace",
+    }),
 });
 
 /** Backwards-compatible alias used by callers that need the create shape. */

--- a/apps/web/src/features/connections/schema.ts
+++ b/apps/web/src/features/connections/schema.ts
@@ -33,7 +33,18 @@ const baseShape = {
  */
 export const connectionInputCreateSchema = z.object({
   ...baseShape,
-  apiKey: z.string().min(1, "required"),
+  // Reject control chars + leading/trailing whitespace at form level
+  // for parity with server-side contract (prevents accidental paste
+  // of token with trailing newline).
+  apiKey: z
+    .string()
+    .min(1, "required")
+    .refine((v) => !/\p{Cc}/u.test(v), {
+      message: "apiKey must not contain control characters",
+    })
+    .refine((v) => v === v.trim(), {
+      message: "apiKey must not have leading or trailing whitespace",
+    }),
 });
 
 /**

--- a/packages/contracts/src/connection.spec.ts
+++ b/packages/contracts/src/connection.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { createConnectionSchema } from "./connection.js";
+
+const validBase = {
+  name: "vllm-prod",
+  baseUrl: "http://10.0.0.1:8000",
+  model: "qwen2.5",
+  customHeaders: "",
+  queryParams: "",
+  category: "chat" as const,
+  tags: [],
+};
+
+describe("createConnectionSchema — apiKey validation", () => {
+  it("accepts a normal apiKey", () => {
+    const result = createConnectionSchema.safeParse({
+      ...validBase,
+      apiKey: "sk-test-abc123",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty apiKey", () => {
+    const result = createConnectionSchema.safeParse({
+      ...validBase,
+      apiKey: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects apiKey with newline (control character)", () => {
+    const result = createConnectionSchema.safeParse({
+      ...validBase,
+      apiKey: "sk-test\nwith-newline",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects apiKey with tab character (control character)", () => {
+    const result = createConnectionSchema.safeParse({
+      ...validBase,
+      apiKey: "sk-test\twith-tab",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects apiKey with leading whitespace", () => {
+    const result = createConnectionSchema.safeParse({
+      ...validBase,
+      apiKey: " sk-test",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects apiKey with trailing whitespace", () => {
+    const result = createConnectionSchema.safeParse({
+      ...validBase,
+      apiKey: "sk-test ",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts apiKey with shell metacharacters (POSIX-safe via parameter expansion)", () => {
+    // POSIX 2.6.5: parameter expansion result is not re-parsed.
+    // These chars are safe in sh -c '... "$VAR" ...'; testing them
+    // at the schema layer confirms we don't over-reject real-world keys.
+    const result = createConnectionSchema.safeParse({
+      ...validBase,
+      apiKey: 'sk-test$(rm)`backtick`"quote',
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/contracts/src/connection.ts
+++ b/packages/contracts/src/connection.ts
@@ -33,7 +33,15 @@ export type ConnectionWithSecret = z.infer<typeof connectionWithSecretSchema>;
 export const createConnectionSchema = z.object({
   name: z.string().min(1).max(120),
   baseUrl: z.string().url(),
-  apiKey: z.string().min(1),
+  apiKey: z
+    .string()
+    .min(1)
+    .refine((v) => !/\p{Cc}/u.test(v), {
+      message: "apiKey must not contain control characters",
+    })
+    .refine((v) => v === v.trim(), {
+      message: "apiKey must not have leading or trailing whitespace",
+    }),
   model: z.string().min(1),
   customHeaders: z.string().default(""),
   queryParams: z.string().default(""),

--- a/packages/tool-adapters/src/genai-perf/runtime.ts
+++ b/packages/tool-adapters/src/genai-perf/runtime.ts
@@ -95,20 +95,29 @@ export function buildCommand(plan: BuildCommandPlan<GenaiPerfParams>): BuildComm
   // $4 = numPrompts, $5 = concurrency, $6 = streaming ("true"|"false")
   // Authorization header is built into the shell script with literal
   // `$OPENAI_API_KEY`, so the secret is expanded by `sh` at exec time
-  // rather than being baked into the K8s pod spec / wrapper argv. The
-  // expanded value WILL appear in the inner genai-perf process argv
-  // (and therefore in /proc/<pid>/cmdline / ps for that process); what
-  // is protected is the wrapper-level argv, the runner log lines
-  // (masked by _redacted), and the K8s Job spec.
+  // rather than being baked into the K8s pod spec / wrapper argv.
   //
-  // Threat-model note: the value is expanded inside a double-quoted
-  // shell string. If the stored apiKey contained shell metacharacters
-  // (`$(...)`, backticks, etc.), the shell would interpret them. This
-  // is accepted because the user controls their own connection's apiKey
-  // — self-injection has no privilege gain over the pod they already own.
-  // Future hardening: route the header through a runner-side argv
-  // substitution (analogous to runner/main.py::_inject_api_key_into_backend_kwargs)
-  // so no shell expansion is involved. Track as follow-up if needed.
+  // Shell-injection safety: POSIX 2.6.5 guarantees that the result of
+  // parameter expansion is NOT subject to further word expansion. So
+  // even if the apiKey contained `$()` or backticks, sh would treat
+  // them as literal characters in the expanded `$OPENAI_API_KEY`. This
+  // has been live-verified — passing apiKey="sk$(touch /tmp/PWN)" via
+  // env to `sh -c '... "$VAR" ...'` does NOT execute the touch.
+  //
+  // The expanded value WILL appear in the inner genai-perf process
+  // argv (visible in /proc/<pid>/cmdline / ps for that process). What
+  // is protected: the wrapper-level argv, the runner log lines (masked
+  // by _redacted), and the K8s Job spec.
+  //
+  // Architectural note: guidellm uses runner-side Python injection
+  // (runner/main.py::_inject_api_key_into_backend_kwargs) instead of
+  // shell expansion. genai-perf uses shell expansion because its
+  // adapter already emits a `sh -c` script (for the STREAMING
+  // conditional + multi-line layout); folding api_key into that
+  // script via `$VAR` is the simplest path. Both routes are POSIX-
+  // safe; the inconsistency is stylistic, not security-relevant.
+  // Defense-in-depth: connection.apiKey is zod-refined to reject
+  // control characters at input boundary (see contracts/connection.ts).
   const script = `set -e
 STREAMING=""
 if [ "$6" = "true" ]; then STREAMING="--streaming"; fi

--- a/tools/build-runner-images.sh
+++ b/tools/build-runner-images.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Build all three benchmark-runner wrapper images and import into the
+# local k3d cluster. Tag is the short git SHA of the most recent commit
+# that touched apps/benchmark-runner/, so devs never need to remember
+# to bump :devN — pulling the branch + running this script always
+# produces a tag that matches the source state.
+#
+# Usage:
+#   ./tools/build-runner-images.sh           # build + import to k3d cluster "modeldoctor"
+#   ./tools/build-runner-images.sh --no-import   # build only, skip k3d import
+#   K3D_CLUSTER=other ./tools/build-runner-images.sh  # different cluster
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Compute content-addressed tag from the latest commit affecting the
+# runner subtree. Falls back to the current HEAD if no path filter
+# matches (e.g. on a fresh worktree before any runner change).
+TAG="$(git log -1 --format=%h -- apps/benchmark-runner/ 2>/dev/null || true)"
+if [[ -z "${TAG:-}" ]]; then
+  TAG="$(git rev-parse --short HEAD)"
+fi
+
+K3D_CLUSTER="${K3D_CLUSTER:-modeldoctor}"
+IMPORT=true
+if [[ "${1:-}" == "--no-import" ]]; then
+  IMPORT=false
+fi
+
+echo "==> Building runner images at tag :$TAG"
+
+for tool in guidellm vegeta genai-perf; do
+  image="md-runner-${tool}:${TAG}"
+  echo "==> docker build $image"
+  docker build \
+    -f "apps/benchmark-runner/images/${tool}.Dockerfile" \
+    -t "$image" \
+    apps/benchmark-runner/
+done
+
+if [[ "$IMPORT" == "true" ]]; then
+  echo "==> k3d image import (cluster: $K3D_CLUSTER)"
+  k3d image import \
+    "md-runner-guidellm:${TAG}" \
+    "md-runner-vegeta:${TAG}" \
+    "md-runner-genai-perf:${TAG}" \
+    -c "$K3D_CLUSTER"
+fi
+
+echo
+echo "==> Done. Set these in your .env (or export RUNNER_IMAGE_TAG=$TAG):"
+echo "RUNNER_IMAGE_GUIDELLM=md-runner-guidellm:${TAG}"
+echo "RUNNER_IMAGE_VEGETA=md-runner-vegeta:${TAG}"
+echo "RUNNER_IMAGE_GENAI_PERF=md-runner-genai-perf:${TAG}"

--- a/tools/build-runner-images.sh
+++ b/tools/build-runner-images.sh
@@ -23,6 +23,15 @@ if [[ -z "${TAG:-}" ]]; then
   TAG="$(git rev-parse --short HEAD)"
 fi
 
+# If there are uncommitted changes in the runner subtree, append a
+# dirty-marker plus a timestamp. Plain `-dirty` would not distinguish
+# two consecutive iterative builds (same tag → docker/k8s cache hits,
+# stale image). Timestamp guarantees each iterative build gets a
+# unique tag so k3d image import + pod restart picks it up.
+if [[ -n "$(git status --porcelain apps/benchmark-runner/)" ]]; then
+  TAG="${TAG}-dirty-$(date +%s)"
+fi
+
 K3D_CLUSTER="${K3D_CLUSTER:-modeldoctor}"
 IMPORT=true
 if [[ "${1:-}" == "--no-import" ]]; then


### PR DESCRIPTION
## Summary

PR #82 (`refactor(runner,adapter): R4 follow-up + content-addressed image tags`) was opened as a stacked PR against `feat/k8s-tools-end-to-end` (which was the live branch for PR #80 at the time). PR #80 merged into main first, then PR #82 merged into the now-orphaned `feat/k8s-tools-end-to-end` — so PR #82's content currently sits on that branch but never flowed to main.

This PR forwards the gap so main matches the post-#82 state.

## Commits being brought across

```
2090f08 Merge pull request #82
45f90ba fix(tools): append dirty-timestamp to image tag when source is uncommitted
4bf7bde fix(web): apply apiKey refine to edit-mode form schema
6db890a feat(tools): content-addressed runner image tag automation
3439a6f feat(api,web): refine apiKey input — reject control chars + edge whitespace
e1d1072 docs(adapter): correct genai-perf R4 shell-safety comment
```

## What's changed (vs. main)

- 8 files, 284 insertions, 26 deletions
- All content originally reviewed + merged via PR #82 (Gemini AI 2 medium-priority comments addressed there)
- No additional code changes in this PR — pure forward-merge of the orphaned content

## Test plan

- [x] All 5 commits already CI-green on PR #82 prior to merge
- [ ] CI re-runs on merged base (main) here

After merge, the stacked branch + all 4 `feat/`+`refactor/` branches from PRs #77, #79, #80, #82 will be cleaned up.