### PR TITLE
feat(web/runs): one-click re-run button on detail page

### DIFF
--- a/apps/web/src/features/runs/RunDetailPage.tsx
+++ b/apps/web/src/features/runs/RunDetailPage.tsx
@@ -12,6 +12,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useDeleteBaseline } from "@/features/baseline/queries";
 import type { Run } from "@modeldoctor/contracts";
 import {
@@ -24,7 +25,7 @@ import {
 } from "@modeldoctor/tool-adapters/schemas";
 import { useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
-import { ArrowLeft, Loader2, SearchX } from "lucide-react";
+import { ArrowLeft, Loader2, RefreshCw, SearchX } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate, useParams } from "react-router-dom";
@@ -32,7 +33,7 @@ import { toast } from "sonner";
 import { RunDetailMetadata } from "./RunDetailMetadata";
 import { RunDetailRawOutput } from "./RunDetailRawOutput";
 import { SetBaselineDialog } from "./SetBaselineDialog";
-import { isTerminalStatus, runKeys, useDeleteRun } from "./queries";
+import { isTerminalStatus, runKeys, useCreateRun, useDeleteRun } from "./queries";
 import { useRunDetail } from "./queries";
 import { GenaiPerfReportView } from "./reports/GenaiPerfReportView";
 import { GuidellmReportView } from "./reports/GuidellmReportView";
@@ -124,6 +125,7 @@ export function RunDetailPage() {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const remove = useDeleteBaseline();
   const deleteRun = useDeleteRun();
+  const createRun = useCreateRun();
   const navigate = useNavigate();
 
   if (isLoading) {
@@ -173,6 +175,32 @@ export function RunDetailPage() {
 
   const isBaseline = run.baselineFor !== null;
   const isTerminal = isTerminalStatus(run.status);
+  // CreateRunRequest requires non-null connectionId; orphaned Runs (FK SET NULL
+  // after Connection delete) cannot be cloned without picking a new connection,
+  // and the spec is one-click rerun without an edit step. Disable instead.
+  const canRerun = run.connectionId !== null;
+
+  async function handleRerun() {
+    if (!run || !run.connectionId) return;
+    // Schema caps name at 128. " (rerun)" is 8 chars; reserve 120 for the source.
+    const sourceName = run.name?.trim() || `run-${run.id.slice(0, 8)}`;
+    const trimmed = sourceName.length > 120 ? sourceName.slice(0, 120) : sourceName;
+    const newName = `${trimmed} (rerun)`;
+    try {
+      const next = await createRun.mutateAsync({
+        tool: run.tool,
+        kind: run.kind,
+        connectionId: run.connectionId,
+        name: newName,
+        description: run.description ?? undefined,
+        params: run.params,
+      });
+      toast.success(t("detail.rerun.success", { name: next.name ?? next.id }));
+      navigate(`/runs/${next.id}`);
+    } catch (e) {
+      toast.error((e as Error).message || t("detail.rerun.errors.generic"));
+    }
+  }
 
   return (
     <>
@@ -190,6 +218,30 @@ export function RunDetailPage() {
                 <Button variant="outline" size="sm" onClick={() => setSetOpen(true)}>
                   {t("detail.baseline.setButton")}
                 </Button>
+              ))}
+            {isTerminal &&
+              (canRerun ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleRerun}
+                  disabled={createRun.isPending}
+                >
+                  <RefreshCw className="mr-1 h-4 w-4" />
+                  {t("detail.rerun.button")}
+                </Button>
+              ) : (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <Button variant="outline" size="sm" disabled={true}>
+                        <RefreshCw className="mr-1 h-4 w-4" />
+                        {t("detail.rerun.button")}
+                      </Button>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>{t("detail.rerun.connectionMissingTooltip")}</TooltipContent>
+                </Tooltip>
               ))}
             {isTerminal && (
               <Button variant="destructive" size="sm" onClick={() => setDeleteOpen(true)}>

--- a/apps/web/src/features/runs/__tests__/RunDetailPage.test.tsx
+++ b/apps/web/src/features/runs/__tests__/RunDetailPage.test.tsx
@@ -327,6 +327,102 @@ describe("RunDetailPage", () => {
     expect(screen.queryByRole("button", { name: /^Delete$|^删除$/ })).not.toBeInTheDocument();
   });
 
+  // ---- F4: Re-run button (one-click clone-and-submit, see #88) ----
+
+  it("renders the Re-run button when terminal", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(makeRun({ status: "completed" }));
+    render(<RunDetailPage />, { wrapper: Wrapper });
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^Re-run$|^重跑$/ })).toBeInTheDocument(),
+    );
+  });
+
+  it("hides the Re-run button while non-terminal", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(
+      makeRun({ status: "running", summaryMetrics: null, rawOutput: null }),
+    );
+    render(<RunDetailPage />, { wrapper: Wrapper });
+    await screen.findByText(/Running…|运行中…/);
+    expect(screen.queryByRole("button", { name: /^Re-run$|^重跑$/ })).not.toBeInTheDocument();
+  });
+
+  it("disables the Re-run button when the source connection has been deleted", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(
+      makeRun({ status: "completed", connectionId: null, connection: null }),
+    );
+    render(<RunDetailPage />, { wrapper: Wrapper });
+    const btn = await screen.findByRole("button", { name: /^Re-run$|^重跑$/ });
+    expect(btn).toBeDisabled();
+  });
+
+  it("clones tool / connectionId / kind / params on click and POSTs to /api/runs", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(
+      makeRun({
+        status: "completed",
+        tool: "guidellm",
+        kind: "benchmark",
+        connectionId: "c1",
+        params: { profile: "throughput", totalRequests: 500 },
+        name: "smoke",
+      }),
+    );
+    vi.mocked(api.post).mockResolvedValueOnce(makeRun({ id: "r2", name: "smoke (rerun)" }));
+    const user = userEvent.setup();
+    render(<RunDetailPage />, { wrapper: Wrapper });
+    const btn = await screen.findByRole("button", { name: /^Re-run$|^重跑$/ });
+    await user.click(btn);
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(1));
+    const [path, body] = vi.mocked(api.post).mock.calls[0] as [string, Record<string, unknown>];
+    expect(path).toBe("/api/runs");
+    expect(body.tool).toBe("guidellm");
+    expect(body.kind).toBe("benchmark");
+    expect(body.connectionId).toBe("c1");
+    expect(body.params).toEqual({ profile: "throughput", totalRequests: 500 });
+    // Name suffix: original name + " (rerun)"
+    expect(body.name).toBe("smoke (rerun)");
+  });
+
+  it("falls back to a synthetic name when the source Run has no name", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(makeRun({ status: "completed", name: null }));
+    vi.mocked(api.post).mockResolvedValueOnce(makeRun({ id: "r2" }));
+    const user = userEvent.setup();
+    render(<RunDetailPage />, { wrapper: Wrapper });
+    const btn = await screen.findByRole("button", { name: /^Re-run$|^重跑$/ });
+    await user.click(btn);
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(1));
+    const [, body] = vi.mocked(api.post).mock.calls[0] as [string, Record<string, unknown>];
+    // Schema requires name to be 1..128; synthesized payload must satisfy that.
+    expect(typeof body.name).toBe("string");
+    expect((body.name as string).length).toBeGreaterThan(0);
+    expect((body.name as string).length).toBeLessThanOrEqual(128);
+  });
+
+  it("truncates the source name so the ' (rerun)' suffix fits within the 128-char limit", async () => {
+    const longName = "x".repeat(125); // 125 + " (rerun)" (8) = 133 > 128
+    vi.mocked(api.get).mockResolvedValueOnce(makeRun({ status: "completed", name: longName }));
+    vi.mocked(api.post).mockResolvedValueOnce(makeRun({ id: "r2" }));
+    const user = userEvent.setup();
+    render(<RunDetailPage />, { wrapper: Wrapper });
+    const btn = await screen.findByRole("button", { name: /^Re-run$|^重跑$/ });
+    await user.click(btn);
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(1));
+    const [, body] = vi.mocked(api.post).mock.calls[0] as [string, Record<string, unknown>];
+    expect((body.name as string).length).toBeLessThanOrEqual(128);
+    expect((body.name as string).endsWith(" (rerun)")).toBe(true);
+  });
+
+  it("navigates to the new Run detail page on success", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(makeRun({ status: "completed" }));
+    // Second api.get is for the new Run detail page after navigation.
+    vi.mocked(api.get).mockResolvedValueOnce(makeRun({ id: "r2", name: "smoke (rerun)" }));
+    vi.mocked(api.post).mockResolvedValueOnce(makeRun({ id: "r2", name: "smoke (rerun)" }));
+    const user = userEvent.setup();
+    render(<RunDetailPage />, { wrapper: Wrapper });
+    const btn = await screen.findByRole("button", { name: /^Re-run$|^重跑$/ });
+    await user.click(btn);
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith("/api/runs/r2"));
+  });
+
   it("polls every 2s while non-terminal and stops on terminal", async () => {
     vi.useFakeTimers();
     try {

--- a/apps/web/src/locales/en-US/runs.json
+++ b/apps/web/src/locales/en-US/runs.json
@@ -131,6 +131,14 @@
         "generic": "Failed to delete"
       }
     },
+    "rerun": {
+      "button": "Re-run",
+      "connectionMissingTooltip": "The original connection has been deleted; pick a new one from \"New Benchmark\" instead.",
+      "success": "Submitted re-run \"{{name}}\"",
+      "errors": {
+        "generic": "Failed to submit re-run"
+      }
+    },
     "running": {
       "pending": "Waiting to start…",
       "title": "Running…",

--- a/apps/web/src/locales/zh-CN/runs.json
+++ b/apps/web/src/locales/zh-CN/runs.json
@@ -131,6 +131,14 @@
         "generic": "删除失败"
       }
     },
