### PR TITLE
fix(benchmark): task management cleanup (#102 class A)

### DIFF
--- a/apps/api/prisma/migrations/20260505080504_benchmark_name_required/migration.sql
+++ b/apps/api/prisma/migrations/20260505080504_benchmark_name_required/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "benchmarks" ALTER COLUMN "name" SET NOT NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -102,7 +102,7 @@ model Benchmark {
   toolVersion String? @map("tool_version")
   driverKind  String  @map("driver_kind") // 'local' | 'k8s'
 
-  name        String?
+  name        String
   description String? @db.Text
 
   status        String  @default("pending")

--- a/apps/api/src/modules/baseline/baseline.service.spec.ts
+++ b/apps/api/src/modules/baseline/baseline.service.spec.ts
@@ -32,7 +32,7 @@ function makeBenchmark(overrides: Partial<PrismaBenchmark> = {}): PrismaBenchmar
     tool: "guidellm",
     toolVersion: null,
     driverKind: "local",
-    name: null,
+    name: "test-benchmark",
     description: null,
     status: "completed",
     statusMessage: null,

--- a/apps/api/src/modules/benchmark-template/benchmark-template.repository.spec.ts
+++ b/apps/api/src/modules/benchmark-template/benchmark-template.repository.spec.ts
@@ -131,6 +131,7 @@ describe("BenchmarkTemplateRepository", () => {
         scenario: "inference",
         tool: "guidellm",
         driverKind: "local",
+        name: "test-benchmark",
         params: {},
         templateId: tpl.id,
       },

--- a/apps/api/src/modules/benchmark/benchmark.controller.spec.ts
+++ b/apps/api/src/modules/benchmark/benchmark.controller.spec.ts
@@ -143,6 +143,7 @@ describe("BenchmarkController", () => {
         scenario: "inference",
         tool: "guidellm",
         driverKind: "local",
+        name: "test-benchmark",
         params: {},
       },
     });
@@ -152,6 +153,7 @@ describe("BenchmarkController", () => {
         scenario: "capacity",
         tool: "guidellm",
         driverKind: "local",
+        name: "test-benchmark",
         params: {},
       },
     });
@@ -161,6 +163,7 @@ describe("BenchmarkController", () => {
         scenario: "inference",
         tool: "guidellm",
         driverKind: "local",
+        name: "test-benchmark",
         params: {},
       },
     });
@@ -186,6 +189,7 @@ describe("BenchmarkController", () => {
         scenario: "inference",
         tool: "guidellm",
         driverKind: "local",
+        name: "test-benchmark",
         params: {},
       },
     });
@@ -208,6 +212,7 @@ describe("BenchmarkController", () => {
         scenario: "inference",
         tool: "guidellm",
         driverKind: "local",
+        name: "test-benchmark",
         params: {},
       },
     });
@@ -261,6 +266,7 @@ describe("BenchmarkController", () => {
         scenario: "inference",
         tool: "guidellm",
         driverKind: "local",
+        name: "test-benchmark",
         params: {},
         status: "running",
         driverHandle: "subprocess:9999",
@@ -282,6 +288,7 @@ describe("BenchmarkController", () => {
         scenario: "inference",
         tool: "guidellm",
         driverKind: "local",
+        name: "test-benchmark",
         params: {},
         status: "completed",
       },
@@ -310,6 +317,7 @@ describe("BenchmarkController", () => {
             scenario: "inference",
             tool: "guidellm",
             driverKind: "local",
+            name: "test-benchmark",
             params: {},
           },
         });
@@ -335,6 +343,7 @@ describe("BenchmarkController", () => {
             scenario: "inference",
             tool: "guidellm",
             driverKind: "local",
+            name: "test-benchmark",
             params: {},
           },
         });
@@ -354,6 +363,7 @@ describe("BenchmarkController", () => {
           scenario: "inference",
           tool: "guidellm",
           driverKind: "local",
+          name: "test-benchmark",
           params: {},
         },
       });
@@ -374,6 +384,7 @@ describe("BenchmarkController", () => {
           scenario: "inference",
           tool: "guidellm",
           driverKind: "local",
+          name: "test-benchmark",
           params: {},
         },
       });
