### PR TITLE
chore(web): unify Vitest to v2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Surface reviewer feedback and any red checks back to the user, then either fix i
 
 - `apps/api/tsconfig.json` must not set `incremental: true` (conflicts with `nest-cli.json` `deleteOutDir`).
 - Vitest config files in `apps/api/` must stay `.mts`.
-- `apps/api` uses vitest@2, `apps/web` uses vitest@1 — do not unify.
+- Vitest 2 across the workspace. `apps/web/src/test/setup.ts` MUST use the explicit `expect.extend(matchers)` form (importing `@testing-library/jest-dom/matchers`); the side-effect `import "@testing-library/jest-dom/vitest"` does not extend `expect` under Vitest 2.
 - `apps/api/tsconfig.json` `include` must stay narrow (`["src/**/*"]`).
 
 ## Page layout convention

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -58,7 +58,7 @@
     "@types/react": "^18.3",
     "@types/react-dom": "^18.3",
     "@vitejs/plugin-react": "^4",
-    "@vitest/ui": "^1",
+    "@vitest/ui": "^2.1.9",
     "autoprefixer": "^10",
     "fake-indexeddb": "^6.2.5",
     "jsdom": "^24",
@@ -66,6 +66,6 @@
     "tailwindcss": "^3.4",
     "tailwindcss-animate": "^1",
     "vite": "^5",
-    "vitest": "^1"
+    "vitest": "^2.1.9"
   }
 }

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,7 +1,9 @@
-import "@testing-library/jest-dom/vitest";
+import * as matchers from "@testing-library/jest-dom/matchers";
 import "fake-indexeddb/auto";
 import { cleanup } from "@testing-library/react";
-import { afterEach } from "vitest";
+import { afterEach, expect } from "vitest";
+
+expect.extend(matchers);
 
 // jsdom@24 does not implement Pointer Events, scrollIntoView, or ResizeObserver.
 // Radix UI primitives (Select, DropdownMenu, Dialog, Tabs, Slider) call these

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,7 +161,7 @@ importers:
         version: 5.1.4(typescript@5.7.2)(vite@5.4.21(@types/node@20.19.39)(terser@5.46.1))
       vitest:
         specifier: ^2
-        version: 2.1.9(@types/node@20.19.39)(@vitest/ui@1.6.1(vitest@1.6.1))(jsdom@24.1.3)(terser@5.46.1)
+        version: 2.1.9(@types/node@20.19.39)(@vitest/ui@2.1.9)(jsdom@24.1.3)(terser@5.46.1)
 
   apps/web:
     dependencies:
@@ -293,8 +293,8 @@ importers:
         specifier: ^4
         version: 4.7.0(vite@5.4.21(@types/node@20.19.39)(terser@5.46.1))
       '@vitest/ui':
-        specifier: ^1
-        version: 1.6.1(vitest@1.6.1)
+        specifier: ^2.1.9
+        version: 2.1.9(vitest@2.1.9)
       autoprefixer:
         specifier: ^10
         version: 10.5.0(postcss@8.5.10)
@@ -317,8 +317,8 @@ importers:
         specifier: ^5
         version: 5.4.21(@types/node@20.19.39)(terser@5.46.1)
       vitest:
-        specifier: ^1
-        version: 1.6.1(@types/node@20.19.39)(@vitest/ui@1.6.1)(jsdom@24.1.3)(terser@5.46.1)
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@20.19.39)(@vitest/ui@2.1.9)(jsdom@24.1.3)(terser@5.46.1)
 
   packages/contracts:
     dependencies:
@@ -2019,6 +2019,11 @@ packages:
     resolution: {integrity: sha512-xa57bCPGuzEFqGjPs3vVLyqareG8DX0uMkr5U/v5vLv5/ZUrBrPL7gzxzTJedEyZxFMfsozwTIbbYfEQVo3kgg==}
     peerDependencies:
       vitest: 1.6.1
