### PR TITLE
docs(claude.md): add PR follow-through policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,14 @@
 
 **Commit / PR conventions.** Conventional-commit prefixes (`feat:`, `build:`, `refactor:`, `test:`, `fix:`, `docs:`, `chore:`), one logical change per commit, explicit `git add <files>` (never `git add -A`), commit bodies end with `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`. One phase of the NestJS refactor = one PR from a `feat/nestjs-phase-<N>` branch cut from `main`; do not mix commits across phases.
 
+**PR follow-through.** A PR is not "done" at `gh pr create`. After opening a PR — and after every subsequent `git push` to the same branch — verify the signals before handing back to the user:
+
+- `gh pr view <N> --json comments,reviews,statusCheckRollup,mergeStateStatus`
+- `gh api repos/weetime/modeldoctor/pulls/<N>/comments` for inline review comments (top-level reviews don't include them)
+- `gh pr checks <N>` for CI conclusions; if pending, `gh run watch <run-id> --exit-status` until it resolves
+
+Surface reviewer feedback and any red checks back to the user, then either fix in a follow-up commit (with reply on the inline comment thread) or pause for direction. Do not declare "PR is open" without these signals confirmed. CI catches things that local `pnpm lint` misses when biome's cache is stale, so treat a CI failure as authoritative even if local was clean.
+
 **Project-specific constraints (do not violate):**
 
 - `apps/api/tsconfig.json` must not set `incremental: true` (conflicts with `nest-cli.json` `deleteOutDir`).


### PR DESCRIPTION
## Summary

Codifies a process gap caught on PR #85: after \`gh pr create\` returned the URL, two CI lint errors (biome \`useSemanticElements\` and a formatter break) and one gemini-code-assist inline review comment (export \`isTerminalStatus\`) sat unaddressed until the user pinged. The lint errors were also masked locally because biome's cache reported them as warnings, while CI's fresh check correctly flagged them as errors.

This adds a **PR follow-through** section to CLAUDE.md that:

- requires \`gh pr view\`, \`gh api .../comments\`, and \`gh pr checks\` after every PR creation and after every subsequent push;
- calls out that inline review comments need a separate \`gh api\` call (top-level reviews from bots like gemini-code-assist don't include the diff-hunk comments);
- treats a CI failure as authoritative even when local \`pnpm lint\` was clean, because biome cache can mask formatting/a11y errors locally.

The same rule already lives in my user-level memory (\`feedback_pr_followthrough.md\`) so future sessions of mine pick it up immediately; this PR makes it visible to all collaborators (and any future AI sessions) by checking it into the repo.

## Test plan

- [x] Diff is doc-only — no code, lint, build, or test impact.
- [ ] Reviewer can sanity-check the wording and the listed \`gh\` commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)