@@ -392,6 +403,7 @@ describe("BenchmarkController", () => {
           scenario: "inference",
           tool: "guidellm",
           driverKind: "local",
+          name: "test-benchmark",
           params: {},
           status: "running",
           driverHandle: "subprocess:cancel-me",
@@ -413,6 +425,7 @@ describe("BenchmarkController", () => {
           scenario: "inference",
           tool: "guidellm",
           driverKind: "local",
+          name: "test-benchmark",
           params: {},
           status: "running",
         },
@@ -432,6 +445,7 @@ describe("BenchmarkController", () => {
           scenario: "inference",
           tool: "guidellm",
           driverKind: "local",
+          name: "test-benchmark",
           params: {},
           status: "completed",
         },
@@ -453,6 +467,7 @@ describe("BenchmarkController", () => {
           scenario: "inference",
           tool: "guidellm",
           driverKind: "local",
+          name: "test-benchmark",
           params: {},
           status: "completed",
         },
@@ -527,6 +542,7 @@ describe("BenchmarkController.getCharts (F3 #88)", () => {
         scenario: "inference",
         tool: "guidellm",
         driverKind: "local",
+        name: "test-benchmark",
         params: {},
         status: "completed",
       },
@@ -546,6 +562,7 @@ describe("BenchmarkController.getCharts (F3 #88)", () => {
         scenario: "inference",
         tool: "vegeta",
         driverKind: "local",
+        name: "test-benchmark",
         params: {},
         status: "completed",
         rawOutput: {
@@ -573,6 +590,7 @@ describe("BenchmarkController.getCharts (F3 #88)", () => {
         scenario: "inference",
         tool: "guidellm",
         driverKind: "local",
+        name: "test-benchmark",
         params: {},
         status: "completed",
       },

--- a/apps/api/src/modules/benchmark/benchmark.repository.spec.ts
+++ b/apps/api/src/modules/benchmark/benchmark.repository.spec.ts
@@ -71,6 +71,7 @@ describe("BenchmarkRepository", () => {
         scenario: i % 2 === 0 ? "inference" : "capacity",
         tool: "guidellm",
         driverKind: "local",
+        name: "test-benchmark",
         params: {},
       });
     }
@@ -99,6 +100,7 @@ describe("BenchmarkRepository", () => {
       scenario: "inference",
       tool: "guidellm",
       driverKind: "local",
+      name: "test-benchmark",
       params: {},
     });
     await repo.create({
@@ -106,6 +108,7 @@ describe("BenchmarkRepository", () => {
       scenario: "inference",
       tool: "vegeta",
       driverKind: "local",
+      name: "test-benchmark",
       params: {},
     });
 
@@ -123,6 +126,7 @@ describe("BenchmarkRepository", () => {
       scenario: "inference",
       tool: "guidellm",
       driverKind: "local",
+      name: "test-benchmark",
       params: {},
     });
 
@@ -150,6 +154,7 @@ describe("BenchmarkRepository", () => {
           scenario: "inference",
           tool: "guidellm",
           driverKind: "local",
+          name: "test-benchmark",
           params: {},
           createdAt: new Date(`2026-04-30T0${i}:00:00Z`),
         },

--- a/apps/api/src/modules/benchmark/benchmark.repository.ts
+++ b/apps/api/src/modules/benchmark/benchmark.repository.ts
@@ -17,7 +17,7 @@ export type CreateBenchmarkInput = {
   tool: "guidellm" | "genai-perf" | "vegeta";
   driverKind: "local" | "k8s";
   params: Prisma.InputJsonValue;
-  name?: string | null;
+  name: string;
   description?: string | null;
   templateId?: string | null;
   parentBenchmarkId?: string | null;
@@ -65,7 +65,7 @@ export class BenchmarkRepository {
       tool: input.tool,
       driverKind: input.driverKind,
       params: input.params,
-      name: input.name ?? null,
+      name: input.name,
       description: input.description ?? null,
     };
     if (input.userId) data.user = { connect: { id: input.userId } };

--- a/apps/api/src/modules/benchmark/benchmark.service.spec.ts
+++ b/apps/api/src/modules/benchmark/benchmark.service.spec.ts
@@ -293,18 +293,14 @@ describe("BenchmarkService.delete", () => {
   });
 
   it("deletes a submitted benchmark and best-effort cancels driver", async () => {
-    repo.setup(
-      makeBenchmarkRow({ id: "b1", status: "submitted", driverHandle: "k8s:job-1" }),
-    );
+    repo.setup(makeBenchmarkRow({ id: "b1", status: "submitted", driverHandle: "k8s:job-1" }));
     await svc.delete("b1", "u1");
     expect(mockDriver.cancel).toHaveBeenCalledWith("k8s:job-1");
     expect(repo.delete).toHaveBeenCalledWith("b1");
   });
 
   it("deletes a running benchmark even when driver.cancel throws", async () => {
-    repo.setup(
-      makeBenchmarkRow({ id: "b1", status: "running", driverHandle: "k8s:job-2" }),
-    );
+    repo.setup(makeBenchmarkRow({ id: "b1", status: "running", driverHandle: "k8s:job-2" }));
     (mockDriver.cancel as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
       new Error("apiserver flake"),
     );

--- a/apps/api/src/modules/benchmark/benchmark.service.spec.ts
+++ b/apps/api/src/modules/benchmark/benchmark.service.spec.ts
@@ -285,15 +285,39 @@ describe("BenchmarkService.delete", () => {
     vi.clearAllMocks();
   });
 
-  it("deletes a terminal benchmark", async () => {
+  it("deletes a terminal benchmark without calling driver.cancel", async () => {
     repo.setup(makeBenchmarkRow({ id: "b1", status: "completed" }));
     await svc.delete("b1", "u1");
     expect(repo.delete).toHaveBeenCalledWith("b1");
+    expect(mockDriver.cancel).not.toHaveBeenCalled();
   });
 
-  it("throws ConflictException when benchmark is not terminal", async () => {
-    repo.setup(makeBenchmarkRow({ id: "b1", status: "running" }));
-    await expect(svc.delete("b1", "u1")).rejects.toThrow(ConflictException);
+  it("deletes a submitted benchmark and best-effort cancels driver", async () => {
+    repo.setup(
+      makeBenchmarkRow({ id: "b1", status: "submitted", driverHandle: "k8s:job-1" }),
+    );
+    await svc.delete("b1", "u1");
+    expect(mockDriver.cancel).toHaveBeenCalledWith("k8s:job-1");
+    expect(repo.delete).toHaveBeenCalledWith("b1");
+  });
+
+  it("deletes a running benchmark even when driver.cancel throws", async () => {
+    repo.setup(
+      makeBenchmarkRow({ id: "b1", status: "running", driverHandle: "k8s:job-2" }),
+    );
+    (mockDriver.cancel as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("apiserver flake"),
+    );
+    await svc.delete("b1", "u1");
+    expect(mockDriver.cancel).toHaveBeenCalledWith("k8s:job-2");
+    expect(repo.delete).toHaveBeenCalledWith("b1");
+  });
+
+  it("does not call driver.cancel when driverHandle is null", async () => {
+    repo.setup(makeBenchmarkRow({ id: "b1", status: "submitted", driverHandle: null }));
+    await svc.delete("b1", "u1");
+    expect(mockDriver.cancel).not.toHaveBeenCalled();
+    expect(repo.delete).toHaveBeenCalledWith("b1");
   });
 });
 

--- a/apps/api/src/modules/benchmark/benchmark.service.ts
+++ b/apps/api/src/modules/benchmark/benchmark.service.ts
@@ -289,8 +289,9 @@ export class BenchmarkService {
       try {
         await this.driver.cancel(row.driverHandle);
       } catch (e) {
+        const err = e as Error;
         this.log.warn(
-          `delete: best-effort driver.cancel failed for ${row.id}: ${(e as Error).message}`,
+          `delete: best-effort driver.cancel failed for ${row.id}: ${err.message}\n${err.stack ?? ""}`,
         );
       }
     }

--- a/apps/api/src/modules/benchmark/benchmark.service.ts
+++ b/apps/api/src/modules/benchmark/benchmark.service.ts
@@ -10,6 +10,7 @@ import {
   ConflictException,
   Inject,
   Injectable,
+  Logger,
   NotFoundException,
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
@@ -34,6 +35,7 @@ const CALLBACK_TTL_SLACK_SECONDS = 15 * 60;
 
 @Injectable()
 export class BenchmarkService {
+  private readonly log = new Logger(BenchmarkService.name);
   private readonly callbackSecret: Buffer;
   private readonly callbackUrl: string;
   private readonly driverKind: "local" | "k8s";
@@ -277,11 +279,20 @@ export class BenchmarkService {
     if (userId !== undefined && row.userId !== userId) {
       throw new NotFoundException(`Benchmark ${id} not found`);
     }
-    if (!(TERMINAL_STATES as readonly string[]).includes(row.status)) {
-      throw new ConflictException({
-        code: "BENCHMARK_NOT_TERMINAL",
-        message: `Cannot delete a benchmark in state '${row.status}'. Cancel it first.`,
-      });
+    // Non-terminal rows may have a backing driver job (K8s Job, subprocess,
+    // …). Best-effort cancel before DB delete so we don't orphan resources.
+    // The K8sJobDriver already treats 404 on the Job as idempotent; any
+    // other error is logged and swallowed so a flaky apiserver doesn't
+    // block the user from clearing a stuck row.
+    const isTerminal = (TERMINAL_STATES as readonly string[]).includes(row.status);
+    if (!isTerminal && row.driverHandle) {
+      try {
+        await this.driver.cancel(row.driverHandle);
+      } catch (e) {
+        this.log.warn(
+          `delete: best-effort driver.cancel failed for ${row.id}: ${(e as Error).message}`,
+        );
+      }
     }
     await this.repo.delete(row.id);
   }

--- a/apps/api/test/e2e/auth.e2e-spec.ts
+++ b/apps/api/test/e2e/auth.e2e-spec.ts
@@ -298,6 +298,7 @@ describe("Auth (e2e)", () => {
       scenario: "gateway",
       tool: "vegeta",
       driverKind: "local",
+      name: "admin-run",
       params: { apiType: "chat", apiBaseUrl: "http://admin-run", model: "m", rate: 1, duration: 1 },
     });
     await repo.update(adminRow.id, { status: "completed", completedAt: new Date(), summaryMetrics: {} });
@@ -307,6 +308,7 @@ describe("Auth (e2e)", () => {
       scenario: "gateway",
       tool: "vegeta",
       driverKind: "local",
+      name: "user2-run",
       params: { apiType: "chat", apiBaseUrl: "http://user2-run", model: "m", rate: 1, duration: 1 },
     });
     await repo.update(user2Row.id, { status: "completed", completedAt: new Date(), summaryMetrics: {} });
@@ -340,6 +342,7 @@ describe("Auth (e2e)", () => {
       scenario: "gateway",
       tool: "vegeta",
       driverKind: "local",
+      name: "own-run",
       params: { apiType: "chat", apiBaseUrl: "http://own-run", model: "m", rate: 1, duration: 1 },
     });
     await repo.update(row.id, { status: "completed", completedAt: new Date(), summaryMetrics: {} });

--- a/apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx
@@ -131,7 +131,7 @@ export function BenchmarkCreatePage() {
       // overrides whatever the form may carry. Keeps a single source of truth.
       const body: CreateBenchmarkRequest = { ...values, scenario };
       const benchmark = await createMut.mutateAsync(body);
-      toast.success(t("create.submitted", { name: benchmark.name ?? benchmark.id }));
+      toast.success(t("create.submitted", { name: benchmark.name }));
       navigate(`/benchmarks/${benchmark.id}`);
     } catch (e) {
       const err = e as { code?: string; message?: string; status?: number };

--- a/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
@@ -30,6 +30,7 @@ import {
   benchmarkKeys,
   isTerminalStatus,
   useBenchmarkDetail,
+  useCancelBenchmark,
   useCreateBenchmark,
   useDeleteBenchmark,
 } from "./queries";
@@ -103,8 +104,10 @@ export function BenchmarkDetailPage() {
   const [setOpen, setSetOpen] = useState(false);
   const [unsetOpen, setUnsetOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [cancelOpen, setCancelOpen] = useState(false);
   const remove = useDeleteBaseline();
   const deleteBenchmark = useDeleteBenchmark();
+  const cancelBenchmark = useCancelBenchmark();
   const createBenchmark = useCreateBenchmark();
   const navigate = useNavigate();
 
@@ -223,11 +226,14 @@ export function BenchmarkDetailPage() {
                   <TooltipContent>{t("detail.rerun.connectionMissingTooltip")}</TooltipContent>
                 </Tooltip>
               ))}
-            {isTerminal && (
-              <Button variant="destructive" size="sm" onClick={() => setDeleteOpen(true)}>
-                {t("detail.delete.button")}
+            {!isTerminal && (
+              <Button variant="outline" size="sm" onClick={() => setCancelOpen(true)}>
+                {t("detail.cancel.button")}
               </Button>
             )}
+            <Button variant="destructive" size="sm" onClick={() => setDeleteOpen(true)}>
+              {t("detail.delete.button")}
+            </Button>
             <Button asChild variant="ghost" size="sm">
               <Link to={`/benchmarks/${benchmark.scenario}`}>
                 <ArrowLeft className="mr-1 h-4 w-4" />
@@ -338,6 +344,34 @@ export function BenchmarkDetailPage() {
               disabled={deleteBenchmark.isPending}
             >
               {t("detail.delete.confirmAction")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={cancelOpen} onOpenChange={setCancelOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("detail.cancel.confirmTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>{t("detail.cancel.confirmBody")}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("detail.cancel.dismiss")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                cancelBenchmark.mutate(benchmark.id, {
+                  onSuccess: () => {
+                    toast.success(t("detail.cancel.success"));
+                    setCancelOpen(false);
+                  },
+                  onError: () => {
+                    toast.error(t("detail.cancel.errors.generic"));
+                  },
+                });
+              }}
+              disabled={cancelBenchmark.isPending}
+            >
+              {t("detail.cancel.confirmAction")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
@@ -166,7 +166,7 @@ export function BenchmarkDetailPage() {
   async function handleRerun() {
     if (!benchmark || !benchmark.connectionId) return;
     // Schema caps name at 128. " (rerun)" is 8 chars; reserve 120 for the source.
-    const sourceName = benchmark.name?.trim() || `run-${benchmark.id.slice(0, 8)}`;
+    const sourceName = benchmark.name;
     const trimmed = sourceName.length > 120 ? sourceName.slice(0, 120) : sourceName;
     const newName = `${trimmed} (rerun)`;
     try {
@@ -178,7 +178,7 @@ export function BenchmarkDetailPage() {
         description: benchmark.description ?? undefined,
         params: benchmark.params,
       });
-      toast.success(t("detail.rerun.success", { name: next.name ?? next.id }));
+      toast.success(t("detail.rerun.success", { name: next.name }));
       navigate(`/benchmarks/${next.id}`);
     } catch (e) {
       toast.error((e as Error).message || t("detail.rerun.errors.generic"));
@@ -188,7 +188,7 @@ export function BenchmarkDetailPage() {
   return (
     <>
       <PageHeader
-        title={benchmark.name ?? benchmark.id}
+        title={benchmark.name}
         subtitle={subtitle}
         rightSlot={
           <div className="flex items-center gap-2">

--- a/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
@@ -229,7 +229,7 @@ export function BenchmarkDetailPage() {
               </Button>
             )}
             <Button asChild variant="ghost" size="sm">
-              <Link to="/benchmarks">
+              <Link to={`/benchmarks/${benchmark.scenario}`}>
                 <ArrowLeft className="mr-1 h-4 w-4" />
                 {t("detail.back")}
               </Link>

--- a/apps/web/src/features/benchmarks/BenchmarkListShell.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkListShell.tsx
@@ -223,6 +223,7 @@ export function BenchmarkListShell({ scenario }: BenchmarkListShellProps) {
               <TableHeader>
                 <TableRow>
                   <TableHead className="w-10" />
+                  <TableHead>{t("columns.name")}</TableHead>
                   <TableHead>{t("columns.createdAt")}</TableHead>
                   <TableHead>{t("columns.tool")}</TableHead>
                   <TableHead>{t("columns.connection")}</TableHead>
@@ -242,6 +243,7 @@ export function BenchmarkListShell({ scenario }: BenchmarkListShellProps) {
                         aria-label={`select ${benchmark.id}`}
                       />
                     </TableCell>
+                    <TableCell className="font-medium">{benchmark.name}</TableCell>
                     <TableCell className="text-muted-foreground">
                       {formatDistanceToNow(new Date(benchmark.createdAt), { addSuffix: true })}
                     </TableCell>

--- a/apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
@@ -585,8 +585,6 @@ describe("BenchmarkDetailPage", () => {
       name: /^Cancel run$|^确认取消$/,
     });
     await user.click(confirm);
-    await waitFor(() =>
-      expect(api.post).toHaveBeenCalledWith("/api/benchmarks/r1/cancel", {}),
-    );
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith("/api/benchmarks/r1/cancel", {}));
   });
 });

--- a/apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
@@ -302,11 +302,11 @@ describe("BenchmarkDetailPage", () => {
     );
   });
 
-  it("hides the delete button while the run is still running", async () => {
+  it("shows the delete button on non-terminal runs", async () => {
     vi.mocked(api.get).mockResolvedValueOnce(makeBenchmark({ status: "running" }));
     render(<BenchmarkDetailPage />, { wrapper: Wrapper });
     await screen.findByText("smoke");
-    expect(screen.queryByRole("button", { name: /^Delete$|^删除$/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Delete$|^删除$/ })).toBeInTheDocument();
   });
 
   it("calls DELETE and navigates back to list after confirm", async () => {
@@ -351,7 +351,7 @@ describe("BenchmarkDetailPage", () => {
     );
   });
 
-  it("hides Set-as-baseline / Delete buttons while non-terminal", async () => {
+  it("hides Set-as-baseline button while non-terminal", async () => {
     vi.mocked(api.get).mockResolvedValueOnce(
       makeBenchmark({ status: "running", summaryMetrics: null, rawOutput: null }),
     );
@@ -360,7 +360,6 @@ describe("BenchmarkDetailPage", () => {
     expect(
       screen.queryByRole("button", { name: /Set as baseline|设为基线/ }),
     ).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /^Delete$|^删除$/ })).not.toBeInTheDocument();
   });
 
   // ---- F4: Re-run button (one-click clone-and-submit, see #88) ----
@@ -552,5 +551,42 @@ describe("BenchmarkDetailPage", () => {
     });
     render(<BenchmarkDetailPage />, { wrapper: Wrapper });
     await waitFor(() => expect(screen.getByText(/vs baseline|vs 基准/i)).toBeInTheDocument());
+  });
+
+  // ---- Cancel button ----
+
+  it("shows the Cancel button while the run is non-terminal", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(makeBenchmark({ status: "running" }));
+    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^Cancel run$|^取消任务$/ })).toBeInTheDocument(),
+    );
+  });
+
+  it("hides the Cancel button when the run is terminal", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(makeBenchmark({ status: "completed" }));
+    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
+    await screen.findByText("smoke");
+    expect(
+      screen.queryByRole("button", { name: /^Cancel run$|^取消任务$/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls cancel API after confirm", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(makeBenchmark({ status: "running" }));
+    vi.mocked(api.post).mockResolvedValueOnce(makeBenchmark({ status: "canceled" }));
+    const user = userEvent.setup();
+    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
+    const cancelBtn = await screen.findByRole("button", {
+      name: /^Cancel run$|^取消任务$/,
+    });
+    await user.click(cancelBtn);
+    const confirm = await screen.findByRole("button", {
+      name: /^Cancel run$|^确认取消$/,
+    });
+    await user.click(confirm);
+    await waitFor(() =>
+      expect(api.post).toHaveBeenCalledWith("/api/benchmarks/r1/cancel", {}),
+    );
   });
 });

--- a/apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
@@ -418,21 +418,6 @@ describe("BenchmarkDetailPage", () => {
     expect(body.name).toBe("smoke (rerun)");
   });
 
-  it("falls back to a synthetic name when the source Run has no name", async () => {
-    vi.mocked(api.get).mockResolvedValueOnce(makeBenchmark({ status: "completed", name: null }));
-    vi.mocked(api.post).mockResolvedValueOnce(makeBenchmark({ id: "r2" }));
-    const user = userEvent.setup();
-    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
-    const btn = await screen.findByRole("button", { name: /^Re-run$|^重跑$/ });
-    await user.click(btn);
-    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(1));
-    const [, body] = vi.mocked(api.post).mock.calls[0] as [string, Record<string, unknown>];
-    // Schema requires name to be 1..128; synthesized payload must satisfy that.
-    expect(typeof body.name).toBe("string");
-    expect((body.name as string).length).toBeGreaterThan(0);
-    expect((body.name as string).length).toBeLessThanOrEqual(128);
-  });
-
   it("truncates the source name so the ' (rerun)' suffix fits within the 128-char limit", async () => {
     const longName = "x".repeat(125); // 125 + " (rerun)" (8) = 133 > 128
     vi.mocked(api.get).mockResolvedValueOnce(

--- a/apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
@@ -499,6 +499,15 @@ describe("BenchmarkDetailPage", () => {
     expect(screen.queryByText(/Distributions|分布图/i)).not.toBeInTheDocument();
   });
 
+  it("back link points to /benchmarks/:scenario based on the loaded benchmark", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(
+      makeBenchmark({ status: "completed", scenario: "gateway" }),
+    );
+    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
+    const backLink = await screen.findByRole("link", { name: /Back to list|返回列表/ });
+    expect(backLink).toHaveAttribute("href", "/benchmarks/gateway");
+  });
+
   it("mounts DetailVerdictRow when run.baselineId is set", async () => {
     const baseline = makeBenchmark({
       id: "br",

--- a/apps/web/src/features/benchmarks/__tests__/BenchmarkListShell.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/BenchmarkListShell.test.tsx
@@ -238,6 +238,16 @@ describe("BenchmarkListShell", () => {
     await waitFor(() => expect(screen.getByText("compare-stub")).toBeInTheDocument());
   });
 
+  it("renders the benchmark name in the first content column", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({
+      items: [makeBenchmark("r1", "guidellm", "completed", guidellmMetrics)],
+      nextCursor: null,
+    } satisfies ListBenchmarksResponse);
+    render(<BenchmarkListShell scenario="inference" />, { wrapper: Wrapper });
+    // benchmark.name is set to the id in makeBenchmark; expect to find "r1"
+    expect(await screen.findByText("r1")).toBeInTheDocument();
+  });
+
   it("Compare button disabled with mixed-tools tooltip when selection mixes tools", async () => {
     vi.mocked(api.get).mockResolvedValueOnce({
       items: [

--- a/apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
+++ b/apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
@@ -56,6 +56,9 @@ export function BenchmarkComparePage() {
   const failedCount = queries.filter((q) => q.isError).length;
   const isLoading = queries.some((q) => q.isLoading);
 
+  const backScenario = successfulBenchmarks[0]?.scenario ?? "gateway";
+  const backHref = `/benchmarks/${backScenario}`;
+
   const tools = new Set(successfulBenchmarks.map((r) => r.tool));
   const isMixed = tools.size > 1;
 
@@ -105,7 +108,7 @@ export function BenchmarkComparePage() {
           title={t("compare.needTwoEmpty")}
           actions={
             <Button asChild variant="outline" size="sm">
-              <Link to="/benchmarks">
+              <Link to={backHref}>
                 <ArrowLeft className="mr-1 h-4 w-4" />
                 {t("compare.back")}
               </Link>
@@ -134,7 +137,7 @@ export function BenchmarkComparePage() {
         subtitle={subtitle}
         rightSlot={
           <Button asChild variant="ghost" size="sm">
-            <Link to="/benchmarks">
+            <Link to={backHref}>
               <ArrowLeft className="mr-1 h-4 w-4" />
               {t("compare.back")}
             </Link>

--- a/apps/web/src/features/benchmarks/compare/CompareGrid.tsx
+++ b/apps/web/src/features/benchmarks/compare/CompareGrid.tsx
@@ -37,7 +37,7 @@ export function CompareGrid({ runs, baselineId }: CompareGridProps) {
                   run.id === baselineId && "bg-amber-50 dark:bg-amber-950/30",
                 )}
               >
-                {run.name ?? run.id}
+                {run.name}
               </TableHead>
             ))}
           </TableRow>

--- a/apps/web/src/features/benchmarks/compare/CompareToolbar.tsx
+++ b/apps/web/src/features/benchmarks/compare/CompareToolbar.tsx
@@ -26,7 +26,7 @@ export function CompareToolbar({ runs, baselineId, onBaselineChange }: CompareTo
           <option value="">{t("compare.baselineNone")}</option>
           {runs.map((run) => (
             <option key={run.id} value={run.id}>
-              {run.name ?? run.id}
+              {run.name}
             </option>
           ))}
         </select>

--- a/apps/web/src/features/benchmarks/compare/__tests__/BenchmarkComparePage.test.tsx
+++ b/apps/web/src/features/benchmarks/compare/__tests__/BenchmarkComparePage.test.tsx
@@ -173,6 +173,17 @@ describe("BenchmarkComparePage", () => {
     );
   });
 
+  it("back link points to /benchmarks/:scenario derived from loaded benchmarks", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce(makeBenchmark("a", "guidellm", 200, "inference"))
+      .mockResolvedValueOnce(makeBenchmark("b", "guidellm", 180, "inference"));
+    renderPage("/benchmarks/compare?ids=a,b");
+    // Wait for the grid to render (both benchmarks loaded)
+    await waitFor(() => expect(screen.getAllByText("a").length).toBeGreaterThan(0));
+    const backLink = screen.getByRole("link", { name: /Back to list|返回列表/ });
+    expect(backLink).toHaveAttribute("href", "/benchmarks/inference");
+  });
+
   it("?baseline=none keeps None even when a Benchmark has baselineFor !== null", async () => {
     // Without the "none" sentinel, defaultBaseline would infer the
     // baselineFor-non-null Benchmark and override the user's None choice.

--- a/apps/web/src/locales/en-US/benchmarks.json
+++ b/apps/web/src/locales/en-US/benchmarks.json
@@ -43,6 +43,7 @@
     "clear": "Clear filters"
   },
   "columns": {
+    "name": "Name",
     "createdAt": "Created",
     "tool": "Tool",
     "connection": "Connection",

--- a/apps/web/src/locales/en-US/benchmarks.json
+++ b/apps/web/src/locales/en-US/benchmarks.json
@@ -125,6 +125,17 @@
         "generic": "Failed to delete"
       }
     },
+    "cancel": {
+      "button": "Cancel run",
+      "confirmTitle": "Cancel this run?",
+      "confirmBody": "The benchmark will stop and its backing K8s job will be removed. The record stays in history with status 'canceled'.",
+      "confirmAction": "Cancel run",
+      "dismiss": "Keep running",
+      "success": "Run canceled",
+      "errors": {
+        "generic": "Failed to cancel"
+      }
+    },
     "rerun": {
       "button": "Re-run",
       "connectionMissingTooltip": "The original connection has been deleted; pick a new one from \"New Benchmark\" instead.",

--- a/apps/web/src/locales/zh-CN/benchmarks.json
+++ b/apps/web/src/locales/zh-CN/benchmarks.json
@@ -43,6 +43,7 @@
     "clear": "清除筛选"
   },
   "columns": {
+    "name": "名称",
     "createdAt": "创建时间",
     "tool": "工具",
     "connection": "Connection",

--- a/apps/web/src/locales/zh-CN/benchmarks.json
+++ b/apps/web/src/locales/zh-CN/benchmarks.json
@@ -125,6 +125,17 @@
         "generic": "删除失败"
       }
     },
+    "cancel": {
+      "button": "取消任务",
+      "confirmTitle": "取消该任务？",
+      "confirmBody": "任务会停止，K8s 中关联的 Job 会被删除。记录保留在历史中，状态为 canceled。",
+      "confirmAction": "确认取消",
+      "dismiss": "保持运行",
+      "success": "已取消",
+      "errors": {
+        "generic": "取消失败"
+      }
+    },
     "rerun": {
       "button": "重跑",
       "connectionMissingTooltip": "原 Connection 已删除，请到「新建基准测试」里重新选一个。",

--- a/docs/superpowers/plans/2026-05-05-benchmark-task-management.md
+++ b/docs/superpowers/plans/2026-05-05-benchmark-task-management.md
@@ -1,0 +1,985 @@
+# Benchmark Task Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix four task-management bugs in benchmark module (#102 sub-bugs 1, 2, 3, 4): submitted-state delete, scenario-aware back link, list-page name column with NOT NULL tightening, and detail-page Cancel action.
+
+**Architecture:** One feature branch (`fix/benchmark-task-management`) with five sequenced commits. Backend changes are isolated to `BenchmarkService.delete` and a Prisma migration. Frontend changes are spread across `BenchmarkDetailPage`, `BenchmarkComparePage`, `BenchmarkListShell`, and i18n bundles. Sub-bug 5 (ImagePullBackOff awareness + SSE logs) is split into a follow-up issue created in Task 0.
+
+**Tech Stack:** Nest.js 11 + Prisma + Vitest 2 (api), React + react-router + react-hook-form + react-i18next + Vitest 1 (web), shared zod contracts in `packages/contracts`.
+
+**Spec:** `docs/superpowers/specs/2026-05-05-benchmark-task-management-design.md`
+
+**Worktree:** `/Users/fangyong/vllm/modeldoctor/fix-benchmark-task-mgmt` (already exists; `pnpm -r build` already run).
+
+---
+
+### Task 0: Create follow-up issue for sub-bug 5
+
+**Files:** none (GitHub-side only)
+
+- [ ] **Step 1: Confirm with user before creating the issue.**
+
+`gh issue create` is not in the autonomous-action allowlist. Print the issue body below and ask the user to confirm before invoking the command.
+
+- [ ] **Step 2: Create the issue.**
+
+```bash
+gh issue create --title "K8s pod watcher + benchmark task SSE logs" --body "$(cat <<'EOF'
+Currently the benchmark API only learns about run state via the callback v2 channel from the runner pod (post `state=running`). Pre-runner-start failures — `ImagePullBackOff`, `CrashLoopBackOff`, scheduler errors, image pull timeouts — never trigger a callback, so the benchmark sits in `submitted` indefinitely.
+
+**Repro:** create a benchmark whose container image cannot be pulled (e.g. typo'd image tag).
+**Expected:** benchmark transitions to `failed` with a `statusMessage` describing the K8s reason within ~30s.
+**Actual:** benchmark stays `submitted` forever; only `kubectl get pods` reveals the cause.
+
+## Required work
+
+1. **K8s pod watcher in `apps/api/src/modules/benchmark/`** — informer or polling loop that watches pods labeled with the benchmark's `runId`. On Pending+ImagePullBackOff/CrashLoopBackOff/Error past a threshold (e.g. 60s), call `BenchmarkService.markFailed(runId, statusMessage=<reason: message>)`.
+2. **Streaming task logs over SSE** — extend `SseHub` or add a sibling channel (`SseHub` today only carries `ProgressEvent` from runner). Pull pod logs via the K8s logs API (follow=true) and forward chunks as SSE events keyed on `runId`. Frontend detail page subscribes and renders a log panel.
+
+## Open design questions
+
+- Single watcher process vs. per-runId goroutine/Subject. NestJS singleton service hosting an `Informer` is probably simplest.
+- Log retention: do we persist the streamed logs to DB / object store, or are they ephemeral and only visible while the pod still exists?
+- Behavior on pod restart (CrashLoopBackOff) — emit one combined log stream or one per attempt?
+
+Split off from #102 (sub-bug 5) so the simpler task-management fixes can ship first.
+EOF
+)"
+```
+
+- [ ] **Step 3: Capture the new issue number.**
+
+The command prints `https://github.com/weetime/modeldoctor/issues/<N>`. Note `<N>` — used in Task 5's PR description as `refs #<N>`.
+
+---
+
+### Task 1: Tighten benchmark.name to NOT NULL (Prisma + contract)
+
+**Files:**
+- Modify: `apps/api/prisma/schema.prisma:105` (`name String?` → `name String`)
+- Create: `apps/api/prisma/migrations/<timestamp>_benchmark_name_required/migration.sql` (Prisma generates)
+- Modify: `packages/contracts/src/benchmark.ts:44` (`z.string().nullable()` → `z.string()`)
+
+- [ ] **Step 1: Pre-flight verify zero NULL rows.**
+
+```bash
+PGPASSWORD=modeldoctor psql -h localhost -U modeldoctor -d modeldoctor -c \
+  "SELECT count(*) FROM benchmarks WHERE name IS NULL;"
+```
+
+Expected: `0`. If non-zero, STOP — coordinate with the user before adding NOT NULL (would require backfill or column default).
+
+- [ ] **Step 2: Edit the Prisma schema.**
+
+In `apps/api/prisma/schema.prisma`, find the `model Benchmark` block. Change:
+
+```prisma
+  name        String?
+  description String? @db.Text
+```
+
+to:
+
+```prisma
+  name        String
+  description String? @db.Text
+```
+
+- [ ] **Step 3: Generate the migration with --create-only.**
+
+```bash
+cd apps/api && pnpm exec prisma migrate dev --create-only --name benchmark_name_required
+```
+
+This writes `apps/api/prisma/migrations/<timestamp>_benchmark_name_required/migration.sql` without applying it. Open the file and confirm the body is just:
+
+```sql
+ALTER TABLE "benchmarks" ALTER COLUMN "name" SET NOT NULL;
+```
+
+If Prisma generated extra DDL, STOP and surface to user.
+
+- [ ] **Step 4: Apply the migration locally.**
+
+```bash
+cd apps/api && pnpm exec prisma migrate dev
+```
+
+Expected: "Database is now in sync." Verify:
+
+```bash
+PGPASSWORD=modeldoctor psql -h localhost -U modeldoctor -d modeldoctor -c "\d benchmarks" | grep " name "
+```
+
+Expected: `name | text | not null`.
+
+- [ ] **Step 5: Update the shared contract.**
+
+In `packages/contracts/src/benchmark.ts`, find line 44 inside `benchmarkSchema`:
+
+```typescript
+  name: z.string().nullable(),
+```
+
+Change to:
+
+```typescript
+  name: z.string(),
+```
+
+- [ ] **Step 6: Rebuild contracts so api/web see the new type.**
+
+```bash
+pnpm -F @modeldoctor/contracts build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 7: Type-check api and web.**
+
+```bash
+pnpm -F api type-check && pnpm -F web type-check
+```
+
+Expected: PASS. (Frontend `benchmark.name ?? id` sites compile fine — `??` is just dead-code on a non-nullable side; cleanup happens in Task 5.)
+
+- [ ] **Step 8: Run impacted tests.**
+
+```bash
+pnpm -F @modeldoctor/contracts test && pnpm -F api test --run benchmark
+```
+
+Expected: all PASS. The contract change does not require new tests — `benchmark.spec.ts` already validates name presence on create-request schema.
+
+- [ ] **Step 9: Commit.**
+
+```bash
+git add apps/api/prisma/schema.prisma \
+        apps/api/prisma/migrations/*_benchmark_name_required \
+        packages/contracts/src/benchmark.ts
+git commit -m "$(cat <<'EOF'
+feat(contracts,api): require non-null benchmark name
+
+Tightens benchmarkSchema.name from nullable to required and adds the
+matching ALTER COLUMN ... SET NOT NULL migration. createBenchmark
+already enforced min(1).max(128) at the input layer, so this is just
+catching the response schema and DB column up to the existing input
+contract. Pre-flight verified zero NULL rows in dev.
+
+Refs #102.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Allow delete on non-terminal with best-effort driver cancel
+
+**Files:**
+- Modify: `apps/api/src/modules/benchmark/benchmark.service.ts:274-287` (delete method)
+- Modify: `apps/api/src/modules/benchmark/benchmark.service.spec.ts` (delete describe block, line 278)
+
+- [ ] **Step 1: Write the failing test for non-terminal delete.**
+
+In `benchmark.service.spec.ts`, locate the `describe("BenchmarkService.delete", ...)` block (line ~278). Replace the body with:
+
+```typescript
+describe("BenchmarkService.delete", () => {
+  let repo: MockRepo;
+  let svc: BenchmarkService;
+
+  beforeEach(() => {
+    repo = new MockRepo();
+    svc = build(repo);
+    vi.clearAllMocks();
+  });
+
+  it("deletes a terminal benchmark", async () => {
+    repo.setup(makeBenchmarkRow({ id: "b1", status: "completed" }));
+    await svc.delete("b1", "u1");
+    expect(repo.delete).toHaveBeenCalledWith("b1");
+    expect(mockDriver.cancel).not.toHaveBeenCalled();
+  });
+
+  it("deletes a submitted benchmark and best-effort cancels driver", async () => {
+    repo.setup(
+      makeBenchmarkRow({ id: "b1", status: "submitted", driverHandle: "k8s:job-1" }),
+    );
+    await svc.delete("b1", "u1");
+    expect(mockDriver.cancel).toHaveBeenCalledWith("k8s:job-1");
+    expect(repo.delete).toHaveBeenCalledWith("b1");
+  });
+
+  it("deletes a running benchmark even when driver.cancel throws", async () => {
+    repo.setup(
+      makeBenchmarkRow({ id: "b1", status: "running", driverHandle: "k8s:job-2" }),
+    );
+    (mockDriver.cancel as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("apiserver flake"),
+    );
+    await svc.delete("b1", "u1");
+    expect(mockDriver.cancel).toHaveBeenCalledWith("k8s:job-2");
+    expect(repo.delete).toHaveBeenCalledWith("b1");
+  });
+
+  it("does not call driver.cancel when driverHandle is null", async () => {
+    repo.setup(makeBenchmarkRow({ id: "b1", status: "submitted", driverHandle: null }));
+    await svc.delete("b1", "u1");
+    expect(mockDriver.cancel).not.toHaveBeenCalled();
+    expect(repo.delete).toHaveBeenCalledWith("b1");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify three of them fail.**
+
+```bash
+pnpm -F api test --run benchmark.service.spec
+```
+
+Expected: "deletes a terminal benchmark" PASS; the three new ones FAIL with `ConflictException` (current code rejects non-terminal).
+
+- [ ] **Step 3: Update `service.delete` to allow non-terminal.**
+
+In `benchmark.service.ts`, find the `delete` method (around line 274). Replace:
+
+```typescript
+  async delete(id: string, userId?: string): Promise<void> {
+    const row = await this.repo.findById(id);
+    if (!row) throw new NotFoundException(`Benchmark ${id} not found`);
+    if (userId !== undefined && row.userId !== userId) {
+      throw new NotFoundException(`Benchmark ${id} not found`);
+    }
+    if (!(TERMINAL_STATES as readonly string[]).includes(row.status)) {
+      throw new ConflictException({
+        code: "BENCHMARK_NOT_TERMINAL",
+        message: `Cannot delete a benchmark in state '${row.status}'. Cancel it first.`,
+      });
+    }
+    await this.repo.delete(row.id);
+  }
+```
+
+with:
+
+```typescript
+  async delete(id: string, userId?: string): Promise<void> {
+    const row = await this.repo.findById(id);
+    if (!row) throw new NotFoundException(`Benchmark ${id} not found`);
+    if (userId !== undefined && row.userId !== userId) {
+      throw new NotFoundException(`Benchmark ${id} not found`);
+    }
+    // Non-terminal rows may have a backing driver job (K8s Job, subprocess,
+    // …). Best-effort cancel before DB delete so we don't orphan resources.
+    // The K8sJobDriver already treats 404 on the Job as idempotent; any
+    // other error is logged and swallowed so a flaky apiserver doesn't block
+    // the user from clearing a stuck row.
+    const isTerminal = (TERMINAL_STATES as readonly string[]).includes(row.status);
+    if (!isTerminal && row.driverHandle) {
+      try {
+        await this.driver.cancel(row.driverHandle);
+      } catch (e) {
+        this.log.warn(
+          `delete: best-effort driver.cancel failed for ${row.id}: ${(e as Error).message}`,
+        );
+      }
+    }
+    await this.repo.delete(row.id);
+  }
+```
+
+- [ ] **Step 4: Verify `this.log` exists on the service.**
+
+```bash
+grep -n "private readonly log\|new Logger" apps/api/src/modules/benchmark/benchmark.service.ts | head -5
+```
+
+If no Logger field exists, add `private readonly log = new Logger(BenchmarkService.name);` near the top of the class and import `Logger` from `@nestjs/common`.
+
+- [ ] **Step 5: Run tests to verify they pass.**
+
+```bash
+pnpm -F api test --run benchmark.service.spec
+```
+
+Expected: all four delete tests PASS. Other describe blocks also PASS.
+
+- [ ] **Step 6: Type-check.**
+
+```bash
+pnpm -F api type-check
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add apps/api/src/modules/benchmark/benchmark.service.ts \
+        apps/api/src/modules/benchmark/benchmark.service.spec.ts
+git commit -m "$(cat <<'EOF'
+fix(api): allow delete on non-terminal benchmark with best-effort driver cancel
+
+Removes the TERMINAL-state guard from BenchmarkService.delete so that
+users can clear runs stuck in submitted/running (e.g. an
+ImagePullBackOff that never reached the runner). When a driverHandle
+is present we attempt driver.cancel first; errors are logged and
+swallowed so a transient apiserver failure does not block the DB
+delete.
+
+Refs #102.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Scenario-aware back link on detail and compare pages
+
+**Files:**
+- Modify: `apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx:332` (the back `<Link>`)
+- Modify: `apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx` (two `<Link to="/benchmarks">` sites)
+
+- [ ] **Step 1: Inspect existing test to understand the back-link assertion.**
+
+Read `apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx` around line 312 (the "calls DELETE and navigates back to list" test). The mock landing page renders the text `list`. We need a similar test verifying the back link's `href`.
+
+- [ ] **Step 2: Add a failing test for scenario-aware back link.**
+
+In `BenchmarkDetailPage.test.tsx`, append inside the main `describe("BenchmarkDetailPage", ...)`:
+
+```typescript
+  it("back link points to /benchmarks/:scenario based on the loaded benchmark", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(
+      makeBenchmark({ status: "completed", scenario: "gateway" }),
+    );
+    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
+    const backLink = await screen.findByRole("link", { name: /Back to list|返回列表/ });
+    expect(backLink).toHaveAttribute("href", "/benchmarks/gateway");
+  });
+```
+
+- [ ] **Step 3: Run the test to verify it fails.**
+
+```bash
+pnpm -F web test --run BenchmarkDetailPage
+```
+
+Expected: the new test FAILS with `expected "/benchmarks/gateway" to be received but got "/benchmarks"`.
+
+- [ ] **Step 4: Fix the detail page back link.**
+
+In `BenchmarkDetailPage.tsx`, find:
+
+```tsx
+            <Button asChild variant="ghost" size="sm">
+              <Link to="/benchmarks">
+```
+
+(around line 331-332). Change to:
+
+```tsx
+            <Button asChild variant="ghost" size="sm">
+              <Link to={`/benchmarks/${benchmark.scenario}`}>
+```
+
+- [ ] **Step 5: Re-run the detail page test.**
+
+```bash
+pnpm -F web test --run BenchmarkDetailPage
+```
+
+Expected: all PASS, including the new test.
+
+- [ ] **Step 6: Fix the compare page back links.**
+
+In `apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx`, two `<Link to="/benchmarks">` sites need to derive scenario from the loaded benchmarks. Read the file to understand how benchmarks are loaded (likely via a `useBenchmarkCompare` or similar hook fetching by ids).
+
+- [ ] **Step 7: Read the compare page to find the scenario source.**
+
+```bash
+sed -n '1,60p' apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
+```
+
+Identify the variable that holds the loaded benchmarks array (e.g. `benchmarks`, `data?.items`). The shared scenario is `benchmarks[0]?.scenario` (compare requires same tool, and tool maps 1-to-1 onto a scenario for guidellm/vegeta, so first item's scenario is authoritative).
+
+- [ ] **Step 8: Compute back-link target inside the component.**
+
+Add near the top of the component body, after the data hook:
+
+```tsx
+  const backScenario = benchmarks[0]?.scenario ?? "gateway";
+  const backHref = `/benchmarks/${backScenario}`;
+```
+
+(Substitute the actual benchmarks variable name from Step 7. The fallback `gateway` is only hit during the initial loading flicker before any benchmark resolves.)
+
+Replace both `to="/benchmarks"` occurrences with `to={backHref}`.
+
+- [ ] **Step 9: Add a failing test for compare back link (if compare has tests).**
+
+Check if `apps/web/src/features/benchmarks/compare/__tests__/BenchmarkComparePage.test.tsx` exists (it does per earlier grep). Add:
+
+```typescript
+  it("back link points to /benchmarks/:scenario derived from loaded benchmarks", async () => {
+    // Match the existing test setup for mocking 2-benchmark compare data.
+    // The fixture benchmarks must include scenario: "inference" (or whatever).
+    // Then assert: const backLink = await screen.findByRole("link", { name: /back/i });
+    //              expect(backLink).toHaveAttribute("href", "/benchmarks/inference");
+  });
+```
+
+Read the existing compare test setup first to copy the mock pattern; do not invent a fixture shape. The pseudo-code above is a template — replace with actual mock invocations matching the rest of the file.
+
+- [ ] **Step 10: Run compare tests.**
+
+```bash
+pnpm -F web test --run BenchmarkComparePage
+```
+
+Expected: all PASS.
+
+- [ ] **Step 11: Type-check.**
+
+```bash
+pnpm -F web type-check
+```
+
+Expected: PASS.
+
+- [ ] **Step 12: Commit.**
+
+```bash
+git add apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx \
+        apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx \
+        apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx \
+        apps/web/src/features/benchmarks/compare/__tests__/BenchmarkComparePage.test.tsx
+git commit -m "$(cat <<'EOF'
+fix(web): scenario-aware back link on benchmark detail and compare pages
+
+The back link previously hard-coded /benchmarks, which is not a real
+route — the lists live at /benchmarks/{gateway,inference,capacity}.
+Detail page now derives the target from the loaded benchmark's
+scenario; compare page reads it off the first benchmark in the
+selection set.
+
+Refs #102.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Add Cancel action to detail page
+
+**Files:**
+- Modify: `apps/web/src/locales/en-US/benchmarks.json` (add `detail.cancel.*` keys)
+- Modify: `apps/web/src/locales/zh-CN/benchmarks.json` (add `detail.cancel.*` keys)
+- Modify: `apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx` (Cancel button + dialog + hook usage)
+- Modify: `apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx` (Cancel test)
+
+- [ ] **Step 1: Add i18n keys (English).**
+
+In `apps/web/src/locales/en-US/benchmarks.json`, locate the `"detail"` → `"delete"` key. Right after the `"delete"` block, add:
+
+```json
+    "cancel": {
+      "button": "Cancel run",
+      "confirmTitle": "Cancel this run?",
+      "confirmBody": "The benchmark will stop and its backing K8s job will be removed. The record stays in history with status 'canceled'.",
+      "confirmAction": "Cancel run",
+      "dismiss": "Keep running",
+      "success": "Run canceled",
+      "errors": {
+        "generic": "Failed to cancel"
+      }
+    },
+```
+
+- [ ] **Step 2: Add i18n keys (Chinese).**
+
+In `apps/web/src/locales/zh-CN/benchmarks.json`, mirror the structure:
+
+```json
+    "cancel": {
+      "button": "取消任务",
+      "confirmTitle": "取消该任务？",
+      "confirmBody": "任务会停止，K8s 中关联的 Job 会被删除。记录保留在历史中，状态为 canceled。",
+      "confirmAction": "确认取消",
+      "dismiss": "保持运行",
+      "success": "已取消",
+      "errors": {
+        "generic": "取消失败"
+      }
+    },
+```
+
+- [ ] **Step 3: Write failing tests for Cancel button.**
+
+In `BenchmarkDetailPage.test.tsx`, append:
+
+```typescript
+  it("shows the Cancel button while the run is non-terminal", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(makeBenchmark({ status: "running" }));
+    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /^Cancel run$|^取消任务$/ }),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("hides the Cancel button when the run is terminal", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(makeBenchmark({ status: "completed" }));
+    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
+    await screen.findByText("smoke");
+    expect(
+      screen.queryByRole("button", { name: /^Cancel run$|^取消任务$/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls POST /:id/cancel after confirm", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(makeBenchmark({ status: "running" }));
+    // The cancel API helper. If the test suite uses api.post for cancel,
+    // mock that. Inspect the actual queries.ts call before mocking.
+    vi.mocked(api.post).mockResolvedValueOnce(
+      makeBenchmark({ status: "canceled" }),
+    );
+    const user = userEvent.setup();
+    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
+    const cancelBtn = await screen.findByRole("button", {
+      name: /^Cancel run$|^取消任务$/,
+    });
+    await user.click(cancelBtn);
+    const confirm = await screen.findByRole("button", {
+      name: /^Cancel run$|^确认取消$/,
+    });
+    await user.click(confirm);
+    await waitFor(() =>
+      expect(api.post).toHaveBeenCalledWith(
+        "/api/benchmarks/r1/cancel",
+        expect.anything(),
+      ),
+    );
+  });
+```
+
+If the test suite mocks `benchmarkApi` rather than the underlying `api.post`, look at how the existing delete test does it (`api.del`) and mirror — the cancel API method is exposed in `apps/web/src/features/benchmarks/api.ts`.
+
+- [ ] **Step 4: Inspect the cancel api wrapper.**
+
+```bash
+grep -n "cancel" apps/web/src/features/benchmarks/api.ts
+```
+
+Note the exact method name (`benchmarkApi.cancel` or similar) and what mock to set in tests. Adjust the test from Step 3 if needed before running.
+
+- [ ] **Step 5: Run tests to verify they fail.**
+
+```bash
+pnpm -F web test --run BenchmarkDetailPage
+```
+
+Expected: the three new Cancel tests FAIL.
+
+- [ ] **Step 6: Implement the Cancel button.**
+
+In `BenchmarkDetailPage.tsx`:
+
+(a) Add to the imports from `./queries`:
+
+```tsx
+import {
+  benchmarkKeys,
+  isTerminalStatus,
+  useBenchmarkDetail,
+  useCancelBenchmark,
+  useCreateBenchmark,
+  useDeleteBenchmark,
+} from "./queries";
+```
+
+(b) Inside the component, near the existing `const deleteBenchmark = useDeleteBenchmark();`, add:
+
+```tsx
+  const [cancelOpen, setCancelOpen] = useState(false);
+  const cancelBenchmark = useCancelBenchmark();
+```
+
+(c) In the `rightSlot` JSX (the buttons row, around line 187), add a Cancel button **before** the Delete button. Render only when non-terminal:
+
+```tsx
+            {!isTerminal && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setCancelOpen(true)}
+              >
+                {t("detail.cancel.button")}
+              </Button>
+            )}
+```
+
+(d) Relax the Delete button rendering: change
+
+```tsx
+            {isTerminal && (
+              <Button variant="destructive" size="sm" onClick={() => setDeleteOpen(true)}>
+                {t("detail.delete.button")}
+              </Button>
+            )}
+```
+
+to
+
+```tsx
+            <Button variant="destructive" size="sm" onClick={() => setDeleteOpen(true)}>
+              {t("detail.delete.button")}
+            </Button>
+```
+
+(e) Add a Cancel confirm `<AlertDialog>` next to the existing Delete dialog (around line 317). Mirror the Delete dialog structure:
+
+```tsx
+      <AlertDialog open={cancelOpen} onOpenChange={setCancelOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("detail.cancel.confirmTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>{t("detail.cancel.confirmBody")}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("detail.cancel.dismiss")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                cancelBenchmark.mutate(benchmark.id, {
+                  onSuccess: () => {
+                    toast.success(t("detail.cancel.success"));
+                    setCancelOpen(false);
+                  },
+                  onError: () => {
+                    toast.error(t("detail.cancel.errors.generic"));
+                  },
+                });
+              }}
+              disabled={cancelBenchmark.isPending}
+            >
+              {t("detail.cancel.confirmAction")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+```
+
+- [ ] **Step 7: Run the tests to verify they pass.**
+
+```bash
+pnpm -F web test --run BenchmarkDetailPage
+```
+
+Expected: all PASS, including the three new Cancel tests **and** all pre-existing Delete-button tests. The earlier "hides the delete button while the run is still running" test must be **deleted or updated** because Delete is now visible always — change it to assert visible:
+
+```typescript
+  it("shows the delete button regardless of run status", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(makeBenchmark({ status: "running" }));
+    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^Delete$|^删除$/ })).toBeInTheDocument(),
+    );
+  });
+```
+
+Also update the "hides Set-as-baseline / Delete buttons while non-terminal" test to drop the Delete assertion (Set-as-baseline still hides; Delete is now always shown).
+
+- [ ] **Step 8: Type-check.**
+
+```bash
+pnpm -F web type-check
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit.**
+
+```bash
+git add apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx \
+        apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx \
+        apps/web/src/locales/en-US/benchmarks.json \
+        apps/web/src/locales/zh-CN/benchmarks.json
+git commit -m "$(cat <<'EOF'
+feat(web): add cancel action to benchmark detail page
+
+Adds an explicit Cancel button on non-terminal runs (wired to
+useCancelBenchmark) and broadens Delete to render in all states. The
+backend already cleans up the K8s Job on cancel and best-effort cancels
+on delete, so users now have a clean two-button mental model: Cancel
+stops the run and keeps the record; Delete removes both record and any
+backing job.
+
+Refs #102.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Show benchmark name in list and remove id fallbacks
+
+**Files:**
+- Modify: `apps/web/src/locales/en-US/benchmarks.json` (add `columns.name`)
+- Modify: `apps/web/src/locales/zh-CN/benchmarks.json` (add `columns.name`)
+- Modify: `apps/web/src/features/benchmarks/BenchmarkListShell.tsx` (add column)
+- Modify: `apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx` (remove `?? id` fallbacks)
+- Modify: `apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx` (remove `?? id` fallback)
+
+- [ ] **Step 1: Add i18n key (English).**
+
+In `apps/web/src/locales/en-US/benchmarks.json`, in the `"columns"` object, add `"name": "Name",` as the first entry:
+
+```json
+  "columns": {
+    "name": "Name",
+    "createdAt": "Created",
+    ...
+```
+
+- [ ] **Step 2: Add i18n key (Chinese).**
+
+In `apps/web/src/locales/zh-CN/benchmarks.json`, add `"name": "名称",` similarly.
+
+- [ ] **Step 3: Write failing test for name column.**
+
+Check whether `BenchmarkListShell` has tests:
+
+```bash
+ls apps/web/src/features/benchmarks/__tests__/ | grep -i list
+```
+
+If a `BenchmarkListShell.test.tsx` does not exist, create one with this minimal test (mirror the existing `BenchmarkDetailPage.test.tsx` setup for Wrapper/api mocking):
+
+```typescript
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import * as api from "../api";
+import { BenchmarkListShell } from "../BenchmarkListShell";
+// ... copy Wrapper / makeBenchmark helpers from BenchmarkDetailPage.test.tsx
+
+describe("BenchmarkListShell", () => {
+  it("renders the benchmark name in the first content column", async () => {
+    vi.mocked(api.list).mockResolvedValueOnce({
+      items: [makeBenchmark({ id: "r1", name: "smoke-test", scenario: "gateway" })],
+      nextCursor: null,
+    });
+    render(<BenchmarkListShell scenario="gateway" />, { wrapper: Wrapper });
+    expect(await screen.findByText("smoke-test")).toBeInTheDocument();
+  });
+});
+```
+
+If a list-shell test file already exists, add the test inside it.
+
+- [ ] **Step 4: Run the test to verify it fails.**
+
+```bash
+pnpm -F web test --run BenchmarkListShell
+```
+
+Expected: FAIL — name not rendered yet.
+
+- [ ] **Step 5: Add the name column to BenchmarkListShell.**
+
+In `apps/web/src/features/benchmarks/BenchmarkListShell.tsx`:
+
+(a) In `<TableHeader>` → `<TableRow>`, after `<TableHead className="w-10" />` (the checkbox header), insert:
+
+```tsx
+                  <TableHead>{t("columns.name")}</TableHead>
+```
+
+(b) In the `items.map((benchmark) => …)` body, after the `<TableCell>` containing the `<Checkbox>`, insert:
+
+```tsx
+                    <TableCell className="font-medium">{benchmark.name}</TableCell>
+```
+
+- [ ] **Step 6: Run list test to verify it passes.**
+
+```bash
+pnpm -F web test --run BenchmarkListShell
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Remove name fallbacks in BenchmarkDetailPage.**
+
+(a) Line 188 — replace:
+
+```tsx
+        title={benchmark.name ?? benchmark.id}
+```
+
+with:
+
+```tsx
+        title={benchmark.name}
+```
+
+(b) Line 166 — replace:
+
+```tsx
+    const sourceName = benchmark.name?.trim() || `run-${benchmark.id.slice(0, 8)}`;
+```
+
+with:
+
+```tsx
+    const sourceName = benchmark.name;
+```
+
+- [ ] **Step 8: Update the rerun-source-name test that exercised the fallback.**
+
+In `BenchmarkDetailPage.test.tsx`, find the test "falls back to a synthetic name when the source Run has no name" (around line 421). Since name is now required and `benchmark.name` cannot be empty, this test no longer makes semantic sense.
+
+Either:
+- **Delete** the test entirely (preferred — the scenario it covered is now contractually impossible), or
+- Replace it with a test that asserts the rerun source name equals `benchmark.name` for a normal case (likely already covered by the surrounding rerun tests; check before duplicating).
+
+The "truncates the source name so the ' (rerun)' suffix fits within the 128-char limit" test at line 436 should still pass — it doesn't depend on the fallback.
+
+- [ ] **Step 9: Remove name fallback in BenchmarkCreatePage.**
+
+In `apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx:134`, replace:
+
+```tsx
+      toast.success(t("create.submitted", { name: benchmark.name ?? benchmark.id }));
+```
+
+with:
+
+```tsx
+      toast.success(t("create.submitted", { name: benchmark.name }));
+```
+
+- [ ] **Step 10: Run the full benchmarks test suite.**
+
+```bash
+pnpm -F web test --run benchmarks
+```
+
+Expected: all PASS.
+
+- [ ] **Step 11: Type-check + lint.**
+
+```bash
+pnpm -F web type-check && pnpm -F web lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 12: Commit.**
+
+```bash
+git add apps/web/src/features/benchmarks/BenchmarkListShell.tsx \
+        apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx \
+        apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx \
+        apps/web/src/features/benchmarks/__tests__/ \
+        apps/web/src/locales/en-US/benchmarks.json \
+        apps/web/src/locales/zh-CN/benchmarks.json
+git commit -m "$(cat <<'EOF'
+feat(web): show benchmark name in list and remove id fallbacks
+
+Adds a Name column as the first content cell of BenchmarkListShell
+(after the row checkbox) and drops the three sites that previously
+defaulted to benchmark.id when name was null. Now that name is required
+at the contract layer, those fallbacks were dead branches.
+
+Refs #102.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Push, open PR, and verify CI signals
+
+**Files:** none
+
+- [ ] **Step 1: Push the branch.**
+
+```bash
+cd /Users/fangyong/vllm/modeldoctor/fix-benchmark-task-mgmt
+git push -u origin fix/benchmark-task-management
+```
+
+- [ ] **Step 2: Open the PR with closes #102 and refs to the new sub-bug-5 issue.**
+
+Substitute `<N>` with the issue number from Task 0.
+
+```bash
+gh pr create --title "fix(benchmark): task management cleanup (#102 class A)" --body "$(cat <<'EOF'
+## Summary
+
+Closes the four small task-management issues from #102:
+
+- Submitted-state benchmarks can now be deleted; backend best-effort cancels the backing K8s Job before removing the row.
+- Detail-page Cancel button added (non-terminal only).
+- Detail and compare pages' "back to list" links now go to the scenario-specific list (`/benchmarks/{gateway,inference,capacity}`) instead of the non-existent `/benchmarks` route.
+- List page shows benchmark name as the first content column.
+- `Benchmark.name` tightened from nullable to required at the schema, contract, and DB layers (zero NULL rows in dev verified pre-migration).
+
+## Out of scope (split off)
+
+Sub-bug 5 (ImagePullBackOff awareness + task SSE logs) needs a K8s pod watcher and a new SSE channel and is tracked separately in #<N>.
+
+## Test plan
+
+- [x] `pnpm -F api test --run benchmark`
+- [x] `pnpm -F web test --run benchmarks`
+- [x] `pnpm -F api type-check && pnpm -F web type-check`
+- [ ] Manual: create a stuck submitted benchmark in dev, click Delete, confirm the K8s Job is removed (`kubectl get jobs -n modeldoctor-benchmarks`).
+- [ ] Manual: open `/benchmarks/gateway` → click into a detail → "back" returns to `/benchmarks/gateway`.
+- [ ] Manual: cancel a running benchmark; status flips to `canceled` and Job is removed.
+
+closes #102
+refs #<N>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Verify CI signals after push.**
+
+```bash
+gh pr view --json number | jq -r '.number' > /tmp/pr-num
+PR=$(cat /tmp/pr-num)
+gh pr checks "$PR"
+gh pr view "$PR" --json comments,reviews,statusCheckRollup,mergeStateStatus
+```
+
+If CI is pending, wait for completion (`gh run watch <run-id> --exit-status`). If CI fails, surface the failure to the user and pause.
+
+- [ ] **Step 4: Hand off.**
+
+Summarize to user: PR number, CI status, any reviewer comments, and the new sub-bug-5 issue number.
+
+---
+
+## Self-review checklist (already addressed inline)
+
+- ✅ All five spec sub-bugs (1, 2, 3, 4 in scope; 5 split into Task 0 issue) have a task.
+- ✅ No "TBD" / "implement later" — every code step has the actual code.
+- ✅ Type names consistent (`benchmark.scenario`, `useCancelBenchmark`, `cancelBenchmark.mutate`).
+- ✅ Test patterns mirror existing tests in the same file (regex for EN/CN button names, `api.del` / `api.post` mocking style).
+- ✅ Migration generates a single `ALTER COLUMN ... SET NOT NULL` — verified by pre-flight count of zero NULL rows.
+- ✅ Commit messages match repo convention (`type(scope): subject` + `Refs #102` + Claude trailer).

--- a/docs/superpowers/specs/2026-05-05-benchmark-task-management-design.md
+++ b/docs/superpowers/specs/2026-05-05-benchmark-task-management-design.md
@@ -1,0 +1,118 @@
+# Benchmark Task Management Fixes (#102 Class A)
+
+**Date:** 2026-05-05
+**Branch:** `fix/benchmark-task-management`
+**Closes:** #102 (after Class B is split out as a new issue)
+**Out of scope (split into new issue):** ImagePullBackOff awareness + task SSE logs (#102 sub-bug 5)
+
+## Problem
+
+[#102](https://github.com/weetime/modeldoctor/issues/102) reports five self-test bugs in the benchmark module. After triage, four are small frontend/contract changes that share one mental model ("task management actions and identification"). The fifth — perceiving K8s pod-level failures and streaming runner logs — needs a K8s pod watcher and SSE log channel; that work has its own architecture decisions and gets a separate issue.
+
+This spec covers the first four:
+
+1. Submitted-state benchmarks cannot be deleted (no button + backend rejects).
+2. Detail page "back to list" link goes to `/benchmarks`, which is not a real list page (the actual lists live at `/benchmarks/{gateway,inference,capacity}`).
+3. List page does not show task name.
+4. Detail page has no Cancel button; users have no way to stop a running benchmark short of deleting it.
+
+## Design
+
+### bug 1 + 4 — Cancel and Delete semantics
+
+**Backend (`apps/api/src/modules/benchmark/benchmark.service.ts`)**
+
+- `service.delete`: remove the `TERMINAL_STATES` guard. When called on a non-terminal benchmark with a `driverHandle`, attempt `driver.cancel(driverHandle)` first on a best-effort basis (swallow errors and log a warning — `K8sJobDriver.cancel` already treats 404 as idempotent), then proceed with `repo.delete`. The user contract becomes: "Delete always works; cleanup of any backing K8s job is automatic."
+- `service.cancel`: unchanged. Still only valid for non-terminal states; returns the benchmark in `canceled` state. `K8sJobDriver.cancel` already calls `deleteNamespacedJob`, so K8s cleanup on cancel is already correct.
+
+**Frontend (`apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx`)**
+
+- Add a Cancel button (rendered only when `!isTerminal`). Wire to existing `useCancelBenchmark` hook in `queries.ts`.
+- Relax Delete button visibility: render in **all** states (today it is gated by `isTerminal`).
+- Disambiguate destructive-action UX: confirm dialogs for Cancel ("Cancel this running task?") and Delete ("Delete this task and clean up its K8s job?") stay distinct — no merged "force delete" flow.
+
+**i18n** — add `detail.cancel.button`, `detail.cancel.confirmTitle`, `detail.cancel.confirmBody`, `detail.cancel.confirmAction` keys to `apps/web/public/locales/{en,zh}/benchmarks.json`.
+
+### bug 2 — Detail-page back link
+
+`BenchmarkDetailPage.tsx:332` currently renders `<Link to="/benchmarks">`. The router has no `/benchmarks` index route — only `/benchmarks/{gateway,inference,capacity}`. Replace with `<Link to={`/benchmarks/${benchmark.scenario}`}>` (scenario is on the loaded benchmark).
+
+Sibling sweep:
+- `apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx` — check the back/cancel link.
+- Any other route inside `features/benchmarks/` whose back action targets `/benchmarks`. Grep `to="/benchmarks"` in that subtree.
+
+### bug 3 — List page shows name + name becomes required
+
+**Schema migration**
+
+- `apps/api/prisma/schema.prisma`: `name String?` → `name String` on `model Benchmark`.
+- Generated migration via `pnpm -F api prisma migrate dev --create-only --name benchmark_name_required`.
+  - Migration body: `ALTER TABLE "benchmarks" ALTER COLUMN "name" SET NOT NULL;`.
+  - Pre-flight verified locally: `SELECT count(*) FROM benchmarks WHERE name IS NULL;` returns 0. `createBenchmarkRequestSchema.name` is already `z.string().min(1).max(128)`, so any new row already had a non-empty name. **No backfill needed.**
+
+**Contract (`packages/contracts/src/benchmark.ts`)**
+
+- `benchmarkSchema.name`: `z.string().nullable()` → `z.string()`.
+
+**Frontend**
+
+- `BenchmarkListShell.tsx`: add a "name" column as the first content column (after the checkbox, before `createdAt`). Cell renders `benchmark.name` directly — no `??` fallback.
+- Sweep all `benchmark.name`-fallback sites; remove the fallback. Confirmed sites under `apps/web/src/features/benchmarks/`:
+  - `BenchmarkDetailPage.tsx:188` — `title={benchmark.name ?? benchmark.id}` becomes `title={benchmark.name}`.
+  - `BenchmarkDetailPage.tsx:166` — `const sourceName = benchmark.name?.trim() || \`run-${benchmark.id.slice(0, 8)}\`` (rerun source-name derivation) becomes `const sourceName = benchmark.name`.
+  - `BenchmarkCreatePage.tsx:134` — toast message `t("create.submitted", { name: benchmark.name ?? benchmark.id })` becomes `name: benchmark.name`.
+- i18n: add `columns.name` key to benchmarks namespace.
+
+## Test plan
+
+- **Backend unit:** `benchmark.service.spec.ts` — extend the delete describe block:
+  - delete on `submitted` calls `driver.cancel` and then `repo.delete`.
+  - delete on `submitted` proceeds even when `driver.cancel` throws (best-effort).
+  - delete on `completed` does not call `driver.cancel`.
+- **Frontend component:** `BenchmarkDetailPage.test.tsx`
+  - Cancel button visible for non-terminal statuses (`pending`, `submitted`, `running`); hidden for terminal (`completed`, `failed`, `canceled`).
+  - Delete button visible in all six states.
+- **Frontend component:** `BenchmarkListShell` (add or extend test) — first row renders `benchmark.name`.
+- **Migration smoke:** run `pnpm -F api prisma migrate dev` on local DB; confirm column shows NOT NULL (`\d benchmarks`).
+- **Manual:** `pnpm dev`, navigate `/benchmarks/gateway` → click into a detail page → "back" returns to `/benchmarks/gateway` (not `/benchmarks`). Try Cancel on a submitted run, confirm K8s job is deleted (`kubectl get jobs -n modeldoctor-benchmarks`).
+
+## Commit plan (one PR, sequenced commits)
+
+1. `feat(contracts,api): require non-null benchmark name` — Prisma migration + schema update + contract change.
+2. `fix(api): allow delete on non-terminal benchmark with best-effort driver cancel` — `service.delete` change + unit tests.
+3. `fix(web): scenario-aware back link on benchmark detail and compare pages` — bug 2.
+4. `feat(web): add cancel action to benchmark detail page` — Cancel button + i18n + tests.
+5. `feat(web): show benchmark name in list and remove id fallbacks` — list column + remove `?? id` sites.
+
+## Out of scope — to be split into new issue
+
+**Title:** "K8s pod watcher + benchmark task SSE logs"
+
+**Body draft:**
+
+> Currently the benchmark API only learns about run state via the callback v2 channel from the runner pod (post `state=running`). Pre-runner-start failures — `ImagePullBackOff`, `CrashLoopBackOff`, scheduler errors, image pull timeouts — never trigger a callback, so the benchmark sits in `submitted` indefinitely.
+>
+> Repro: create a benchmark whose container image cannot be pulled (e.g. typo'd image tag).
+> Expected: benchmark transitions to `failed` with a `statusMessage` describing the K8s reason within ~30s.
+> Actual: benchmark stays `submitted` forever; only `kubectl get pods` reveals the cause.
+>
+> **Required work:**
+>
+> 1. **K8s pod watcher in `apps/api/src/modules/benchmark/`** — informer or polling loop that watches pods labeled with the benchmark's `runId`. On Pending+ImagePullBackOff/CrashLoopBackOff/Error past a threshold (e.g. 60s), call `service.markFailed(runId, statusMessage=<reason: message>)`.
+> 2. **Streaming task logs over SSE** — extend `SseHub` or add a sibling channel (`SseHub` today only carries `ProgressEvent` from runner). Pull pod logs via the K8s logs API (follow=true) and forward chunks as SSE events keyed on `runId`. Frontend detail page subscribes and renders a log panel.
+>
+> Open design questions:
+>
+> - Single watcher process vs. per-runId goroutine/Subject. NestJS singleton service hosting an `Informer` is probably simplest.
+> - Log retention: do we persist the streamed logs to DB / object store, or are they ephemeral and only visible while the pod still exists?
+> - Behavior on pod restart (CrashLoopBackOff) — emit one combined log stream or one per attempt?
+>
+> **Split off from #102 (sub-bug 5)** so the simpler task-management fixes can ship first.
+
+The new issue is created during implementation (before merging this PR) so the closing commit can reference both: `closes #102` and `refs #<new>` for the carry-over.
+
+## Risks and notes
+
+- The Prisma migration is the only DB-touching change. It is non-destructive (no data backfill, no column drop), but per repo policy any DB change requires the user to apply it locally — agent will not run `prisma migrate dev` without explicit approval if it would conflict with local drift. We will verify with a dry-run plan first.
+- The relaxed `service.delete` semantics break the previous "must cancel first" contract. Any caller that relied on a 4xx for delete-on-non-terminal will now get 200. Search confirms only the frontend Detail page invokes delete; no other internal caller.
+- Bug 5 carry-over is tracked via the new issue. The Class A PR uses `closes #102` because all of #102's listed sub-bugs except sub-bug 5 are addressed, and sub-bug 5 explicitly migrates to the new issue.

--- a/packages/contracts/src/benchmark.spec.ts
+++ b/packages/contracts/src/benchmark.spec.ts
@@ -51,7 +51,7 @@ function minimalBenchmark() {
     tool: "guidellm" as const,
     toolVersion: null,
     driverKind: "local" as const,
-    name: null,
+    name: "test-benchmark",
     description: null,
     status: "completed" as const,
     statusMessage: null,

--- a/packages/contracts/src/benchmark.ts
+++ b/packages/contracts/src/benchmark.ts
@@ -41,7 +41,7 @@ export const benchmarkSchema = z.object({
   toolVersion: z.string().nullable(),
   driverKind: benchmarkDriverKindSchema,
 
-  name: z.string().nullable(),
+  name: z.string(),
   description: z.string().nullable(),
 
   status: benchmarkStatusSchema,


### PR DESCRIPTION
## Summary

Closes #102's four small task-management sub-bugs in one branch:

- **Submitted-state benchmarks can now be deleted.** Backend best-effort cancels the backing K8s Job before removing the row (errors logged + swallowed; K8sJobDriver already treats 404 as idempotent).
- **Detail-page Cancel button added** (non-terminal only). Cancel stops the run and keeps the record (status flips to `canceled`, K8s Job removed). Delete now works in all states with the same K8s cleanup path.
- **Detail and compare pages' "back to list" links** now go to `/benchmarks/{gateway,inference,capacity}` (the actual scenario-specific list pages) instead of the non-existent `/benchmarks` route.
- **List page shows benchmark name as the first content column.** `Benchmark.name` tightened from nullable to required at the schema, contract, and DB layers (zero NULL rows in dev verified pre-migration); five `?? benchmark.id` dead-code fallbacks removed across detail / create / compare components.

## Out of scope (split off)

Sub-bug 5 (ImagePullBackOff awareness + task SSE logs) needs a K8s pod watcher and a new SSE channel. Tracked in #109 to land in a separate PR.

## Commits

1. `d4fc9bd feat(contracts,api): require non-null benchmark name` — Prisma migration + contract.
2. `d14dadd fix(api): allow delete on non-terminal benchmark with best-effort driver cancel` — service.delete + 4 unit tests.
3. `0842ca8 fix(web): scenario-aware back link on benchmark detail and compare pages` — detail + compare.
4. `a4a00ab feat(web): add cancel action to benchmark detail page` — Cancel button + AlertDialog + i18n + 3 tests.
5. `495bdda feat(web): show benchmark name in list and remove id fallbacks` — Name column + 5 fallback removals.

## Test plan

- [x] `pnpm -F api test --run benchmark` — 118 passed
- [x] `pnpm -F web test --run benchmarks` — 145 passed
- [x] `pnpm -F api type-check && pnpm -F web type-check`
- [ ] Manual: create a stuck `submitted` benchmark in dev, click Delete, confirm the K8s Job is removed (`kubectl get jobs -n modeldoctor-benchmarks`)
- [ ] Manual: open `/benchmarks/gateway` → click into a detail → "back" returns to `/benchmarks/gateway` (not `/benchmarks`)
- [ ] Manual: cancel a running benchmark; status flips to `canceled` and Job is removed

## Notes

- `BENCHMARK_NOT_TERMINAL` error code in `packages/contracts/src/errors.ts` is now never thrown server-side. Kept for the append-only-codes invariant; safe to ignore on the client.

closes #102
refs #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)