### PR TITLE
chore(ci): add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,129 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Strategy:
+# - One npm ecosystem entry at the repo root — pnpm workspace's lockfile is at
+#   the root, and Dependabot's npm ecosystem supports pnpm-lock.yaml since 2024.
+#   It scans every package.json reachable through the workspace, so we don't
+#   need separate entries per app/package.
+# - Group minor + patch updates per scope (production, dev, NestJS, React, types)
+#   so we get one PR per scope per week instead of dozens of single-package PRs.
+# - Major updates land as individual PRs (NOT grouped) so each major lands with
+#   its own review + CI cycle.
+# - GitHub Actions ecosystem covers the runner-image / action versions used in
+#   .github/workflows/.
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 8
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    groups:
+      nestjs:
+        patterns:
+          - "@nestjs/*"
+          - "nestjs-*"
+        update-types:
+          - "minor"
+          - "patch"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "react-router*"
+          - "react-i18next"
+          - "react-hook-form"
+          - "@hookform/*"
+          - "@radix-ui/*"
+        update-types:
+          - "minor"
+          - "patch"
+      tooling:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "vite"
+          - "@vitejs/*"
+          - "@biomejs/*"
+          - "typescript"
+          - "tsx"
+          - "@types/*"
+        update-types:
+          - "minor"
+          - "patch"
+      prisma:
+        patterns:
+          - "prisma"
+          - "@prisma/*"
+        update-types:
+          - "minor"
+          - "patch"
+      production-minor:
+        dependency-type: "production"
+        update-types:
+          - "patch"
+        exclude-patterns:
+          - "@nestjs/*"
+          - "nestjs-*"
+          - "react*"
+          - "@radix-ui/*"
+          - "@hookform/*"
+          - "prisma"
+          - "@prisma/*"
+      development-minor:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+        exclude-patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "vite"
+          - "@vitejs/*"
+          - "@biomejs/*"
+          - "typescript"
+          - "tsx"
+          - "@types/*"
+    ignore:
+      # Vitest is intentionally on different majors per app (apps/api v2,
+      # apps/web v1). CLAUDE.md "do not unify" — block major bumps from Dependabot.
+      - dependency-name: "vitest"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@vitest/*"
+        update-types: ["version-update:semver-major"]
+      # zod v4 is breaking (errorMap behavior change for refines among others);
+      # plan it as a deliberate migration, not an auto-PR.
+      - dependency-name: "zod"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 4
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    groups:
+      actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Add \`.github/dependabot.yml\` to enable automated dependency PRs.

**Strategy:**

- **Single npm ecosystem entry at repo root** — pnpm-lock.yaml + every workspace package.json is scanned automatically.
- **Grouped to keep PR noise low:**
  - \`@nestjs/*\` + \`nestjs-*\` together
  - React stack (react, react-router, react-i18next, react-hook-form, @hookform, @radix-ui) together
  - Tooling (vitest, vite, biome, typescript, @types) together
  - Prisma + @prisma together
  - Remaining production patches grouped
  - Remaining dev minor+patch grouped
- **Major updates land as individual PRs** (not grouped) so each gets its own review/CI cycle.

**Ignored majors:**

- \`vitest\` / \`@vitest/*\` — apps/api v2 vs apps/web v1 is intentional per \`CLAUDE.md\` "do not unify"
- \`zod\` — v4 has breaking errorMap behavior; plan as deliberate migration, not auto-PR

**GitHub Actions** ecosystem in a second entry, all updates grouped.

Refs post-#99 audit recommending Dependabot as the highest-leverage short-term hardening.

## Test plan

- [x] YAML parses
- [ ] After merge: confirm Dependabot is enabled in repo Settings → Code security and analysis (it's auto-detected from \`.github/dependabot.yml\`)
- [ ] First Monday after merge: review the initial batch of grouped PRs

## Note on Swagger

Originally requested alongside Dependabot, but Swagger is **already wired** in \`apps/api/src/main.ts\` via \`@nestjs/swagger\` + \`nestjs-zod\` \`patchNestJsSwagger()\`. Visit \`http://localhost:<API_PORT>/api/docs\` (Swagger UI) and \`/api/docs-json\` (OpenAPI JSON) once the API is running. Schema descriptions come automatically from the zod schemas in \`@modeldoctor/contracts\`. No work needed; flagged as a follow-up if specific docs improvements are wanted.