### PR TITLE
feat(web): poll run detail until terminal (closes #57)

### DIFF
--- a/apps/web/src/features/runs/RunDetailPage.tsx
+++ b/apps/web/src/features/runs/RunDetailPage.tsx
@@ -32,7 +32,7 @@ import { toast } from "sonner";
 import { RunDetailMetadata } from "./RunDetailMetadata";
 import { RunDetailRawOutput } from "./RunDetailRawOutput";
 import { SetBaselineDialog } from "./SetBaselineDialog";
-import { runKeys, useDeleteRun } from "./queries";
+import { isTerminalStatus, runKeys, useDeleteRun } from "./queries";
 import { useRunDetail } from "./queries";
 import { GenaiPerfReportView } from "./reports/GenaiPerfReportView";
 import { GuidellmReportView } from "./reports/GuidellmReportView";
@@ -58,8 +58,7 @@ function RunningSection({ run }: { run: Run }) {
   const isPending = run.status === "pending" || run.status === "submitted";
 
   return (
-    <div
-      role="status"
+    <output
       aria-live="polite"
       className="flex flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border p-12 text-center"
     >
@@ -70,7 +69,7 @@ function RunningSection({ run }: { run: Run }) {
       <div className="text-xs text-muted-foreground tabular-nums">
         {t("detail.running.elapsed", { sec: elapsedSec })}
       </div>
-    </div>
+    </output>
   );
 }
 
@@ -173,8 +172,7 @@ export function RunDetailPage() {
   });
 
   const isBaseline = run.baselineFor !== null;
-  const isTerminal =
-    run.status === "completed" || run.status === "failed" || run.status === "canceled";
+  const isTerminal = isTerminalStatus(run.status);
 
   return (
     <>

--- a/apps/web/src/features/runs/RunDetailPage.tsx
+++ b/apps/web/src/features/runs/RunDetailPage.tsx
@@ -24,8 +24,8 @@ import {
 } from "@modeldoctor/tool-adapters/schemas";
 import { useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
-import { ArrowLeft, SearchX } from "lucide-react";
-import { useState } from "react";
+import { ArrowLeft, Loader2, SearchX } from "lucide-react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
@@ -38,6 +38,41 @@ import { GenaiPerfReportView } from "./reports/GenaiPerfReportView";
 import { GuidellmReportView } from "./reports/GuidellmReportView";
 import { UnknownReportView } from "./reports/UnknownReportView";
 import { VegetaReportView } from "./reports/VegetaReportView";
+
+/**
+ * Pre-terminal placeholder rendered while the run is still in flight.
+ * Polls via `useRunDetail`; once the backend writes a terminal status the
+ * parent flips to the metrics + raw-output report layout.
+ */
+function RunningSection({ run }: { run: Run }) {
+  const { t } = useTranslation("runs");
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const handle = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(handle);
+  }, []);
+
+  const startedAt = run.startedAt ?? run.createdAt;
+  const elapsedSec = Math.max(0, Math.floor((now - new Date(startedAt).getTime()) / 1000));
+  const isPending = run.status === "pending" || run.status === "submitted";
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border p-12 text-center"
+    >
+      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" strokeWidth={1.5} />
+      <div className="text-sm font-medium">
+        {isPending ? t("detail.running.pending") : t("detail.running.title")}
+      </div>
+      <div className="text-xs text-muted-foreground tabular-nums">
+        {t("detail.running.elapsed", { sec: elapsedSec })}
+      </div>
+    </div>
+  );
+}
 
 function ReportSection({ metrics }: { metrics: Run["summaryMetrics"] }) {
   const { t } = useTranslation("runs");
@@ -148,15 +183,16 @@ export function RunDetailPage() {
         subtitle={subtitle}
         rightSlot={
           <div className="flex items-center gap-2">
-            {isBaseline ? (
-              <Button variant="secondary" size="sm" onClick={() => setUnsetOpen(true)}>
-                {t("detail.baseline.unsetButton")}
-              </Button>
-            ) : (
-              <Button variant="outline" size="sm" onClick={() => setSetOpen(true)}>
-                {t("detail.baseline.setButton")}
-              </Button>
-            )}
+            {isTerminal &&
+              (isBaseline ? (
+                <Button variant="secondary" size="sm" onClick={() => setUnsetOpen(true)}>
+                  {t("detail.baseline.unsetButton")}
+                </Button>
+              ) : (
+                <Button variant="outline" size="sm" onClick={() => setSetOpen(true)}>
+                  {t("detail.baseline.setButton")}
+                </Button>
+              ))}
             {isTerminal && (
               <Button variant="destructive" size="sm" onClick={() => setDeleteOpen(true)}>
                 {t("detail.delete.button")}
@@ -185,16 +221,22 @@ export function RunDetailPage() {
             </AlertDescription>
           </Alert>
         )}
-        <section>
-          <h3 className="mb-3 text-sm font-semibold">{t("detail.metrics.title")}</h3>
-          <ReportSection metrics={run.summaryMetrics} />
-        </section>
-        <section>
-          <RunDetailRawOutput
-            rawOutput={run.rawOutput as Record<string, unknown> | null}
-            logs={run.logs}
-          />
-        </section>
+        {isTerminal ? (
+          <>
+            <section>
+              <h3 className="mb-3 text-sm font-semibold">{t("detail.metrics.title")}</h3>
+              <ReportSection metrics={run.summaryMetrics} />
+            </section>
+            <section>
+              <RunDetailRawOutput
+                rawOutput={run.rawOutput as Record<string, unknown> | null}
+                logs={run.logs}
+              />
+            </section>
+          </>
+        ) : (
+          <RunningSection run={run} />
+        )}
       </div>
 
       <SetBaselineDialog

--- a/apps/web/src/features/runs/__tests__/RunDetailPage.test.tsx
+++ b/apps/web/src/features/runs/__tests__/RunDetailPage.test.tsx
@@ -300,9 +300,7 @@ describe("RunDetailPage", () => {
       }),
     );
     render(<RunDetailPage />, { wrapper: Wrapper });
-    await waitFor(() =>
-      expect(screen.getByText(/Running…|运行中…/)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/Running…|运行中…/)).toBeInTheDocument());
     expect(screen.queryByText(/Raw output|原始输出/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Summary metrics|汇总指标/i)).not.toBeInTheDocument();
   });
