### PR TITLE
feat(benchmark): PR2 — benchmark_templates CRUD + list/edit UI

### DIFF
--- a/apps/api/src/common/filters/all-exceptions.filter.ts
+++ b/apps/api/src/common/filters/all-exceptions.filter.ts
@@ -61,6 +61,12 @@ export class AllExceptionsFilter implements ExceptionFilter {
         if ("details" in rec) {
           details = rec.details;
         }
+        // Domain-specific code override: if the exception body carries an explicit
+        // `code` string (e.g. "BENCHMARK_TEMPLATE_OFFICIAL_FORBIDDEN"), use it
+        // instead of the generic HTTP-status-derived code so client UIs can switch on it.
+        if (typeof rec.code === "string") {
+          code = rec.code as ErrorCode;
+        }
       } else {
         message = exception.message;
       }

--- a/apps/api/src/modules/benchmark-template/benchmark-template.controller.spec.ts
+++ b/apps/api/src/modules/benchmark-template/benchmark-template.controller.spec.ts
@@ -1,0 +1,95 @@
+import { Test } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
+import { BenchmarkTemplateController } from "./benchmark-template.controller.js";
+import { BenchmarkTemplateService } from "./benchmark-template.service.js";
+
+const mockService = {
+  list: vi.fn(),
+  findByIdOrFail: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+};
+
+describe("BenchmarkTemplateController", () => {
+  let controller: BenchmarkTemplateController;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const moduleRef = await Test.createTestingModule({
+      controllers: [BenchmarkTemplateController],
+      providers: [{ provide: BenchmarkTemplateService, useValue: mockService }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+    controller = moduleRef.get(BenchmarkTemplateController);
+  });
+
+  it("list delegates to service.list with parsed query", async () => {
+    mockService.list.mockResolvedValue({ items: [], nextCursor: null });
+    const out = await controller.list({ scenario: "inference", limit: 50 } as never);
+    expect(out).toEqual({ items: [], nextCursor: null });
+    expect(mockService.list).toHaveBeenCalledWith({ scenario: "inference", limit: 50 });
+  });
+
+  it("create maps JwtPayload → TemplateActor (non-admin)", async () => {
+    mockService.create.mockResolvedValue({ id: "t1" });
+    await controller.create(
+      { sub: "user-1", email: "u@x", roles: ["user"] },
+      {
+        name: "t",
+        scenario: "inference",
+        tool: "guidellm",
+        config: {},
+        isOfficial: false,
+        tags: [],
+      },
+    );
+    expect(mockService.create).toHaveBeenCalledWith(
+      { sub: "user-1", isAdmin: false },
+      expect.objectContaining({ name: "t" }),
+    );
+  });
+
+  it("create maps admin role correctly", async () => {
+    mockService.create.mockResolvedValue({ id: "t1" });
+    await controller.create(
+      { sub: "admin-1", email: "a@x", roles: ["admin"] },
+      {
+        name: "t",
+        scenario: "inference",
+        tool: "guidellm",
+        config: {},
+        isOfficial: true,
+        tags: [],
+      },
+    );
+    expect(mockService.create).toHaveBeenCalledWith(
+      { sub: "admin-1", isAdmin: true },
+      expect.objectContaining({ isOfficial: true }),
+    );
+  });
+
+  it("update strips isOfficial / scenario / tool from PATCH body before service call", async () => {
+    mockService.update.mockResolvedValue({ id: "t1" });
+    await controller.update(
+      { sub: "owner-1", email: "o@x", roles: ["user"] },
+      "t1",
+      // The schema should already omit these — assert what reaches service
+      { name: "renamed", description: "d" } as never,
+    );
+    const [, , patchArg] = mockService.update.mock.calls[0];
+    expect(patchArg).not.toHaveProperty("scenario");
+    expect(patchArg).not.toHaveProperty("tool");
+    expect(patchArg).not.toHaveProperty("isOfficial");
+    expect(patchArg).toEqual(expect.objectContaining({ name: "renamed" }));
+  });
+
+  it("delete returns void (204) and forwards actor", async () => {
+    mockService.delete.mockResolvedValue(undefined);
+    await controller.delete({ sub: "owner-1", email: "o@x", roles: ["user"] }, "t1");
+    expect(mockService.delete).toHaveBeenCalledWith({ sub: "owner-1", isAdmin: false }, "t1");
+  });
+});

--- a/apps/api/src/modules/benchmark-template/benchmark-template.controller.spec.ts
+++ b/apps/api/src/modules/benchmark-template/benchmark-template.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test } from "@nestjs/testing";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
-import { BenchmarkTemplateController } from "./benchmark-template.controller.js";
+import { BenchmarkTemplateController, patchSchema } from "./benchmark-template.controller.js";
 import { BenchmarkTemplateService } from "./benchmark-template.service.js";
 
 const mockService = {
@@ -91,5 +91,23 @@ describe("BenchmarkTemplateController", () => {
     mockService.delete.mockResolvedValue(undefined);
     await controller.delete({ sub: "owner-1", email: "o@x", roles: ["user"] }, "t1");
     expect(mockService.delete).toHaveBeenCalledWith({ sub: "owner-1", isAdmin: false }, "t1");
+  });
+});
+
+describe("patchSchema", () => {
+  it("silently strips isOfficial / scenario / tool from input (defense in depth)", () => {
+    const raw = {
+      name: "renamed",
+      description: "d",
+      // These three fields should be stripped by the .omit() in patchSchema
+      isOfficial: true,
+      scenario: "capacity",
+      tool: "vegeta",
+    };
+    const parsed = patchSchema.parse(raw);
+    expect(parsed).not.toHaveProperty("isOfficial");
+    expect(parsed).not.toHaveProperty("scenario");
+    expect(parsed).not.toHaveProperty("tool");
+    expect(parsed).toEqual({ name: "renamed", description: "d" });
   });
 });

--- a/apps/api/src/modules/benchmark-template/benchmark-template.controller.ts
+++ b/apps/api/src/modules/benchmark-template/benchmark-template.controller.ts
@@ -1,0 +1,83 @@
+import {
+  type BenchmarkTemplate,
+  type CreateBenchmarkTemplateRequest,
+  type ListBenchmarkTemplatesQuery,
+  type ListBenchmarkTemplatesResponse,
+  createBenchmarkTemplateRequestSchema,
+  listBenchmarkTemplatesQuerySchema,
+  updateBenchmarkTemplateRequestSchema,
+} from "@modeldoctor/contracts";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
+import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
+import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
+import type { JwtPayload } from "../auth/jwt.strategy.js";
+import { BenchmarkTemplateService, type TemplateActor } from "./benchmark-template.service.js";
+
+// PATCH body schema: drop isOfficial (immutable post-create) + scenario/tool
+// (changing these would invalidate the stored config). Anything the client
+// sends in these fields is stripped here, never reaches the service.
+const patchSchema = updateBenchmarkTemplateRequestSchema.omit({
+  isOfficial: true,
+  scenario: true,
+  tool: true,
+});
+
+function actorFrom(user: JwtPayload): TemplateActor {
+  return { sub: user.sub, isAdmin: user.roles.includes("admin") };
+}
+
+@Controller("benchmark-templates")
+@UseGuards(JwtAuthGuard)
+export class BenchmarkTemplateController {
+  constructor(private readonly service: BenchmarkTemplateService) {}
+
+  @Get()
+  list(
+    @Query(new ZodValidationPipe(listBenchmarkTemplatesQuerySchema))
+    query: ListBenchmarkTemplatesQuery,
+  ): Promise<ListBenchmarkTemplatesResponse> {
+    return this.service.list(query);
+  }
+
+  @Get(":id")
+  detail(@Param("id") id: string): Promise<BenchmarkTemplate> {
+    return this.service.findByIdOrFail(id);
+  }
+
+  @Post()
+  create(
+    @CurrentUser() user: JwtPayload,
+    @Body(new ZodValidationPipe(createBenchmarkTemplateRequestSchema))
+    body: CreateBenchmarkTemplateRequest,
+  ): Promise<BenchmarkTemplate> {
+    return this.service.create(actorFrom(user), body);
+  }
+
+  @Patch(":id")
+  update(
+    @CurrentUser() user: JwtPayload,
+    @Param("id") id: string,
+    @Body(new ZodValidationPipe(patchSchema)) body: Record<string, unknown>,
+  ): Promise<BenchmarkTemplate> {
+    return this.service.update(actorFrom(user), id, body);
+  }
+
+  @Delete(":id")
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async delete(@CurrentUser() user: JwtPayload, @Param("id") id: string): Promise<void> {
+    await this.service.delete(actorFrom(user), id);
+  }
+}

--- a/apps/api/src/modules/benchmark-template/benchmark-template.controller.ts
+++ b/apps/api/src/modules/benchmark-template/benchmark-template.controller.ts
@@ -29,7 +29,7 @@ import { BenchmarkTemplateService, type TemplateActor } from "./benchmark-templa
 // PATCH body schema: drop isOfficial (immutable post-create) + scenario/tool
 // (changing these would invalidate the stored config). Anything the client
 // sends in these fields is stripped here, never reaches the service.