+    "rerun": {
+      "button": "重跑",
+      "connectionMissingTooltip": "原 Connection 已删除，请到「新建基准测试」里重新选一个。",
+      "success": "已提交重跑「{{name}}」",
+      "errors": {
+        "generic": "重跑提交失败"
+      }
+    },
     "running": {
       "pending": "等待启动…",
       "title": "运行中…",


### PR DESCRIPTION
## Summary

Closes the **F4** item in #88 — adds a one-click \"Re-run\" / \"重跑\" button to `RunDetailPage`'s right slot.

Per the design alignment in #88: clicking the button immediately POSTs a cloned `CreateRunRequest` (no intermediate edit form) and navigates to the new Run's detail page.

## Behavior

| State | Behavior |
|---|---|
| Source Run is **terminal** + `connectionId` non-null | Button enabled |
| Source Run is **terminal** + `connectionId` is null (Connection was deleted; FK ON DELETE SET NULL) | Button shown but **disabled** with tooltip explaining how to recover (\"原 Connection 已删除，请到「新建基准测试」里重新选一个\") |
| Source Run **non-terminal** (pending / submitted / running) | Button hidden — same pattern as Delete + Set-as-baseline |
| Click → mutation pending | Button disabled (loading) |
| Click → success | Toast `已提交重跑「<new-name>」` + navigate to `/runs/<new-id>` |
| Click → error | Toast with server message (or generic fallback) |

## Cloned payload

| Field | Source |
|---|---|
| `tool` | `run.tool` |
| `kind` | `run.kind` |
| `connectionId` | `run.connectionId` (guarded non-null) |
| `params` | `run.params` (raw passthrough) |
| `description` | `run.description ?? undefined` |
| `name` | `${source.name} (rerun)`; source name truncated to 120 chars so the suffix fits the 128-char schema cap; falls back to `run-${id.slice(0,8)}` when `source.name` is null |

Not cloned: `templateId` / `templateVersion` / `parentRunId` / `baselineId` — those describe the source Run's lineage, not the rerun's. (If lineage tracking is wanted later, set `parentRunId: source.id`; out of scope for F4.)

## Test plan

- [x] 6 new vitest cases in `RunDetailPage.test.tsx` (RED first, then GREEN):
  - renders the Re-run button when terminal
  - hides the Re-run button while non-terminal
  - disables the button when source connection has been deleted
  - clones tool / connectionId / kind / params on click and POSTs to `/api/runs`
  - falls back to a synthetic name when source has no name
  - truncates source name so ` (rerun)` suffix fits within 128 chars
  - navigates to new Run detail on success
- [x] Full `pnpm -F @modeldoctor/web test --run` — 469/469 pass
- [x] `pnpm -F @modeldoctor/web type-check` — clean
- [x] Biome check on all 4 touched files — clean
- [ ] Reviewer: in dev, complete a Run, click 重跑, confirm new Run appears with name suffix and lands on its detail page; then delete the source Run's Connection and confirm the button goes disabled with tooltip

## Issue trailer

Uses `addresses #88` (not `closes`) per the umbrella-issue trailer policy added after PR #89 auto-closed #88 via `closes`. F1 / F2 / F3 remain open for follow-ups; I'll tick the F4 checkbox in the #88 body after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)