@@ -334,8 +332,12 @@ describe("RunDetailPage", () => {
     try {
       const get = vi.mocked(api.get);
       get
-        .mockResolvedValueOnce(makeRun({ status: "running", summaryMetrics: null, rawOutput: null }))
-        .mockResolvedValueOnce(makeRun({ status: "running", summaryMetrics: null, rawOutput: null }))
+        .mockResolvedValueOnce(
+          makeRun({ status: "running", summaryMetrics: null, rawOutput: null }),
+        )
+        .mockResolvedValueOnce(
+          makeRun({ status: "running", summaryMetrics: null, rawOutput: null }),
+        )
         .mockResolvedValueOnce(makeRun({ status: "completed" }));
       render(<RunDetailPage />, { wrapper: Wrapper });
       // Initial fetch

--- a/apps/web/src/features/runs/__tests__/RunDetailPage.test.tsx
+++ b/apps/web/src/features/runs/__tests__/RunDetailPage.test.tsx
@@ -290,4 +290,67 @@ describe("RunDetailPage", () => {
     await waitFor(() => expect(api.del).toHaveBeenCalledWith("/api/runs/r1"));
     await waitFor(() => expect(screen.getByText("list")).toBeInTheDocument());
   });
+
+  it("shows the running placeholder while status=running and hides metrics", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(
+      makeRun({
+        status: "running",
+        summaryMetrics: null,
+        rawOutput: null,
+      }),
+    );
+    render(<RunDetailPage />, { wrapper: Wrapper });
+    await waitFor(() =>
+      expect(screen.getByText(/Running…|运行中…/)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/Raw output|原始输出/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Summary metrics|汇总指标/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the pending label while status=submitted", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(
+      makeRun({ status: "submitted", startedAt: null, summaryMetrics: null, rawOutput: null }),
+    );
+    render(<RunDetailPage />, { wrapper: Wrapper });
+    await waitFor(() =>
+      expect(screen.getByText(/Waiting to start…|等待启动…/)).toBeInTheDocument(),
+    );
+  });
+
+  it("hides Set-as-baseline / Delete buttons while non-terminal", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(
+      makeRun({ status: "running", summaryMetrics: null, rawOutput: null }),
+    );
+    render(<RunDetailPage />, { wrapper: Wrapper });
+    await screen.findByText(/Running…|运行中…/);
+    expect(
+      screen.queryByRole("button", { name: /Set as baseline|设为基线/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Delete$|^删除$/ })).not.toBeInTheDocument();
+  });
+
+  it("polls every 2s while non-terminal and stops on terminal", async () => {
+    vi.useFakeTimers();
+    try {
+      const get = vi.mocked(api.get);
+      get
+        .mockResolvedValueOnce(makeRun({ status: "running", summaryMetrics: null, rawOutput: null }))
+        .mockResolvedValueOnce(makeRun({ status: "running", summaryMetrics: null, rawOutput: null }))
+        .mockResolvedValueOnce(makeRun({ status: "completed" }));
+      render(<RunDetailPage />, { wrapper: Wrapper });
+      // Initial fetch
+      await vi.waitFor(() => expect(get).toHaveBeenCalledTimes(1));
+      // Advance 2s — should fetch again (still running)
+      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.waitFor(() => expect(get).toHaveBeenCalledTimes(2));
+      // Advance 2s more — third fetch returns terminal
+      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.waitFor(() => expect(get).toHaveBeenCalledTimes(3));
+      // After terminal, advancing 4s must NOT trigger another fetch
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(get).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/apps/web/src/features/runs/queries.ts
+++ b/apps/web/src/features/runs/queries.ts
@@ -1,6 +1,17 @@
-import type { CreateRunRequest, ListRunsQuery } from "@modeldoctor/contracts";
+import type { CreateRunRequest, ListRunsQuery, Run } from "@modeldoctor/contracts";
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { runApi } from "./api";
+
+/**
+ * Polling cadence for non-terminal runs. Backend already pushes `status`
+ * updates to DB via the callback v2 channel (#53), so 2 s is enough latency
+ * for the user to see "running → completed" without spamming requests.
+ */
+const POLL_INTERVAL_MS = 2_000;
+
+function isTerminal(status: Run["status"] | undefined): boolean {
+  return status === "completed" || status === "failed" || status === "canceled";
+}
 
 export const runKeys = {
   all: ["runs"] as const,
@@ -27,6 +38,7 @@ export function useRunDetail(id: string) {
     queryKey: runKeys.detail(id),
     queryFn: () => runApi.get(id),
     enabled: id.length > 0,
+    refetchInterval: (query) => (isTerminal(query.state.data?.status) ? false : POLL_INTERVAL_MS),
   });
 }
 

--- a/apps/web/src/features/runs/queries.ts
+++ b/apps/web/src/features/runs/queries.ts
@@ -9,7 +9,7 @@ import { runApi } from "./api";
  */
 const POLL_INTERVAL_MS = 2_000;
 
-function isTerminal(status: Run["status"] | undefined): boolean {
+export function isTerminalStatus(status: Run["status"] | undefined): boolean {
   return status === "completed" || status === "failed" || status === "canceled";
 }
 
@@ -38,7 +38,8 @@ export function useRunDetail(id: string) {
     queryKey: runKeys.detail(id),
     queryFn: () => runApi.get(id),
     enabled: id.length > 0,
-    refetchInterval: (query) => (isTerminal(query.state.data?.status) ? false : POLL_INTERVAL_MS),
+    refetchInterval: (query) =>
+      isTerminalStatus(query.state.data?.status) ? false : POLL_INTERVAL_MS,
   });
 }
 

--- a/apps/web/src/locales/en-US/runs.json
+++ b/apps/web/src/locales/en-US/runs.json
@@ -130,6 +130,11 @@
       "errors": {
         "generic": "Failed to delete"
       }
+    },
+    "running": {
+      "pending": "Waiting to start…",
+      "title": "Running…",
+      "elapsed": "{{sec}}s elapsed"
     }
   }
 }

