### PR TITLE
chore(env): use literal runner image tags in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,12 +56,15 @@ BENCHMARK_K8S_NAMESPACE=modeldoctor-benchmarks
 # tag from `git log -1 --format=%h -- apps/benchmark-runner/`):
 #   ./tools/build-runner-images.sh
 #
-# The script prints the resulting tag at the end. Copy the three
-# RUNNER_IMAGE_* lines it suggests into this .env, OR export
-# RUNNER_IMAGE_TAG=<tag> and use the parametrized form below.
-RUNNER_IMAGE_GUIDELLM=md-runner-guidellm:${RUNNER_IMAGE_TAG:-dev3}
-RUNNER_IMAGE_VEGETA=md-runner-vegeta:${RUNNER_IMAGE_TAG:-dev3}
-RUNNER_IMAGE_GENAI_PERF=md-runner-genai-perf:${RUNNER_IMAGE_TAG:-dev3}
+# The script prints the resulting tag at the end. Either edit the lines
+# below, or export RUNNER_IMAGE_TAG before launching pnpm dev and inline
+# it via your own shell.  NOTE: dotenv (used by @nestjs/config) does NOT
+# expand shell-style ${VAR:-default} fallbacks — Pod spec receives the
+# raw string and the runner pod fails with "InvalidImageName". Use a
+# literal tag here.
+RUNNER_IMAGE_GUIDELLM=md-runner-guidellm:dev3
+RUNNER_IMAGE_VEGETA=md-runner-vegeta:dev3
+RUNNER_IMAGE_GENAI_PERF=md-runner-genai-perf:dev3
 
 # Optional kubeconfig override for out-of-cluster local dev. Leave unset in
 # production (the API runs as a pod and uses its in-cluster ServiceAccount).


### PR DESCRIPTION
## Summary

The template `.env.example` shipped `${RUNNER_IMAGE_TAG:-dev3}` shell-style fallbacks for the three `RUNNER_IMAGE_*` lines. **dotenv (used by `@nestjs/config`) does not expand `${VAR:-default}`** — the literal string `"md-runner-vegeta:\${RUNNER_IMAGE_TAG:-dev3}"` flows into the K8s Pod spec, and the runner pod fails with:

```
Failed to apply default image tag "md-runner-vegeta:${RUNNER_IMAGE_TAG:-dev3}":
couldn't parse image name "md-runner-vegeta:${RUNNER_IMAGE_TAG:-dev3}":
invalid reference format
```

Hit this while doing the manual smoke for #91 (F3 charts) — `BENCHMARK_DRIVER=k8s` ran the runner pod with literal-string image refs, K8s rejected them with `InvalidImageName`, and the Run sat in `submitted` forever.

## Change

Switch the template to literal `:dev3` tags and add an inline comment warning future readers about dotenv's expansion limitation. Real setups should override these in their own (gitignored) `.env` to match the tag printed by `tools/build-runner-images.sh`.

## Test plan

- [x] `cat .env.example | grep RUNNER_IMAGE_` — three literal `:dev3` lines, no `\${...}` syntax
- [ ] Reviewer: copy `.env.example` to `.env`, set `BENCHMARK_DRIVER=k8s`, trigger any benchmark Run; pod boots without `InvalidImageName`

addresses #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)