+
+  '@vitest/ui@2.1.9':
+    resolution: {integrity: sha512-izzd2zmnk8Nl5ECYkW27328RbQ1nKvkm6Bb5DAaz1Gk59EbLkiCMa6OLT0NoaAYTjOFS6N+SMYW1nh4/9ljPiw==}
+    peerDependencies:
+      vitest: 2.1.9
 
   '@vitest/utils@1.6.1':
     resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
@@ -4391,6 +4396,10 @@ packages:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
 
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
   size-sensor@1.0.3:
     resolution: {integrity: sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==}
 
@@ -6761,6 +6770,18 @@ snapshots:
       picocolors: 1.1.1
       sirv: 2.0.4
       vitest: 1.6.1(@types/node@20.19.39)(@vitest/ui@1.6.1)(jsdom@24.1.3)(terser@5.46.1)
+    optional: true
+
+  '@vitest/ui@2.1.9(vitest@2.1.9)':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      fflate: 0.8.2
+      flatted: 3.4.2
+      pathe: 1.1.2
+      sirv: 3.0.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 1.2.0
+      vitest: 2.1.9(@types/node@20.19.39)(@vitest/ui@2.1.9)(jsdom@24.1.3)(terser@5.46.1)
 
   '@vitest/utils@1.6.1':
     dependencies:
@@ -9218,6 +9239,13 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+    optional: true
+
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
 
   size-sensor@1.0.3: {}
 
@@ -9822,7 +9850,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@20.19.39)(@vitest/ui@1.6.1(vitest@1.6.1))(jsdom@24.1.3)(terser@5.46.1):
+  vitest@2.1.9(@types/node@20.19.39)(@vitest/ui@2.1.9)(jsdom@24.1.3)(terser@5.46.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.39)(terser@5.46.1))
@@ -9846,7 +9874,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.39
-      '@vitest/ui': 1.6.1(vitest@1.6.1)
+      '@vitest/ui': 2.1.9(vitest@2.1.9)
       jsdom: 24.1.3
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
## Summary

Investigation outcome: **the \"don't unify Vitest\" rule in CLAUDE.md was a forgotten symptom of a one-line setup issue, not a real architectural blocker.**

Bumps \`apps/web\` from vitest 1 → 2 to match \`apps/api\` (already on 2).

## What changed

1. \`apps/web/package.json\`: \`vitest\` and \`@vitest/ui\` from \`^1\` → \`^2\`.
2. \`apps/web/src/test/setup.ts\`: switch from the side-effect import to the explicit \`expect.extend(matchers)\` form. **This is the fix that unblocks the bump.**
3. \`CLAUDE.md\`: replace \"do not unify\" with the documented setup-file constraint so it doesn't regress.

## Why the side-effect import broke

In Vitest 2, \`import \"@testing-library/jest-dom/vitest\"\` no longer extends the test-file \`expect\` automatically (the bridge file extends a different \`expect\` instance under the new globals plumbing). 199 / 587 tests failed with \`Invalid Chai property: toBeInTheDocument\` until the explicit \`expect.extend(matchers)\` was applied.

## Verification

- \`pnpm -F @modeldoctor/web test --run\` → **587 / 587 pass** (was 587/587 on v1)
- \`pnpm -F @modeldoctor/api test --run\` → 372 / 372 pass (unchanged)
- \`pnpm -F @modeldoctor/web build\` → clean
- \`pnpm -F @modeldoctor/web lint\` → 6 pre-existing warnings, no new ones

## Why this is worth doing

- Removes the "why does this work in api but not web" mental tax
- One less version-skew to track in Dependabot rules
- Vitest 2 has measurably better startup + watch perf
- Future contributors stop guessing whether the split is intentional

## Test plan

- [x] \`pnpm -F @modeldoctor/web test --run\` passes
- [x] \`pnpm -F @modeldoctor/api test --run\` passes
- [x] \`pnpm -F @modeldoctor/web build\` clean
- [x] \`pnpm -F @modeldoctor/web lint\` clean (6 pre-existing warnings)