--- a/apps/web/src/locales/zh-CN/runs.json
+++ b/apps/web/src/locales/zh-CN/runs.json
@@ -130,6 +130,11 @@
       "errors": {
         "generic": "删除失败"
       }
+    },
+    "running": {
+      "pending": "等待启动…",
+      "title": "运行中…",
+      "elapsed": "已耗时 {{sec}}s"
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes the last gap in the benchmark MVP main flow: after submitting a run, the detail page now refreshes itself until the run finishes, instead of leaving the user to F5.

- `useRunDetail` gains a `refetchInterval` callback that returns `2000` ms while status is `pending | submitted | running` and `false` once it flips to `completed | failed | canceled`. No new API endpoint — the backend already updates `Run.status` in DB through the callback v2 channel (#53).
- `RunDetailPage` renders a new `RunningSection` placeholder (spinner + status label + client-side elapsed seconds counter) while non-terminal, and hides everything that isn't meaningful yet: metrics, raw output, baseline buttons, and the delete button. Once status goes terminal, the existing #46 report layout takes over without a route change.
- Status labels: `pending|submitted` → "等待启动… / Waiting to start…", `running` → "运行中… / Running…".

## Out of scope (Phase 2, per #57 spec)

- SSE log streaming, live progress events, `Last-Event-ID` resume — all explicitly deferred.
- The in-memory `SseHub` plumbing #53 left in place stays unused for now.
- `kubectl logs -f` for k8s driver runs.

## Test plan

- [x] `pnpm -F @modeldoctor/web type-check` — clean
- [x] `pnpm -F @modeldoctor/web test` — 78 files / 459 tests pass (4 new tests cover running placeholder, pending label, hidden buttons, polling cadence stops on terminal)
- [x] `pnpm -F @modeldoctor/web lint` — only the 6 pre-existing biome warnings, none introduced
- [x] `pnpm -r build` — green
- [ ] Manual smoke (reviewer): submit a benchmark, confirm spinner + elapsed counter ticks once per second on `/runs/:id`, page flips to the report layout when status reaches terminal, no further network calls afterwards (Network tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)