-const patchSchema = updateBenchmarkTemplateRequestSchema.omit({
+export const patchSchema = updateBenchmarkTemplateRequestSchema.omit({
   isOfficial: true,
   scenario: true,
   tool: true,

--- a/apps/api/src/modules/benchmark-template/benchmark-template.module.ts
+++ b/apps/api/src/modules/benchmark-template/benchmark-template.module.ts
@@ -1,9 +1,12 @@
 import { Module } from "@nestjs/common";
 import { PrismaService } from "../../database/prisma.service.js";
+import { BenchmarkTemplateController } from "./benchmark-template.controller.js";
 import { BenchmarkTemplateRepository } from "./benchmark-template.repository.js";
+import { BenchmarkTemplateService } from "./benchmark-template.service.js";
 
 @Module({
-  providers: [PrismaService, BenchmarkTemplateRepository],
-  exports: [BenchmarkTemplateRepository],
+  controllers: [BenchmarkTemplateController],
+  providers: [PrismaService, BenchmarkTemplateRepository, BenchmarkTemplateService],
+  exports: [BenchmarkTemplateRepository, BenchmarkTemplateService],
 })
 export class BenchmarkTemplateModule {}

--- a/apps/api/src/modules/benchmark-template/benchmark-template.repository.spec.ts
+++ b/apps/api/src/modules/benchmark-template/benchmark-template.repository.spec.ts
@@ -1,19 +1,15 @@
 import { ConfigService } from "@nestjs/config";
 import { Test } from "@nestjs/testing";
-import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { PrismaService } from "../../database/prisma.service.js";
 import { BenchmarkTemplateRepository } from "./benchmark-template.repository.js";
 
-/**
- * Minimal placeholder spec — full coverage lands in PR2 (BenchmarkTemplate
- * CRUD). For now this only proves the skeleton wires up against the live
- * Prisma client and that findByIdOrNull returns null on a miss.
- */
 describe("BenchmarkTemplateRepository", () => {
   let repo: BenchmarkTemplateRepository;
   let prisma: PrismaService;
+  let userId: string;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
       providers: [
         BenchmarkTemplateRepository,
@@ -21,25 +17,254 @@ describe("BenchmarkTemplateRepository", () => {
         {
           provide: ConfigService,
           useValue: {
-            get: (key: string) => {
-              if (key === "DATABASE_URL") return process.env.DATABASE_URL;
-              return undefined;
-            },
+            get: (key: string) => (key === "DATABASE_URL" ? process.env.DATABASE_URL : undefined),
           },
         },
       ],
     }).compile();
-
     repo = moduleRef.get(BenchmarkTemplateRepository);
     prisma = moduleRef.get(PrismaService);
+
+    const u = await prisma.user.create({
+      data: {
+        email: `repo-spec-${Date.now()}@example.com`,
+        passwordHash: "x",
+        roles: ["user"],
+      },
+    });
+    userId = u.id;
+  });
+
+  beforeEach(async () => {
+    await prisma.benchmarkTemplate.deleteMany({ where: { createdBy: userId } });
   });
 
   afterAll(async () => {
+    await prisma.benchmarkTemplate.deleteMany({ where: { createdBy: userId } });
+    await prisma.user.delete({ where: { id: userId } });
     await prisma.$disconnect();
   });
 
-  it("findByIdOrNull returns null when no template exists for the given id", async () => {
+  it("findByIdOrNull returns null for missing id", async () => {
     const result = await repo.findByIdOrNull("00000000-0000-0000-0000-000000000000");
     expect(result).toBeNull();
+  });
+
+  it("create persists a row with sensible defaults", async () => {
+    const created = await repo.create({
+      name: "My GuideLLM Template",
+      description: "constant rate baseline",
+      scenario: "inference",
+      tool: "guidellm",
+      config: { rateType: "constant", rate: 5 },
+      createdBy: userId,
+      tags: ["baseline", "qa"],
+    });
+    expect(created.id).toBeDefined();
+    expect(created.isOfficial).toBe(false);
+    expect(created.tags).toEqual(["baseline", "qa"]);
+    expect(created.config).toEqual({ rateType: "constant", rate: 5 });
+
+    const found = await repo.findByIdOrNull(created.id);
+    expect(found).not.toBeNull();
+    expect(found?.name).toBe("My GuideLLM Template");
+  });
+
+  it("update mutates name/description/config/tags but not scenario/tool/isOfficial", async () => {
+    const created = await repo.create({
+      name: "v1",
+      scenario: "inference",
+      tool: "guidellm",
+      config: { rateType: "constant", rate: 5 },
+      createdBy: userId,
+    });
+    const before = created.updatedAt;
+    await new Promise((r) => setTimeout(r, 10));
+    const updated = await repo.update(created.id, {
+      name: "v2",
+      tags: ["promoted"],
+      config: { rateType: "constant", rate: 10 },
+    });
+    expect(updated.name).toBe("v2");
+    expect(updated.tags).toEqual(["promoted"]);
+    expect(updated.config).toEqual({ rateType: "constant", rate: 10 });
+    expect(updated.scenario).toBe("inference");
+    expect(updated.tool).toBe("guidellm");
+    expect(updated.isOfficial).toBe(false);
+    expect(updated.updatedAt.getTime()).toBeGreaterThan(before.getTime());
+  });
+
+  it("delete removes the row", async () => {
+    const created = await repo.create({
+      name: "doomed",
+      scenario: "inference",
+      tool: "guidellm",
+      config: {},
+      createdBy: userId,
+    });
+    await repo.delete(created.id);
+    expect(await repo.findByIdOrNull(created.id)).toBeNull();
+  });
+
+  it("deleting a template referenced by a benchmark sets benchmark.templateId to null", async () => {
+    const tpl = await repo.create({
+      name: "t",
+      scenario: "inference",
+      tool: "guidellm",
+      config: { rateType: "constant", rate: 5 },
+      createdBy: userId,
+    });
+    const conn = await prisma.connection.create({
+      data: {
+        userId,
+        name: "c",
+        baseUrl: "http://upstream/",
+        apiKeyCipher: "v1:placeholder",
+        model: "m",
+        category: "text",
+      },
+    });
+    const bm = await prisma.benchmark.create({
+      data: {
+        userId,
+        connectionId: conn.id,
+        scenario: "inference",
+        tool: "guidellm",
+        driverKind: "local",
+        params: {},
+        templateId: tpl.id,
+      },
+    });
+    await repo.delete(tpl.id);
+    const reloaded = await prisma.benchmark.findUnique({ where: { id: bm.id } });
+    expect(reloaded?.templateId).toBeNull();
+
+    await prisma.benchmark.delete({ where: { id: bm.id } });
+    await prisma.connection.delete({ where: { id: conn.id } });
+  });
+
+  it("list returns rows ordered by isOfficial DESC, updatedAt DESC, id DESC", async () => {
+    const a = await repo.create({
+      name: "A user",
+      scenario: "inference",
+      tool: "guidellm",
+      config: {},
+      createdBy: userId,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    const b = await repo.create({
+      name: "B user",
+      scenario: "inference",
+      tool: "guidellm",
+      config: {},
+      createdBy: userId,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    const off = await prisma.benchmarkTemplate.create({
+      data: {
+        name: "Official",
+        scenario: "inference",
+        tool: "guidellm",
+        config: {},
+        isOfficial: true,
+        creator: { connect: { id: userId } },
+      },
+    });
+
+    const res = await repo.list({ scenario: "inference" });
+    const ids = res.items.map((r) => r.id);
+    expect(ids[0]).toBe(off.id);
+    expect(ids.indexOf(b.id)).toBeLessThan(ids.indexOf(a.id));
+  });
+
+  it("list filters by scenario", async () => {
+    await repo.create({
+      name: "inf",
+      scenario: "inference",
+      tool: "guidellm",
+      config: {},
+      createdBy: userId,
+    });
+    await repo.create({
+      name: "cap",
+      scenario: "capacity",
+      tool: "guidellm",
+      config: {},
+      createdBy: userId,
+    });
+    const inf = await repo.list({ scenario: "inference" });
+    expect(inf.items.every((r) => r.scenario === "inference")).toBe(true);
+    expect(inf.items.some((r) => r.name === "inf")).toBe(true);
+    expect(inf.items.some((r) => r.name === "cap")).toBe(false);
+  });
+
+  it("list filters by isOfficial", async () => {
+    await prisma.benchmarkTemplate.create({
+      data: {
+        name: "off",
+        scenario: "inference",
+        tool: "guidellm",
+        config: {},
+        isOfficial: true,
+        creator: { connect: { id: userId } },
+      },
+    });
+    await repo.create({
+      name: "personal",
+      scenario: "inference",
+      tool: "guidellm",
+      config: {},
+      createdBy: userId,
+    });
+    const officials = await repo.list({ isOfficial: true });
+    expect(officials.items.every((r) => r.isOfficial)).toBe(true);
+  });
+
+  it("list filters by search (case-insensitive on name + description)", async () => {
+    await repo.create({
+      name: "Latency baseline",
+      description: null,
+      scenario: "inference",
+      tool: "guidellm",
+      config: {},
+      createdBy: userId,
+    });
+    await repo.create({
+      name: "Throughput peak",
+      description: "for capacity planning",
+      scenario: "capacity",
+      tool: "guidellm",
+      config: {},
+      createdBy: userId,
+    });
+    const lat = await repo.list({ search: "lateNCY" });
+    expect(lat.items.some((r) => r.name === "Latency baseline")).toBe(true);
+    expect(lat.items.some((r) => r.name === "Throughput peak")).toBe(false);
+    const cap = await repo.list({ search: "capacity" });
+    expect(cap.items.some((r) => r.name === "Throughput peak")).toBe(true);
+  });
+
+  it("list paginates via cursor", async () => {
+    for (let i = 0; i < 5; i++) {
+      await repo.create({
+        name: `p${i}`,
+        scenario: "inference",
+        tool: "guidellm",
+        config: {},
+        createdBy: userId,
+      });
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    const page1 = await repo.list({ scenario: "inference", limit: 2 });
+    expect(page1.items.length).toBe(2);
+    expect(page1.nextCursor).not.toBeNull();
+    const cursor = page1.nextCursor ?? undefined;
+    const page2 = await repo.list({
+      scenario: "inference",
+      limit: 2,
+      cursor,
+    });
+    expect(page2.items.length).toBe(2);
+    expect(page2.items.map((r) => r.id)).not.toEqual(page1.items.map((r) => r.id));
   });
 });

--- a/apps/api/src/modules/benchmark-template/benchmark-template.repository.ts
+++ b/apps/api/src/modules/benchmark-template/benchmark-template.repository.ts
@@ -1,16 +1,96 @@
 import { Injectable } from "@nestjs/common";
+import { Prisma, type BenchmarkTemplate as PrismaBenchmarkTemplate } from "@prisma/client";
 import { PrismaService } from "../../database/prisma.service.js";
 
-/**
- * Skeleton repository for BenchmarkTemplate. PR2 will add full CRUD; for now
- * BenchmarkService only needs to validate that a templateId references an
- * existing row when the caller supplies one.
- */
+export type CreateBenchmarkTemplateInput = {
+  name: string;
+  description?: string | null;
+  scenario: string;
+  tool: string;
+  config: Prisma.InputJsonValue;
+  isOfficial?: boolean;
+  createdBy: string;
+  tags?: string[];
+};
+
+export type UpdateBenchmarkTemplateInput = Partial<{
+  name: string;
+  description: string | null;
+  config: Prisma.InputJsonValue;
+  tags: string[];
+}>;
+
+export type ListBenchmarkTemplatesInput = {
+  scenario?: string;
+  tool?: string;
+  isOfficial?: boolean;
+  search?: string;
+  cursor?: string;
+  limit?: number;
+};
+
 @Injectable()
 export class BenchmarkTemplateRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findByIdOrNull(id: string) {
+  async findByIdOrNull(id: string): Promise<PrismaBenchmarkTemplate | null> {
     return this.prisma.benchmarkTemplate.findUnique({ where: { id } });
+  }
+
+  async create(input: CreateBenchmarkTemplateInput): Promise<PrismaBenchmarkTemplate> {
+    return this.prisma.benchmarkTemplate.create({
+      data: {
+        name: input.name,
+        description: input.description ?? null,
+        scenario: input.scenario,
+        tool: input.tool,
+        config: input.config,
+        isOfficial: input.isOfficial ?? false,
+        tags: input.tags ?? [],
+        creator: { connect: { id: input.createdBy } },
+      },
+    });
+  }
+
+  async update(id: string, input: UpdateBenchmarkTemplateInput): Promise<PrismaBenchmarkTemplate> {
+    return this.prisma.benchmarkTemplate.update({
+      where: { id },
+      data: input as Prisma.BenchmarkTemplateUpdateInput,
+    });
+  }
+
+  async delete(id: string): Promise<PrismaBenchmarkTemplate> {
+    return this.prisma.benchmarkTemplate.delete({ where: { id } });
+  }
+
+  async list(input: ListBenchmarkTemplatesInput): Promise<{
+    items: PrismaBenchmarkTemplate[];
+    nextCursor: string | null;
+  }> {
+    const limit = Math.min(input.limit ?? 50, 100);
+    const where: Prisma.BenchmarkTemplateWhereInput = {};
+    if (input.scenario) where.scenario = input.scenario;
+    if (input.tool) where.tool = input.tool;
+    if (input.isOfficial !== undefined) where.isOfficial = input.isOfficial;
+    if (input.search) {
+      where.OR = [
+        { name: { contains: input.search, mode: "insensitive" } },
+        { description: { contains: input.search, mode: "insensitive" } },
+      ];
+    }
+
+    const items = await this.prisma.benchmarkTemplate.findMany({
+      where,
+      orderBy: [{ isOfficial: "desc" }, { updatedAt: "desc" }, { id: "desc" }],
+      take: limit + 1,
+      ...(input.cursor && { cursor: { id: input.cursor }, skip: 1 }),
+    });
+
+    const hasMore = items.length > limit;
+    const sliced = hasMore ? items.slice(0, limit) : items;
+    return {
+      items: sliced,
+      nextCursor: hasMore ? sliced[sliced.length - 1].id : null,
+    };
   }
 }

--- a/apps/api/src/modules/benchmark-template/benchmark-template.service.spec.ts
+++ b/apps/api/src/modules/benchmark-template/benchmark-template.service.spec.ts
@@ -141,6 +141,27 @@ describe("BenchmarkTemplateService", () => {
       expect(out.name).toBe("renamed");
     });
 
+    it("re-validates config against the existing row's (scenario, tool) when patch.config is supplied", async () => {
+      // The existing row is inference + guidellm. We patch with a NEW config.
+      // The mocked applyScenarioConstraints / paramsSchema accept anything,
+      // so this should succeed — what matters is verifying repo.update
+      // received the new config (i.e. validateConfig didn't reject it).
+      (repo.findByIdOrNull as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeRow({ createdBy: "owner-1", scenario: "inference", tool: "guidellm" }),
+      );
+      (repo.update as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeRow({ config: { rateType: "constant", rate: 99 } }),
+      );
+      const out = await svc.update({ sub: "owner-1", isAdmin: false }, "tpl-1", {
+        config: { rateType: "constant", rate: 99 },
+      });
+      expect(repo.update).toHaveBeenCalledWith(
+        "tpl-1",
+        expect.objectContaining({ config: { rateType: "constant", rate: 99 } }),
+      );
+      expect(out.config).toEqual({ rateType: "constant", rate: 99 });
+    });
+
     it("allows admin to patch any template", async () => {
       (repo.findByIdOrNull as ReturnType<typeof vi.fn>).mockResolvedValue(
         makeRow({ createdBy: "owner-1" }),

--- a/apps/api/src/modules/benchmark-template/benchmark-template.service.spec.ts
+++ b/apps/api/src/modules/benchmark-template/benchmark-template.service.spec.ts
@@ -1,0 +1,188 @@
+import { BadRequestException, ForbiddenException, NotFoundException } from "@nestjs/common";
+import type { BenchmarkTemplate as PrismaBenchmarkTemplate } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BenchmarkTemplateRepository } from "./benchmark-template.repository.js";
+import { BenchmarkTemplateService } from "./benchmark-template.service.js";
+
+vi.mock("@modeldoctor/tool-adapters", async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return {
+    ...actual,
+    applyScenarioConstraints: () => ({ parse: (x: unknown) => x }),
+    byTool: (name: string) => ({
+      name,
+      // guidellm supports inference + capacity, vegeta only gateway,
+      // genai-perf only inference — matches the real adapter declarations.
+      scenarios:
+        name === "guidellm"
+          ? ["inference", "capacity"]
+          : name === "vegeta"
+            ? ["gateway"]
+            : ["inference"],
+      paramsSchema: { parse: (x: unknown) => x },
+    }),
+  };
+});
+
+function makeRow(over: Partial<PrismaBenchmarkTemplate> = {}): PrismaBenchmarkTemplate {
+  return {
+    id: "tpl-1",
+    name: "t",
+    description: null,
+    scenario: "inference",
+    tool: "guidellm",
+    config: {},
+    isOfficial: false,
+    createdBy: "owner-1",
+    tags: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...over,
+  } as PrismaBenchmarkTemplate;
+}
+
+function makeRepo(): BenchmarkTemplateRepository {
+  return {
+    findByIdOrNull: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    list: vi.fn(),
+  } as unknown as BenchmarkTemplateRepository;
+}
+
+describe("BenchmarkTemplateService", () => {
+  let svc: BenchmarkTemplateService;
+  let repo: BenchmarkTemplateRepository;
+
+  beforeEach(() => {
+    repo = makeRepo();
+    svc = new BenchmarkTemplateService(repo);
+  });
+
+  describe("create", () => {
+    it("creates a non-official template for any authenticated user", async () => {
+      (repo.create as ReturnType<typeof vi.fn>).mockResolvedValue(makeRow());
+      const out = await svc.create(
+        { sub: "user-2", isAdmin: false },
+        {
+          name: "t",
+          scenario: "inference",
+          tool: "guidellm",
+          config: {},
+          isOfficial: false,
+          tags: [],
+        },
+      );
+      expect(out.id).toBe("tpl-1");
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ isOfficial: false, createdBy: "user-2" }),
+      );
+    });
+
+    it("rejects isOfficial=true from non-admin with BENCHMARK_TEMPLATE_OFFICIAL_FORBIDDEN", async () => {
+      await expect(
+        svc.create(
+          { sub: "user-2", isAdmin: false },
+          {
+            name: "t",
+            scenario: "inference",
+            tool: "guidellm",
+            config: {},
+            isOfficial: true,
+            tags: [],
+          },
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it("permits isOfficial=true from admin", async () => {
+      (repo.create as ReturnType<typeof vi.fn>).mockResolvedValue(makeRow({ isOfficial: true }));
+      const out = await svc.create(
+        { sub: "admin-1", isAdmin: true },
+        {
+          name: "Official",
+          scenario: "inference",
+          tool: "guidellm",
+          config: {},
+          isOfficial: true,
+          tags: [],
+        },
+      );
+      expect(out.isOfficial).toBe(true);
+    });
+
+    it("rejects scenario × tool mismatch with BENCHMARK_TEMPLATE_SCENARIO_TOOL_MISMATCH", async () => {
+      await expect(
+        svc.create(
+          { sub: "user-2", isAdmin: false },
+          {
+            name: "t",
+            scenario: "gateway", // gateway only supports vegeta
+            tool: "guidellm",
+            config: {},
+            isOfficial: false,
+            tags: [],
+          },
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe("update", () => {
+    it("allows the owner to patch name/config", async () => {
+      (repo.findByIdOrNull as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeRow({ createdBy: "owner-1" }),
+      );
+      (repo.update as ReturnType<typeof vi.fn>).mockResolvedValue(makeRow({ name: "renamed" }));
+      const out = await svc.update({ sub: "owner-1", isAdmin: false }, "tpl-1", {
+        name: "renamed",
+      });
+      expect(out.name).toBe("renamed");
+    });
+
+    it("allows admin to patch any template", async () => {
+      (repo.findByIdOrNull as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeRow({ createdBy: "owner-1" }),
+      );
+      (repo.update as ReturnType<typeof vi.fn>).mockResolvedValue(makeRow());
+      await svc.update({ sub: "admin-1", isAdmin: true }, "tpl-1", { name: "x" });
+      expect(repo.update).toHaveBeenCalled();
+    });
+
+    it("rejects non-owner non-admin with ForbiddenException", async () => {
+      (repo.findByIdOrNull as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeRow({ createdBy: "owner-1" }),
+      );
+      await expect(
+        svc.update({ sub: "intruder", isAdmin: false }, "tpl-1", { name: "x" }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it("returns 404 when template missing", async () => {
+      (repo.findByIdOrNull as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      await expect(
+        svc.update({ sub: "owner-1", isAdmin: false }, "missing", { name: "x" }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("delete", () => {
+    it("allows owner to delete", async () => {
+      (repo.findByIdOrNull as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeRow({ createdBy: "owner-1" }),
+      );
+      await svc.delete({ sub: "owner-1", isAdmin: false }, "tpl-1");
+      expect(repo.delete).toHaveBeenCalledWith("tpl-1");
+    });
+
+    it("rejects non-owner non-admin", async () => {
+      (repo.findByIdOrNull as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeRow({ createdBy: "owner-1" }),
+      );
+      await expect(svc.delete({ sub: "intruder", isAdmin: false }, "tpl-1")).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+});

--- a/apps/api/src/modules/benchmark-template/benchmark-template.service.ts
+++ b/apps/api/src/modules/benchmark-template/benchmark-template.service.ts
@@ -1,0 +1,150 @@
+import {
+  type BenchmarkTemplate,
+  type CreateBenchmarkTemplateRequest,
+  type ListBenchmarkTemplatesQuery,
+  type ListBenchmarkTemplatesResponse,
+} from "@modeldoctor/contracts";
+import { type ToolName, applyScenarioConstraints, byTool } from "@modeldoctor/tool-adapters";
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import type { Prisma, BenchmarkTemplate as PrismaBenchmarkTemplate } from "@prisma/client";
+import {
+  BenchmarkTemplateRepository,
+  type UpdateBenchmarkTemplateInput,
+} from "./benchmark-template.repository.js";
+
+/**
+ * Caller identity used for authorization decisions. The controller flattens
+ * `JwtPayload` into this shape so the service stays test-friendly without
+ * a JwtPayload import in tests.
+ */
+export interface TemplateActor {
+  sub: string;
+  isAdmin: boolean;
+}
+
+@Injectable()
+export class BenchmarkTemplateService {
+  constructor(private readonly repo: BenchmarkTemplateRepository) {}
+
+  async list(query: ListBenchmarkTemplatesQuery): Promise<ListBenchmarkTemplatesResponse> {
+    const result = await this.repo.list(query);
+    return {
+      items: result.items.map(toContract),
+      nextCursor: result.nextCursor,
+    };
+  }
+
+  async findByIdOrFail(id: string): Promise<BenchmarkTemplate> {
+    const row = await this.repo.findByIdOrNull(id);
+    if (!row) throw new NotFoundException(`BenchmarkTemplate ${id} not found`);
+    return toContract(row);
+  }
+
+  async create(
+    actor: TemplateActor,
+    req: CreateBenchmarkTemplateRequest,
+  ): Promise<BenchmarkTemplate> {
+    if (req.isOfficial && !actor.isAdmin) {
+      throw new ForbiddenException({
+        code: "BENCHMARK_TEMPLATE_OFFICIAL_FORBIDDEN",
+        message: "only admin can create official templates",
+      });
+    }
+    this.assertScenarioToolPair(req.scenario, req.tool);
+    this.validateConfig(req.scenario, req.tool, req.config);
+
+    const row = await this.repo.create({
+      name: req.name,
+      description: req.description ?? null,
+      scenario: req.scenario,
+      tool: req.tool,
+      config: req.config as Prisma.InputJsonValue,
+      isOfficial: req.isOfficial ?? false,
+      createdBy: actor.sub,
+      tags: req.tags ?? [],
+    });
+    return toContract(row);
+  }
+
+  async update(
+    actor: TemplateActor,
+    id: string,
+    patch: UpdateBenchmarkTemplateInput,
+  ): Promise<BenchmarkTemplate> {
+    const row = await this.repo.findByIdOrNull(id);
+    if (!row) throw new NotFoundException(`BenchmarkTemplate ${id} not found`);
+    this.assertCanWrite(actor, row);
+
+    if (patch.config !== undefined) {
+      this.validateConfig(row.scenario, row.tool, patch.config);
+    }
+    const updated = await this.repo.update(id, patch);
+    return toContract(updated);
+  }
+
+  async delete(actor: TemplateActor, id: string): Promise<void> {
+    const row = await this.repo.findByIdOrNull(id);
+    if (!row) throw new NotFoundException(`BenchmarkTemplate ${id} not found`);
+    this.assertCanWrite(actor, row);
+    await this.repo.delete(id);
+  }
+
+  private assertCanWrite(actor: TemplateActor, row: PrismaBenchmarkTemplate): void {
+    if (actor.isAdmin) return;
+    if (row.createdBy === actor.sub) return;
+    throw new ForbiddenException({
+      code: "BENCHMARK_TEMPLATE_FORBIDDEN",
+      message: "only the template owner or an admin can modify this template",
+    });
+  }
+
+  private assertScenarioToolPair(scenario: string, tool: string): void {
+    const adapter = byTool(tool as ToolName);
+    if (!(adapter.scenarios as readonly string[]).includes(scenario)) {
+      throw new BadRequestException({
+        code: "BENCHMARK_TEMPLATE_SCENARIO_TOOL_MISMATCH",
+        message: `scenario '${scenario}' does not support tool '${tool}'`,
+      });
+    }
+  }
+
+  private validateConfig(scenario: string, tool: string, config: unknown): void {
+    try {
+      // Same double-parse pattern as BenchmarkService.create:
+      // 1) scenario-narrowed schema (e.g. capacity forces rateType=sweep)
+      // 2) adapter base schema (preserves cross-field superRefine rules
+      //    that applyScenarioConstraints unwraps)
+      applyScenarioConstraints(
+        scenario as Parameters<typeof applyScenarioConstraints>[0],
+        tool as ToolName,
+      ).parse(config);
+      byTool(tool as ToolName).paramsSchema.parse(config);
+    } catch (e) {
+      throw new BadRequestException({
+        code: "BENCHMARK_TEMPLATE_CONFIG_INVALID",
+        message: `config validation failed: ${(e as Error).message}`,
+      });
+    }
+  }
+}
+
+function toContract(row: PrismaBenchmarkTemplate): BenchmarkTemplate {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    scenario: row.scenario as BenchmarkTemplate["scenario"],
+    tool: row.tool as BenchmarkTemplate["tool"],
+    config: row.config as Record<string, unknown>,
+    isOfficial: row.isOfficial,
+    createdBy: row.createdBy,
+    tags: row.tags,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}

--- a/apps/api/test/e2e/auth.e2e-spec.ts
+++ b/apps/api/test/e2e/auth.e2e-spec.ts
@@ -370,9 +370,8 @@ describe("Auth (e2e)", () => {
       .get("/api/benchmarks?scope=all")
       .set("Authorization", `Bearer ${userToken}`)
       .expect(403);
-    // AllExceptionsFilter normalizes the http status → "FORBIDDEN" (the controller's
-    // exception body `code: "BENCHMARK_SCOPE_FORBIDDEN"` is preserved in the message instead).
-    expect(res.body.error.code).toBe("FORBIDDEN");
+    // AllExceptionsFilter preserves the domain-specific code from the exception body.
+    expect(res.body.error.code).toBe("BENCHMARK_SCOPE_FORBIDDEN");
     expect(res.body.error.message).toMatch(/admin role required/i);
   });
 

--- a/apps/api/test/e2e/benchmark-template.e2e-spec.ts
+++ b/apps/api/test/e2e/benchmark-template.e2e-spec.ts
@@ -1,0 +1,192 @@
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { PrismaService } from "../../src/database/prisma.service.js";
+import { type E2EContext, bootE2E, registerUser } from "../helpers/app.js";
+
+/**
+ * Minimum valid config for scenario=inference + tool=guidellm.
+ * The inference scenario merges `rateType` (required enum) into the base
+ * guidellm schema; `profile`, `apiType`, `datasetName` are required base fields.
+ * Using datasetName="sharegpt" avoids the extra datasetInputTokens requirement.
+ */
+const VALID_GUIDELLM_CONFIG = {
+  profile: "throughput",
+  apiType: "chat",
+  datasetName: "sharegpt",
+  rateType: "constant",
+} as const;
+
+describe("BenchmarkTemplate (e2e)", () => {
+  let ctx: E2EContext;
+  let adminToken: string;
+  let userToken: string;
+  let adminId: string;
+  let userId: string;
+
+  beforeAll(async () => {
+    ctx = await bootE2E();
+    // Wipe so the first registration becomes the admin (per the
+    // auth-bootstrap rule: first user gets ["admin"] role).
+    // Delete in reverse FK order to avoid constraint violations:
+    // Baseline.benchmarkId has onDelete: Restrict, so baselines must go first.
+    const prisma = ctx.app.get(PrismaService);
+    await prisma.baseline.deleteMany();
+    await prisma.benchmark.deleteMany();
+    await prisma.benchmarkTemplate.deleteMany();
+    await prisma.diagnosticsRun.deleteMany();
+    await prisma.connection.deleteMany();
+    await prisma.user.deleteMany();
+
+    const admin = await registerUser(ctx.app, "admin@example.com", "Password1!");
+    adminToken = admin.token;
+    adminId = admin.user.id;
+    expect(admin.user.roles).toContain("admin");
+
+    const user = await registerUser(ctx.app, "user@example.com", "Password1!");
+    userToken = user.token;
+    userId = user.user.id;
+    expect(user.user.roles).not.toContain("admin");
+  }, 120_000);
+
+  afterAll(async () => {
+    await ctx.teardown();
+  });
+
+  it("admin can create an official template", async () => {
+    const res = await request(ctx.app.getHttpServer())
+      .post("/api/benchmark-templates")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({
+        name: "Inference baseline",
+        scenario: "inference",
+        tool: "guidellm",
+        config: VALID_GUIDELLM_CONFIG,
+        isOfficial: true,
+        tags: ["baseline"],
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.isOfficial).toBe(true);
+    expect(res.body.createdBy).toBe(adminId);
+  });
+
+  it("non-admin gets 403 attempting isOfficial=true", async () => {
+    const res = await request(ctx.app.getHttpServer())
+      .post("/api/benchmark-templates")
+      .set("Authorization", `Bearer ${userToken}`)
+      .send({
+        name: "fake official",
+        scenario: "inference",
+        tool: "guidellm",
+        config: VALID_GUIDELLM_CONFIG,
+        isOfficial: true,
+        tags: [],
+      });
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("BENCHMARK_TEMPLATE_OFFICIAL_FORBIDDEN");
+  });
+
+  it("non-admin can create a personal template", async () => {
+    const res = await request(ctx.app.getHttpServer())
+      .post("/api/benchmark-templates")
+      .set("Authorization", `Bearer ${userToken}`)
+      .send({
+        name: "My personal config",
+        scenario: "inference",
+        tool: "guidellm",
+        config: VALID_GUIDELLM_CONFIG,
+        isOfficial: false,
+        tags: ["personal"],
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.isOfficial).toBe(false);
+    expect(res.body.createdBy).toBe(userId);
+  });
+
+  it("any authenticated user can list — official first", async () => {
+    const res = await request(ctx.app.getHttpServer())
+      .get("/api/benchmark-templates?scenario=inference")
+      .set("Authorization", `Bearer ${userToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.items.length).toBeGreaterThanOrEqual(2);
+    expect(res.body.items[0].isOfficial).toBe(true);
+  });
+
+  it("non-owner non-admin cannot edit a foreign template", async () => {
+    // Find admin's official template
+    const list = await request(ctx.app.getHttpServer())
+      .get("/api/benchmark-templates?isOfficial=true")
+      .set("Authorization", `Bearer ${userToken}`);
+    const officialId = list.body.items[0].id;
+
+    const res = await request(ctx.app.getHttpServer())
+      .patch(`/api/benchmark-templates/${officialId}`)
+      .set("Authorization", `Bearer ${userToken}`)
+      .send({ name: "hijacked" });
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("BENCHMARK_TEMPLATE_FORBIDDEN");
+  });
+
+  it("PATCH strips isOfficial/scenario/tool from body", async () => {
+    const list = await request(ctx.app.getHttpServer())
+      .get("/api/benchmark-templates?isOfficial=false")
+      .set("Authorization", `Bearer ${userToken}`);
+    const personalId = list.body.items.find(
+      (t: { createdBy: string }) => t.createdBy === userId,
+    ).id;
+
+    const res = await request(ctx.app.getHttpServer())
+      .patch(`/api/benchmark-templates/${personalId}`)
+      .set("Authorization", `Bearer ${userToken}`)
+      .send({
+        name: "renamed",
+        // These three should be silently stripped by the schema
+        isOfficial: true,
+        scenario: "capacity",
+        tool: "vegeta",
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe("renamed");
+    expect(res.body.isOfficial).toBe(false); // unchanged
+    expect(res.body.scenario).toBe("inference"); // unchanged
+    expect(res.body.tool).toBe("guidellm"); // unchanged
+  });
+
+  it("owner can delete their template", async () => {
+    const created = await request(ctx.app.getHttpServer())
+      .post("/api/benchmark-templates")
+      .set("Authorization", `Bearer ${userToken}`)
+      .send({
+        name: "doomed",
+        scenario: "inference",
+        tool: "guidellm",
+        config: VALID_GUIDELLM_CONFIG,
+        isOfficial: false,
+        tags: [],
+      });
+    const res = await request(ctx.app.getHttpServer())
+      .delete(`/api/benchmark-templates/${created.body.id}`)
+      .set("Authorization", `Bearer ${userToken}`);
+    expect(res.status).toBe(204);
+
+    const after = await request(ctx.app.getHttpServer())
+      .get(`/api/benchmark-templates/${created.body.id}`)
+      .set("Authorization", `Bearer ${userToken}`);
+    expect(after.status).toBe(404);
+  });
+
+  it("(scenario, tool) mismatch surfaces a 400 with explicit code", async () => {
+    const res = await request(ctx.app.getHttpServer())
+      .post("/api/benchmark-templates")
+      .set("Authorization", `Bearer ${userToken}`)
+      .send({
+        name: "bad pair",
+        scenario: "gateway",
+        tool: "guidellm", // gateway only supports vegeta
+        config: {},
+        isOfficial: false,
+        tags: [],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("BENCHMARK_TEMPLATE_SCENARIO_TOOL_MISMATCH");
+  });
+});

--- a/apps/web/src/components/sidebar/sidebar-config.tsx
+++ b/apps/web/src/components/sidebar/sidebar-config.tsx
@@ -7,6 +7,7 @@ import {
   Gauge,
   GitCompare,
   Image as ImageIcon,
+  Layers,
   LineChart,
   ListOrdered,
   type LucideIcon,
@@ -53,7 +54,7 @@ export const sidebarGroups: SidebarGroup[] = [
       { to: "/benchmarks/capacity", icon: Activity, labelKey: "items.benchmarkCapacity" },
       { to: "/benchmarks/gateway", icon: Network, labelKey: "items.benchmarkGateway" },
       { to: "/benchmarks/compare", icon: GitCompare, labelKey: "items.benchmarkCompare" },
-      // benchmark-templates entry omitted in PR1; lands in PR2.
+      { to: "/benchmark-templates", icon: Layers, labelKey: "items.benchmarkTemplates" },
     ],
   },
   {

--- a/apps/web/src/features/benchmark-templates/DeleteTemplateDialog.tsx
+++ b/apps/web/src/features/benchmark-templates/DeleteTemplateDialog.tsx
@@ -1,0 +1,53 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import type { BenchmarkTemplate } from "@modeldoctor/contracts";
+import { useTranslation } from "react-i18next";
+
+export interface DeleteTemplateDialogProps {
+  template: BenchmarkTemplate | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  pending: boolean;
+}
+
+export function DeleteTemplateDialog({
+  template,
+  open,
+  onOpenChange,
+  onConfirm,
+  pending,
+}: DeleteTemplateDialogProps) {
+  const { t } = useTranslation("benchmark-templates");
+  if (!template) return null;
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {t("edit.deleteConfirm.title", { name: template.name })}
+          </AlertDialogTitle>
+          <AlertDialogDescription>{t("edit.deleteConfirm.body")}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{t("edit.deleteConfirm.cancel")}</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={pending}
+            onClick={onConfirm}
+            className="bg-destructive hover:bg-destructive/90"
+          >
+            {t("edit.deleteConfirm.confirm")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/src/features/benchmark-templates/TemplateCard.tsx
+++ b/apps/web/src/features/benchmark-templates/TemplateCard.tsx
@@ -1,0 +1,80 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { BenchmarkTemplate } from "@modeldoctor/contracts";
+import { MoreHorizontal, ShieldCheck } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+
+export interface TemplateCardProps {
+  template: BenchmarkTemplate;
+  canEdit: boolean;
+  onDeleteClick: () => void;
+}
+
+export function TemplateCard({ template, canEdit, onDeleteClick }: TemplateCardProps) {
+  const { t } = useTranslation("benchmark-templates");
+  return (
+    <div className="group relative rounded-lg border border-border bg-card p-4 transition hover:border-primary/40">
+      <Link to={`/benchmark-templates/${template.id}`} className="block space-y-2">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-2">
+            {template.isOfficial && <ShieldCheck className="h-4 w-4 text-primary" aria-hidden />}
+            <h3 className="truncate text-sm font-semibold">{template.name}</h3>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Badge variant="outline" className="text-xs">
+            {template.tool}
+          </Badge>
+          {template.isOfficial && (
+            <Badge variant="default" className="text-xs">
+              {t("list.official")}
+            </Badge>
+          )}
+          {template.tags.map((tag) => (
+            <Badge key={tag} variant="outline" className="text-xs">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+        <p className="line-clamp-2 text-xs text-muted-foreground">{template.description || ""}</p>
+        <p className="text-xs text-muted-foreground">
+          {t("list.updatedAt", {
+            when: new Date(template.updatedAt).toLocaleString(),
+          })}
+        </p>
+      </Link>
+      {canEdit && (
+        <div className="absolute right-2 top-2 opacity-0 transition group-hover:opacity-100">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" aria-label="actions">
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem asChild>
+                <Link to={`/benchmark-templates/${template.id}`}>{t("actions.edit")}</Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="text-destructive"
+                onClick={(e) => {
+                  e.preventDefault();
+                  onDeleteClick();
+                }}
+              >
+                {t("actions.delete")}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/benchmark-templates/TemplateCreatePage.tsx
+++ b/apps/web/src/features/benchmark-templates/TemplateCreatePage.tsx
@@ -1,0 +1,81 @@
+import { PageHeader } from "@/components/common/page-header";
+import { Button } from "@/components/ui/button";
+import { TOOL_DEFAULTS } from "@/features/benchmarks/forms/ToolParamsEditor";
+import { SCENARIOS } from "@/features/benchmarks/scenarios";
+import { useAuthStore } from "@/stores/auth-store";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  type CreateBenchmarkTemplateRequest,
+  type ScenarioId,
+  createBenchmarkTemplateRequestSchema,
+  scenarioIdSchema,
+} from "@modeldoctor/contracts";
+import { FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { toast } from "sonner";
+import { TemplateForm } from "./TemplateForm";
+import { useCreateTemplate } from "./queries";
+
+export function TemplateCreatePage() {
+  const { t } = useTranslation("benchmark-templates");
+  const navigate = useNavigate();
+  const [params] = useSearchParams();
+  const user = useAuthStore((s) => s.user);
+  const isAdmin = (user?.roles ?? []).includes("admin");
+  const createMut = useCreateTemplate();
+
+  const scenarioParam = params.get("scenario");
+  const scenarioParse = scenarioIdSchema.safeParse(scenarioParam);
+  const scenario: ScenarioId = scenarioParse.success ? scenarioParse.data : "inference";
+  const tool = SCENARIOS[scenario].tools[0];
+
+  const form = useForm<CreateBenchmarkTemplateRequest>({
+    resolver: zodResolver(createBenchmarkTemplateRequestSchema),
+    mode: "onChange",
+    defaultValues: {
+      name: "",
+      description: undefined,
+      scenario,
+      tool,
+      config: TOOL_DEFAULTS[tool] as Record<string, unknown>,
+      isOfficial: false,
+      tags: [],
+    },
+  });
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    try {
+      const created = await createMut.mutateAsync(values);
+      toast.success(t("create.submitted", { name: created.name }));
+      navigate(`/benchmark-templates?scenario=${created.scenario}`);
+    } catch (e) {
+      toast.error((e as Error).message ?? t("create.errors.submitFailed"));
+    }
+  });
+
+  return (
+    <>
+      <PageHeader title={t("create.title")} subtitle={t("create.subtitle")} />
+      <div className="mx-auto max-w-3xl px-8 py-6">
+        <FormProvider {...form}>
+          <form onSubmit={onSubmit} className="space-y-6">
+            <TemplateForm mode="create" isAdmin={isAdmin} />
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => navigate("/benchmark-templates")}
+              >
+                {t("actions.cancel")}
+              </Button>
+              <Button type="submit" disabled={!form.formState.isValid || createMut.isPending}>
+                {createMut.isPending ? "…" : t("actions.save")}
+              </Button>
+            </div>
+          </form>
+        </FormProvider>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/features/benchmark-templates/TemplateEditPage.tsx
+++ b/apps/web/src/features/benchmark-templates/TemplateEditPage.tsx
@@ -1,0 +1,144 @@
+import { PageHeader } from "@/components/common/page-header";
+import { Button } from "@/components/ui/button";
+import { useAuthStore } from "@/stores/auth-store";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  type UpdateBenchmarkTemplateRequest,
+  updateBenchmarkTemplateRequestSchema,
+} from "@modeldoctor/contracts";
+import { useEffect, useState } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { useNavigate, useParams } from "react-router-dom";
+import { toast } from "sonner";
+import { DeleteTemplateDialog } from "./DeleteTemplateDialog";
+import { TemplateForm } from "./TemplateForm";
+import { useDeleteTemplate, useTemplate, useUpdateTemplate } from "./queries";
+
+export function TemplateEditPage() {
+  const { t } = useTranslation("benchmark-templates");
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const tplQ = useTemplate(id);
+  const user = useAuthStore((s) => s.user);
+  const myId = user?.id;
+  const isAdmin = (user?.roles ?? []).includes("admin");
+  const updateMut = useUpdateTemplate(id ?? "");
+  const deleteMut = useDeleteTemplate();
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  const tpl = tplQ.data;
+  const canEdit = !!tpl && (isAdmin || tpl.createdBy === myId);
+  const mode = !canEdit ? "edit-readonly" : "edit-owner";
+
+  const patchSchema = updateBenchmarkTemplateRequestSchema.omit({
+    isOfficial: true,
+    scenario: true,
+    tool: true,
+  });
+
+  const form = useForm<Partial<UpdateBenchmarkTemplateRequest>>({
+    resolver: zodResolver(patchSchema),
+    mode: "onChange",
+    defaultValues: {},
+  });
+
+  useEffect(() => {
+    if (!tpl) return;
+    form.reset({
+      name: tpl.name,
+      description: tpl.description ?? undefined,
+      config: tpl.config,
+      tags: tpl.tags,
+    });
+    // Set the disabled fields so the disabled selectors render the right value
+    form.setValue("scenario" as never, tpl.scenario as never);
+    form.setValue("tool" as never, tpl.tool as never);
+    form.setValue("isOfficial" as never, tpl.isOfficial as never);
+  }, [tpl, form]);
+
+  if (tplQ.isLoading) {
+    return (
+      <>
+        <PageHeader title={t("edit.title")} subtitle={t("edit.subtitle")} />
+        <div className="mx-auto max-w-3xl px-8 py-6 text-sm text-muted-foreground">…</div>
+      </>
+    );
+  }
+  if (!tpl) {
+    return (
+      <>
+        <PageHeader title={t("edit.title")} subtitle={t("edit.subtitle")} />
+        <div className="mx-auto max-w-3xl px-8 py-6 text-sm text-destructive">404</div>
+      </>
+    );
+  }
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    try {
+      await updateMut.mutateAsync(values);
+      toast.success(t("edit.saved"));
+    } catch (e) {
+      toast.error((e as Error).message ?? t("edit.errors.saveFailed"));
+    }
+  });
+
+  async function onDelete() {
+    if (!id) return;
+    try {
+      await deleteMut.mutateAsync(id);
+      toast.success(t("edit.deleted"));
+      navigate("/benchmark-templates");
+    } catch (e) {
+      toast.error((e as Error).message ?? t("edit.errors.deleteFailed"));
+    }
+  }
+
+  return (
+    <>
+      <PageHeader title={t("edit.title")} subtitle={t("edit.subtitle")} />
+      <div className="mx-auto max-w-3xl space-y-4 px-8 py-6">
+        {!canEdit && (
+          <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100">
+            {t("edit.readonlyBanner")}
+          </div>
+        )}
+        <FormProvider {...form}>
+          <form onSubmit={onSubmit} className="space-y-6">
+            <TemplateForm mode={mode} isAdmin={isAdmin} />
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => navigate("/benchmark-templates")}
+              >
+                {t("actions.back")}
+              </Button>
+              {canEdit && (
+                <>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    onClick={() => setConfirmingDelete(true)}
+                  >
+                    {t("actions.delete")}
+                  </Button>
+                  <Button type="submit" disabled={updateMut.isPending}>
+                    {updateMut.isPending ? "…" : t("actions.save")}
+                  </Button>
+                </>
+              )}
+            </div>
+          </form>
+        </FormProvider>
+      </div>
+      <DeleteTemplateDialog
+        template={tpl}
+        open={confirmingDelete}
+        onOpenChange={setConfirmingDelete}
+        onConfirm={onDelete}
+        pending={deleteMut.isPending}
+      />
+    </>
+  );
+}

--- a/apps/web/src/features/benchmark-templates/TemplateForm.tsx
+++ b/apps/web/src/features/benchmark-templates/TemplateForm.tsx
@@ -1,0 +1,142 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { TOOL_DEFAULTS, ToolParamsEditor } from "@/features/benchmarks/forms/ToolParamsEditor";
+import { SCENARIOS, type ScenarioId } from "@/features/benchmarks/scenarios";
+import { useId } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+
+export interface TemplateFormProps {
+  /** "create" exposes scenario/tool selectors + admin-only isOfficial.
+   *  "edit-owner" disables scenario/tool/isOfficial; rest editable.
+   *  "edit-readonly" disables everything (used when viewer is not owner+not admin). */
+  mode: "create" | "edit-owner" | "edit-readonly";
+  isAdmin: boolean;
+}
+
+export function TemplateForm({ mode, isAdmin }: TemplateFormProps) {
+  const { t } = useTranslation("benchmark-templates");
+  const { register, control, reset, getValues } = useFormContext();
+  const id = useId();
+  const nameId = `${id}-name`;
+  const descId = `${id}-desc`;
+  const tagsId = `${id}-tags`;
+  const scenarioId = `${id}-scenario`;
+  const officialId = `${id}-official`;
+
+  const scenario = (useWatch({ control, name: "scenario" }) ?? "inference") as ScenarioId;
+  const disableScenarioTool = mode !== "create";
+  const disableAll = mode === "edit-readonly";
+
+  function handleScenarioChange(next: ScenarioId) {
+    const nextTool = SCENARIOS[next].tools[0];
+    reset({
+      ...getValues(),
+      scenario: next,
+      tool: nextTool,
+      config: TOOL_DEFAULTS[nextTool] as Record<string, unknown>,
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-lg border border-border bg-card p-4 space-y-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          {t("create.sections.basic")}
+        </h2>
+        <div>
+          <Label htmlFor={nameId}>{t("create.fields.name")}</Label>
+          <Input
+            id={nameId}
+            {...register("name")}
+            placeholder={t("create.fields.namePlaceholder")}
+            disabled={disableAll}
+          />
+        </div>
+        <div>
+          <Label htmlFor={descId}>{t("create.fields.description")}</Label>
+          <Textarea
+            id={descId}
+            rows={2}
+            {...register("description", {
+              setValueAs: (v) => (v === "" || v === undefined ? null : v),
+            })}
+            disabled={disableAll}
+          />
+        </div>
+        <div>
+          <Label htmlFor={tagsId}>{t("create.fields.tags")}</Label>
+          <Input
+            id={tagsId}
+            placeholder={t("create.fields.tagsPlaceholder")}
+            disabled={disableAll}
+            {...register("tags", {
+              setValueAs: (v) =>
+                typeof v === "string"
+                  ? v
+                      .split(",")
+                      .map((s) => s.trim())
+                      .filter(Boolean)
+                  : (v ?? []),
+            })}
+          />
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-border bg-card p-4">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          {t("create.sections.scenario")}
+        </h2>
+        <div className="max-w-xs">
+          <Label htmlFor={scenarioId}>{t("create.fields.scenario")}</Label>
+          {disableScenarioTool ? (
+            <div className="flex h-10 items-center rounded-md border border-input bg-muted px-3 text-sm">
+              {t(`list.tabs.${scenario}`)}
+            </div>
+          ) : (
+            <Select value={scenario} onValueChange={(v) => handleScenarioChange(v as ScenarioId)}>
+              <SelectTrigger id={scenarioId} aria-label="Scenario">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {(["inference", "capacity", "gateway"] as ScenarioId[]).map((sid) => (
+                  <SelectItem key={sid} value={sid}>
+                    {t(`list.tabs.${sid}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+      </section>
+
+      <ToolParamsEditor scenario={scenario} paramsFieldName="config" />
+
+      {mode === "create" && isAdmin && (
+        <section className="rounded-lg border border-border bg-card p-4">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            {t("create.sections.official")}
+          </h2>
+          <label htmlFor={officialId} className="flex items-center gap-2 text-sm">
+            <input
+              id={officialId}
+              type="checkbox"
+              className="h-4 w-4 rounded border border-primary"
+              {...register("isOfficial")}
+            />
+            {t("create.fields.isOfficial")}
+          </label>
+          <p className="mt-1 text-xs text-muted-foreground">{t("create.officialHint")}</p>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/benchmark-templates/TemplateListPage.tsx
+++ b/apps/web/src/features/benchmark-templates/TemplateListPage.tsx
@@ -1,0 +1,146 @@
+import { PageHeader } from "@/components/common/page-header";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useAuthStore } from "@/stores/auth-store";
+import type { BenchmarkTemplate, ScenarioId } from "@modeldoctor/contracts";
+import { Plus } from "lucide-react";
+import { useId, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { toast } from "sonner";
+import { DeleteTemplateDialog } from "./DeleteTemplateDialog";
+import { TemplateCard } from "./TemplateCard";
+import { useDeleteTemplate, useTemplates } from "./queries";
+
+const SCENARIO_TABS: { id: ScenarioId; labelKey: string }[] = [
+  { id: "inference", labelKey: "list.tabs.inference" },
+  { id: "capacity", labelKey: "list.tabs.capacity" },
+  { id: "gateway", labelKey: "list.tabs.gateway" },
+];
+
+export function TemplateListPage() {
+  const { t } = useTranslation("benchmark-templates");
+  const navigate = useNavigate();
+  const [params, setParams] = useSearchParams();
+  const idPrefix = useId();
+  const searchId = `${idPrefix}-search`;
+  const officialId = `${idPrefix}-official`;
+
+  const scenario = (params.get("scenario") as ScenarioId) || "inference";
+  const officialOnly = params.get("isOfficial") === "true";
+  const search = params.get("search") ?? "";
+
+  const { data, isLoading } = useTemplates({
+    scenario,
+    isOfficial: officialOnly || undefined,
+    search: search || undefined,
+    limit: 50,
+  });
+  const deleteMut = useDeleteTemplate();
+  const user = useAuthStore((s) => s.user);
+  const myId = user?.id;
+  const isAdmin = (user?.roles ?? []).includes("admin");
+
+  const [pendingDelete, setPendingDelete] = useState<BenchmarkTemplate | null>(null);
+
+  function setParam(key: string, value: string | null) {
+    const next = new URLSearchParams(params);
+    if (value === null || value === "") next.delete(key);
+    else next.set(key, value);
+    setParams(next);
+  }
+
+  async function handleConfirmDelete() {
+    if (!pendingDelete) return;
+    try {
+      await deleteMut.mutateAsync(pendingDelete.id);
+      toast.success(t("edit.deleted"));
+      setPendingDelete(null);
+    } catch (e) {
+      toast.error((e as Error).message ?? t("edit.errors.deleteFailed"));
+    }
+  }
+
+  return (
+    <>
+      <PageHeader title={t("title")} subtitle={t("subtitle")} />
+      <div className="mx-auto max-w-6xl space-y-4 px-8 py-6">
+        <div className="flex flex-wrap items-center gap-3">
+          <Input
+            id={searchId}
+            value={search}
+            onChange={(e) => setParam("search", e.target.value)}
+            placeholder={t("list.filters.search")}
+            className="max-w-xs"
+          />
+          <label
+            htmlFor={officialId}
+            className="flex items-center gap-2 text-sm text-muted-foreground"
+          >
+            <Switch
+              id={officialId}
+              checked={officialOnly}
+              onCheckedChange={(v) => setParam("isOfficial", v ? "true" : null)}
+            />
+            {t("list.filters.officialOnly")}
+          </label>
+          <div className="ml-auto">
+            <Button onClick={() => navigate(`/benchmark-templates/new?scenario=${scenario}`)}>
+              <Plus className="mr-1 h-4 w-4" />
+              {t("actions.new")}
+            </Button>
+          </div>
+        </div>
+
+        <Tabs value={scenario} onValueChange={(v) => setParam("scenario", v)}>
+          <TabsList>
+            {SCENARIO_TABS.map((tab) => (
+              <TabsTrigger key={tab.id} value={tab.id}>
+                {t(tab.labelKey)}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+
+        {isLoading && <div className="text-sm text-muted-foreground">…</div>}
+
+        {!isLoading && data && data.items.length === 0 && (
+          <div className="rounded-lg border border-dashed border-border p-12 text-center">
+            <p className="text-base font-medium">{t("list.empty.title")}</p>
+            <p className="mt-1 text-sm text-muted-foreground">{t("list.empty.subtitle")}</p>
+            <Button
+              className="mt-4"
+              onClick={() => navigate(`/benchmark-templates/new?scenario=${scenario}`)}
+            >
+              <Plus className="mr-1 h-4 w-4" />
+              {t("actions.new")}
+            </Button>
+          </div>
+        )}
+
+        {!isLoading && data && data.items.length > 0 && (
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {data.items.map((tpl) => (
+              <TemplateCard
+                key={tpl.id}
+                template={tpl}
+                canEdit={isAdmin || tpl.createdBy === myId}
+                onDeleteClick={() => setPendingDelete(tpl)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <DeleteTemplateDialog
+        template={pendingDelete}
+        open={pendingDelete !== null}
+        onOpenChange={(open) => !open && setPendingDelete(null)}
+        onConfirm={handleConfirmDelete}
+        pending={deleteMut.isPending}
+      />
+    </>
+  );
+}

--- a/apps/web/src/features/benchmark-templates/__tests__/TemplateCreatePage.test.tsx
+++ b/apps/web/src/features/benchmark-templates/__tests__/TemplateCreatePage.test.tsx
@@ -1,0 +1,56 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/stores/auth-store", () => ({
+  useAuthStore: vi.fn(),
+}));
+vi.mock("../queries", () => ({
+  useCreateTemplate: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+import { useAuthStore } from "@/stores/auth-store";
+import { TemplateCreatePage } from "../TemplateCreatePage";
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe("TemplateCreatePage", () => {
+  it("hides the isOfficial checkbox for non-admin users", () => {
+    (useAuthStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (selector: (s: { user: { id: string; roles: string[] } | null }) => unknown) =>
+        selector({ user: { id: "user-1", roles: ["user"] } }),
+    );
+    render(
+      <Wrapper>
+        <TemplateCreatePage />
+      </Wrapper>,
+    );
+    // Both literal "official" text and the i18n key form should be absent
+    expect(screen.queryByLabelText(/官方|official|create\.fields\.isOfficial/i)).toBeNull();
+  });
+
+  it("shows the isOfficial checkbox for admin users", () => {
+    (useAuthStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (selector: (s: { user: { id: string; roles: string[] } | null }) => unknown) =>
+        selector({ user: { id: "admin-1", roles: ["admin"] } }),
+    );
+    render(
+      <Wrapper>
+        <TemplateCreatePage />
+      </Wrapper>,
+    );
+    // The checkbox label uses i18n key "create.fields.isOfficial" or its translation
+    expect(
+      screen.getByText(/标记为官方模板|mark as official|create\.fields\.isOfficial/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/benchmark-templates/__tests__/TemplateEditPage.test.tsx
+++ b/apps/web/src/features/benchmark-templates/__tests__/TemplateEditPage.test.tsx
@@ -1,0 +1,88 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/stores/auth-store", () => ({
+  useAuthStore: vi.fn(),
+}));
+vi.mock("../queries", () => ({
+  useTemplate: vi.fn(),
+  useUpdateTemplate: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDeleteTemplate: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+import { useAuthStore } from "@/stores/auth-store";
+import { TemplateEditPage } from "../TemplateEditPage";
+import { useTemplate } from "../queries";
+
+function Wrapper({
+  children,
+  route = "/benchmark-templates/abc",
+}: { children: ReactNode; route?: string }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[route]}>
+        <Routes>
+          <Route path="/benchmark-templates/:id" element={children} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+const tpl = {
+  id: "abc",
+  name: "Mine",
+  description: null,
+  scenario: "inference" as const,
+  tool: "guidellm" as const,
+  config: {
+    profile: "throughput",
+    apiType: "chat",
+    datasetName: "sharegpt",
+    rateType: "constant",
+  },
+  isOfficial: false,
+  createdBy: "user-1",
+  tags: [],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+describe("TemplateEditPage", () => {
+  it("hides delete and shows readonly banner when current user is not the owner", () => {
+    (useTemplate as ReturnType<typeof vi.fn>).mockReturnValue({ data: tpl, isLoading: false });
+    (useAuthStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (selector: (s: { user: { id: string; roles: string[] } | null }) => unknown) =>
+        selector({ user: { id: "someone-else", roles: ["user"] } }),
+    );
+    render(
+      <Wrapper>
+        <TemplateEditPage />
+      </Wrapper>,
+    );
+    expect(
+      screen.getByText(/不是此模板的所有者|read-only|edit\.readonlyBanner/i),
+    ).toBeInTheDocument();
+    // Delete button should not exist
+    expect(screen.queryByText(/^删除$|^Delete$|actions\.delete/i)).toBeNull();
+  });
+
+  it("shows save and delete when the current user is the owner", () => {
+    (useTemplate as ReturnType<typeof vi.fn>).mockReturnValue({ data: tpl, isLoading: false });
+    (useAuthStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (selector: (s: { user: { id: string; roles: string[] } | null }) => unknown) =>
+        selector({ user: { id: "user-1", roles: ["user"] } }),
+    );
+    render(
+      <Wrapper>
+        <TemplateEditPage />
+      </Wrapper>,
+    );
+    expect(screen.getByText(/^保存$|^Save$|actions\.save/i)).toBeInTheDocument();
+    expect(screen.getByText(/^删除$|^Delete$|actions\.delete/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/benchmark-templates/__tests__/TemplateListPage.test.tsx
+++ b/apps/web/src/features/benchmark-templates/__tests__/TemplateListPage.test.tsx
@@ -1,0 +1,87 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../queries", () => ({
+  useTemplates: vi.fn(),
+  useDeleteTemplate: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock("@/stores/auth-store", () => ({
+  useAuthStore: (selector: (s: { user: { id: string; roles: string[] } | null }) => unknown) =>
+    selector({ user: { id: "user-1", roles: ["user"] } }),
+}));
+
+import { TemplateListPage } from "../TemplateListPage";
+import { useTemplates } from "../queries";
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe("TemplateListPage", () => {
+  it("renders official badge for official templates and orders official first", async () => {
+    (useTemplates as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        items: [
+          {
+            id: "off",
+            name: "Official",
+            isOfficial: true,
+            scenario: "inference",
+            tool: "guidellm",
+            createdBy: "admin-1",
+            tags: [],
+            updatedAt: new Date().toISOString(),
+            createdAt: new Date().toISOString(),
+            description: null,
+            config: {},
+          },
+          {
+            id: "mine",
+            name: "Mine",
+            isOfficial: false,
+            scenario: "inference",
+            tool: "guidellm",
+            createdBy: "user-1",
+            tags: [],
+            updatedAt: new Date().toISOString(),
+            createdAt: new Date().toISOString(),
+            description: null,
+            config: {},
+          },
+        ],
+        nextCursor: null,
+      },
+      isLoading: false,
+    });
+    render(
+      <Wrapper>
+        <TemplateListPage />
+      </Wrapper>,
+    );
+    await waitFor(() => expect(screen.getByText("Official")).toBeInTheDocument());
+    expect(screen.getByText("Mine")).toBeInTheDocument();
+    const html = document.body.innerHTML;
+    expect(html.indexOf("Official")).toBeLessThan(html.indexOf("Mine"));
+  });
+
+  it("shows empty-state copy when items array is empty", () => {
+    (useTemplates as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { items: [], nextCursor: null },
+      isLoading: false,
+    });
+    render(
+      <Wrapper>
+        <TemplateListPage />
+      </Wrapper>,
+    );
+    expect(screen.getByText(/no templates yet|还没有模板|list\.empty\.title/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/benchmark-templates/api.ts
+++ b/apps/web/src/features/benchmark-templates/api.ts
@@ -1,0 +1,31 @@
+import { api } from "@/lib/api-client";
+import type {
+  BenchmarkTemplate,
+  CreateBenchmarkTemplateRequest,
+  ListBenchmarkTemplatesQuery,
+  ListBenchmarkTemplatesResponse,
+  UpdateBenchmarkTemplateRequest,
+} from "@modeldoctor/contracts";
+
+function buildListQuery(q: Partial<ListBenchmarkTemplatesQuery>): string {
+  const usp = new URLSearchParams();
+  if (q.limit !== undefined) usp.set("limit", String(q.limit));
+  if (q.cursor) usp.set("cursor", q.cursor);
+  if (q.scenario) usp.set("scenario", q.scenario);
+  if (q.tool) usp.set("tool", q.tool);
+  if (q.isOfficial !== undefined) usp.set("isOfficial", String(q.isOfficial));
+  if (q.search) usp.set("search", q.search);
+  const qs = usp.toString();
+  return qs ? `?${qs}` : "";
+}
+
+export const benchmarkTemplateApi = {
+  list: (q: Partial<ListBenchmarkTemplatesQuery>) =>
+    api.get<ListBenchmarkTemplatesResponse>(`/api/benchmark-templates${buildListQuery(q)}`),
+  get: (id: string) => api.get<BenchmarkTemplate>(`/api/benchmark-templates/${id}`),
+  create: (body: CreateBenchmarkTemplateRequest) =>
+    api.post<BenchmarkTemplate>("/api/benchmark-templates", body),
+  update: (id: string, body: Partial<UpdateBenchmarkTemplateRequest>) =>
+    api.patch<BenchmarkTemplate>(`/api/benchmark-templates/${id}`, body),
+  delete: (id: string) => api.del<void>(`/api/benchmark-templates/${id}`),
+};

--- a/apps/web/src/features/benchmark-templates/queries.ts
+++ b/apps/web/src/features/benchmark-templates/queries.ts
@@ -1,0 +1,61 @@
+import type {
+  BenchmarkTemplate,
+  CreateBenchmarkTemplateRequest,
+  ListBenchmarkTemplatesQuery,
+  ListBenchmarkTemplatesResponse,
+  UpdateBenchmarkTemplateRequest,
+} from "@modeldoctor/contracts";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { benchmarkTemplateApi } from "./api";
+
+export const benchmarkTemplateKeys = {
+  all: ["benchmark-templates"] as const,
+  lists: () => [...benchmarkTemplateKeys.all, "list"] as const,
+  list: (q: Partial<ListBenchmarkTemplatesQuery>) => [...benchmarkTemplateKeys.lists(), q] as const,
+  details: () => [...benchmarkTemplateKeys.all, "detail"] as const,
+  detail: (id: string) => [...benchmarkTemplateKeys.details(), id] as const,
+};
+
+export function useTemplates(q: Partial<ListBenchmarkTemplatesQuery> = {}) {
+  return useQuery<ListBenchmarkTemplatesResponse>({
+    queryKey: benchmarkTemplateKeys.list(q),
+    queryFn: () => benchmarkTemplateApi.list(q),
+  });
+}
+
+export function useTemplate(id: string | undefined) {
+  return useQuery<BenchmarkTemplate>({
+    queryKey: benchmarkTemplateKeys.detail(id ?? ""),
+    // biome-ignore lint/style/noNonNullAssertion: enabled gates this
+    queryFn: () => benchmarkTemplateApi.get(id!),
+    enabled: Boolean(id),
+  });
+}
+
+export function useCreateTemplate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateBenchmarkTemplateRequest) => benchmarkTemplateApi.create(body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: benchmarkTemplateKeys.all }),
+  });
+}
+
+export function useUpdateTemplate(id: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: Partial<UpdateBenchmarkTemplateRequest>) =>
+      benchmarkTemplateApi.update(id, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: benchmarkTemplateKeys.detail(id) });
+      qc.invalidateQueries({ queryKey: benchmarkTemplateKeys.lists() });
+    },
+  });
+}
+
+export function useDeleteTemplate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => benchmarkTemplateApi.delete(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: benchmarkTemplateKeys.all }),
+  });
+}

--- a/apps/web/src/features/benchmark-templates/queries.ts
+++ b/apps/web/src/features/benchmark-templates/queries.ts
@@ -56,6 +56,9 @@ export function useDeleteTemplate() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => benchmarkTemplateApi.delete(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: benchmarkTemplateKeys.all }),
+    onSuccess: (_v, id) => {
+      qc.removeQueries({ queryKey: benchmarkTemplateKeys.detail(id) });
+      qc.invalidateQueries({ queryKey: benchmarkTemplateKeys.lists() });
+    },
   });
 }

--- a/apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx
@@ -29,9 +29,7 @@ import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
-import { GenaiPerfParamsForm } from "./forms/GenaiPerfParamsForm";
-import { GuidellmParamsForm } from "./forms/GuidellmParamsForm";
-import { VegetaParamsForm } from "./forms/VegetaParamsForm";
+import { ToolParamsEditor } from "./forms/ToolParamsEditor";
 import { useCreateBenchmark } from "./queries";
 import { SCENARIOS } from "./scenarios";
 
@@ -87,7 +85,6 @@ export function BenchmarkCreatePage() {
   const createMut = useCreateBenchmark();
   const idPrefix = useId();
   const connectionFieldId = `${idPrefix}-connection`;
-  const toolFieldId = `${idPrefix}-tool`;
   const nameFieldId = `${idPrefix}-name`;
   const descFieldId = `${idPrefix}-desc`;
 
@@ -99,8 +96,7 @@ export function BenchmarkCreatePage() {
   const scenarioParam = params.get("scenario");
   const scenarioParse = scenarioIdSchema.safeParse(scenarioParam);
   const scenario: ScenarioId = scenarioParse.success ? scenarioParse.data : "inference";
-  const availableTools = SCENARIOS[scenario].tools;
-  const defaultTool = availableTools[0];
+  const defaultTool = SCENARIOS[scenario].tools[0];
 
   const form = useForm<CreateBenchmarkRequest>({
     resolver: zodResolver(createBenchmarkRequestSchema),
@@ -135,29 +131,11 @@ export function BenchmarkCreatePage() {
     });
   }, [scenario]);
 
-  // Single source of truth: form state. useWatch keeps the section render +
-  // tool-specific subform in sync without a duplicate useState/useEffect pair.
-  const tool = (useWatch({ control: form.control, name: "tool" }) ?? defaultTool) as ToolName;
   const connectionId = useWatch({ control: form.control, name: "connectionId" }) ?? "";
-
-  function handleToolChange(next: ToolName) {
-    form.reset({
-      ...form.getValues(),
-      tool: next,
-      params: TOOL_DEFAULTS[next] as Record<string, unknown>,
-    });
-  }
 
   function handleConnectionChange(next: string) {
     form.setValue("connectionId", next, { shouldValidate: true });
   }
-
-  const ParamsForm =
-    tool === "guidellm"
-      ? GuidellmParamsForm
-      : tool === "vegeta"
-        ? VegetaParamsForm
-        : GenaiPerfParamsForm;
 
   const onSubmit = form.handleSubmit(async (values) => {
     try {
@@ -196,38 +174,7 @@ export function BenchmarkCreatePage() {
               />
             </section>
 
-            {/* Tool section — single-tool scenarios (capacity, gateway) skip
-                the dropdown and just label the auto-selected tool. */}
-            <section className="rounded-lg border border-border bg-card p-4">
-              <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-                {t("create.sections.tool")}
-              </h2>
-              <div className="max-w-xs">
-                <Label htmlFor={toolFieldId}>{t("create.fields.tool")}</Label>
-                {availableTools.length > 1 ? (
-                  <Select value={tool} onValueChange={(v) => handleToolChange(v as ToolName)}>
-                    <SelectTrigger id={toolFieldId} aria-label="Tool">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {availableTools.map((tn) => (
-                        <SelectItem key={tn} value={tn}>
-                          {t(`create.tools.${tn}`)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                ) : (
-                  <div
-                    id={toolFieldId}
-                    aria-label="Tool"
-                    className="flex h-10 items-center rounded-md border border-input bg-muted px-3 text-sm"
-                  >
-                    {t(`create.tools.${tool}`)}
-                  </div>
-                )}
-              </div>
-            </section>
+            <ToolParamsEditor scenario={scenario} />
 
             {/* Run metadata section */}
             <section className="rounded-lg border border-border bg-card p-4 space-y-3">
@@ -248,14 +195,6 @@ export function BenchmarkCreatePage() {
                   })}
                 />
               </div>
-            </section>
-
-            {/* Parameters section */}
-            <section className="rounded-lg border border-border bg-card p-4">
-              <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-                {t("create.sections.parameters")}
-              </h2>
-              <ParamsForm />
             </section>
 
             <div className="flex justify-end gap-2">

--- a/apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx
@@ -18,26 +18,14 @@ import {
   createBenchmarkRequestSchema,
   scenarioIdSchema,
 } from "@modeldoctor/contracts";
-import {
-  genaiPerfParamDefaults,
-  guidellmParamDefaults,
-  vegetaParamDefaults,
-} from "@modeldoctor/tool-adapters/schemas";
-import type { ToolName } from "@modeldoctor/tool-adapters/schemas";
 import { useEffect, useId } from "react";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
-import { ToolParamsEditor } from "./forms/ToolParamsEditor";
+import { TOOL_DEFAULTS, ToolParamsEditor } from "./forms/ToolParamsEditor";
 import { useCreateBenchmark } from "./queries";
 import { SCENARIOS } from "./scenarios";
-
-const TOOL_DEFAULTS: Record<ToolName, unknown> = {
-  guidellm: guidellmParamDefaults,
-  vegeta: vegetaParamDefaults,
-  "genai-perf": genaiPerfParamDefaults,
-};
 
 /**
  * Thin inline connection picker — lists the user's saved connections in a

--- a/apps/web/src/features/benchmarks/__tests__/ToolParamsEditor.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/ToolParamsEditor.test.tsx
@@ -9,8 +9,6 @@ function Wrapper({
   defaultValues,
   children,
 }: {
-  scenario: "inference" | "capacity" | "gateway";
-  paramsFieldName: "params" | "config";
   defaultValues: Record<string, unknown>;
   children: ReactNode;
 }) {
@@ -26,7 +24,7 @@ function Wrapper({
 describe("ToolParamsEditor", () => {
   it("renders a readonly tool badge when scenario has a single tool (capacity)", () => {
     render(
-      <Wrapper scenario="capacity" paramsFieldName="params" defaultValues={{ tool: "guidellm", params: {} }}>
+      <Wrapper defaultValues={{ tool: "guidellm", params: {} }}>
         <ToolParamsEditor scenario="capacity" />
       </Wrapper>,
     );
@@ -36,19 +34,26 @@ describe("ToolParamsEditor", () => {
 
   it("renders a tool dropdown when scenario has multiple tools (inference)", () => {
     render(
-      <Wrapper scenario="inference" paramsFieldName="params" defaultValues={{ tool: "guidellm", params: {} }}>
+      <Wrapper defaultValues={{ tool: "guidellm", params: {} }}>
         <ToolParamsEditor scenario="inference" />
       </Wrapper>,
     );
     expect(screen.getByRole("combobox", { name: /tool/i })).toBeInTheDocument();
   });
 
-  it("uses paramsFieldName='config' for register paths when prop is supplied", () => {
+  it("propagates paramsFieldName='config' to the sub-form's registered field paths", () => {
     render(
-      <Wrapper scenario="inference" paramsFieldName="config" defaultValues={{ tool: "guidellm", config: {} }}>
+      <Wrapper defaultValues={{ tool: "guidellm", config: { profile: "throughput" } }}>
         <ToolParamsEditor scenario="inference" paramsFieldName="config" />
       </Wrapper>,
     );
-    expect(screen.getByRole("combobox", { name: /tool/i })).toBeInTheDocument();
+    // GuidellmParamsForm always renders several <Input> fields via register().
+    // With paramsFieldName="config" they should all be prefixed "config.", not "params.".
+    const inputs = document.querySelectorAll("input[name]");
+    expect(inputs.length).toBeGreaterThan(0);
+    for (const el of inputs) {
+      const name = (el as HTMLInputElement).name;
+      expect(name.startsWith("config.")).toBe(true);
+    }
   });
 });

--- a/apps/web/src/features/benchmarks/__tests__/ToolParamsEditor.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/ToolParamsEditor.test.tsx
@@ -1,0 +1,54 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+import { ToolParamsEditor } from "../forms/ToolParamsEditor";
+
+function Wrapper({
+  defaultValues,
+  children,
+}: {
+  scenario: "inference" | "capacity" | "gateway";
+  paramsFieldName: "params" | "config";
+  defaultValues: Record<string, unknown>;
+  children: ReactNode;
+}) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const form = useForm({ defaultValues });
+  return (
+    <QueryClientProvider client={qc}>
+      <FormProvider {...form}>{children}</FormProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe("ToolParamsEditor", () => {
+  it("renders a readonly tool badge when scenario has a single tool (capacity)", () => {
+    render(
+      <Wrapper scenario="capacity" paramsFieldName="params" defaultValues={{ tool: "guidellm", params: {} }}>
+        <ToolParamsEditor scenario="capacity" />
+      </Wrapper>,
+    );
+    expect(screen.queryByRole("combobox", { name: /tool/i })).toBeNull();
+    expect(screen.getByText(/guidellm/i)).toBeInTheDocument();
+  });
+
+  it("renders a tool dropdown when scenario has multiple tools (inference)", () => {
+    render(
+      <Wrapper scenario="inference" paramsFieldName="params" defaultValues={{ tool: "guidellm", params: {} }}>
+        <ToolParamsEditor scenario="inference" />
+      </Wrapper>,
+    );
+    expect(screen.getByRole("combobox", { name: /tool/i })).toBeInTheDocument();
+  });
+
+  it("uses paramsFieldName='config' for register paths when prop is supplied", () => {
+    render(
+      <Wrapper scenario="inference" paramsFieldName="config" defaultValues={{ tool: "guidellm", config: {} }}>
+        <ToolParamsEditor scenario="inference" paramsFieldName="config" />
+      </Wrapper>,
+    );
+    expect(screen.getByRole("combobox", { name: /tool/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/benchmarks/forms/GenaiPerfParamsForm.tsx
+++ b/apps/web/src/features/benchmarks/forms/GenaiPerfParamsForm.tsx
@@ -19,10 +19,14 @@ const ENDPOINT_TYPES: GenaiPerfParams["endpointType"][] = [
   "rankings",
 ];
 
-export function GenaiPerfParamsForm() {
+interface GenaiPerfParamsFormProps {
+  fieldPrefix?: "params" | "config";
+}
+
+export function GenaiPerfParamsForm({ fieldPrefix = "params" }: GenaiPerfParamsFormProps = {}) {
   const { register, setValue, control } = useFormContext();
-  const endpointType = useWatch({ control, name: "params.endpointType" });
-  const streaming = useWatch({ control, name: "params.streaming" });
+  const endpointType = useWatch({ control, name: `${fieldPrefix}.endpointType` });
+  const streaming = useWatch({ control, name: `${fieldPrefix}.streaming` });
 
   const idPrefix = useId();
   const ids = {
@@ -44,7 +48,7 @@ export function GenaiPerfParamsForm() {
         <Select
           value={endpointType ?? ""}
           onValueChange={(v) =>
-            setValue("params.endpointType", v as GenaiPerfParams["endpointType"], {
+            setValue(`${fieldPrefix}.endpointType`, v as GenaiPerfParams["endpointType"], {
               shouldValidate: true,
             })
           }
@@ -67,7 +71,7 @@ export function GenaiPerfParamsForm() {
           <Input
             id={ids.numPrompts}
             type="number"
-            {...register("params.numPrompts", { valueAsNumber: true })}
+            {...register(`${fieldPrefix}.numPrompts`, { valueAsNumber: true })}
           />
         </div>
         <div>
@@ -75,7 +79,7 @@ export function GenaiPerfParamsForm() {
           <Input
             id={ids.concurrency}
             type="number"
-            {...register("params.concurrency", { valueAsNumber: true })}
+            {...register(`${fieldPrefix}.concurrency`, { valueAsNumber: true })}
           />
         </div>
       </div>
@@ -85,7 +89,7 @@ export function GenaiPerfParamsForm() {
           <Input
             id={ids.inputTokensMean}
             type="number"
-            {...register("params.inputTokensMean", {
+            {...register(`${fieldPrefix}.inputTokensMean`, {
               setValueAs: (v) => (v === "" || v === undefined ? undefined : Number(v)),
             })}
           />
@@ -95,7 +99,7 @@ export function GenaiPerfParamsForm() {
           <Input
             id={ids.inputTokensStddev}
             type="number"
-            {...register("params.inputTokensStddev", { valueAsNumber: true })}
+            {...register(`${fieldPrefix}.inputTokensStddev`, { valueAsNumber: true })}
           />
         </div>
       </div>
@@ -105,7 +109,7 @@ export function GenaiPerfParamsForm() {
           <Input
             id={ids.outputTokensMean}
             type="number"
-            {...register("params.outputTokensMean", {
+            {...register(`${fieldPrefix}.outputTokensMean`, {
               setValueAs: (v) => (v === "" || v === undefined ? undefined : Number(v)),
             })}
           />
@@ -115,7 +119,7 @@ export function GenaiPerfParamsForm() {
           <Input
             id={ids.outputTokensStddev}
             type="number"
-            {...register("params.outputTokensStddev", { valueAsNumber: true })}
+            {...register(`${fieldPrefix}.outputTokensStddev`, { valueAsNumber: true })}
           />
         </div>
       </div>
@@ -123,7 +127,7 @@ export function GenaiPerfParamsForm() {
         <Switch
           id={ids.streaming}
           checked={streaming === true}
-          onCheckedChange={(v) => setValue("params.streaming", v, { shouldValidate: true })}
+          onCheckedChange={(v) => setValue(`${fieldPrefix}.streaming`, v, { shouldValidate: true })}
         />
         <Label htmlFor={ids.streaming}>Streaming</Label>
       </div>
@@ -131,7 +135,7 @@ export function GenaiPerfParamsForm() {
         <Label htmlFor={ids.tokenizer}>Tokenizer (HuggingFace id, optional)</Label>
         <Input
           id={ids.tokenizer}
-          {...register("params.tokenizer", {
+          {...register(`${fieldPrefix}.tokenizer`, {
             setValueAs: (v) => (v === "" || v === undefined ? undefined : v),
           })}
           placeholder="Overrides connection-level default; leave empty to use it."

--- a/apps/web/src/features/benchmarks/forms/GuidellmParamsForm.tsx
+++ b/apps/web/src/features/benchmarks/forms/GuidellmParamsForm.tsx
@@ -210,7 +210,9 @@ export function GuidellmParamsForm({ fieldPrefix = "params" }: GuidellmParamsFor
         <Switch
           id={ids.validateBackend}
           checked={validateBackend === true}
-          onCheckedChange={(v) => setValue(`${fieldPrefix}.validateBackend`, v, { shouldValidate: true })}
+          onCheckedChange={(v) =>
+            setValue(`${fieldPrefix}.validateBackend`, v, { shouldValidate: true })
+          }
         />
         <Label htmlFor={ids.validateBackend}>Validate backend before run</Label>
       </div>

--- a/apps/web/src/features/benchmarks/forms/GuidellmParamsForm.tsx
+++ b/apps/web/src/features/benchmarks/forms/GuidellmParamsForm.tsx
@@ -24,12 +24,16 @@ const PROFILES: GuidellmParams["profile"][] = [
 const API_TYPES: GuidellmParams["apiType"][] = ["chat", "completion"];
 const DATASETS: GuidellmParams["datasetName"][] = ["random", "sharegpt"];
 
-export function GuidellmParamsForm() {
+interface GuidellmParamsFormProps {
+  fieldPrefix?: "params" | "config";
+}
+
+export function GuidellmParamsForm({ fieldPrefix = "params" }: GuidellmParamsFormProps = {}) {
   const { register, setValue, control } = useFormContext();
-  const profile = useWatch({ control, name: "params.profile" });
-  const apiType = useWatch({ control, name: "params.apiType" });
-  const datasetName = useWatch({ control, name: "params.datasetName" });
-  const validateBackend = useWatch({ control, name: "params.validateBackend" });
+  const profile = useWatch({ control, name: `${fieldPrefix}.profile` });
+  const apiType = useWatch({ control, name: `${fieldPrefix}.apiType` });
+  const datasetName = useWatch({ control, name: `${fieldPrefix}.datasetName` });
+  const validateBackend = useWatch({ control, name: `${fieldPrefix}.validateBackend` });
 
   const idPrefix = useId();
   const ids = {
@@ -54,7 +58,7 @@ export function GuidellmParamsForm() {
           <Label htmlFor={ids.profile}>Profile</Label>
           <Select
             onValueChange={(v) =>
-              setValue("params.profile", v as GuidellmParams["profile"], {
+              setValue(`${fieldPrefix}.profile`, v as GuidellmParams["profile"], {
                 shouldValidate: true,
               })
             }
@@ -76,7 +80,7 @@ export function GuidellmParamsForm() {
           <Label htmlFor={ids.apiType}>API type</Label>
           <Select
             onValueChange={(v) =>
-              setValue("params.apiType", v as GuidellmParams["apiType"], {
+              setValue(`${fieldPrefix}.apiType`, v as GuidellmParams["apiType"], {
                 shouldValidate: true,
               })
             }
@@ -101,7 +105,7 @@ export function GuidellmParamsForm() {
           <Label htmlFor={ids.dataset}>Dataset</Label>
           <Select
             onValueChange={(v) =>
-              setValue("params.datasetName", v as GuidellmParams["datasetName"], {
+              setValue(`${fieldPrefix}.datasetName`, v as GuidellmParams["datasetName"], {
                 shouldValidate: true,
               })
             }
@@ -124,7 +128,7 @@ export function GuidellmParamsForm() {
           <Input
             id={ids.seed}
             type="number"
-            {...register("params.datasetSeed", {
+            {...register(`${fieldPrefix}.datasetSeed`, {
               setValueAs: (v) => (v === "" || v === undefined ? undefined : Number(v)),
             })}
           />
@@ -138,7 +142,7 @@ export function GuidellmParamsForm() {
             <Input
               id={ids.inputTokens}
               type="number"
-              {...register("params.datasetInputTokens", { valueAsNumber: true })}
+              {...register(`${fieldPrefix}.datasetInputTokens`, { valueAsNumber: true })}
             />
           </div>
           <div>
@@ -146,7 +150,7 @@ export function GuidellmParamsForm() {
             <Input
               id={ids.outputTokens}
               type="number"
-              {...register("params.datasetOutputTokens", { valueAsNumber: true })}
+              {...register(`${fieldPrefix}.datasetOutputTokens`, { valueAsNumber: true })}
             />
           </div>
         </div>
@@ -159,7 +163,7 @@ export function GuidellmParamsForm() {
             id={ids.requestRate}
             type="number"
             step="0.1"
-            {...register("params.requestRate", { valueAsNumber: true })}
+            {...register(`${fieldPrefix}.requestRate`, { valueAsNumber: true })}
           />
         </div>
         <div>
@@ -167,7 +171,7 @@ export function GuidellmParamsForm() {
           <Input
             id={ids.totalRequests}
             type="number"
-            {...register("params.totalRequests", { valueAsNumber: true })}
+            {...register(`${fieldPrefix}.totalRequests`, { valueAsNumber: true })}
           />
         </div>
       </div>
@@ -178,7 +182,7 @@ export function GuidellmParamsForm() {
           <Input
             id={ids.maxDuration}
             type="number"
-            {...register("params.maxDurationSeconds", { valueAsNumber: true })}
+            {...register(`${fieldPrefix}.maxDurationSeconds`, { valueAsNumber: true })}
           />
         </div>
         <div>
@@ -186,7 +190,7 @@ export function GuidellmParamsForm() {
           <Input
             id={ids.maxConcurrency}
             type="number"
-            {...register("params.maxConcurrency", { valueAsNumber: true })}
+            {...register(`${fieldPrefix}.maxConcurrency`, { valueAsNumber: true })}
           />
         </div>
       </div>
@@ -195,7 +199,7 @@ export function GuidellmParamsForm() {
         <Label htmlFor={ids.processor}>Processor (optional)</Label>
         <Input
           id={ids.processor}
-          {...register("params.processor", {
+          {...register(`${fieldPrefix}.processor`, {
             setValueAs: (v) => (v === "" || v === undefined ? undefined : v),
           })}
           placeholder="HuggingFace tokenizer name"
@@ -206,7 +210,7 @@ export function GuidellmParamsForm() {
         <Switch
           id={ids.validateBackend}
           checked={validateBackend === true}
-          onCheckedChange={(v) => setValue("params.validateBackend", v, { shouldValidate: true })}
+          onCheckedChange={(v) => setValue(`${fieldPrefix}.validateBackend`, v, { shouldValidate: true })}
         />
         <Label htmlFor={ids.validateBackend}>Validate backend before run</Label>
       </div>

--- a/apps/web/src/features/benchmarks/forms/ToolParamsEditor.tsx
+++ b/apps/web/src/features/benchmarks/forms/ToolParamsEditor.tsx
@@ -1,0 +1,101 @@
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { ScenarioId } from "@modeldoctor/contracts";
+import {
+  genaiPerfParamDefaults,
+  guidellmParamDefaults,
+  vegetaParamDefaults,
+} from "@modeldoctor/tool-adapters/schemas";
+import type { ToolName } from "@modeldoctor/tool-adapters/schemas";
+import { useId } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { SCENARIOS } from "../scenarios";
+import { GenaiPerfParamsForm } from "./GenaiPerfParamsForm";
+import { GuidellmParamsForm } from "./GuidellmParamsForm";
+import { VegetaParamsForm } from "./VegetaParamsForm";
+
+const TOOL_DEFAULTS: Record<ToolName, unknown> = {
+  guidellm: guidellmParamDefaults,
+  vegeta: vegetaParamDefaults,
+  "genai-perf": genaiPerfParamDefaults,
+};
+
+export interface ToolParamsEditorProps {
+  scenario: ScenarioId;
+  /** Form field name where the tool's params live. Defaults to "params" so
+   * existing BenchmarkCreatePage callers don't need to change. Template
+   * forms pass "config" because that's the BenchmarkTemplate column name. */
+  paramsFieldName?: "params" | "config";
+}
+
+export function ToolParamsEditor({ scenario, paramsFieldName = "params" }: ToolParamsEditorProps) {
+  const { t } = useTranslation("benchmarks");
+  const { control, reset, getValues } = useFormContext();
+  const tool = (useWatch({ control, name: "tool" }) ?? SCENARIOS[scenario].tools[0]) as ToolName;
+  const id = useId();
+  const toolFieldId = `${id}-tool`;
+
+  const availableTools = SCENARIOS[scenario].tools;
+
+  function handleToolChange(next: ToolName) {
+    reset({
+      ...getValues(),
+      tool: next,
+      [paramsFieldName]: TOOL_DEFAULTS[next] as Record<string, unknown>,
+    });
+  }
+
+  const ParamsForm =
+    tool === "guidellm" ? GuidellmParamsForm
+      : tool === "vegeta" ? VegetaParamsForm
+        : GenaiPerfParamsForm;
+
+  return (
+    <>
+      <section className="rounded-lg border border-border bg-card p-4">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          {t("create.sections.tool")}
+        </h2>
+        <div className="max-w-xs">
+          <Label htmlFor={toolFieldId}>{t("create.fields.tool")}</Label>
+          {availableTools.length > 1 ? (
+            <Select value={tool} onValueChange={(v) => handleToolChange(v as ToolName)}>
+              <SelectTrigger id={toolFieldId} aria-label="Tool">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {availableTools.map((tn) => (
+                  <SelectItem key={tn} value={tn}>
+                    {t(`create.tools.${tn}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <div
+              id={toolFieldId}
+              aria-label="Tool"
+              className="flex h-10 items-center rounded-md border border-input bg-muted px-3 text-sm"
+            >
+              {t(`create.tools.${tool}`)}
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-border bg-card p-4">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          {t("create.sections.parameters")}
+        </h2>
+        <ParamsForm fieldPrefix={paramsFieldName} />
+      </section>
+    </>
+  );
+}

--- a/apps/web/src/features/benchmarks/forms/ToolParamsEditor.tsx
+++ b/apps/web/src/features/benchmarks/forms/ToolParamsEditor.tsx
@@ -21,7 +21,7 @@ import { GenaiPerfParamsForm } from "./GenaiPerfParamsForm";
 import { GuidellmParamsForm } from "./GuidellmParamsForm";
 import { VegetaParamsForm } from "./VegetaParamsForm";
 
-const TOOL_DEFAULTS: Record<ToolName, unknown> = {
+export const TOOL_DEFAULTS: Record<ToolName, unknown> = {
   guidellm: guidellmParamDefaults,
   vegeta: vegetaParamDefaults,
   "genai-perf": genaiPerfParamDefaults,
@@ -53,8 +53,10 @@ export function ToolParamsEditor({ scenario, paramsFieldName = "params" }: ToolP
   }
 
   const ParamsForm =
-    tool === "guidellm" ? GuidellmParamsForm
-      : tool === "vegeta" ? VegetaParamsForm
+    tool === "guidellm"
+      ? GuidellmParamsForm
+      : tool === "vegeta"
+        ? VegetaParamsForm
         : GenaiPerfParamsForm;
 
   return (

--- a/apps/web/src/features/benchmarks/forms/VegetaParamsForm.tsx
+++ b/apps/web/src/features/benchmarks/forms/VegetaParamsForm.tsx
@@ -20,9 +20,13 @@ const API_TYPES: VegetaParams["apiType"][] = [
   "chat-audio",
 ];
 
-export function VegetaParamsForm() {
+interface VegetaParamsFormProps {
+  fieldPrefix?: "params" | "config";
+}
+
+export function VegetaParamsForm({ fieldPrefix = "params" }: VegetaParamsFormProps = {}) {
   const { register, setValue, control } = useFormContext();
-  const apiType = useWatch({ control, name: "params.apiType" });
+  const apiType = useWatch({ control, name: `${fieldPrefix}.apiType` });
 
   const idPrefix = useId();
   const ids = {
@@ -38,7 +42,7 @@ export function VegetaParamsForm() {
         <Select
           value={apiType ?? ""}
           onValueChange={(v) =>
-            setValue("params.apiType", v as VegetaParams["apiType"], {
+            setValue(`${fieldPrefix}.apiType`, v as VegetaParams["apiType"], {
               shouldValidate: true,
             })
           }
@@ -61,7 +65,7 @@ export function VegetaParamsForm() {
           <Input
             id={ids.rate}
             type="number"
-            {...register("params.rate", { valueAsNumber: true })}
+            {...register(`${fieldPrefix}.rate`, { valueAsNumber: true })}
           />
         </div>
         <div>
@@ -69,7 +73,7 @@ export function VegetaParamsForm() {
           <Input
             id={ids.duration}
             type="number"
-            {...register("params.duration", { valueAsNumber: true })}
+            {...register(`${fieldPrefix}.duration`, { valueAsNumber: true })}
           />
         </div>
       </div>

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -1,6 +1,7 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 
+import enBenchmarkTemplates from "@/locales/en-US/benchmark-templates.json";
 import enBenchmarks from "@/locales/en-US/benchmarks.json";
 import enCommon from "@/locales/en-US/common.json";
 import enConnections from "@/locales/en-US/connections.json";
@@ -9,6 +10,7 @@ import enDiagnostics from "@/locales/en-US/diagnostics.json";
 import enPlayground from "@/locales/en-US/playground.json";
 import enSettings from "@/locales/en-US/settings.json";
 import enSidebar from "@/locales/en-US/sidebar.json";
+import zhBenchmarkTemplates from "@/locales/zh-CN/benchmark-templates.json";
 import zhBenchmarks from "@/locales/zh-CN/benchmarks.json";
 import zhCommon from "@/locales/zh-CN/common.json";
 import zhConnections from "@/locales/zh-CN/connections.json";
@@ -26,6 +28,7 @@ void i18n.use(initReactI18next).init({
       connections: enConnections,
       diagnostics: enDiagnostics,
       benchmarks: enBenchmarks,
+      "benchmark-templates": enBenchmarkTemplates,
       debug: enDebug,
       settings: enSettings,
       playground: enPlayground,
@@ -36,6 +39,7 @@ void i18n.use(initReactI18next).init({
       connections: zhConnections,
       diagnostics: zhDiagnostics,
       benchmarks: zhBenchmarks,
+      "benchmark-templates": zhBenchmarkTemplates,
       debug: zhDebug,
       settings: zhSettings,
       playground: zhPlayground,
@@ -50,6 +54,7 @@ void i18n.use(initReactI18next).init({
     "connections",
     "diagnostics",
     "benchmarks",
+    "benchmark-templates",
     "debug",
     "settings",
     "playground",

--- a/apps/web/src/locales/en-US/benchmark-templates.json
+++ b/apps/web/src/locales/en-US/benchmark-templates.json
@@ -1,0 +1,71 @@
+{
+  "title": "Test Templates",
+  "subtitle": "Manage reusable benchmark configurations across connections",
+  "actions": {
+    "new": "New template",
+    "edit": "Edit",
+    "delete": "Delete",
+    "save": "Save",
+    "cancel": "Cancel",
+    "back": "Back to list"
+  },
+  "list": {
+    "tabs": {
+      "inference": "Inference benchmark",
+      "capacity": "Capacity planning",
+      "gateway": "Gateway load test"
+    },
+    "filters": {
+      "search": "Search name or description…",
+      "officialOnly": "Official only"
+    },
+    "official": "Official",
+    "createdAt": "Created {{when}}",
+    "updatedAt": "Updated {{when}}",
+    "by": "by {{name}}",
+    "empty": {
+      "title": "No templates yet",
+      "subtitle": "Create the first template for this scenario"
+    }
+  },
+  "create": {
+    "title": "New template",
+    "subtitle": "Save a reusable benchmark configuration",
+    "sections": {
+      "basic": "Basic info",
+      "scenario": "Scenario",
+      "official": "Visibility"
+    },
+    "fields": {
+      "name": "Name",
+      "namePlaceholder": "e.g. Inference baseline (short text)",
+      "description": "Description",
+      "tags": "Tags",
+      "tagsPlaceholder": "Press Enter to add",
+      "scenario": "Scenario",
+      "isOfficial": "Mark as official template"
+    },
+    "officialHint": "Admin only. The isOfficial field is immutable after creation.",
+    "submitted": "Template '{{name}}' created",
+    "errors": {
+      "submitFailed": "Failed to create template"
+    }
+  },
+  "edit": {
+    "title": "Edit template",
+    "subtitle": "name / description / config / tags are editable; scenario / tool / official flag are not",
+    "readonlyBanner": "You are not the owner of this template — read-only view",
+    "saved": "Saved",
+    "deleteConfirm": {
+      "title": "Delete template '{{name}}'?",
+      "body": "Irreversible. Benchmarks already referencing this template are unaffected; their templateId will be set to NULL.",
+      "confirm": "Delete",
+      "cancel": "Cancel"
+    },
+    "deleted": "Template deleted",
+    "errors": {
+      "saveFailed": "Failed to save",
+      "deleteFailed": "Failed to delete"
+    }
+  }
+}

--- a/apps/web/src/locales/en-US/sidebar.json
+++ b/apps/web/src/locales/en-US/sidebar.json
@@ -15,6 +15,7 @@
     "benchmarkCapacity": "Capacity Planning",
     "benchmarkGateway": "Gateway Load Test",
     "benchmarkCompare": "Compare",
+    "benchmarkTemplates": "Test Templates",
     "requestDebug": "Request Debug",
     "diagnostics": "Endpoint Health",
     "connections": "Connections",

--- a/apps/web/src/locales/zh-CN/benchmark-templates.json
+++ b/apps/web/src/locales/zh-CN/benchmark-templates.json
@@ -1,0 +1,71 @@
+{
+  "title": "测试模板",
+  "subtitle": "管理跨连接复用的基准测试配置",
+  "actions": {
+    "new": "新建模板",
+    "edit": "编辑",
+    "delete": "删除",
+    "save": "保存",
+    "cancel": "取消",
+    "back": "返回列表"
+  },
+  "list": {
+    "tabs": {
+      "inference": "推理性能基准",
+      "capacity": "容量规划",
+      "gateway": "网关压测"
+    },
+    "filters": {
+      "search": "按名称或描述搜索…",
+      "officialOnly": "仅官方"
+    },
+    "official": "官方",
+    "createdAt": "创建于 {{when}}",
+    "updatedAt": "更新于 {{when}}",
+    "by": "by {{name}}",
+    "empty": {
+      "title": "还没有模板",
+      "subtitle": "为该场景创建第一个模板"
+    }
+  },
+  "create": {
+    "title": "新建模板",
+    "subtitle": "保存一份可复用的 benchmark 配置",
+    "sections": {
+      "basic": "基本信息",
+      "scenario": "测试场景",
+      "official": "可见性"
+    },
+    "fields": {
+      "name": "名称",
+      "namePlaceholder": "例:推理基线短文本",
+      "description": "描述",
+      "tags": "标签",
+      "tagsPlaceholder": "回车添加",
+      "scenario": "场景",
+      "isOfficial": "标记为官方模板"
+    },
+    "officialHint": "仅管理员可见。官方模板创建后不可修改 isOfficial 字段。",
+    "submitted": "模板「{{name}}」创建成功",
+    "errors": {
+      "submitFailed": "创建失败"
+    }
+  },
+  "edit": {
+    "title": "编辑模板",
+    "subtitle": "name / description / config / tags 可修改;scenario / tool / 是否官方不可改",
+    "readonlyBanner": "你不是此模板的所有者,无法编辑",
+    "saved": "已保存",
+    "deleteConfirm": {
+      "title": "删除模板「{{name}}」?",
+      "body": "此操作不可撤销。已经引用此模板的 benchmark 不会被影响,只是 templateId 会被置空。",
+      "confirm": "确认删除",
+      "cancel": "取消"
+    },
+    "deleted": "模板已删除",
+    "errors": {
+      "saveFailed": "保存失败",
+      "deleteFailed": "删除失败"
+    }
+  }
+}

--- a/apps/web/src/locales/zh-CN/sidebar.json
+++ b/apps/web/src/locales/zh-CN/sidebar.json
@@ -15,6 +15,7 @@
     "benchmarkCapacity": "容量规划",
     "benchmarkGateway": "网关压测",
     "benchmarkCompare": "对比分析",
+    "benchmarkTemplates": "测试模板",
     "requestDebug": "请求调试",
     "diagnostics": "端点检测",
     "connections": "连接",

--- a/apps/web/src/router/index.tsx
+++ b/apps/web/src/router/index.tsx
@@ -1,6 +1,9 @@
 import { LoginPage } from "@/features/auth/LoginPage";
 import { ProtectedRoute } from "@/features/auth/ProtectedRoute";
 import { RegisterPage } from "@/features/auth/RegisterPage";
+import { TemplateCreatePage } from "@/features/benchmark-templates/TemplateCreatePage";
+import { TemplateEditPage } from "@/features/benchmark-templates/TemplateEditPage";
+import { TemplateListPage } from "@/features/benchmark-templates/TemplateListPage";
 import { BenchmarkCapacityPage } from "@/features/benchmarks/BenchmarkCapacityPage";
 import { BenchmarkCreatePage } from "@/features/benchmarks/BenchmarkCreatePage";
 import { BenchmarkDetailPage } from "@/features/benchmarks/BenchmarkDetailPage";
@@ -46,6 +49,9 @@ export const routes: RouteObject[] = [
           { path: "benchmarks/compare", element: <BenchmarkComparePage /> },
           { path: "benchmarks/new", element: <BenchmarkCreatePage /> },
           { path: "benchmarks/:id", element: <BenchmarkDetailPage /> },
+          { path: "benchmark-templates", element: <TemplateListPage /> },
+          { path: "benchmark-templates/new", element: <TemplateCreatePage /> },
+          { path: "benchmark-templates/:id", element: <TemplateEditPage /> },
           { path: "diagnostics", element: <DiagnosticsPage /> },
           { path: "debug", element: <RequestDebugPage /> },
           { path: "connections", element: <ConnectionsPage /> },


### PR DESCRIPTION
## Summary
- 后端:5 个 endpoint (`/api/benchmark-templates*`) + 权限模型(任何登录用户可读;owner/admin 可写;只有 admin 可创建 `isOfficial:true`;`isOfficial` 创建后不可改)
- 前端:列表页(三 scenario tab + 官方优先 + 搜索 + ⋯ 菜单)/ 创建页 / 编辑页;sidebar 补 PR1 预留位置
- 抽出 `<ToolParamsEditor>` 公共组件,被 `BenchmarkCreatePage` 和模板表单同时消费,为 PR3 三 tab 创建流提前准备
- 单 PR + phase-per-commit(13 commits,含 4 次 fix-up),从 main `b1311760` 切

## Spec / Plan
- Spec: `docs/superpowers/specs/2026-05-05-benchmark-restructure-pr2-design.md` (PR #104)
- Plan: `docs/superpowers/plans/2026-05-05-benchmark-restructure-pr2.md` (PR #105)

## Key decisions (from spec)
- `isOfficial` create-only & immutable — 消除"提升后谁能改"的边界 case
- update DTO schema omit `isOfficial / scenario / tool` — 双层防护(schema + repository UpdateInput type)
- 列表排序 `isOfficial DESC, updatedAt DESC, id DESC` — 官方推荐位
- 模板不存 `connectionId` — 模板可跨连接复用
- 非 owner 看编辑页 = 展示但 disabled + amber readonly banner — 不直接 404
- `<ToolParamsEditor>` 抽出 `paramsFieldName?: "params" | "config"` — 让 BenchmarkCreatePage(params)和 TemplateForm(config)共用同一组件

## Out-of-scope changes (with rationale)
- **`apps/api/src/common/filters/all-exceptions.filter.ts`** (+6 lines): now extracts domain `code` from exception body. Required for e2e to assert on contract codes (`BENCHMARK_TEMPLATE_OFFICIAL_FORBIDDEN`, etc.) instead of generic HTTP status codes. Frontend already treats `code` as opaque string (no breaking change). Documented as follow-up on #96 — `packages/contracts/src/errors.ts` ErrorCodes is now stale (~12 unregistered domain codes pass through), to be cleaned up in PR3 / chore PR.
- **`apps/api/test/e2e/auth.e2e-spec.ts`**: previously asserted `BENCHMARK_SCOPE_FORBIDDEN` "normalized to FORBIDDEN" (capturing the broken behavior). Updated to assert the now-surfacing domain code.

## Commit list (13 commits, each phase-per-commit + 4 review-driven fixes)

| # | Commit | Phase |
|---|---|---|
| 1 | `1a5475b refactor(web)` | Task 1: extract ToolParamsEditor |
| 2 | `987ffcb fix(web)` | Task 1 fix-ups (TOOL_DEFAULTS export, biome format, test polish) |
| 3 | `90db6aa feat(api)` | Task 2: repository CRUD |
| 4 | `85860b1 feat(api)` | Task 3: service with permission gating |
| 5 | `18ea231 test(api)` | Task 3 fix-up: cover update config-validation branch |
| 6 | `efc2bcd feat(api)` | Task 4: controller |
| 7 | `eefff29 test(api)` | Task 4 fix-up: assert patchSchema strips fields |
| 8 | `3d338fe test(api)` | Task 5: e2e + filter domain-code surfacing |
| 9 | `d0fa7e3 feat(web)` | Task 6: queries + api + i18n |
| 10 | `202ba3e fix(web)` | Task 6 fix-up: align useDeleteTemplate cache strategy |
| 11 | `3e64b8d feat(web)` | Task 7: TemplateListPage |
| 12 | `ad4ded9 feat(web)` | Task 8: TemplateCreatePage + TemplateEditPage |
| 13 | `a0bea60 feat(web)` | Task 9: route + sidebar wiring |

## Test plan
- [x] `pnpm -F @modeldoctor/api test` — 355+ tests green (controller + service + repository + e2e)
- [x] `pnpm -F @modeldoctor/web test` — 564+ tests green (TemplateListPage + TemplateCreatePage + TemplateEditPage + ToolParamsEditor + regression)
- [x] `pnpm -F @modeldoctor/api type-check` clean
- [x] `pnpm -F @modeldoctor/web type-check` clean
- [x] `pnpm -F @modeldoctor/web build` succeeds
- [x] `pnpm -F @modeldoctor/api lint` / `web lint` clean
- [x] e2e `benchmark-template.e2e-spec.ts` covers admin/owner permissions + PATCH sanitization + (scenario, tool) mismatch
- [ ] **Manual UX smoke (recommended before merge)**: log in as admin → create official template → log in as user → see official + create personal → owner can edit/delete personal → cannot edit admin's official. Plan Task 9 step 5 has the full script.

## Trailers
- `closes #96` (PR2 stub issue)
- `addresses #94` (umbrella — **not** closes; per memory `feedback_umbrella_issue_trailers`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)