### PR TITLE
fix(api/test): isolate spec runs to modeldoctor_test DB (closes #81)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,7 @@
     "db:generate": "prisma generate",
     "db:migrate:deploy": "prisma migrate deploy",
     "db:migrate:dev": "prisma migrate dev",
+    "db:setup:test": "createdb modeldoctor_test 2>&1 | grep -v 'already exists' || true; psql -d modeldoctor_test -c \"GRANT ALL ON SCHEMA public TO modeldoctor; ALTER DATABASE modeldoctor_test OWNER TO modeldoctor;\" && DATABASE_URL=postgresql://modeldoctor:modeldoctor@localhost:5432/modeldoctor_test prisma migrate deploy",
     "db:studio": "prisma studio",
     "start": "node dist/main.js",
     "start:dev": "nest start --watch",

--- a/apps/api/test/setup/db-guard.ts
+++ b/apps/api/test/setup/db-guard.ts
@@ -1,3 +1,5 @@
+import { isTestDatabase } from "./pick-test-db-url.js";
+
 /**
  * Vitest setupFiles guard: fail-fast assertion that the DATABASE_URL the
  * test worker sees points at a `_test` database, before any spec runs.
@@ -11,9 +13,8 @@
  * is intentionally narrow to `src/**` (see project CLAUDE.md).
  */
 const url = process.env.DATABASE_URL ?? "";
-const dbName = url.split("/").pop()?.split("?")[0] ?? "";
-if (!/_test(\W|$)/.test(dbName)) {
+if (!isTestDatabase(url)) {
   throw new Error(
-    `db-guard: refusing to run tests against DATABASE_URL='${url}'. Expected database name ending with '_test' (got '${dbName}'). This prevents spec-level deleteMany() from wiping your dev DB.`,
+    `db-guard: refusing to run tests against DATABASE_URL='${url}'. Expected the database name to end with '_test'. This prevents spec-level deleteMany() from wiping your dev DB.`,
   );
 }

--- a/apps/api/test/setup/db-guard.ts
+++ b/apps/api/test/setup/db-guard.ts
@@ -1,0 +1,19 @@
+/**
+ * Vitest setupFiles guard: fail-fast assertion that the DATABASE_URL the
+ * test worker sees points at a `_test` database, before any spec runs.
+ *
+ * Belt-and-suspenders next to vitest.config.mts `test.env` and the
+ * `pickTestDatabaseUrl` helper — if either layer is bypassed (someone
+ * runs vitest directly, an IDE plugin overrides env, etc.), this throws
+ * here before spec-level `deleteMany()` calls can wipe a dev DB.
+ *
+ * Lives in `test/setup/` (not `src/test/`) because `tsconfig.json#include`
+ * is intentionally narrow to `src/**` (see project CLAUDE.md).
+ */
+const url = process.env.DATABASE_URL ?? "";
+const dbName = url.split("/").pop()?.split("?")[0] ?? "";
+if (!/_test(\W|$)/.test(dbName)) {
+  throw new Error(
+    `db-guard: refusing to run tests against DATABASE_URL='${url}'. Expected database name ending with '_test' (got '${dbName}'). This prevents spec-level deleteMany() from wiping your dev DB.`,
+  );
+}

--- a/apps/api/test/setup/global-setup.mts
+++ b/apps/api/test/setup/global-setup.mts
@@ -1,0 +1,31 @@
+import { execSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { pickTestDatabaseUrl } from "./pick-test-db-url.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const apiDir = resolve(here, "../..");
+
+/**
+ * Vitest globalSetup: applies pending Prisma migrations to the test database
+ * before any spec runs. Idempotent — if schema is current it's a no-op.
+ *
+ * Defends against a footgun: spec files in this repo call `deleteMany()` to
+ * clear shared tables between cases. The URL pick logic in
+ * `pick-test-db-url.ts` ignores a dev-pointing `DATABASE_URL` (the common
+ * case when the developer's shell has it exported for `pnpm start:dev`)
+ * and falls back to `modeldoctor_test`.
+ *
+ * If the test DB doesn't exist yet on a fresh checkout, run
+ * `pnpm -F @modeldoctor/api db:setup:test` first (one-time createdb +
+ * grant + migrate). Prisma's "database does not exist" error message
+ * also points the way.
+ */
+export async function setup() {
+  const url = pickTestDatabaseUrl();
+  execSync("pnpm exec prisma migrate deploy", {
+    stdio: "inherit",
+    cwd: apiDir,
+    env: { ...process.env, DATABASE_URL: url },
+  });
+}

--- a/apps/api/test/setup/pick-test-db-url.ts
+++ b/apps/api/test/setup/pick-test-db-url.ts
@@ -20,14 +20,31 @@
  * for the worker process). Keep this module dependency-free so the
  * `.mts` setup can import it without a transformer.
  */
+// NOTE: keep in sync with the literal in `apps/api/package.json` →
+// `db:setup:test` script. That script can't import this module (it's
+// invoked as a shell oneliner before any TS transformer is loaded).
 const DEFAULT_TEST_DATABASE_URL =
   "postgresql://modeldoctor:modeldoctor@localhost:5432/modeldoctor_test";
 
-const TEST_DB_PATTERN = /_test(\W|$)/;
+const TEST_DB_NAME_PATTERN = /_test(\W|$)/;
+
+/**
+ * True when the URL's database segment ends with a `_test` suffix.
+ *
+ * Match against the **database name only**, not the whole connection
+ * string — otherwise a username like `user_test` or a host like
+ * `db_test.example.com` would falsely pass while pointing at a non-test
+ * database. (`postgresql://user:pw@host:5432/proddb?schema=public` →
+ * pop "proddb?schema=public", strip query, test "proddb".)
+ */
+export function isTestDatabase(url: string): boolean {
+  const dbName = url.split("/").pop()?.split("?")[0] ?? "";
+  return TEST_DB_NAME_PATTERN.test(dbName);
+}
 
 export function pickTestDatabaseUrl(): string {
   if (process.env.TEST_DATABASE_URL) return process.env.TEST_DATABASE_URL;
   const env = process.env.DATABASE_URL;
-  if (env && TEST_DB_PATTERN.test(env)) return env;
+  if (env && isTestDatabase(env)) return env;
   return DEFAULT_TEST_DATABASE_URL;
 }

--- a/apps/api/test/setup/pick-test-db-url.ts
+++ b/apps/api/test/setup/pick-test-db-url.ts
@@ -1,0 +1,33 @@
+/**
+ * Resolve which Postgres URL the test process should use.
+ *
+ * Order:
+ *   1. `TEST_DATABASE_URL` — explicit override (e.g. CI matrix variant).
+ *   2. `DATABASE_URL` if it already names a `_test` database — honors the
+ *      CI pattern where the workflow sets DATABASE_URL directly.
+ *   3. Local Postgres convention: `postgresql://modeldoctor:modeldoctor@localhost:5432/modeldoctor_test`.
+ *
+ * **A non-test `DATABASE_URL` is intentionally ignored**: the developer
+ * shell typically exports `DATABASE_URL=postgresql://.../modeldoctor` so
+ * that `pnpm start:dev` connects to the dev DB. Honoring that here would
+ * silently route `pnpm test` at the dev DB and let `deleteMany()` wipe
+ * real data. The fallback in step 3 keeps the test process safe by
+ * default; `db-guard.ts` is the second layer that asserts whatever URL
+ * we end up with names a `_test` database.
+ *
+ * Imported by both `global-setup.mts` (vitest parent process, before
+ * `test.env` is applied) and `vitest.config.mts` (which sets `test.env`
+ * for the worker process). Keep this module dependency-free so the
+ * `.mts` setup can import it without a transformer.
+ */
+const DEFAULT_TEST_DATABASE_URL =
+  "postgresql://modeldoctor:modeldoctor@localhost:5432/modeldoctor_test";
+
+const TEST_DB_PATTERN = /_test(\W|$)/;
+
+export function pickTestDatabaseUrl(): string {
+  if (process.env.TEST_DATABASE_URL) return process.env.TEST_DATABASE_URL;
+  const env = process.env.DATABASE_URL;
+  if (env && TEST_DB_PATTERN.test(env)) return env;
+  return DEFAULT_TEST_DATABASE_URL;
+}

--- a/apps/api/vitest.config.mts
+++ b/apps/api/vitest.config.mts
@@ -1,6 +1,14 @@
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
 import swc from "unplugin-swc";
+import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
+import { pickTestDatabaseUrl } from "./test/setup/pick-test-db-url.js";
+
+// Spec processes must connect to a `_test` database. A developer shell
+// typically exports DATABASE_URL pointing at the dev DB so `pnpm start:dev`
+// works; if that leaked into the test worker, `deleteMany()` would wipe
+// real data. `pickTestDatabaseUrl` ignores a non-`_test` DATABASE_URL and
+// falls back to `modeldoctor_test`; see that file for the full order.
+const TEST_DATABASE_URL = pickTestDatabaseUrl();
 
 export default defineConfig({
   plugins: [
@@ -19,11 +27,15 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.spec.ts"],
     exclude: ["node_modules", "dist", "test/**"],
-    // Many repository/service specs share the local Postgres dev DB and
-    // wipe rows in `beforeEach`. Running spec files in parallel races
-    // those wipes against in-flight inserts (FK violations on baselines
-    // → runs). Force file-level serialization; tests within a file still
-    // run in order.
+    // Repository / service specs share one Postgres DB and clear rows in
+    // beforeEach; running spec files in parallel races those wipes against
+    // in-flight inserts (FK violations on baselines → runs). Force file
+    // serialization; tests within a single file still run in order.
     fileParallelism: false,
+    globalSetup: ["./test/setup/global-setup.mts"],
+    setupFiles: ["./test/setup/db-guard.ts"],
+    env: {
+      DATABASE_URL: TEST_DATABASE_URL,
+    },
   },
 });

--- a/apps/api/vitest.e2e.config.mts
+++ b/apps/api/vitest.e2e.config.mts
@@ -1,6 +1,10 @@
 import swc from "unplugin-swc";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
+import { pickTestDatabaseUrl } from "./test/setup/pick-test-db-url.js";
+
+// Same test DB resolution as vitest.config.mts. See that file for rationale.
+const TEST_DATABASE_URL = pickTestDatabaseUrl();
 
 export default defineConfig({
   plugins: [
@@ -21,7 +25,9 @@ export default defineConfig({
     exclude: ["node_modules", "dist"],
     testTimeout: 30_000,
     hookTimeout: 120_000,
+    setupFiles: ["./test/setup/db-guard.ts"],
     env: {
+      DATABASE_URL: TEST_DATABASE_URL,
       // passport-jwt validates secretOrKey at strategy-construction time,
       // so AppModule boot needs a non-empty JWT secret even in test mode.
       JWT_ACCESS_SECRET: "e2e-test-jwt-secret-not-for-production-use-only-32+chars",

--- a/apps/api/vitest.e2e.config.mts
+++ b/apps/api/vitest.e2e.config.mts
@@ -25,6 +25,7 @@ export default defineConfig({
     exclude: ["node_modules", "dist"],
     testTimeout: 30_000,
     hookTimeout: 120_000,
+    globalSetup: ["./test/setup/global-setup.mts"],
     setupFiles: ["./test/setup/db-guard.ts"],
     env: {
       DATABASE_URL: TEST_DATABASE_URL,


### PR DESCRIPTION
## Summary

Three integration spec files (\`run.controller.spec\`, \`run.repository.spec\`, \`e2e-test.service.spec\`) call \`prisma.user/run/baseline.deleteMany()\` in their setup hooks. Before this PR the URL came straight from \`process.env.DATABASE_URL\` — which a developer's shell typically points at the dev DB so \`pnpm start:dev\` works. Result: any time \`pnpm test\` ran in that shell (including from an automation / sub-agent), all dev-DB rows got wiped. Already happened once mid-Playwright session; surfaced as #81.

CI was never affected — its workflow sets \`DATABASE_URL\` to the isolated \`modeldoctor_test\` service-container DB. This PR makes local runs behave the same way, defensively.

## Three layers of defense

1. \`test/setup/pick-test-db-url.ts\` resolves a safe URL: explicit \`TEST_DATABASE_URL\` first, then \`DATABASE_URL\` only if it already names a \`_test\` DB (CI's pattern), else falls back to \`postgresql://modeldoctor:modeldoctor@localhost:5432/modeldoctor_test\`. A non-\`_test\` \`DATABASE_URL\` is intentionally ignored.
2. \`vitest.config.mts\` / \`vitest.e2e.config.mts\` set \`test.env.DATABASE_URL\` from that helper, so the worker process always sees the safe URL. Both configs also wire \`setupFiles: [db-guard.ts]\` that asserts the URL ends in \`_test\` and throws otherwise — a second layer if \`test.env\` is bypassed (vitest direct, IDE plugin, etc.).
3. \`globalSetup\` in the unit config runs \`prisma migrate deploy\` against the resolved URL once per \`pnpm test\` invocation, so a fresh checkout's \`modeldoctor_test\` schema stays current automatically (idempotent — no-op when up to date).

## First-time bootstrap

New \`db:setup:test\` script in \`apps/api/package.json\` covers the one-time \`createdb\` + grant \`public\` to \`modeldoctor\` + initial \`migrate deploy\`:

\`\`\`bash
pnpm -F @modeldoctor/api db:setup:test
\`\`\`

CI doesn't run this — its Postgres service container provisions the \`modeldoctor_test\` database in the workflow file directly.

## Test plan

- [x] \`pnpm -F @modeldoctor/api type-check\` — clean
- [x] \`pnpm -F @modeldoctor/api lint\` — clean (0 errors, 0 warnings)
- [x] \`pnpm -F @modeldoctor/api test\` — 38 files / 305 tests pass
- [x] \`pnpm -F @modeldoctor/api test:e2e\` — 7 files / 41 tests pass
- [x] **Worst-case local sim**: \`DATABASE_URL=postgresql://...modeldoctor pnpm -F @modeldoctor/api test\` (shell points at dev DB) — tests pass; dev DB row counts unchanged before/after.
- [ ] Manual smoke (reviewer): on a fresh worktree, \`pnpm -F @modeldoctor/api db:setup:test\` then \`pnpm -F @modeldoctor/api test\` should both succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)