### PR TITLE
feat(web/benchmarks): close benchmark template main-flow loop (#138)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-dialog": "^1",
     "@radix-ui/react-dropdown-menu": "^2",
     "@radix-ui/react-label": "^2",
+    "@radix-ui/react-popover": "^1",
     "@radix-ui/react-progress": "^1",
     "@radix-ui/react-radio-group": "^1",
     "@radix-ui/react-scroll-area": "^1",

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -1,0 +1,29 @@
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Popover = PopoverPrimitive.Root;
+const PopoverTrigger = PopoverPrimitive.Trigger;
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverAnchor, PopoverContent };

--- a/apps/web/src/features/benchmark-templates/TemplateCard.tsx
+++ b/apps/web/src/features/benchmark-templates/TemplateCard.tsx
@@ -20,12 +20,17 @@ export interface TemplateCardProps {
 export function TemplateCard({ template, canEdit, onDeleteClick }: TemplateCardProps) {
   const { t } = useTranslation("benchmark-templates");
   return (
-    <div className="group relative rounded-lg border border-border bg-card p-4 transition hover:border-primary/40">
-      <Link to={`/benchmark-templates/${template.id}`} className="block space-y-2">
+    <div className="group relative flex flex-col gap-3 rounded-lg border border-border bg-card p-4 transition hover:border-primary/40">
+      <div className="space-y-2">
         <div className="flex items-start justify-between gap-2">
           <div className="flex min-w-0 items-center gap-2">
             {template.isOfficial && <ShieldCheck className="h-4 w-4 text-primary" aria-hidden />}
-            <h3 className="truncate text-sm font-semibold">{template.name}</h3>
+            <Link
+              to={`/benchmark-templates/${template.id}`}
+              className="truncate text-sm font-semibold hover:text-primary hover:underline"
+            >
+              {template.name}
+            </Link>
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-1.5">
@@ -49,7 +54,16 @@ export function TemplateCard({ template, canEdit, onDeleteClick }: TemplateCardP
             when: new Date(template.updatedAt).toLocaleString(),
           })}
         </p>
-      </Link>
+      </div>
+
+      <div className="flex justify-end">
+        <Button asChild size="sm">
+          <Link to={`/benchmarks/new?scenario=${template.scenario}&templateId=${template.id}`}>
+            {t("list.cards.useThisTemplate")}
+          </Link>
+        </Button>
+      </div>
+
       {canEdit && (
         <div className="absolute right-2 top-2 opacity-0 transition group-hover:opacity-100">
           <DropdownMenu>

--- a/apps/web/src/features/benchmark-templates/__tests__/TemplateCard.test.tsx
+++ b/apps/web/src/features/benchmark-templates/__tests__/TemplateCard.test.tsx
@@ -1,0 +1,49 @@
+import "@/lib/i18n";
+import type { BenchmarkTemplate } from "@modeldoctor/contracts";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { TemplateCard } from "../TemplateCard";
+
+function tpl(overrides: Partial<BenchmarkTemplate> = {}): BenchmarkTemplate {
+  return {
+    id: "tpl-42",
+    name: "vLLM single concurrency",
+    description: "low load",
+    scenario: "inference",
+    tool: "guidellm",
+    config: {},
+    isOfficial: false,
+    createdBy: "u1",
+    tags: [],
+    createdAt: "2026-05-07T00:00:00.000Z",
+    updatedAt: "2026-05-07T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("TemplateCard", () => {
+  it("renders 'use this template' CTA pointing to /benchmarks/new with scenario+templateId", () => {
+    render(
+      <MemoryRouter>
+        <TemplateCard
+          template={tpl({ scenario: "gateway", id: "tpl-42" })}
+          canEdit={false}
+          onDeleteClick={() => {}}
+        />
+      </MemoryRouter>,
+    );
+    const cta = screen.getByRole("link", { name: /use this template|使用此模板/i });
+    expect(cta).toHaveAttribute("href", "/benchmarks/new?scenario=gateway&templateId=tpl-42");
+  });
+
+  it("still renders detail link on the card name area", () => {
+    render(
+      <MemoryRouter>
+        <TemplateCard template={tpl()} canEdit={false} onDeleteClick={() => {}} />
+      </MemoryRouter>,
+    );
+    const detailLink = screen.getByRole("link", { name: /vLLM single concurrency/i });
+    expect(detailLink).toHaveAttribute("href", "/benchmark-templates/tpl-42");
+  });
+});

--- a/apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx
@@ -1,6 +1,7 @@
 import { FormActions } from "@/components/common/form-actions";
 import { PageHeader } from "@/components/common/page-header";
 import { ConnectionPicker } from "@/components/connection/ConnectionPicker";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Form,
@@ -10,9 +11,9 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { useTemplate } from "@/features/benchmark-templates/queries";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   type BenchmarkTemplate,
@@ -21,20 +22,19 @@ import {
   createBenchmarkRequestSchema,
   scenarioIdSchema,
 } from "@modeldoctor/contracts";
+import { X } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { useForm, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
-import { X } from "lucide-react";
-import { useTemplate } from "@/features/benchmark-templates/queries";
+import { PrefillFromTemplatePopover } from "./PrefillFromTemplatePopover";
 import {
   TOOL_DEFAULTS,
   ToolParamsForm,
   ToolSelectorField,
   useToolUnsupported,
 } from "./forms/ToolParamsEditor";
-import { PrefillFromTemplatePopover } from "./PrefillFromTemplatePopover";
 import { useCreateBenchmark } from "./queries";
 import { SCENARIOS } from "./scenarios";
 
@@ -131,6 +131,7 @@ export function BenchmarkCreatePage() {
   }, [tplQuery.data]);
 
   // 404 / fetch error: toast + drop the bad URL param
+  // biome-ignore lint/correctness/useExhaustiveDependencies: params and setSearchParams are stable RouterDom returns; t is stable i18n; we only re-run when templateIdParam or fetch error state changes
   useEffect(() => {
     if (templateIdParam && tplQuery.isError) {
       toast.error(t("create.prefillFromTemplate.notFound"));
@@ -164,9 +165,7 @@ export function BenchmarkCreatePage() {
           <form onSubmit={onSubmit} className="space-y-6">
             {watchedTemplateId && bannerTpl.data && (
               <div className="flex items-center justify-between rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-sm">
-                <span>
-                  {t("create.prefilledBanner.label", { name: bannerTpl.data.name })}
-                </span>
+                <span>{t("create.prefilledBanner.label", { name: bannerTpl.data.name })}</span>
                 <Button
                   type="button"
                   variant="ghost"

--- a/apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx
@@ -103,10 +103,18 @@ export function BenchmarkCreatePage() {
   const bannerTpl = useTemplate(watchedTemplateId ?? undefined);
 
   function applyTemplate(template: BenchmarkTemplate) {
+    // Scenario mismatch: redirect URL so the page re-renders under the
+    // template's scenario, then the prefill effect re-runs and applies the
+    // template cleanly. URL stays the single source of truth for scenario.
     if (template.scenario !== scenario) {
       toast.warning(
         t("create.prefillFromTemplate.scenarioMismatch", { scenario: template.scenario }),
       );
+      const next = new URLSearchParams(params);
+      next.set("scenario", template.scenario);
+      next.set("templateId", template.id);
+      setSearchParams(next, { replace: true });
+      return;
     }
     form.reset({
       tool: template.tool,
@@ -120,15 +128,20 @@ export function BenchmarkCreatePage() {
     toast.info(t("create.prefillFromTemplate.applied", { name: template.name }));
   }
 
-  // One-shot prefill from URL ?templateId=
+  // One-shot prefill from URL ?templateId=. Re-runs across a scenario change
+  // so the redirect path in applyTemplate can land and reapply.
   const hasAppliedRef = useRef(false);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: applyTemplate is stable; we only want to run when template loads
+  // biome-ignore lint/correctness/useExhaustiveDependencies: applyTemplate is stable; we only want to run when template loads or scenario settles
   useEffect(() => {
     if (tplQuery.data && !hasAppliedRef.current) {
       applyTemplate(tplQuery.data);
-      hasAppliedRef.current = true;
+      // Only consider it applied when scenarios actually matched — otherwise
+      // applyTemplate redirected and we want the post-redirect render to retry.
+      if (tplQuery.data.scenario === scenario) {
+        hasAppliedRef.current = true;
+      }
     }
-  }, [tplQuery.data]);
+  }, [tplQuery.data, scenario]);
 
   // 404 / fetch error: toast + drop the bad URL param
   // biome-ignore lint/correctness/useExhaustiveDependencies: params and setSearchParams are stable RouterDom returns; t is stable i18n; we only re-run when templateIdParam or fetch error state changes
@@ -143,8 +156,7 @@ export function BenchmarkCreatePage() {
 
   const onSubmit = form.handleSubmit(async (values) => {
     try {
-      const body: CreateBenchmarkRequest = { ...values, scenario };
-      const benchmark = await createMut.mutateAsync(body);
+      const benchmark = await createMut.mutateAsync(values);
       toast.success(t("create.submitted", { name: benchmark.name }));
       navigate(`/benchmarks/${benchmark.id}`);
     } catch (e) {

--- a/apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx
@@ -10,26 +10,31 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
+  type BenchmarkTemplate,
   type CreateBenchmarkRequest,
   type ScenarioId,
   createBenchmarkRequestSchema,
   scenarioIdSchema,
 } from "@modeldoctor/contracts";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useForm, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
+import { X } from "lucide-react";
+import { useTemplate } from "@/features/benchmark-templates/queries";
 import {
   TOOL_DEFAULTS,
   ToolParamsForm,
   ToolSelectorField,
   useToolUnsupported,
 } from "./forms/ToolParamsEditor";
+import { PrefillFromTemplatePopover } from "./PrefillFromTemplatePopover";
 import { useCreateBenchmark } from "./queries";
 import { SCENARIOS } from "./scenarios";
 
@@ -59,11 +64,12 @@ export function BenchmarkCreatePage() {
   const navigate = useNavigate();
   const createMut = useCreateBenchmark();
 
-  const [params] = useSearchParams();
+  const [params, setSearchParams] = useSearchParams();
   const scenarioParam = params.get("scenario");
   const scenarioParse = scenarioIdSchema.safeParse(scenarioParam);
   const scenario: ScenarioId = scenarioParse.success ? scenarioParse.data : "inference";
   const defaultTool = SCENARIOS[scenario].tools[0];
+  const templateIdParam = params.get("templateId");
 
   const form = useForm<CreateBenchmarkRequest>({
     resolver: zodResolver(createBenchmarkRequestSchema),
@@ -75,6 +81,7 @@ export function BenchmarkCreatePage() {
       name: "",
       description: undefined,
       params: TOOL_DEFAULTS[defaultTool] as Record<string, unknown>,
+      templateId: undefined,
     },
   });
 
@@ -87,8 +94,51 @@ export function BenchmarkCreatePage() {
       name: "",
       description: undefined,
       params: TOOL_DEFAULTS[defaultTool] as Record<string, unknown>,
+      templateId: undefined,
     });
   }, [scenario]);
+
+  const watchedTemplateId = form.watch("templateId");
+  const tplQuery = useTemplate(templateIdParam ?? undefined);
+  const bannerTpl = useTemplate(watchedTemplateId ?? undefined);
+
+  function applyTemplate(template: BenchmarkTemplate) {
+    if (template.scenario !== scenario) {
+      toast.warning(
+        t("create.prefillFromTemplate.scenarioMismatch", { scenario: template.scenario }),
+      );
+    }
+    form.reset({
+      tool: template.tool,
+      scenario: template.scenario,
+      connectionId: form.getValues("connectionId") ?? "",
+      name: template.name,
+      description: template.description ?? undefined,
+      params: template.config,
+      templateId: template.id,
+    });
+    toast.info(t("create.prefillFromTemplate.applied", { name: template.name }));
+  }
+
+  // One-shot prefill from URL ?templateId=
+  const hasAppliedRef = useRef(false);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: applyTemplate is stable; we only want to run when template loads
+  useEffect(() => {
+    if (tplQuery.data && !hasAppliedRef.current) {
+      applyTemplate(tplQuery.data);
+      hasAppliedRef.current = true;
+    }
+  }, [tplQuery.data]);
+
+  // 404 / fetch error: toast + drop the bad URL param
+  useEffect(() => {
+    if (templateIdParam && tplQuery.isError) {
+      toast.error(t("create.prefillFromTemplate.notFound"));
+      const next = new URLSearchParams(params);
+      next.delete("templateId");
+      setSearchParams(next, { replace: true });
+    }
+  }, [templateIdParam, tplQuery.isError]);
 
   const onSubmit = form.handleSubmit(async (values) => {
     try {
@@ -104,10 +154,31 @@ export function BenchmarkCreatePage() {
 
   return (
     <>
-      <PageHeader title={t(`create.titleByScenario.${scenario}`)} subtitle={t("create.subtitle")} />
+      <PageHeader
+        title={t(`create.titleByScenario.${scenario}`)}
+        subtitle={t("create.subtitle")}
+        rightSlot={<PrefillFromTemplatePopover scenario={scenario} onPick={applyTemplate} />}
+      />
       <div className="space-y-6 px-8 py-6">
         <Form {...form}>
           <form onSubmit={onSubmit} className="space-y-6">
+            {watchedTemplateId && bannerTpl.data && (
+              <div className="flex items-center justify-between rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-sm">
+                <span>
+                  {t("create.prefilledBanner.label", { name: bannerTpl.data.name })}
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => form.setValue("templateId", undefined, { shouldDirty: true })}
+                  className="gap-1"
+                >
+                  <X className="h-3.5 w-3.5" />
+                  {t("create.prefilledBanner.clear")}
+                </Button>
+              </div>
+            )}
             {/* Top row: 基本信息 (left) + 目标 (right) — both info-light, paired
              * for 2-col on md+. On small screens they stack naturally. */}
             <div className="grid grid-cols-1 gap-6 md:grid-cols-2">

--- a/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
@@ -19,7 +19,7 @@ import type { Benchmark } from "@modeldoctor/contracts";
 import { migrateVegetaParams } from "@modeldoctor/tool-adapters/schemas";
 import { useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
-import { ArrowLeft, Loader2, RefreshCw, SearchX } from "lucide-react";
+import { ArrowLeft, Copy, Loader2, RefreshCw, SearchX } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate, useParams } from "react-router-dom";
@@ -27,6 +27,7 @@ import { toast } from "sonner";
 import { BenchmarkDetailMetadata } from "./BenchmarkDetailMetadata";
 import { BenchmarkDetailRawOutput } from "./BenchmarkDetailRawOutput";
 import { RequestDetailsSection } from "./RequestDetailsSection";
+import { SaveAsTemplateDialog } from "./SaveAsTemplateDialog";
 import { SetBaselineDialog } from "./SetBaselineDialog";
 import { DetailVerdictRow } from "./compare/DetailVerdictRow";
 import {
@@ -112,6 +113,7 @@ export function BenchmarkDetailPage() {
   const [unsetOpen, setUnsetOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [cancelOpen, setCancelOpen] = useState(false);
+  const [saveTplOpen, setSaveTplOpen] = useState(false);
   const remove = useDeleteBaseline();
   const deleteBenchmark = useDeleteBenchmark();
   const cancelBenchmark = useCancelBenchmark();
@@ -239,6 +241,12 @@ export function BenchmarkDetailPage() {
                   <TooltipContent>{t("detail.rerun.connectionMissingTooltip")}</TooltipContent>
                 </Tooltip>
               ))}
+            {isTerminal && benchmark.status === "completed" && (
+              <Button variant="outline" size="sm" onClick={() => setSaveTplOpen(true)}>
+                <Copy className="mr-1 h-4 w-4" />
+                {t("detail.saveAsTemplate.button")}
+              </Button>
+            )}
             {!isTerminal && (
               <Button variant="outline" size="sm" onClick={() => setCancelOpen(true)}>
                 {t("detail.cancel.button")}
@@ -396,6 +404,11 @@ export function BenchmarkDetailPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <SaveAsTemplateDialog
+        benchmark={saveTplOpen ? benchmark : null}
+        onOpenChange={setSaveTplOpen}
+      />
     </>
   );
 }

--- a/apps/web/src/features/benchmarks/BenchmarkListShell.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkListShell.tsx
@@ -29,7 +29,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { useCreateTemplate } from "@/features/benchmark-templates/queries";
 import type {
   Benchmark,
   BenchmarkStatus,
@@ -51,6 +50,7 @@ import { useTranslation } from "react-i18next";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import { BenchmarkListFilters } from "./BenchmarkListFilters";
+import { SaveAsTemplateDialog } from "./SaveAsTemplateDialog";
 import { readErrorRate, readP95Latency } from "./compare/metrics";
 import { useBenchmarkList, useCreateBenchmark, useDeleteBenchmark } from "./queries";
 import { SCENARIOS, type ScenarioId } from "./scenarios";
@@ -117,9 +117,9 @@ export function BenchmarkListShell({ scenario }: BenchmarkListShellProps) {
 
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const [saveTplBenchmark, setSaveTplBenchmark] = useState<Benchmark | null>(null);
   const deleteBenchmark = useDeleteBenchmark();
   const createBenchmark = useCreateBenchmark();
-  const createTemplate = useCreateTemplate();
   const navigate = useNavigate();
 
   async function handleRerunRow(b: Benchmark) {
@@ -148,25 +148,6 @@ export function BenchmarkListShell({ scenario }: BenchmarkListShellProps) {
       navigate(`/benchmarks/${next.id}`);
     } catch (e) {
       toast.error((e as Error).message || t("detail.rerun.errors.generic"));
-    }
-  }
-
-  async function handleSaveAsTemplate(b: Benchmark) {
-    const trimmed = b.name.length > 90 ? b.name.slice(0, 90) : b.name;
-    const newName = `${trimmed} (template)`;
-    try {
-      const next = await createTemplate.mutateAsync({
-        name: newName,
-        description: b.description ?? undefined,
-        scenario: b.scenario,
-        tool: b.tool,
-        config: b.params as Record<string, unknown>,
-        tags: [],
-        isOfficial: false,
-      });
-      toast.success(t("rowActions.saveAsTemplate.success", { name: next.name }));
-    } catch (e) {
-      toast.error((e as Error).message || t("rowActions.saveAsTemplate.errors.generic"));
     }
   }
 
@@ -390,14 +371,31 @@ export function BenchmarkListShell({ scenario }: BenchmarkListShellProps) {
                             </Button>
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="end">
-                            <DropdownMenuItem
-                              onClick={() => handleSaveAsTemplate(benchmark)}
-                              disabled={createTemplate.isPending}
-                              className="gap-2"
-                            >
-                              <CopyIcon className="h-4 w-4" />
-                              {t("rowActions.saveAsTemplate.label")}
-                            </DropdownMenuItem>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span>
+                                  <DropdownMenuItem
+                                    onClick={(e) => {
+                                      if (benchmark.status !== "completed") {
+                                        e.preventDefault();
+                                        return;
+                                      }
+                                      setSaveTplBenchmark(benchmark);
+                                    }}
+                                    disabled={benchmark.status !== "completed"}
+                                    className="gap-2"
+                                  >
+                                    <CopyIcon className="h-4 w-4" />
+                                    {t("rowActions.saveAsTemplate.label")}
+                                  </DropdownMenuItem>
+                                </span>
+                              </TooltipTrigger>
+                              {benchmark.status !== "completed" && (
+                                <TooltipContent>
+                                  {t("rowActions.saveAsTemplate.disabledTooltip")}
+                                </TooltipContent>
+                              )}
+                            </Tooltip>
                             <DropdownMenuItem
                               onClick={() => setPendingDeleteId(benchmark.id)}
                               className="gap-2 text-destructive focus:text-destructive"
@@ -463,6 +461,11 @@ export function BenchmarkListShell({ scenario }: BenchmarkListShellProps) {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <SaveAsTemplateDialog
+        benchmark={saveTplBenchmark}
+        onOpenChange={(o) => !o && setSaveTplBenchmark(null)}
+      />
     </>
   );
 }

--- a/apps/web/src/features/benchmarks/PrefillFromTemplatePopover.tsx
+++ b/apps/web/src/features/benchmarks/PrefillFromTemplatePopover.tsx
@@ -1,0 +1,105 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useTemplates } from "@/features/benchmark-templates/queries";
+import type { BenchmarkTemplate, ScenarioId } from "@modeldoctor/contracts";
+import { Layers, ShieldCheck } from "lucide-react";
+import { useId, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+
+interface PrefillFromTemplatePopoverProps {
+  scenario: ScenarioId;
+  onPick: (template: BenchmarkTemplate) => void;
+}
+
+export function PrefillFromTemplatePopover({ scenario, onPick }: PrefillFromTemplatePopoverProps) {
+  const { t } = useTranslation("benchmarks");
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const searchId = useId();
+
+  const { data } = useTemplates({ scenario, limit: 50 });
+  const items = data?.pages.flatMap((p) => p.items) ?? [];
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter(
+      (it) =>
+        it.name.toLowerCase().includes(q) ||
+        (it.description ?? "").toLowerCase().includes(q) ||
+        it.tags.some((tag) => tag.toLowerCase().includes(q)),
+    );
+  }, [items, search]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Layers className="mr-1 h-4 w-4" />
+          {t("create.prefillFromTemplate.button")}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-96 p-0" align="end">
+        <div className="border-b p-2">
+          <Input
+            id={searchId}
+            aria-label={t("create.prefillFromTemplate.search")}
+            placeholder={t("create.prefillFromTemplate.search")}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="h-8"
+          />
+        </div>
+        <div className="max-h-72 overflow-auto">
+          {filtered.length === 0 ? (
+            <div className="p-3 text-sm text-muted-foreground">
+              {t("create.prefillFromTemplate.empty")}
+            </div>
+          ) : (
+            <ul className="divide-y">
+              {filtered.map((it) => (
+                <li key={it.id}>
+                  <button
+                    type="button"
+                    className="flex w-full flex-col gap-1 px-3 py-2 text-left hover:bg-accent"
+                    onClick={() => {
+                      onPick(it);
+                      setOpen(false);
+                    }}
+                  >
+                    <span className="flex items-center gap-1 text-sm font-medium">
+                      {it.isOfficial && <ShieldCheck className="h-3.5 w-3.5 text-primary" aria-hidden />}
+                      <span className="truncate">{it.name}</span>
+                    </span>
+                    <span className="flex flex-wrap items-center gap-1.5">
+                      <Badge variant="outline" className="text-xs">
+                        {it.tool}
+                      </Badge>
+                      {it.tags.slice(0, 3).map((tag) => (
+                        <Badge key={tag} variant="outline" className="text-xs">
+                          {tag}
+                        </Badge>
+                      ))}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div className="border-t p-2">
+          <Link
+            to={`/benchmark-templates?scenario=${scenario}`}
+            className="block px-1 text-xs text-muted-foreground hover:text-foreground"
+            onClick={() => setOpen(false)}
+          >
+            {t("create.prefillFromTemplate.manage")}
+          </Link>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/features/benchmarks/PrefillFromTemplatePopover.tsx
+++ b/apps/web/src/features/benchmarks/PrefillFromTemplatePopover.tsx
@@ -71,7 +71,9 @@ export function PrefillFromTemplatePopover({ scenario, onPick }: PrefillFromTemp
                     }}
                   >
                     <span className="flex items-center gap-1 text-sm font-medium">
-                      {it.isOfficial && <ShieldCheck className="h-3.5 w-3.5 text-primary" aria-hidden />}
+                      {it.isOfficial && (
+                        <ShieldCheck className="h-3.5 w-3.5 text-primary" aria-hidden />
+                      )}
                       <span className="truncate">{it.name}</span>
                     </span>
                     <span className="flex flex-wrap items-center gap-1.5">

--- a/apps/web/src/features/benchmarks/SaveAsTemplateDialog.tsx
+++ b/apps/web/src/features/benchmarks/SaveAsTemplateDialog.tsx
@@ -1,0 +1,188 @@
+import { FormActions } from "@/components/common/form-actions";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { useCreateTemplate } from "@/features/benchmark-templates/queries";
+import type { Benchmark } from "@modeldoctor/contracts";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { z } from "zod";
+
+const formSchema = z.object({
+  name: z.string().trim().min(1).max(100),
+  description: z.string().trim().max(2048).optional(),
+  tagsInput: z.string().optional(),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+export interface SaveAsTemplateDialogProps {
+  /** When null the dialog is closed; pass the benchmark to open. */
+  benchmark: Benchmark | null;
+  onOpenChange: (open: boolean) => void;
+}
+
+function defaultName(benchmarkName: string): string {
+  // Schema caps name at 100. " (template)" is 11 chars; reserve 89 for the source name.
+  const trimmed = benchmarkName.length > 89 ? benchmarkName.slice(0, 89) : benchmarkName;
+  return `${trimmed} (template)`;
+}
+
+export function SaveAsTemplateDialog({ benchmark, onOpenChange }: SaveAsTemplateDialogProps) {
+  const { t } = useTranslation("benchmarks");
+  const create = useCreateTemplate();
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    mode: "onTouched",
+    defaultValues: { name: "", description: undefined, tagsInput: "" },
+  });
+
+  // Re-seed defaults whenever the dialog re-opens with a (possibly different) benchmark.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: form ref is stable
+  useEffect(() => {
+    if (benchmark) {
+      form.reset({
+        name: defaultName(benchmark.name),
+        description: benchmark.description ?? undefined,
+        tagsInput: "",
+      });
+      setSubmitError(null);
+    }
+  }, [benchmark?.id]);
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    if (!benchmark) return;
+    const tags = (values.tagsInput ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    setSubmitError(null);
+    try {
+      const next = await create.mutateAsync({
+        name: values.name,
+        ...(values.description ? { description: values.description } : {}),
+        scenario: benchmark.scenario,
+        tool: benchmark.tool,
+        config: benchmark.params as Record<string, unknown>,
+        tags,
+        isOfficial: false,
+      });
+      toast.success(t("rowActions.saveAsTemplate.success", { name: next.name }));
+      onOpenChange(false);
+    } catch {
+      setSubmitError(t("rowActions.saveAsTemplate.errors.generic"));
+    }
+  });
+
+  return (
+    <Dialog open={benchmark !== null} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <Form {...form}>
+          <form onSubmit={onSubmit} className="space-y-4">
+            <DialogHeader>
+              <DialogTitle>{t("detail.saveAsTemplate.button")}</DialogTitle>
+              <DialogDescription>
+                {t("rowActions.saveAsTemplate.label")}
+              </DialogDescription>
+            </DialogHeader>
+
+            {submitError && (
+              <Alert variant="destructive">
+                <AlertDescription>{submitError}</AlertDescription>
+              </Alert>
+            )}
+
+            <div className="space-y-3">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel required>
+                      {t("benchmark-templates:create.fields.name", { defaultValue: "Template name" })}
+                    </FormLabel>
+                    <FormControl>
+                      <Input maxLength={100} {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("benchmark-templates:create.fields.description", { defaultValue: "Description" })}
+                    </FormLabel>
+                    <FormControl>
+                      <Textarea
+                        rows={2}
+                        {...field}
+                        value={field.value ?? ""}
+                        onChange={(e) =>
+                          field.onChange(e.target.value === "" ? undefined : e.target.value)
+                        }
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="tagsInput"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("benchmark-templates:create.fields.tags", { defaultValue: "Tags" })}
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder={t("detail.baseline.dialog.tagsLabel", { defaultValue: "" })}
+                        {...field}
+                        value={field.value ?? ""}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <DialogFooter>
+              <FormActions
+                onCancel={() => onOpenChange(false)}
+                cancelLabel={t("detail.baseline.dialog.cancel")}
+                submitLabel={t("detail.baseline.dialog.submit")}
+                disabled={!form.formState.isValid}
+                pending={create.isPending}
+              />
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/benchmarks/SaveAsTemplateDialog.tsx
+++ b/apps/web/src/features/benchmarks/SaveAsTemplateDialog.tsx
@@ -20,8 +20,8 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { useCreateTemplate } from "@/features/benchmark-templates/queries";
-import type { Benchmark } from "@modeldoctor/contracts";
 import { zodResolver } from "@hookform/resolvers/zod";
+import type { Benchmark } from "@modeldoctor/contracts";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -103,9 +103,7 @@ export function SaveAsTemplateDialog({ benchmark, onOpenChange }: SaveAsTemplate
           <form onSubmit={onSubmit} className="space-y-4">
             <DialogHeader>
               <DialogTitle>{t("detail.saveAsTemplate.button")}</DialogTitle>
-              <DialogDescription>
-                {t("rowActions.saveAsTemplate.label")}
-              </DialogDescription>
+              <DialogDescription>{t("rowActions.saveAsTemplate.label")}</DialogDescription>
             </DialogHeader>
 
             {submitError && (
@@ -121,7 +119,9 @@ export function SaveAsTemplateDialog({ benchmark, onOpenChange }: SaveAsTemplate
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel required>
-                      {t("benchmark-templates:create.fields.name", { defaultValue: "Template name" })}
+                      {t("benchmark-templates:create.fields.name", {
+                        defaultValue: "Template name",
+                      })}
                     </FormLabel>
                     <FormControl>
                       <Input maxLength={100} {...field} />
@@ -136,7 +136,9 @@ export function SaveAsTemplateDialog({ benchmark, onOpenChange }: SaveAsTemplate
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>
-                      {t("benchmark-templates:create.fields.description", { defaultValue: "Description" })}
+                      {t("benchmark-templates:create.fields.description", {
+                        defaultValue: "Description",
+                      })}
                     </FormLabel>
                     <FormControl>
                       <Textarea

--- a/apps/web/src/features/benchmarks/SaveAsTemplateDialog.tsx
+++ b/apps/web/src/features/benchmarks/SaveAsTemplateDialog.tsx
@@ -1,4 +1,5 @@
 import { FormActions } from "@/components/common/form-actions";
+import { FormSection } from "@/components/common/form-section";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   Dialog,
@@ -113,7 +114,7 @@ export function SaveAsTemplateDialog({ benchmark, onOpenChange }: SaveAsTemplate
               </Alert>
             )}
 
-            <div className="space-y-3">
+            <FormSection>
               <FormField
                 control={form.control}
                 name="name"
@@ -169,7 +170,7 @@ export function SaveAsTemplateDialog({ benchmark, onOpenChange }: SaveAsTemplate
                   </FormItem>
                 )}
               />
-            </div>
+            </FormSection>
 
             <DialogFooter>
               <FormActions

--- a/apps/web/src/features/benchmarks/__tests__/BenchmarkCreatePage.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/BenchmarkCreatePage.test.tsx
@@ -13,7 +13,7 @@ vi.mock("@/features/benchmark-templates/queries", () => ({
 
 vi.mock("@/features/connections/queries", () => ({
   useConnections: () => ({
-    data: [{ id: "c1", name: "test-conn", baseUrl: "http://x", model: "m" }],
+    data: [{ id: "c1", name: "test-conn", baseUrl: "http://x", model: "m", category: "chat" }],
     isLoading: false,
   }),
   useConnection: () => ({ data: null }),
@@ -57,6 +57,7 @@ function Wrapper({ children }: { children: React.ReactNode }) {
 describe("BenchmarkCreatePage", () => {
   beforeEach(() => {
     mockUseTemplate.mockReturnValue({ data: undefined, isError: false });
+    mockMutate.mockReset();
   });
 
   it("renders target, tool, name, description sections", () => {
@@ -254,5 +255,83 @@ describe("BenchmarkCreatePage", () => {
     // …but Name field still has "preset"
     const nameInput = screen.getByLabelText(/Name|名称/i) as HTMLInputElement;
     expect(nameInput.value).toBe("preset");
+  });
+
+  it("submits with templateId from URL prefill in payload", async () => {
+    mockUseTemplate.mockReturnValue({
+      data: {
+        id: "tpl-1",
+        name: "preset",
+        description: null,
+        scenario: "inference",
+        tool: "guidellm",
+        config: { profile: "throughput" },
+        isOfficial: false,
+        createdBy: null,
+        tags: [],
+        createdAt: "2026-05-07T00:00:00.000Z",
+        updatedAt: "2026-05-07T00:00:00.000Z",
+      },
+      isError: false,
+    });
+    mockMutate.mockResolvedValue({ id: "b-new", scenario: "inference", name: "preset" });
+
+    const { default: userEvent } = await import("@testing-library/user-event");
+    renderAt("/benchmarks/new?scenario=inference&templateId=tpl-1");
+    // Wait for prefill so the Name field is populated.
+    await waitFor(() => {
+      const nameInput = screen.getByLabelText(/Name|名称/i) as HTMLInputElement;
+      expect(nameInput.value).toBe("preset");
+    });
+    // Select the connection via ConnectionPicker — it's the first combobox in DOM order.
+    const [connectionCombo] = screen.getAllByRole("combobox");
+    await userEvent.click(connectionCombo);
+    await userEvent.click(await screen.findByText("test-conn"));
+    // Submit.
+    const submit = screen.getByRole("button", { name: /Submit|提交/i });
+    await waitFor(() => expect(submit).not.toBeDisabled());
+    await userEvent.click(submit);
+    await waitFor(() => expect(mockMutate).toHaveBeenCalled());
+    const payload = mockMutate.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload.templateId).toBe("tpl-1");
+  });
+
+  it("submits without templateId after clear-link is clicked", async () => {
+    mockUseTemplate.mockReturnValue({
+      data: {
+        id: "tpl-1",
+        name: "preset",
+        description: null,
+        scenario: "inference",
+        tool: "guidellm",
+        config: { profile: "throughput" },
+        isOfficial: false,
+        createdBy: null,
+        tags: [],
+        createdAt: "2026-05-07T00:00:00.000Z",
+        updatedAt: "2026-05-07T00:00:00.000Z",
+      },
+      isError: false,
+    });
+    mockMutate.mockResolvedValue({ id: "b-new", scenario: "inference", name: "preset" });
+
+    const { default: userEvent } = await import("@testing-library/user-event");
+    renderAt("/benchmarks/new?scenario=inference&templateId=tpl-1");
+    await screen.findByText(/prefilled from template|已从模板/i);
+    // Select the connection via ConnectionPicker — it's the first combobox in DOM order.
+    const [connectionCombo] = screen.getAllByRole("combobox");
+    await userEvent.click(connectionCombo);
+    await userEvent.click(await screen.findByText("test-conn"));
+    // Clear the template link.
+    await userEvent.click(screen.getByRole("button", { name: /clear link|清除关联/i }));
+    // Submit.
+    const submit = screen.getByRole("button", { name: /Submit|提交/i });
+    await waitFor(() => expect(submit).not.toBeDisabled());
+    await userEvent.click(submit);
+    await waitFor(() => expect(mockMutate).toHaveBeenCalled());
+    const payload = mockMutate.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload.templateId).toBeUndefined();
+    // Prefilled params are still present after clearing the link.
+    expect((payload.params as Record<string, unknown>).profile).toBe("throughput");
   });
 });

--- a/apps/web/src/features/benchmarks/__tests__/BenchmarkCreatePage.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/BenchmarkCreatePage.test.tsx
@@ -1,8 +1,15 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, render, screen, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter, useNavigate } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BenchmarkCreatePage } from "../BenchmarkCreatePage";
+
+const mockUseTemplate = vi.fn();
+vi.mock("@/features/benchmark-templates/queries", () => ({
+  useTemplate: (...args: unknown[]) => mockUseTemplate(...args),
+  useTemplates: () => ({ data: { pages: [{ items: [], nextCursor: null }] }, isLoading: false }),
+  useCreateTemplate: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+}));
 
 vi.mock("@/features/connections/queries", () => ({
   useConnections: () => ({
@@ -48,6 +55,10 @@ function Wrapper({ children }: { children: React.ReactNode }) {
 }
 
 describe("BenchmarkCreatePage", () => {
+  beforeEach(() => {
+    mockUseTemplate.mockReturnValue({ data: undefined, isError: false });
+  });
+
   it("renders target, tool, name, description sections", () => {
     render(<BenchmarkCreatePage />, { wrapper: Wrapper });
     // Endpoint + tool now collapse into a single "Target" card.
@@ -168,5 +179,80 @@ describe("BenchmarkCreatePage", () => {
     expect(label).toHaveTextContent(/vegeta/i);
     // And the VegetaParamsForm should now be the rendered subform.
     expect(screen.getByLabelText(/Rate \(req\/s\)/i)).toBeInTheDocument();
+  });
+
+  it("prefills form when ?templateId= present in URL", async () => {
+    mockUseTemplate.mockReturnValue({
+      data: {
+        id: "tpl-1",
+        name: "preset",
+        description: null,
+        scenario: "inference",
+        tool: "guidellm",
+        config: { profile: "throughput" },
+        isOfficial: false,
+        createdBy: null,
+        tags: [],
+        createdAt: "2026-05-07T00:00:00.000Z",
+        updatedAt: "2026-05-07T00:00:00.000Z",
+      },
+      isError: false,
+    });
+    renderAt("/benchmarks/new?scenario=inference&templateId=tpl-1");
+    // Wait for prefill effect to fire:
+    await waitFor(() => {
+      const nameInput = screen.getByLabelText(/Name|名称/i) as HTMLInputElement;
+      expect(nameInput.value).toBe("preset");
+    });
+  });
+
+  it("shows prefilled banner with clear-link button when templateId is set", async () => {
+    mockUseTemplate.mockReturnValue({
+      data: {
+        id: "tpl-1",
+        name: "preset",
+        description: null,
+        scenario: "inference",
+        tool: "guidellm",
+        config: { profile: "throughput" },
+        isOfficial: false,
+        createdBy: null,
+        tags: [],
+        createdAt: "2026-05-07T00:00:00.000Z",
+        updatedAt: "2026-05-07T00:00:00.000Z",
+      },
+      isError: false,
+    });
+    renderAt("/benchmarks/new?scenario=inference&templateId=tpl-1");
+    expect(await screen.findByText(/prefilled from template|已从模板/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /clear link|清除关联/i })).toBeInTheDocument();
+  });
+
+  it("clear-link button strips templateId but keeps params", async () => {
+    mockUseTemplate.mockReturnValue({
+      data: {
+        id: "tpl-1",
+        name: "preset",
+        description: null,
+        scenario: "inference",
+        tool: "guidellm",
+        config: { profile: "throughput" },
+        isOfficial: false,
+        createdBy: null,
+        tags: [],
+        createdAt: "2026-05-07T00:00:00.000Z",
+        updatedAt: "2026-05-07T00:00:00.000Z",
+      },
+      isError: false,
+    });
+    renderAt("/benchmarks/new?scenario=inference&templateId=tpl-1");
+    await screen.findByText(/prefilled from template|已从模板/i);
+    const { default: userEvent } = await import("@testing-library/user-event");
+    await userEvent.click(screen.getByRole("button", { name: /clear link|清除关联/i }));
+    // Banner gone…
+    expect(screen.queryByText(/prefilled from template|已从模板/i)).not.toBeInTheDocument();
+    // …but Name field still has "preset"
+    const nameInput = screen.getByLabelText(/Name|名称/i) as HTMLInputElement;
+    expect(nameInput.value).toBe("preset");
   });
 });

--- a/apps/web/src/features/benchmarks/__tests__/BenchmarkCreatePage.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/BenchmarkCreatePage.test.tsx
@@ -296,6 +296,73 @@ describe("BenchmarkCreatePage", () => {
     expect(payload.templateId).toBe("tpl-1");
   });
 
+  it("redirects URL scenario when template's scenario differs (URL prefill)", async () => {
+    // Template is for gateway, but URL says scenario=inference. Page should
+    // redirect URL to scenario=gateway so form state and submission stay
+    // coherent with the visible page (single-source-of-truth = URL).
+    mockUseTemplate.mockReturnValue({
+      data: {
+        id: "tpl-1",
+        name: "preset",
+        description: null,
+        scenario: "gateway",
+        tool: "vegeta",
+        config: { rate: 50, duration: 30 },
+        isOfficial: false,
+        createdBy: null,
+        tags: [],
+        createdAt: "2026-05-07T00:00:00.000Z",
+        updatedAt: "2026-05-07T00:00:00.000Z",
+      },
+      isError: false,
+    });
+    renderAt("/benchmarks/new?scenario=inference&templateId=tpl-1");
+    // After redirect + re-apply, Vegeta-only "Rate (req/s)" field is mounted.
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Rate \(req\/s\)/i)).toBeInTheDocument();
+    });
+    // And the prefilled banner should reflect the template name.
+    expect(await screen.findByText(/prefilled from template|已从模板/i)).toBeInTheDocument();
+  });
+
+  it("submits with form scenario (not URL scenario) — onSubmit uses values", async () => {
+    // Regression: previously onSubmit overrode `scenario` from URL, which
+    // could disagree with the form's scenario in mid-redirect frames.
+    // After the fix, payload.scenario must come from form values.
+    mockUseTemplate.mockReturnValue({
+      data: {
+        id: "tpl-1",
+        name: "preset",
+        description: null,
+        scenario: "inference",
+        tool: "guidellm",
+        config: { profile: "throughput" },
+        isOfficial: false,
+        createdBy: null,
+        tags: [],
+        createdAt: "2026-05-07T00:00:00.000Z",
+        updatedAt: "2026-05-07T00:00:00.000Z",
+      },
+      isError: false,
+    });
+    mockMutate.mockResolvedValue({ id: "b-new", scenario: "inference", name: "preset" });
+    const { default: userEvent } = await import("@testing-library/user-event");
+    renderAt("/benchmarks/new?scenario=inference&templateId=tpl-1");
+    await waitFor(() => {
+      const nameInput = screen.getByLabelText(/Name|名称/i) as HTMLInputElement;
+      expect(nameInput.value).toBe("preset");
+    });
+    const [connectionCombo] = screen.getAllByRole("combobox");
+    await userEvent.click(connectionCombo);
+    await userEvent.click(await screen.findByText("test-conn"));
+    const submit = screen.getByRole("button", { name: /Submit|提交/i });
+    await waitFor(() => expect(submit).not.toBeDisabled());
+    await userEvent.click(submit);
+    await waitFor(() => expect(mockMutate).toHaveBeenCalled());
+    const payload = mockMutate.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload.scenario).toBe("inference");
+  });
+
   it("submits without templateId after clear-link is clicked", async () => {
     mockUseTemplate.mockReturnValue({
       data: {

--- a/apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
@@ -629,4 +629,36 @@ describe("BenchmarkDetailPage", () => {
     await user.click(confirm);
     await waitFor(() => expect(api.post).toHaveBeenCalledWith("/api/benchmarks/r1/cancel", {}));
   });
+
+  it("renders Save-as-Template button when status is completed", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(makeBenchmark({ status: "completed" }));
+    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
+    expect(
+      await screen.findByRole("button", { name: /save as template|保存为模板/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides Save-as-Template button when status is failed", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(
+      makeBenchmark({ status: "failed", statusMessage: "boom" }),
+    );
+    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
+    // Wait for the page to settle on a non-button anchor we know exists for failed:
+    await screen.findByText(/boom/);
+    expect(
+      screen.queryByRole("button", { name: /save as template|保存为模板/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Save-as-Template button when status is running", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(
+      makeBenchmark({ status: "running", summaryMetrics: null }),
+    );
+    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
+    // Wait for the running placeholder so we know the page is past initial loading:
+    await screen.findByText(/Running…|运行中…/);
+    expect(
+      screen.queryByRole("button", { name: /save as template|保存为模板/i }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/benchmarks/__tests__/BenchmarkListShell.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/BenchmarkListShell.test.tsx
@@ -265,4 +265,29 @@ describe("BenchmarkListShell", () => {
     const compareBtn = screen.getByRole("button", { name: /Compare \(2\)|对比 \(2\)/i });
     expect(compareBtn).toBeDisabled();
   });
+
+  it("save-as-template menu item is disabled for non-completed rows", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      items: [makeBenchmark("r1", "guidellm", "running", null)],
+      nextCursor: null,
+    } satisfies ListBenchmarksResponse);
+    render(<BenchmarkListShell scenario="inference" />, { wrapper: Wrapper });
+    await screen.findByText("r1");
+    await userEvent.click(screen.getByRole("button", { name: /more|更多/i }));
+    const menuItem = await screen.findByRole("menuitem", { name: /save as template|保存为模板/i });
+    expect(menuItem).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("save-as-template menu item opens dialog for completed rows", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      items: [makeBenchmark("r1", "guidellm", "completed", guidellmMetrics)],
+      nextCursor: null,
+    } satisfies ListBenchmarksResponse);
+    render(<BenchmarkListShell scenario="inference" />, { wrapper: Wrapper });
+    await screen.findByText("r1");
+    await userEvent.click(screen.getByRole("button", { name: /more|更多/i }));
+    const menuItem = await screen.findByRole("menuitem", { name: /save as template|保存为模板/i });
+    await userEvent.click(menuItem);
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/benchmarks/__tests__/PrefillFromTemplatePopover.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/PrefillFromTemplatePopover.test.tsx
@@ -10,7 +10,10 @@ import { PrefillFromTemplatePopover } from "../PrefillFromTemplatePopover";
 
 vi.mock("@/lib/api-client", () => {
   class ApiError extends Error {
-    constructor(public status: number, message: string) {
+    constructor(
+      public status: number,
+      message: string,
+    ) {
       super(message);
     }
   }
@@ -49,12 +52,19 @@ describe("PrefillFromTemplatePopover", () => {
 
   it("opens, lists templates filtered by current scenario", async () => {
     vi.mocked(api.get).mockResolvedValue({
-      items: [tpl({ id: "t1", name: "vLLM single" }), tpl({ id: "t2", name: "Internal gateway", tool: "vegeta" })],
+      items: [
+        tpl({ id: "t1", name: "vLLM single" }),
+        tpl({ id: "t2", name: "Internal gateway", tool: "vegeta" }),
+      ],
       nextCursor: null,
     } satisfies ListBenchmarkTemplatesResponse);
 
-    render(<PrefillFromTemplatePopover scenario="inference" onPick={() => {}} />, { wrapper: Wrapper });
-    await userEvent.click(screen.getByRole("button", { name: /prefill from template|从模板预填/i }));
+    render(<PrefillFromTemplatePopover scenario="inference" onPick={() => {}} />, {
+      wrapper: Wrapper,
+    });
+    await userEvent.click(
+      screen.getByRole("button", { name: /prefill from template|从模板预填/i }),
+    );
     expect(await screen.findByText("vLLM single")).toBeInTheDocument();
     expect(screen.getByText("Internal gateway")).toBeInTheDocument();
     // Verify the api was called with scenario filter:
@@ -69,10 +79,17 @@ describe("PrefillFromTemplatePopover", () => {
       nextCursor: null,
     } satisfies ListBenchmarkTemplatesResponse);
 
-    render(<PrefillFromTemplatePopover scenario="inference" onPick={() => {}} />, { wrapper: Wrapper });
-    await userEvent.click(screen.getByRole("button", { name: /prefill from template|从模板预填/i }));
+    render(<PrefillFromTemplatePopover scenario="inference" onPick={() => {}} />, {
+      wrapper: Wrapper,
+    });
+    await userEvent.click(
+      screen.getByRole("button", { name: /prefill from template|从模板预填/i }),
+    );
     await screen.findByText("vLLM single");
-    await userEvent.type(screen.getByRole("textbox", { name: /search templates|搜索模板/i }), "vLLM");
+    await userEvent.type(
+      screen.getByRole("textbox", { name: /search templates|搜索模板/i }),
+      "vLLM",
+    );
     expect(screen.getByText("vLLM single")).toBeInTheDocument();
     expect(screen.queryByText("Internal gateway")).not.toBeInTheDocument();
   });
@@ -83,8 +100,12 @@ describe("PrefillFromTemplatePopover", () => {
       nextCursor: null,
     } satisfies ListBenchmarkTemplatesResponse);
 
-    render(<PrefillFromTemplatePopover scenario="inference" onPick={() => {}} />, { wrapper: Wrapper });
-    await userEvent.click(screen.getByRole("button", { name: /prefill from template|从模板预填/i }));
+    render(<PrefillFromTemplatePopover scenario="inference" onPick={() => {}} />, {
+      wrapper: Wrapper,
+    });
+    await userEvent.click(
+      screen.getByRole("button", { name: /prefill from template|从模板预填/i }),
+    );
     expect(await screen.findByText(/no templates|还没有此场景/i)).toBeInTheDocument();
     const manage = screen.getByRole("link", { name: /manage templates|去模板库管理/i });
     expect(manage).toHaveAttribute("href", "/benchmark-templates?scenario=inference");
@@ -98,8 +119,12 @@ describe("PrefillFromTemplatePopover", () => {
     } satisfies ListBenchmarkTemplatesResponse);
 
     const onPick = vi.fn();
-    render(<PrefillFromTemplatePopover scenario="inference" onPick={onPick} />, { wrapper: Wrapper });
-    await userEvent.click(screen.getByRole("button", { name: /prefill from template|从模板预填/i }));
+    render(<PrefillFromTemplatePopover scenario="inference" onPick={onPick} />, {
+      wrapper: Wrapper,
+    });
+    await userEvent.click(
+      screen.getByRole("button", { name: /prefill from template|从模板预填/i }),
+    );
     await userEvent.click(await screen.findByRole("button", { name: /vLLM single/ }));
     expect(onPick).toHaveBeenCalledWith(expect.objectContaining({ id: "t1", name: "vLLM single" }));
   });

--- a/apps/web/src/features/benchmarks/__tests__/PrefillFromTemplatePopover.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/PrefillFromTemplatePopover.test.tsx
@@ -1,0 +1,106 @@
+import "@/lib/i18n";
+import type { BenchmarkTemplate, ListBenchmarkTemplatesResponse } from "@modeldoctor/contracts";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PrefillFromTemplatePopover } from "../PrefillFromTemplatePopover";
+
+vi.mock("@/lib/api-client", () => {
+  class ApiError extends Error {
+    constructor(public status: number, message: string) {
+      super(message);
+    }
+  }
+  return { ApiError, api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), del: vi.fn() } };
+});
+import { api } from "@/lib/api-client";
+
+function tpl(overrides: Partial<BenchmarkTemplate> = {}): BenchmarkTemplate {
+  return {
+    id: "tpl-1",
+    name: "vLLM single concurrency",
+    description: "official low-load",
+    scenario: "inference",
+    tool: "guidellm",
+    config: {},
+    isOfficial: true,
+    createdBy: null,
+    tags: ["official"],
+    createdAt: "2026-05-07T00:00:00.000Z",
+    updatedAt: "2026-05-07T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe("PrefillFromTemplatePopover", () => {
+  beforeEach(() => vi.mocked(api.get).mockReset());
+
+  it("opens, lists templates filtered by current scenario", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      items: [tpl({ id: "t1", name: "vLLM single" }), tpl({ id: "t2", name: "Internal gateway", tool: "vegeta" })],
+      nextCursor: null,
+    } satisfies ListBenchmarkTemplatesResponse);
+
+    render(<PrefillFromTemplatePopover scenario="inference" onPick={() => {}} />, { wrapper: Wrapper });
+    await userEvent.click(screen.getByRole("button", { name: /prefill from template|从模板预填/i }));
+    expect(await screen.findByText("vLLM single")).toBeInTheDocument();
+    expect(screen.getByText("Internal gateway")).toBeInTheDocument();
+    // Verify the api was called with scenario filter:
+    await waitFor(() =>
+      expect(api.get).toHaveBeenCalledWith(expect.stringContaining("scenario=inference")),
+    );
+  });
+
+  it("filters items locally by search input", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      items: [tpl({ id: "t1", name: "vLLM single" }), tpl({ id: "t2", name: "Internal gateway" })],
+      nextCursor: null,
+    } satisfies ListBenchmarkTemplatesResponse);
+
+    render(<PrefillFromTemplatePopover scenario="inference" onPick={() => {}} />, { wrapper: Wrapper });
+    await userEvent.click(screen.getByRole("button", { name: /prefill from template|从模板预填/i }));
+    await screen.findByText("vLLM single");
+    await userEvent.type(screen.getByRole("textbox", { name: /search templates|搜索模板/i }), "vLLM");
+    expect(screen.getByText("vLLM single")).toBeInTheDocument();
+    expect(screen.queryByText("Internal gateway")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state with manage link when no templates exist", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      items: [],
+      nextCursor: null,
+    } satisfies ListBenchmarkTemplatesResponse);
+
+    render(<PrefillFromTemplatePopover scenario="inference" onPick={() => {}} />, { wrapper: Wrapper });
+    await userEvent.click(screen.getByRole("button", { name: /prefill from template|从模板预填/i }));
+    expect(await screen.findByText(/no templates|还没有此场景/i)).toBeInTheDocument();
+    const manage = screen.getByRole("link", { name: /manage templates|去模板库管理/i });
+    expect(manage).toHaveAttribute("href", "/benchmark-templates?scenario=inference");
+  });
+
+  it("calls onPick with the full template object on click", async () => {
+    const t1 = tpl({ id: "t1", name: "vLLM single" });
+    vi.mocked(api.get).mockResolvedValue({
+      items: [t1],
+      nextCursor: null,
+    } satisfies ListBenchmarkTemplatesResponse);
+
+    const onPick = vi.fn();
+    render(<PrefillFromTemplatePopover scenario="inference" onPick={onPick} />, { wrapper: Wrapper });
+    await userEvent.click(screen.getByRole("button", { name: /prefill from template|从模板预填/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /vLLM single/ }));
+    expect(onPick).toHaveBeenCalledWith(expect.objectContaining({ id: "t1", name: "vLLM single" }));
+  });
+});

--- a/apps/web/src/features/benchmarks/__tests__/SaveAsTemplateDialog.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/SaveAsTemplateDialog.test.tsx
@@ -1,0 +1,160 @@
+import "@/lib/i18n";
+import type { Benchmark, BenchmarkTemplate } from "@modeldoctor/contracts";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { Toaster } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SaveAsTemplateDialog } from "../SaveAsTemplateDialog";
+
+vi.mock("@/lib/api-client", () => {
+  class ApiError extends Error {
+    constructor(public status: number, message: string) {
+      super(message);
+    }
+  }
+  return { ApiError, api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), del: vi.fn() } };
+});
+import { api } from "@/lib/api-client";
+
+function makeBenchmark(overrides: Partial<Benchmark> = {}): Benchmark {
+  return {
+    id: "b1",
+    userId: "u1",
+    connectionId: "c1",
+    connection: null,
+    scenario: "inference",
+    tool: "guidellm",
+    toolVersion: null,
+    name: "my run",
+    description: "desc text",
+    status: "completed",
+    statusMessage: null,
+    progress: null,
+    driverHandle: null,
+    params: { foo: "bar" },
+    rawOutput: null,
+    summaryMetrics: null,
+    serverMetrics: null,
+    templateId: null,
+    parentBenchmarkId: null,
+    baselineId: null,
+    baselineFor: null,
+    logs: null,
+    createdAt: "2026-04-30T12:00:00.000Z",
+    startedAt: null,
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return (
+    <QueryClientProvider client={qc}>
+      {children}
+      <Toaster />
+    </QueryClientProvider>
+  );
+}
+
+describe("SaveAsTemplateDialog", () => {
+  beforeEach(() => {
+    vi.mocked(api.post).mockReset();
+  });
+
+  it("prefills name with `${benchmark.name} (template)` suffix", () => {
+    render(
+      <SaveAsTemplateDialog benchmark={makeBenchmark({ name: "vLLM run" })} onOpenChange={() => {}} />,
+      { wrapper: Wrapper },
+    );
+    // The label resolves to "Name" (en-US) / "名称" (zh-CN) via benchmark-templates:create.fields.name.
+    // getByLabelText sees "Name *" (includes aria-hidden asterisk in textContent), so we use a
+    // prefix-anchored pattern to avoid matching "Description" but still catch "Name" and "名称".
+    const nameInput = screen.getByLabelText(/^name|^名称|template name|模板名称/i) as HTMLInputElement;
+    expect(nameInput.value).toBe("vLLM run (template)");
+  });
+
+  it("submits with split tags and forwards scenario+tool+params from benchmark", async () => {
+    const created: BenchmarkTemplate = {
+      id: "tpl-1",
+      name: "vLLM run (template)",
+      description: "desc text",
+      scenario: "inference",
+      tool: "guidellm",
+      config: { foo: "bar" },
+      isOfficial: false,
+      createdBy: "u1",
+      tags: ["a", "b", "c"],
+      createdAt: "2026-05-07T00:00:00.000Z",
+      updatedAt: "2026-05-07T00:00:00.000Z",
+    };
+    vi.mocked(api.post).mockResolvedValue(created);
+    const onOpenChange = vi.fn();
+
+    render(
+      <SaveAsTemplateDialog
+        benchmark={makeBenchmark({ name: "vLLM run", params: { foo: "bar" } })}
+        onOpenChange={onOpenChange}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    await userEvent.type(screen.getByLabelText(/tags|标签/i), "a, b, c");
+    await userEvent.click(screen.getByRole("button", { name: /save|保存/i }));
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith(
+        "/api/benchmark-templates",
+        expect.objectContaining({
+          name: "vLLM run (template)",
+          description: "desc text",
+          scenario: "inference",
+          tool: "guidellm",
+          config: { foo: "bar" },
+          tags: ["a", "b", "c"],
+          isOfficial: false,
+        }),
+      );
+    });
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it("strips empty description from payload", async () => {
+    vi.mocked(api.post).mockResolvedValue({} as BenchmarkTemplate);
+    render(
+      <SaveAsTemplateDialog
+        benchmark={makeBenchmark({ description: null })}
+        onOpenChange={() => {}}
+      />,
+      { wrapper: Wrapper },
+    );
+    await userEvent.click(screen.getByRole("button", { name: /save|保存/i }));
+    await waitFor(() => expect(api.post).toHaveBeenCalled());
+    const body = vi.mocked(api.post).mock.calls[0][1] as Record<string, unknown>;
+    expect(body).not.toHaveProperty("description");
+  });
+
+  it("shows inline error and keeps dialog open on mutation failure", async () => {
+    vi.mocked(api.post).mockRejectedValue(new Error("boom"));
+    const onOpenChange = vi.fn();
+    render(
+      <SaveAsTemplateDialog benchmark={makeBenchmark()} onOpenChange={onOpenChange} />,
+      { wrapper: Wrapper },
+    );
+    await userEvent.click(screen.getByRole("button", { name: /save|保存/i }));
+    // Alert role appears with the localized generic error message.
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+    expect(screen.getByRole("alert").textContent).toMatch(/save as template|保存为模板失败/i);
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("renders nothing when benchmark is null", () => {
+    const { container } = render(
+      <SaveAsTemplateDialog benchmark={null} onOpenChange={() => {}} />,
+      { wrapper: Wrapper },
+    );
+    expect(container.querySelector("[role=dialog]")).toBeNull();
+  });
+});

--- a/apps/web/src/features/benchmarks/__tests__/SaveAsTemplateDialog.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/SaveAsTemplateDialog.test.tsx
@@ -10,7 +10,10 @@ import { SaveAsTemplateDialog } from "../SaveAsTemplateDialog";
 
 vi.mock("@/lib/api-client", () => {
   class ApiError extends Error {
-    constructor(public status: number, message: string) {
+    constructor(
+      public status: number,
+      message: string,
+    ) {
       super(message);
     }
   }
@@ -50,7 +53,9 @@ function makeBenchmark(overrides: Partial<Benchmark> = {}): Benchmark {
 }
 
 function Wrapper({ children }: { children: ReactNode }) {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
   return (
     <QueryClientProvider client={qc}>
       {children}
@@ -66,13 +71,18 @@ describe("SaveAsTemplateDialog", () => {
 
   it("prefills name with `${benchmark.name} (template)` suffix", () => {
     render(
-      <SaveAsTemplateDialog benchmark={makeBenchmark({ name: "vLLM run" })} onOpenChange={() => {}} />,
+      <SaveAsTemplateDialog
+        benchmark={makeBenchmark({ name: "vLLM run" })}
+        onOpenChange={() => {}}
+      />,
       { wrapper: Wrapper },
     );
     // The label resolves to "Name" (en-US) / "名称" (zh-CN) via benchmark-templates:create.fields.name.
     // getByLabelText sees "Name *" (includes aria-hidden asterisk in textContent), so we use a
     // prefix-anchored pattern to avoid matching "Description" but still catch "Name" and "名称".
-    const nameInput = screen.getByLabelText(/^name|^名称|template name|模板名称/i) as HTMLInputElement;
+    const nameInput = screen.getByLabelText(
+      /^name|^名称|template name|模板名称/i,
+    ) as HTMLInputElement;
     expect(nameInput.value).toBe("vLLM run (template)");
   });
 
@@ -139,10 +149,9 @@ describe("SaveAsTemplateDialog", () => {
   it("shows inline error and keeps dialog open on mutation failure", async () => {
     vi.mocked(api.post).mockRejectedValue(new Error("boom"));
     const onOpenChange = vi.fn();
-    render(
-      <SaveAsTemplateDialog benchmark={makeBenchmark()} onOpenChange={onOpenChange} />,
-      { wrapper: Wrapper },
-    );
+    render(<SaveAsTemplateDialog benchmark={makeBenchmark()} onOpenChange={onOpenChange} />, {
+      wrapper: Wrapper,
+    });
     await userEvent.click(screen.getByRole("button", { name: /save|保存/i }));
     // Alert role appears with the localized generic error message.
     expect(await screen.findByRole("alert")).toBeInTheDocument();

--- a/apps/web/src/locales/en-US/benchmark-templates.json
+++ b/apps/web/src/locales/en-US/benchmark-templates.json
@@ -31,6 +31,9 @@
         "title": "No matching results",
         "subtitle": "Try adjusting the search or scenario"
       }
+    },
+    "cards": {
+      "useThisTemplate": "Use this template"
     }
   },
   "create": {

--- a/apps/web/src/locales/en-US/benchmarks.json
+++ b/apps/web/src/locales/en-US/benchmarks.json
@@ -45,6 +45,19 @@
       "title": "{{tool}} does not support '{{category}}' connections",
       "suggestSwitch": "Switch to {{alternatives}} to continue",
       "suggestChangeConnection": "Pick a compatible connection, or choose a different scenario"
+    },
+    "prefillFromTemplate": {
+      "button": "Prefill from template",
+      "search": "Search templates…",
+      "empty": "No templates for this scenario yet",
+      "manage": "→ Manage templates",
+      "applied": "Prefilled from template \"{{name}}\". You can still edit.",
+      "scenarioMismatch": "Template belongs to {{scenario}}; scenario switched",
+      "notFound": "Template not found or deleted"
+    },
+    "prefilledBanner": {
+      "label": "Prefilled from template \"{{name}}\"",
+      "clear": "Clear link"
     }
   },
   "status": {
@@ -86,6 +99,7 @@
     "saveAsTemplate": {
       "label": "Save as template",
       "success": "Saved as template \"{{name}}\"",
+      "disabledTooltip": "Only completed benchmarks can be saved as a template",
       "errors": {
         "generic": "Failed to save as template"
       }
@@ -155,6 +169,9 @@
       "body": "It may have been deleted, or you may not own it."
     },
     "loadError": "Failed to load",
+    "saveAsTemplate": {
+      "button": "Save as template"
+    },
     "delete": {
       "button": "Delete",
       "confirmTitle": "Delete this benchmark?",

--- a/apps/web/src/locales/zh-CN/benchmark-templates.json
+++ b/apps/web/src/locales/zh-CN/benchmark-templates.json
@@ -31,6 +31,9 @@
         "title": "没有匹配的结果",
         "subtitle": "试试调整搜索条件或场景"
       }
+    },
+    "cards": {
+      "useThisTemplate": "使用此模板"
     }
   },
   "create": {

--- a/apps/web/src/locales/zh-CN/benchmarks.json
+++ b/apps/web/src/locales/zh-CN/benchmarks.json
@@ -45,6 +45,19 @@
       "title": "{{tool}} 不支持 {{category}} 类型连接",
       "suggestSwitch": "请改用 {{alternatives}} 继续",
       "suggestChangeConnection": "请更换为兼容的连接，或选择其他场景"
+    },
+    "prefillFromTemplate": {
+      "button": "从模板预填",
+      "search": "搜索模板…",
+      "empty": "还没有此场景的模板",
+      "manage": "→ 去模板库管理",
+      "applied": "已从模板「{{name}}」预填,可继续修改",
+      "scenarioMismatch": "模板属于 {{scenario}},已切换 scenario",
+      "notFound": "模板不存在或已删除"
+    },
+    "prefilledBanner": {
+      "label": "已从模板「{{name}}」预填",
+      "clear": "清除关联"
     }
   },
   "status": {
@@ -86,6 +99,7 @@
     "saveAsTemplate": {
       "label": "保存为模板",
       "success": "已保存为模板「{{name}}」",
+      "disabledTooltip": "仅已完成的 benchmark 可保存为模板",
       "errors": {
         "generic": "保存为模板失败"
       }
@@ -155,6 +169,9 @@
       "body": "可能已被删除，或不属于你的账户。"
     },
     "loadError": "加载失败",
+    "saveAsTemplate": {
+      "button": "保存为模板"
+    },
     "delete": {
       "button": "删除",
       "confirmTitle": "删除这次基准测试？",

--- a/docs/superpowers/plans/2026-05-07-issue-138-benchmark-template-loop.md
+++ b/docs/superpowers/plans/2026-05-07-issue-138-benchmark-template-loop.md
@@ -1,0 +1,1821 @@
+# Issue #138 Benchmark Template Loop — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the loop between `benchmark_templates` and the benchmark main flow — list/detail pages can save current params as a template, create page can prefill from a template (popover or `?templateId` URL), template list page has a "use this template" CTA.
+
+**Architecture:** One shared `SaveAsTemplateDialog` (used by list + detail), one create-page-only `PrefillFromTemplatePopover`, plus targeted edits in 4 existing files. Backend already supports `Benchmark.templateId` provenance — frontend only.
+
+**Tech Stack:** React 18 · react-hook-form 7 + zod · shadcn (Radix) · @tanstack/react-query 5 · react-i18next 14 · Vitest 2 · Tailwind. New top-level dep: `@radix-ui/react-popover` (~5KB gzipped).
+
+**Spec:** `docs/superpowers/specs/2026-05-07-issue-138-benchmark-template-loop-design.md`
+
+**Working tree:** `/Users/fangyong/vllm/modeldoctor/feat-benchmark-template-loop` on branch `feat/benchmark-template-loop` (already created).
+
+**One-time setup before Task 1:**
+
+```bash
+pnpm -r build
+```
+
+This is required after `git worktree add` in this repo — apps/api typecheck depends on `packages/contracts/dist`. Skip if you've run it in this worktree already.
+
+---
+
+## File Map
+
+| Path | Purpose | Action |
+|---|---|---|
+| `apps/web/package.json` | Add `@radix-ui/react-popover` dep | Modify |
+| `apps/web/src/components/ui/popover.tsx` | shadcn Popover primitive | Create |
+| `apps/web/src/locales/zh-CN/benchmarks.json` | New i18n keys (zh) | Modify |
+| `apps/web/src/locales/en-US/benchmarks.json` | New i18n keys (en) | Modify |
+| `apps/web/src/locales/zh-CN/benchmark-templates.json` | "Use this template" CTA (zh) | Modify |
+| `apps/web/src/locales/en-US/benchmark-templates.json` | "Use this template" CTA (en) | Modify |
+| `apps/web/src/features/benchmarks/SaveAsTemplateDialog.tsx` | Shared save-as-template dialog | Create |
+| `apps/web/src/features/benchmarks/__tests__/SaveAsTemplateDialog.test.tsx` | Dialog unit tests | Create |
+| `apps/web/src/features/benchmarks/BenchmarkListShell.tsx` | Replace direct-copy with dialog + status gate | Modify |
+| `apps/web/src/features/benchmarks/__tests__/BenchmarkListShell.test.tsx` | Add status gating test | Modify |
+| `apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx` | Add "save as template" header button | Modify |
+| `apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx` | Status gating tests | Modify |
+| `apps/web/src/features/benchmarks/PrefillFromTemplatePopover.tsx` | Popover with scenario-filtered template list | Create |
+| `apps/web/src/features/benchmarks/__tests__/PrefillFromTemplatePopover.test.tsx` | Popover unit tests | Create |
+| `apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx` | Add popover + URL `?templateId` + banner | Modify |
+| `apps/web/src/features/benchmarks/__tests__/BenchmarkCreatePage.test.tsx` | Prefill behavior tests | Modify |
+| `apps/web/src/features/benchmark-templates/TemplateCard.tsx` | Restructure for "use this template" CTA | Modify |
+| `apps/web/src/features/benchmark-templates/__tests__/TemplateCard.test.tsx` | CTA href test | Create |
+
+---
+
+## Task 1: Add Popover primitive
+
+**Files:**
+- Modify: `apps/web/package.json`
+- Create: `apps/web/src/components/ui/popover.tsx`
+
+- [ ] **Step 1: Install dep**
+
+```bash
+pnpm -F @modeldoctor/web add @radix-ui/react-popover@^1
+```
+
+Expected: `package.json` gains `"@radix-ui/react-popover": "^1.x.x"` in `dependencies`. Lockfile updated.
+
+- [ ] **Step 2: Create primitive**
+
+Write `apps/web/src/components/ui/popover.tsx`:
+
+```tsx
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Popover = PopoverPrimitive.Root;
+const PopoverTrigger = PopoverPrimitive.Trigger;
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverAnchor, PopoverContent };
+```
+
+- [ ] **Step 3: Verify build/types pass**
+
+```bash
+pnpm -F @modeldoctor/web type-check
+```
+
+Expected: PASS (no new errors). Pre-existing errors are not introduced by this change.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/package.json pnpm-lock.yaml apps/web/src/components/ui/popover.tsx
+git commit -m "$(cat <<'EOF'
+build(web): add @radix-ui/react-popover + shadcn Popover primitive
+
+Needed for the prefill-from-template popover on BenchmarkCreatePage.
+Mirrors the shape of the existing dialog/dropdown-menu primitives.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: i18n keys
+
+**Files:**
+- Modify: `apps/web/src/locales/zh-CN/benchmarks.json`
+- Modify: `apps/web/src/locales/en-US/benchmarks.json`
+- Modify: `apps/web/src/locales/zh-CN/benchmark-templates.json`
+- Modify: `apps/web/src/locales/en-US/benchmark-templates.json`
+
+- [ ] **Step 1: Update zh-CN/benchmarks.json**
+
+Inside `rowActions.saveAsTemplate`, add `disabledTooltip`. After `rowActions.saveAsTemplate.errors.generic`:
+
+Find the existing block (around line 86-92):
+```json
+    "saveAsTemplate": {
+      "label": "保存为模板",
+      "success": "已保存为模板「{{name}}」",
+      "errors": {
+        "generic": "保存为模板失败"
+      }
+    }
+```
+
+Replace with:
+```json
+    "saveAsTemplate": {
+      "label": "保存为模板",
+      "success": "已保存为模板「{{name}}」",
+      "disabledTooltip": "仅已完成的 benchmark 可保存为模板",
+      "errors": {
+        "generic": "保存为模板失败"
+      }
+    }
+```
+
+In `detail` block, after the `rerun` sub-object (around line 179-188), add `saveAsTemplate` and `prefilledBanner`:
+
+```json
+    "saveAsTemplate": {
+      "button": "保存为模板"
+    },
+```
+
+After the existing `create` block opening (find `"create": {`), add three new keys at the same level as `title`/`titleByScenario`/etc — leave existing keys untouched, append new ones near the end of the `create` object. Add nested `prefillFromTemplate` and `prefilledBanner`:
+
+```json
+    "prefillFromTemplate": {
+      "button": "从模板预填",
+      "search": "搜索模板…",
+      "empty": "还没有此场景的模板",
+      "manage": "→ 去模板库管理",
+      "applied": "已从模板「{{name}}」预填,可继续修改",
+      "scenarioMismatch": "模板属于 {{scenario}},已切换 scenario",
+      "notFound": "模板不存在或已删除"
+    },
+    "prefilledBanner": {
+      "label": "已从模板「{{name}}」预填",
+      "clear": "清除关联"
+    }
+```
+
+After modification, validate JSON parses:
+```bash
+node -e "JSON.parse(require('fs').readFileSync('apps/web/src/locales/zh-CN/benchmarks.json','utf8'))"
+```
+Expected: no output (valid JSON).
+
+- [ ] **Step 2: Update en-US/benchmarks.json mirroring same structure**
+
+Apply the same key additions with English values:
+
+In `rowActions.saveAsTemplate` add:
+```json
+"disabledTooltip": "Only completed benchmarks can be saved as a template"
+```
+
+In `detail` add:
+```json
+"saveAsTemplate": { "button": "Save as template" },
+```
+
+In `create` add:
+```json
+"prefillFromTemplate": {
+  "button": "Prefill from template",
+  "search": "Search templates…",
+  "empty": "No templates for this scenario yet",
+  "manage": "→ Manage templates",
+  "applied": "Prefilled from template \"{{name}}\". You can still edit.",
+  "scenarioMismatch": "Template belongs to {{scenario}}; scenario switched",
+  "notFound": "Template not found or deleted"
+},
+"prefilledBanner": {
+  "label": "Prefilled from template \"{{name}}\"",
+  "clear": "Clear link"
+}
+```
+
+Validate:
+```bash
+node -e "JSON.parse(require('fs').readFileSync('apps/web/src/locales/en-US/benchmarks.json','utf8'))"
+```
+
+- [ ] **Step 3: Update zh-CN/benchmark-templates.json**
+
+Find the `list` object (around line 17-31). Inside `list`, **after** the existing `empty` block (around line 27-35), add a new `cards` block at the same level:
+
+```json
+    "cards": {
+      "useThisTemplate": "使用此模板"
+    }
+```
+
+So the `list` object now has both `empty` and `cards` as children.
+
+Validate JSON.
+
+- [ ] **Step 4: Update en-US/benchmark-templates.json**
+
+Same shape, English values:
+
+```json
+    "cards": {
+      "useThisTemplate": "Use this template"
+    }
+```
+
+Validate JSON.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/locales
+git commit -m "$(cat <<'EOF'
+feat(web/i18n): add benchmark template loop strings
+
+Adds disabled-tooltip + dialog title for "save as template", popover
+labels + applied/mismatch/not-found toasts + prefilled banner copy
+for the create page, and the "use this template" CTA on cards.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: SaveAsTemplateDialog component (TDD)
+
+**Files:**
+- Create: `apps/web/src/features/benchmarks/SaveAsTemplateDialog.tsx`
+- Create: `apps/web/src/features/benchmarks/__tests__/SaveAsTemplateDialog.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+Write `apps/web/src/features/benchmarks/__tests__/SaveAsTemplateDialog.test.tsx`:
+
+```tsx
+import "@/lib/i18n";
+import type { Benchmark, BenchmarkTemplate } from "@modeldoctor/contracts";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { Toaster } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SaveAsTemplateDialog } from "../SaveAsTemplateDialog";
+
+vi.mock("@/lib/api-client", () => {
+  class ApiError extends Error {
+    constructor(public status: number, message: string) {
+      super(message);
+    }
+  }
+  return { ApiError, api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), del: vi.fn() } };
+});
+import { api } from "@/lib/api-client";
+
+function makeBenchmark(overrides: Partial<Benchmark> = {}): Benchmark {
+  return {
+    id: "b1",
+    userId: "u1",
+    connectionId: "c1",
+    connection: null,
+    scenario: "inference",
+    tool: "guidellm",
+    toolVersion: null,
+    name: "my run",
+    description: "desc text",
+    status: "completed",
+    statusMessage: null,
+    progress: null,
+    driverHandle: null,
+    params: { foo: "bar" },
+    rawOutput: null,
+    summaryMetrics: null,
+    serverMetrics: null,
+    templateId: null,
+    parentBenchmarkId: null,
+    baselineId: null,
+    baselineFor: null,
+    logs: null,
+    createdAt: "2026-04-30T12:00:00.000Z",
+    startedAt: null,
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return (
+    <QueryClientProvider client={qc}>
+      {children}
+      <Toaster />
+    </QueryClientProvider>
+  );
+}
+
+describe("SaveAsTemplateDialog", () => {
+  beforeEach(() => {
+    vi.mocked(api.post).mockReset();
+  });
+
+  it("prefills name with `${benchmark.name} (template)` suffix", () => {
+    render(
+      <SaveAsTemplateDialog benchmark={makeBenchmark({ name: "vLLM run" })} onOpenChange={() => {}} />,
+      { wrapper: Wrapper },
+    );
+    const nameInput = screen.getByLabelText(/template name|模板名称/i) as HTMLInputElement;
+    expect(nameInput.value).toBe("vLLM run (template)");
+  });
+
+  it("submits with split tags and forwards scenario+tool+params from benchmark", async () => {
+    const created: BenchmarkTemplate = {
+      id: "tpl-1",
+      name: "vLLM run (template)",
+      description: "desc text",
+      scenario: "inference",
+      tool: "guidellm",
+      config: { foo: "bar" },
+      isOfficial: false,
+      createdBy: "u1",
+      tags: ["a", "b", "c"],
+      createdAt: "2026-05-07T00:00:00.000Z",
+      updatedAt: "2026-05-07T00:00:00.000Z",
+    };
+    vi.mocked(api.post).mockResolvedValue(created);
+    const onOpenChange = vi.fn();
+
+    render(
+      <SaveAsTemplateDialog
+        benchmark={makeBenchmark({ name: "vLLM run", params: { foo: "bar" } })}
+        onOpenChange={onOpenChange}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    await userEvent.type(screen.getByLabelText(/tags|标签/i), "a, b, c");
+    await userEvent.click(screen.getByRole("button", { name: /save|保存/i }));
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith(
+        "/api/benchmark-templates",
+        expect.objectContaining({
+          name: "vLLM run (template)",
+          description: "desc text",
+          scenario: "inference",
+          tool: "guidellm",
+          config: { foo: "bar" },
+          tags: ["a", "b", "c"],
+          isOfficial: false,
+        }),
+      );
+    });
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it("strips empty description from payload", async () => {
+    vi.mocked(api.post).mockResolvedValue({} as BenchmarkTemplate);
+    render(
+      <SaveAsTemplateDialog
+        benchmark={makeBenchmark({ description: null })}
+        onOpenChange={() => {}}
+      />,
+      { wrapper: Wrapper },
+    );
+    await userEvent.click(screen.getByRole("button", { name: /save|保存/i }));
+    await waitFor(() => expect(api.post).toHaveBeenCalled());
+    const body = vi.mocked(api.post).mock.calls[0][1] as Record<string, unknown>;
+    expect(body).not.toHaveProperty("description");
+  });
+
+  it("shows inline error and keeps dialog open on mutation failure", async () => {
+    vi.mocked(api.post).mockRejectedValue(new Error("boom"));
+    const onOpenChange = vi.fn();
+    render(
+      <SaveAsTemplateDialog benchmark={makeBenchmark()} onOpenChange={onOpenChange} />,
+      { wrapper: Wrapper },
+    );
+    await userEvent.click(screen.getByRole("button", { name: /save|保存/i }));
+    expect(await screen.findByText(/save as template|保存为模板失败/i)).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("renders nothing when benchmark is null", () => {
+    const { container } = render(
+      <SaveAsTemplateDialog benchmark={null} onOpenChange={() => {}} />,
+      { wrapper: Wrapper },
+    );
+    expect(container.querySelector("[role=dialog]")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+pnpm -F @modeldoctor/web test -- SaveAsTemplateDialog
+```
+
+Expected: FAIL with "Cannot find module '../SaveAsTemplateDialog'" or similar.
+
+- [ ] **Step 3: Implement component**
+
+Write `apps/web/src/features/benchmarks/SaveAsTemplateDialog.tsx`:
+
+```tsx
+import { FormActions } from "@/components/common/form-actions";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { useCreateTemplate } from "@/features/benchmark-templates/queries";
+import type { Benchmark } from "@modeldoctor/contracts";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { z } from "zod";
+
+const formSchema = z.object({
+  name: z.string().trim().min(1).max(100),
+  description: z.string().trim().max(2048).optional(),
+  tagsInput: z.string().optional(),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+export interface SaveAsTemplateDialogProps {
+  /** When null the dialog is closed; pass the benchmark to open. */
+  benchmark: Benchmark | null;
+  onOpenChange: (open: boolean) => void;
+}
+
+function defaultName(benchmarkName: string): string {
+  // Schema caps name at 100. " (template)" is 11 chars; reserve 89 for the source name.
+  const trimmed = benchmarkName.length > 89 ? benchmarkName.slice(0, 89) : benchmarkName;
+  return `${trimmed} (template)`;
+}
+
+export function SaveAsTemplateDialog({ benchmark, onOpenChange }: SaveAsTemplateDialogProps) {
+  const { t } = useTranslation("benchmarks");
+  const create = useCreateTemplate();
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    mode: "onTouched",
+    defaultValues: { name: "", description: undefined, tagsInput: "" },
+  });
+
+  // Re-seed defaults whenever the dialog re-opens with a (possibly different) benchmark.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: form ref is stable
+  useEffect(() => {
+    if (benchmark) {
+      form.reset({
+        name: defaultName(benchmark.name),
+        description: benchmark.description ?? undefined,
+        tagsInput: "",
+      });
+      setSubmitError(null);
+    }
+  }, [benchmark?.id]);
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    if (!benchmark) return;
+    const tags = (values.tagsInput ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    setSubmitError(null);
+    try {
+      const next = await create.mutateAsync({
+        name: values.name,
+        ...(values.description ? { description: values.description } : {}),
+        scenario: benchmark.scenario,
+        tool: benchmark.tool,
+        config: benchmark.params as Record<string, unknown>,
+        tags,
+        isOfficial: false,
+      });
+      toast.success(t("rowActions.saveAsTemplate.success", { name: next.name }));
+      onOpenChange(false);
+    } catch (e) {
+      setSubmitError((e as Error).message || t("rowActions.saveAsTemplate.errors.generic"));
+    }
+  });
+
+  return (
+    <Dialog open={benchmark !== null} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <Form {...form}>
+          <form onSubmit={onSubmit} className="space-y-4">
+            <DialogHeader>
+              <DialogTitle>{t("detail.saveAsTemplate.button")}</DialogTitle>
+              <DialogDescription>
+                {t("rowActions.saveAsTemplate.label")}
+              </DialogDescription>
+            </DialogHeader>
+
+            {submitError && (
+              <Alert variant="destructive">
+                <AlertDescription>{submitError}</AlertDescription>
+              </Alert>
+            )}
+
+            <div className="space-y-3">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel required>
+                      {t("benchmark-templates:create.fields.name", { defaultValue: "Template name" })}
+                    </FormLabel>
+                    <FormControl>
+                      <Input maxLength={100} {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("benchmark-templates:create.fields.description", { defaultValue: "Description" })}
+                    </FormLabel>
+                    <FormControl>
+                      <Textarea
+                        rows={2}
+                        {...field}
+                        value={field.value ?? ""}
+                        onChange={(e) =>
+                          field.onChange(e.target.value === "" ? undefined : e.target.value)
+                        }
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="tagsInput"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("benchmark-templates:create.fields.tags", { defaultValue: "Tags" })}
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder={t("detail.baseline.dialog.tagsLabel", { defaultValue: "" })}
+                        {...field}
+                        value={field.value ?? ""}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <DialogFooter>
+              <FormActions
+                onCancel={() => onOpenChange(false)}
+                cancelLabel={t("detail.baseline.dialog.cancel")}
+                submitLabel={t("detail.baseline.dialog.submit")}
+                disabled={!form.formState.isValid}
+                pending={create.isPending}
+              />
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+```bash
+pnpm -F @modeldoctor/web test -- SaveAsTemplateDialog
+```
+
+Expected: all 5 tests PASS.
+
+If `screen.getByLabelText(/template name|模板名称/i)` fails because the i18n label resolves differently, check that `apps/web/src/lib/i18n.ts` registers both `benchmarks` and `benchmark-templates` namespaces (it does — see existing imports).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/features/benchmarks/SaveAsTemplateDialog.tsx \
+        apps/web/src/features/benchmarks/__tests__/SaveAsTemplateDialog.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(web/benchmarks): add shared SaveAsTemplateDialog
+
+Used by BenchmarkListShell + BenchmarkDetailPage to save the current
+benchmark's params as a reusable template. Name/description/tags are
+editable; scenario/tool/config come straight from the source benchmark.
+Inline error on mutation failure keeps the dialog open.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Wire SaveAsTemplateDialog into BenchmarkListShell
+
+**Files:**
+- Modify: `apps/web/src/features/benchmarks/BenchmarkListShell.tsx`
+- Modify: `apps/web/src/features/benchmarks/__tests__/BenchmarkListShell.test.tsx`
+
+- [ ] **Step 1: Add failing test**
+
+Append to `apps/web/src/features/benchmarks/__tests__/BenchmarkListShell.test.tsx` (inside the existing `describe("BenchmarkListShell", ...)` block):
+
+```tsx
+  it("save-as-template menu item is disabled for non-completed rows", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      items: [makeBenchmark("r1", "guidellm", "running", null)],
+      nextCursor: null,
+    } satisfies ListBenchmarksResponse);
+    render(<BenchmarkListShell scenario="inference" />, { wrapper: Wrapper });
+    await screen.findByText("r1");
+    await userEvent.click(screen.getByRole("button", { name: /more|更多/i }));
+    const menuItem = await screen.findByRole("menuitem", { name: /save as template|保存为模板/i });
+    expect(menuItem).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("save-as-template menu item opens dialog for completed rows", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      items: [makeBenchmark("r1", "guidellm", "completed", guidellmMetrics)],
+      nextCursor: null,
+    } satisfies ListBenchmarksResponse);
+    render(<BenchmarkListShell scenario="inference" />, { wrapper: Wrapper });
+    await screen.findByText("r1");
+    await userEvent.click(screen.getByRole("button", { name: /more|更多/i }));
+    const menuItem = await screen.findByRole("menuitem", { name: /save as template|保存为模板/i });
+    await userEvent.click(menuItem);
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+pnpm -F @modeldoctor/web test -- BenchmarkListShell
+```
+
+Expected: 2 new tests fail (the menu item is currently always enabled and there's no dialog).
+
+- [ ] **Step 3: Edit BenchmarkListShell.tsx**
+
+Apply 3 edits.
+
+**Edit 1**: Replace the `handleSaveAsTemplate` function (currently lines 154-171). Find:
+
+```tsx
+  async function handleSaveAsTemplate(b: Benchmark) {
+    const trimmed = b.name.length > 90 ? b.name.slice(0, 90) : b.name;
+    const newName = `${trimmed} (template)`;
+    try {
+      const next = await createTemplate.mutateAsync({
+        name: newName,
+        description: b.description ?? undefined,
+        scenario: b.scenario,
+        tool: b.tool,
+        config: b.params as Record<string, unknown>,
+        tags: [],
+        isOfficial: false,
+      });
+      toast.success(t("rowActions.saveAsTemplate.success", { name: next.name }));
+    } catch (e) {
+      toast.error((e as Error).message || t("rowActions.saveAsTemplate.errors.generic"));
+    }
+  }
+```
+
+Delete this block. Also delete the now-unused `createTemplate` declaration at line 122 and the unused `useCreateTemplate` import at line 32.
+
+**Edit 2**: Add a new state, near `pendingDeleteId`:
+
+Find:
+```tsx
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+```
+
+Insert after it:
+```tsx
+  const [saveTplBenchmark, setSaveTplBenchmark] = useState<Benchmark | null>(null);
+```
+
+**Edit 3**: Replace the DropdownMenuItem for save-as-template (currently lines 393-400):
+
+Find:
+```tsx
+                            <DropdownMenuItem
+                              onClick={() => handleSaveAsTemplate(benchmark)}
+                              disabled={createTemplate.isPending}
+                              className="gap-2"
+                            >
+                              <CopyIcon className="h-4 w-4" />
+                              {t("rowActions.saveAsTemplate.label")}
+                            </DropdownMenuItem>
+```
+
+Replace with:
+```tsx
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span>
+                                  <DropdownMenuItem
+                                    onClick={(e) => {
+                                      if (benchmark.status !== "completed") {
+                                        e.preventDefault();
+                                        return;
+                                      }
+                                      setSaveTplBenchmark(benchmark);
+                                    }}
+                                    disabled={benchmark.status !== "completed"}
+                                    className="gap-2"
+                                  >
+                                    <CopyIcon className="h-4 w-4" />
+                                    {t("rowActions.saveAsTemplate.label")}
+                                  </DropdownMenuItem>
+                                </span>
+                              </TooltipTrigger>
+                              {benchmark.status !== "completed" && (
+                                <TooltipContent>
+                                  {t("rowActions.saveAsTemplate.disabledTooltip")}
+                                </TooltipContent>
+                              )}
+                            </Tooltip>
+```
+
+**Edit 4**: Add the dialog at the bottom, just before the closing `</>`. Find:
+
+```tsx
+      </AlertDialog>
+    </>
+  );
+}
+```
+
+Insert before `</>`:
+```tsx
+      <SaveAsTemplateDialog
+        benchmark={saveTplBenchmark}
+        onOpenChange={(o) => !o && setSaveTplBenchmark(null)}
+      />
+```
+
+**Edit 5**: Add import at top:
+```tsx
+import { SaveAsTemplateDialog } from "./SaveAsTemplateDialog";
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+```bash
+pnpm -F @modeldoctor/web test -- BenchmarkListShell
+```
+
+Expected: ALL pass (existing + 2 new).
+
+- [ ] **Step 5: Type-check**
+
+```bash
+pnpm -F @modeldoctor/web type-check
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/features/benchmarks/BenchmarkListShell.tsx \
+        apps/web/src/features/benchmarks/__tests__/BenchmarkListShell.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(web/benchmarks): list page save-as-template dialog + status gate
+
+Replaces the silent ${name} (template) copy with the shared
+SaveAsTemplateDialog and disables the menu item (with tooltip) for
+non-completed rows.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Add save-as-template button to BenchmarkDetailPage
+
+**Files:**
+- Modify: `apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx`
+- Modify: `apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx`
+
+- [ ] **Step 1: Add failing test**
+
+Append three cases inside the existing `describe("BenchmarkDetailPage", ...)` block (uses the file-local `makeBenchmark` and `Wrapper` helpers already defined at the top of the file):
+
+```tsx
+  it("renders Save-as-Template button when status is completed", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(makeBenchmark({ status: "completed" }));
+    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
+    expect(
+      await screen.findByRole("button", { name: /save as template|保存为模板/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides Save-as-Template button when status is failed", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(
+      makeBenchmark({ status: "failed", statusMessage: "boom" }),
+    );
+    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
+    // Wait for the page to settle on a non-button anchor we know exists for failed:
+    await screen.findByText(/boom/);
+    expect(
+      screen.queryByRole("button", { name: /save as template|保存为模板/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Save-as-Template button when status is running", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(
+      makeBenchmark({ status: "running", summaryMetrics: null }),
+    );
+    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
+    // Wait for the running placeholder so we know the page is past initial loading:
+    await screen.findByText(/Running|运行中/);
+    expect(
+      screen.queryByRole("button", { name: /save as template|保存为模板/i }),
+    ).not.toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+pnpm -F @modeldoctor/web test -- BenchmarkDetailPage
+```
+
+Expected: 2 new tests fail (no such button exists).
+
+- [ ] **Step 3: Edit BenchmarkDetailPage.tsx**
+
+**Edit 1**: Add imports near the existing icon imports (line ~22):
+```tsx
+import { ArrowLeft, Copy, Loader2, RefreshCw, SearchX } from "lucide-react";
+```
+(Add `Copy` to the existing import list — preserve alphabetical order.)
+
+Add after the `SetBaselineDialog` import:
+```tsx
+import { SaveAsTemplateDialog } from "./SaveAsTemplateDialog";
+```
+
+**Edit 2**: Add new state alongside the others (near line 113):
+```tsx
+  const [saveTplOpen, setSaveTplOpen] = useState(false);
+```
+
+**Edit 3**: Insert the new button in the header `rightSlot`. Find the rerun block (lines 218-241, the conditional `{isTerminal && (canRerun ? ... : ...)}`). Immediately AFTER that block and BEFORE the cancel block (`{!isTerminal && ...`), insert:
+
+```tsx
+            {isTerminal && benchmark.status === "completed" && (
+              <Button variant="outline" size="sm" onClick={() => setSaveTplOpen(true)}>
+                <Copy className="mr-1 h-4 w-4" />
+                {t("detail.saveAsTemplate.button")}
+              </Button>
+            )}
+```
+
+**Edit 4**: At the end of the JSX (after the last `<AlertDialog>` for cancel, just before the closing `</>`), insert:
+
+```tsx
+      <SaveAsTemplateDialog
+        benchmark={saveTplOpen ? benchmark : null}
+        onOpenChange={setSaveTplOpen}
+      />
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm -F @modeldoctor/web test -- BenchmarkDetailPage
+```
+
+Expected: all PASS (incl. 2 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx \
+        apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(web/benchmarks): detail page save-as-template button
+
+Header button shown only when status === "completed". Reuses the
+shared SaveAsTemplateDialog from the list page.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: PrefillFromTemplatePopover component (TDD)
+
+**Files:**
+- Create: `apps/web/src/features/benchmarks/PrefillFromTemplatePopover.tsx`
+- Create: `apps/web/src/features/benchmarks/__tests__/PrefillFromTemplatePopover.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+Write `apps/web/src/features/benchmarks/__tests__/PrefillFromTemplatePopover.test.tsx`:
+
+```tsx
+import "@/lib/i18n";
+import type { BenchmarkTemplate, ListBenchmarkTemplatesResponse } from "@modeldoctor/contracts";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PrefillFromTemplatePopover } from "../PrefillFromTemplatePopover";
+
+vi.mock("@/lib/api-client", () => {
+  class ApiError extends Error {
+    constructor(public status: number, message: string) {
+      super(message);
+    }
+  }
+  return { ApiError, api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), del: vi.fn() } };
+});
+import { api } from "@/lib/api-client";
+
+function tpl(overrides: Partial<BenchmarkTemplate> = {}): BenchmarkTemplate {
+  return {
+    id: "tpl-1",
+    name: "vLLM single concurrency",
+    description: "official low-load",
+    scenario: "inference",
+    tool: "guidellm",
+    config: {},
+    isOfficial: true,
+    createdBy: null,
+    tags: ["official"],
+    createdAt: "2026-05-07T00:00:00.000Z",
+    updatedAt: "2026-05-07T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe("PrefillFromTemplatePopover", () => {
+  beforeEach(() => vi.mocked(api.get).mockReset());
+
+  it("opens, lists templates filtered by current scenario", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      items: [tpl({ id: "t1", name: "vLLM single" }), tpl({ id: "t2", name: "Internal gateway", tool: "vegeta" })],
+      nextCursor: null,
+    } satisfies ListBenchmarkTemplatesResponse);
+
+    render(<PrefillFromTemplatePopover scenario="inference" onPick={() => {}} />, { wrapper: Wrapper });
+    await userEvent.click(screen.getByRole("button", { name: /prefill from template|从模板预填/i }));
+    expect(await screen.findByText("vLLM single")).toBeInTheDocument();
+    expect(screen.getByText("Internal gateway")).toBeInTheDocument();
+    // Verify the api was called with scenario filter:
+    await waitFor(() =>
+      expect(api.get).toHaveBeenCalledWith(expect.stringContaining("scenario=inference")),
+    );
+  });
+
+  it("filters items locally by search input", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      items: [tpl({ id: "t1", name: "vLLM single" }), tpl({ id: "t2", name: "Internal gateway" })],
+      nextCursor: null,
+    } satisfies ListBenchmarkTemplatesResponse);
+
+    render(<PrefillFromTemplatePopover scenario="inference" onPick={() => {}} />, { wrapper: Wrapper });
+    await userEvent.click(screen.getByRole("button", { name: /prefill from template|从模板预填/i }));
+    await screen.findByText("vLLM single");
+    await userEvent.type(screen.getByRole("textbox", { name: /search templates|搜索模板/i }), "vLLM");
+    expect(screen.getByText("vLLM single")).toBeInTheDocument();
+    expect(screen.queryByText("Internal gateway")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state with manage link when no templates exist", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      items: [],
+      nextCursor: null,
+    } satisfies ListBenchmarkTemplatesResponse);
+
+    render(<PrefillFromTemplatePopover scenario="inference" onPick={() => {}} />, { wrapper: Wrapper });
+    await userEvent.click(screen.getByRole("button", { name: /prefill from template|从模板预填/i }));
+    expect(await screen.findByText(/no templates|还没有此场景/i)).toBeInTheDocument();
+    const manage = screen.getByRole("link", { name: /manage templates|去模板库管理/i });
+    expect(manage).toHaveAttribute("href", "/benchmark-templates?scenario=inference");
+  });
+
+  it("calls onPick with the full template object on click", async () => {
+    const t1 = tpl({ id: "t1", name: "vLLM single" });
+    vi.mocked(api.get).mockResolvedValue({
+      items: [t1],
+      nextCursor: null,
+    } satisfies ListBenchmarkTemplatesResponse);
+
+    const onPick = vi.fn();
+    render(<PrefillFromTemplatePopover scenario="inference" onPick={onPick} />, { wrapper: Wrapper });
+    await userEvent.click(screen.getByRole("button", { name: /prefill from template|从模板预填/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /vLLM single/ }));
+    expect(onPick).toHaveBeenCalledWith(expect.objectContaining({ id: "t1", name: "vLLM single" }));
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+```bash
+pnpm -F @modeldoctor/web test -- PrefillFromTemplatePopover
+```
+
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement component**
+
+Write `apps/web/src/features/benchmarks/PrefillFromTemplatePopover.tsx`:
+
+```tsx
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useTemplates } from "@/features/benchmark-templates/queries";
+import type { BenchmarkTemplate, ScenarioId } from "@modeldoctor/contracts";
+import { Layers, ShieldCheck } from "lucide-react";
+import { useId, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+
+interface PrefillFromTemplatePopoverProps {
+  scenario: ScenarioId;
+  onPick: (template: BenchmarkTemplate) => void;
+}
+
+export function PrefillFromTemplatePopover({ scenario, onPick }: PrefillFromTemplatePopoverProps) {
+  const { t } = useTranslation("benchmarks");
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const searchId = useId();
+
+  const { data } = useTemplates({ scenario, limit: 50 });
+  const items = data?.pages.flatMap((p) => p.items) ?? [];
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter(
+      (it) =>
+        it.name.toLowerCase().includes(q) ||
+        (it.description ?? "").toLowerCase().includes(q) ||
+        it.tags.some((tag) => tag.toLowerCase().includes(q)),
+    );
+  }, [items, search]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Layers className="mr-1 h-4 w-4" />
+          {t("create.prefillFromTemplate.button")}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-96 p-0" align="end">
+        <div className="border-b p-2">
+          <Input
+            id={searchId}
+            aria-label={t("create.prefillFromTemplate.search")}
+            placeholder={t("create.prefillFromTemplate.search")}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="h-8"
+          />
+        </div>
+        <div className="max-h-72 overflow-auto">
+          {filtered.length === 0 ? (
+            <div className="p-3 text-sm text-muted-foreground">
+              {t("create.prefillFromTemplate.empty")}
+            </div>
+          ) : (
+            <ul className="divide-y">
+              {filtered.map((it) => (
+                <li key={it.id}>
+                  <button
+                    type="button"
+                    className="flex w-full flex-col gap-1 px-3 py-2 text-left hover:bg-accent"
+                    onClick={() => {
+                      onPick(it);
+                      setOpen(false);
+                    }}
+                  >
+                    <span className="flex items-center gap-1 text-sm font-medium">
+                      {it.isOfficial && <ShieldCheck className="h-3.5 w-3.5 text-primary" aria-hidden />}
+                      <span className="truncate">{it.name}</span>
+                    </span>
+                    <span className="flex flex-wrap items-center gap-1.5">
+                      <Badge variant="outline" className="text-xs">
+                        {it.tool}
+                      </Badge>
+                      {it.tags.slice(0, 3).map((tag) => (
+                        <Badge key={tag} variant="outline" className="text-xs">
+                          {tag}
+                        </Badge>
+                      ))}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div className="border-t p-2">
+          <Link
+            to={`/benchmark-templates?scenario=${scenario}`}
+            className="block px-1 text-xs text-muted-foreground hover:text-foreground"
+            onClick={() => setOpen(false)}
+          >
+            {t("create.prefillFromTemplate.manage")}
+          </Link>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+```bash
+pnpm -F @modeldoctor/web test -- PrefillFromTemplatePopover
+```
+
+Expected: ALL pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/features/benchmarks/PrefillFromTemplatePopover.tsx \
+        apps/web/src/features/benchmarks/__tests__/PrefillFromTemplatePopover.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(web/benchmarks): add PrefillFromTemplatePopover
+
+Compact popover that lists templates filtered by the current scenario,
+supports local search, and emits a picked template via onPick. Empty
+state and footer link both route to /benchmark-templates.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Wire prefill into BenchmarkCreatePage
+
+**Files:**
+- Modify: `apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx`
+- Modify: `apps/web/src/features/benchmarks/__tests__/BenchmarkCreatePage.test.tsx`
+
+- [ ] **Step 1: Add failing test**
+
+The existing test file uses `vi.mock("../queries", ...)` for `useCreateBenchmark`. We add a parallel mock for `@/features/benchmark-templates/queries`. Insert at the top of the file, alongside the existing mocks:
+
+```tsx
+const mockUseTemplate = vi.fn();
+vi.mock("@/features/benchmark-templates/queries", () => ({
+  useTemplate: (...args: unknown[]) => mockUseTemplate(...args),
+  useTemplates: () => ({ data: { pages: [{ items: [], nextCursor: null }] }, isLoading: false }),
+  useCreateTemplate: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+}));
+```
+
+Then add a `beforeEach` (also at the top of `describe`):
+```tsx
+beforeEach(() => {
+  mockUseTemplate.mockReturnValue({ data: undefined, isError: false });
+});
+```
+
+Then append three test cases to the existing `describe("BenchmarkCreatePage", ...)`:
+
+```tsx
+  it("prefills form when ?templateId= present in URL", async () => {
+    mockUseTemplate.mockReturnValue({
+      data: {
+        id: "tpl-1",
+        name: "preset",
+        description: null,
+        scenario: "inference",
+        tool: "guidellm",
+        config: { profile: "throughput" },
+        isOfficial: false,
+        createdBy: null,
+        tags: [],
+        createdAt: "2026-05-07T00:00:00.000Z",
+        updatedAt: "2026-05-07T00:00:00.000Z",
+      },
+      isError: false,
+    });
+    renderAt("/benchmarks/new?scenario=inference&templateId=tpl-1");
+    // Wait for prefill effect to fire:
+    await waitFor(() => {
+      const nameInput = screen.getByLabelText(/Name|名称/i) as HTMLInputElement;
+      expect(nameInput.value).toBe("preset");
+    });
+  });
+
+  it("shows prefilled banner with clear-link button when templateId is set", async () => {
+    mockUseTemplate.mockReturnValue({
+      data: {
+        id: "tpl-1",
+        name: "preset",
+        description: null,
+        scenario: "inference",
+        tool: "guidellm",
+        config: { profile: "throughput" },
+        isOfficial: false,
+        createdBy: null,
+        tags: [],
+        createdAt: "2026-05-07T00:00:00.000Z",
+        updatedAt: "2026-05-07T00:00:00.000Z",
+      },
+      isError: false,
+    });
+    renderAt("/benchmarks/new?scenario=inference&templateId=tpl-1");
+    expect(await screen.findByText(/prefilled from template|已从模板/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /clear link|清除关联/i })).toBeInTheDocument();
+  });
+
+  it("clear-link button strips templateId but keeps params", async () => {
+    mockUseTemplate.mockReturnValue({
+      data: {
+        id: "tpl-1",
+        name: "preset",
+        description: null,
+        scenario: "inference",
+        tool: "guidellm",
+        config: { profile: "throughput" },
+        isOfficial: false,
+        createdBy: null,
+        tags: [],
+        createdAt: "2026-05-07T00:00:00.000Z",
+        updatedAt: "2026-05-07T00:00:00.000Z",
+      },
+      isError: false,
+    });
+    renderAt("/benchmarks/new?scenario=inference&templateId=tpl-1");
+    await screen.findByText(/prefilled from template|已从模板/i);
+    const { default: userEvent } = await import("@testing-library/user-event");
+    await userEvent.click(screen.getByRole("button", { name: /clear link|清除关联/i }));
+    // Banner gone…
+    expect(screen.queryByText(/prefilled from template|已从模板/i)).not.toBeInTheDocument();
+    // …but Name field still has "preset"
+    const nameInput = screen.getByLabelText(/Name|名称/i) as HTMLInputElement;
+    expect(nameInput.value).toBe("preset");
+  });
+```
+
+Make sure `waitFor` is in the testing-library imports at the top:
+```tsx
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+pnpm -F @modeldoctor/web test -- BenchmarkCreatePage
+```
+
+Expected: 2 new tests fail.
+
+- [ ] **Step 3: Edit BenchmarkCreatePage.tsx**
+
+**Edit 1**: Imports — add to existing imports:
+
+```tsx
+import { Button } from "@/components/ui/button";
+import { useTemplate } from "@/features/benchmark-templates/queries";
+import { X } from "lucide-react";
+import { useEffect, useRef } from "react";  // adjust if useEffect already imported
+import { toast } from "sonner";  // already imported
+import { PrefillFromTemplatePopover } from "./PrefillFromTemplatePopover";
+import type { BenchmarkTemplate } from "@modeldoctor/contracts";
+```
+
+(Merge with existing imports; don't duplicate.)
+
+**Edit 2**: Inside `BenchmarkCreatePage`, after the existing `defaultTool` derivation (before `useForm`), read the templateId param:
+
+```tsx
+  const templateIdParam = params.get("templateId");
+```
+
+**Edit 3**: Update `defaultValues` in `useForm` — add `templateId: undefined`:
+
+```tsx
+    defaultValues: {
+      tool: defaultTool,
+      scenario,
+      connectionId: "",
+      name: "",
+      description: undefined,
+      params: TOOL_DEFAULTS[defaultTool] as Record<string, unknown>,
+      templateId: undefined,
+    },
+```
+
+Same in the `useEffect([scenario])` reset block — add `templateId: undefined` so changing scenario clears prefill.
+
+**Edit 4**: Add the templateId hook + `applyTemplate` + URL-prefill effect, after the `useEffect([scenario])`:
+
+```tsx
+  const tplQuery = useTemplate(templateIdParam ?? undefined);
+
+  function applyTemplate(template: BenchmarkTemplate) {
+    if (template.scenario !== scenario) {
+      toast.warning(
+        t("create.prefillFromTemplate.scenarioMismatch", { scenario: template.scenario }),
+      );
+    }
+    form.reset({
+      tool: template.tool,
+      scenario: template.scenario,
+      connectionId: form.getValues("connectionId") ?? "",
+      name: template.name,
+      description: template.description ?? undefined,
+      params: template.config,
+      templateId: template.id,
+    });
+    toast.info(t("create.prefillFromTemplate.applied", { name: template.name }));
+  }
+
+  // One-shot prefill from URL ?templateId=
+  const hasAppliedRef = useRef(false);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: applyTemplate is stable enough; we only want to run when template loads
+  useEffect(() => {
+    if (tplQuery.data && !hasAppliedRef.current) {
+      applyTemplate(tplQuery.data);
+      hasAppliedRef.current = true;
+    }
+  }, [tplQuery.data]);
+
+  // 404 / fetch error: toast + drop the bad URL param
+  useEffect(() => {
+    if (templateIdParam && tplQuery.isError) {
+      toast.error(t("create.prefillFromTemplate.notFound"));
+      const next = new URLSearchParams(params);
+      next.delete("templateId");
+      // setSearchParams isn't currently destructured — destructure both:
+      setSearchParams(next, { replace: true });
+    }
+  }, [templateIdParam, tplQuery.isError]);
+```
+
+To make `setSearchParams` available, change:
+```tsx
+  const [params] = useSearchParams();
+```
+to:
+```tsx
+  const [params, setSearchParams] = useSearchParams();
+```
+
+**Edit 5**: Replace the `PageHeader` line. Find:
+```tsx
+      <PageHeader title={t(`create.titleByScenario.${scenario}`)} subtitle={t("create.subtitle")} />
+```
+Replace with:
+```tsx
+      <PageHeader
+        title={t(`create.titleByScenario.${scenario}`)}
+        subtitle={t("create.subtitle")}
+        rightSlot={<PrefillFromTemplatePopover scenario={scenario} onPick={applyTemplate} />}
+      />
+```
+
+**Edit 6**: Insert the prefilled banner inside the form, immediately AFTER `<form onSubmit={onSubmit} className="space-y-6">` and BEFORE the existing first `<div className="grid grid-cols-1 gap-6 md:grid-cols-2">`:
+
+```tsx
+            {form.watch("templateId") && tplQuery.data && (
+              <div className="flex items-center justify-between rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-sm">
+                <span>
+                  {t("create.prefilledBanner.label", { name: tplQuery.data.name })}
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => form.setValue("templateId", undefined, { shouldDirty: true })}
+                  className="gap-1"
+                >
+                  <X className="h-3.5 w-3.5" />
+                  {t("create.prefilledBanner.clear")}
+                </Button>
+              </div>
+            )}
+```
+
+Note: when the user clicks the popover (path A), `tplQuery.data` won't be set because no `?templateId` is in the URL. To make the banner appear in path A too, re-derive `tplQuery.data` from a separate hook keyed off `form.watch("templateId")`. Easiest: use one shared call:
+
+```tsx
+  const watchedTemplateId = form.watch("templateId");
+  const bannerTpl = useTemplate(watchedTemplateId ?? undefined);
+```
+
+Then change the banner condition:
+```tsx
+            {watchedTemplateId && bannerTpl.data && (
+              <div ...>
+                <span>{t("create.prefilledBanner.label", { name: bannerTpl.data.name })}</span>
+                ...
+              </div>
+            )}
+```
+
+And keep `tplQuery` (URL-driven) only for the URL-prefill effect / error effect — `bannerTpl` is the rendering hook. React-query will dedupe the two calls when the IDs match (same query key).
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm -F @modeldoctor/web test -- BenchmarkCreatePage
+```
+
+Expected: ALL pass.
+
+- [ ] **Step 5: Type-check**
+
+```bash
+pnpm -F @modeldoctor/web type-check
+```
+
+Expected: PASS. If `templateId: undefined` flags a "Type 'undefined' is not assignable" error, double-check `CreateBenchmarkRequest.templateId` is optional (it is — `packages/contracts/src/benchmark.ts:82`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx \
+        apps/web/src/features/benchmarks/__tests__/BenchmarkCreatePage.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(web/benchmarks): create page prefill from template
+
+Adds PrefillFromTemplatePopover to the page header, supports URL
+?templateId for one-shot prefill, and renders a "prefilled from
+template X [✕ clear]" banner so users can drop the link without
+losing the params they're staring at. templateId is sent on submit so
+the resulting benchmark records its provenance.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: TemplateCard "use this template" CTA
+
+**Files:**
+- Modify: `apps/web/src/features/benchmark-templates/TemplateCard.tsx`
+- Create: `apps/web/src/features/benchmark-templates/__tests__/TemplateCard.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+Write `apps/web/src/features/benchmark-templates/__tests__/TemplateCard.test.tsx`:
+
+```tsx
+import "@/lib/i18n";
+import type { BenchmarkTemplate } from "@modeldoctor/contracts";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { TemplateCard } from "../TemplateCard";
+
+function tpl(overrides: Partial<BenchmarkTemplate> = {}): BenchmarkTemplate {
+  return {
+    id: "tpl-42",
+    name: "vLLM single concurrency",
+    description: "low load",
+    scenario: "inference",
+    tool: "guidellm",
+    config: {},
+    isOfficial: false,
+    createdBy: "u1",
+    tags: [],
+    createdAt: "2026-05-07T00:00:00.000Z",
+    updatedAt: "2026-05-07T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("TemplateCard", () => {
+  it("renders 'use this template' CTA pointing to /benchmarks/new with scenario+templateId", () => {
+    render(
+      <MemoryRouter>
+        <TemplateCard template={tpl({ scenario: "gateway", id: "tpl-42" })} canEdit={false} onDeleteClick={() => {}} />
+      </MemoryRouter>,
+    );
+    const cta = screen.getByRole("link", { name: /use this template|使用此模板/i });
+    expect(cta).toHaveAttribute("href", "/benchmarks/new?scenario=gateway&templateId=tpl-42");
+  });
+
+  it("still renders detail link on the card name area", () => {
+    render(
+      <MemoryRouter>
+        <TemplateCard template={tpl()} canEdit={false} onDeleteClick={() => {}} />
+      </MemoryRouter>,
+    );
+    const detailLink = screen.getByRole("link", { name: /vLLM single concurrency/i });
+    expect(detailLink).toHaveAttribute("href", "/benchmark-templates/tpl-42");
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+pnpm -F @modeldoctor/web test -- TemplateCard
+```
+
+Expected: FAIL — currently no CTA, and name is wrapped in a Link covering the whole card (the test will pass for the second case, fail on the first).
+
+- [ ] **Step 3: Edit TemplateCard.tsx**
+
+Replace the entire file with:
+
+```tsx
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { BenchmarkTemplate } from "@modeldoctor/contracts";
+import { MoreHorizontal, ShieldCheck } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+
+export interface TemplateCardProps {
+  template: BenchmarkTemplate;
+  canEdit: boolean;
+  onDeleteClick: () => void;
+}
+
+export function TemplateCard({ template, canEdit, onDeleteClick }: TemplateCardProps) {
+  const { t } = useTranslation("benchmark-templates");
+  return (
+    <div className="group relative flex flex-col gap-3 rounded-lg border border-border bg-card p-4 transition hover:border-primary/40">
+      <div className="space-y-2">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-2">
+            {template.isOfficial && <ShieldCheck className="h-4 w-4 text-primary" aria-hidden />}
+            <Link
+              to={`/benchmark-templates/${template.id}`}
+              className="truncate text-sm font-semibold hover:text-primary hover:underline"
+            >
+              {template.name}
+            </Link>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Badge variant="outline" className="text-xs">
+            {template.tool}
+          </Badge>
+          {template.isOfficial && (
+            <Badge variant="default" className="text-xs">
+              {t("list.official")}
+            </Badge>
+          )}
+          {template.tags.map((tag) => (
+            <Badge key={tag} variant="outline" className="text-xs">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+        <p className="line-clamp-2 text-xs text-muted-foreground">{template.description || ""}</p>
+        <p className="text-xs text-muted-foreground">
+          {t("list.updatedAt", {
+            when: new Date(template.updatedAt).toLocaleString(),
+          })}
+        </p>
+      </div>
+
+      <div className="flex justify-end">
+        <Button asChild size="sm">
+          <Link to={`/benchmarks/new?scenario=${template.scenario}&templateId=${template.id}`}>
+            {t("list.cards.useThisTemplate")}
+          </Link>
+        </Button>
+      </div>
+
+      {canEdit && (
+        <div className="absolute right-2 top-2 opacity-0 transition group-hover:opacity-100">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" aria-label="actions">
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem asChild>
+                <Link to={`/benchmark-templates/${template.id}`}>{t("actions.edit")}</Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="text-destructive"
+                onClick={(e) => {
+                  e.preventDefault();
+                  onDeleteClick();
+                }}
+              >
+                {t("actions.delete")}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+Key change vs current: the outer `<Link>` wrapping the whole card is gone — only the **name** is a link to detail, and the **CTA button** is a separate link to new-benchmark. This avoids nested `<a>` tags and aligns with the design's "list page action conventions" memory (first column = detail link).
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm -F @modeldoctor/web test -- TemplateCard
+```
+
+Expected: ALL pass.
+
+- [ ] **Step 5: Sanity-check TemplateListPage tests still pass**
+
+```bash
+pnpm -F @modeldoctor/web test -- TemplateListPage
+```
+
+Expected: PASS — TemplateListPage renders cards but doesn't assert on the wrapping link; layout-only changes shouldn't break it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/features/benchmark-templates/TemplateCard.tsx \
+        apps/web/src/features/benchmark-templates/__tests__/TemplateCard.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(web/templates): "use this template" CTA on TemplateCard
+
+Restructures the card so the name links to the detail view and a
+separate "Use this template" button links to /benchmarks/new with the
+template prefilled via ?templateId. The whole-card Link wrapper is
+removed (it nested anchors and would have nested again with the CTA).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Final verification
+
+- [ ] **Step 1: Workspace-wide tests**
+
+```bash
+pnpm -F @modeldoctor/web test
+```
+
+Expected: ALL pass. If a TemplateListPage / BenchmarkComparePage test broke from card-link restructure, fix the assertion (do not weaken the new test).
+
+- [ ] **Step 2: Type-check the whole web package**
+
+```bash
+pnpm -F @modeldoctor/web type-check
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Lint**
+
+```bash
+pnpm -F @modeldoctor/web lint
+```
+
+Expected: PASS. If biome flags `useExhaustiveDependencies` on the prefill effect, the inline `// biome-ignore` comment in the implementation handles that.
+
+- [ ] **Step 4: Workspace build**
+
+```bash
+pnpm -F @modeldoctor/web build
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Manual smoke (if dev server reachable)**
+
+```bash
+pnpm dev
+```
+
+Then in a browser (default `http://localhost:5173`):
+
+1. `/benchmarks/inference` — open the more-menu on a `running` row → "保存为模板" should be greyed; tooltip explains why
+2. Same row when status is `completed` → menu item active → click opens dialog → submit creates a template (verify in `/benchmark-templates`)
+3. `/benchmarks/{completed-id}` (detail) — header shows "保存为模板" button → opens same dialog
+4. `/benchmarks/{failed-id}` — no "保存为模板" button in header
+5. `/benchmark-templates` — each card has "使用此模板" → click → routes to `/benchmarks/new?scenario=...&templateId=...` → form is prefilled, banner shows "已从模板「X」预填", you can edit name, click ✕ clears banner
+6. On `/benchmarks/new?scenario=inference`, click "从模板预填" → popover lists templates → search filters → click an item → form prefills + toast
+
+If you cannot run the dev server in this session, say so explicitly in the handoff message rather than claiming success.
+
+- [ ] **Step 6: Final commit if any fixes were needed in step 1-5**
+
+(Otherwise this step is a no-op.)
+
+---
+
+## Acceptance Checklist (from spec)
+
+- [ ] 详情页 / 列表页:`completed` benchmark 看到"保存为模板",非 `completed` disabled+tooltip
+- [ ] Dialog 能改 name / description / tags,提交后 toast,在 `/benchmark-templates` 看到新模板
+- [ ] 新建页"从模板预填" popover 仅显示当前 scenario 模板,选中后表单按模板预填,可继续改
+- [ ] 模板列表页"使用此模板" → 跳到 `/benchmarks/new?scenario=...&templateId=...` 自动预填
+- [ ] 提交后 `Benchmark.templateId` 正确落库;banner ✕ 后不落库
+- [ ] `pnpm -F @modeldoctor/web test` / `type-check` / `lint` 全绿
+
+---
+
+## Out-of-Scope Follow-Ups
+
+After implementation, post a single comment on issue #138 listing the deferred items so future work has context:
+
+- Detail page does not yet display "派生自模板 X" provenance even though `Benchmark.templateId` is now consistently set.
+- No reverse "以此模板再开一次新 benchmark" entry from the detail page (only TemplateCard CTA).
+- No backfill of `templateId` on existing benchmarks created before this change — provenance is forward-only.

--- a/docs/superpowers/specs/2026-05-07-issue-138-benchmark-template-loop-design.md
+++ b/docs/superpowers/specs/2026-05-07-issue-138-benchmark-template-loop-design.md
@@ -1,0 +1,288 @@
+# Issue #138 — Benchmark 模板与主流程闭环
+
+**Date:** 2026-05-07
+**Issue:** [#138](https://github.com/weetime/modeldoctor/issues/138)
+**Status:** Design approved, awaiting implementation plan
+
+## Problem
+
+`benchmark_templates` CRUD 后端 + 前端模板管理页(via #106 / #108)已落地,但模板与 benchmark 主流程未打通:
+
+- 列表页 `BenchmarkListShell.tsx:154-171` 的"保存为模板"无 status 门控,无 dialog,直接拷贝 `${name} (template)` 出去
+- 详情页 `BenchmarkDetailPage.tsx` header 没有任何"保存为模板"入口
+- 新建页 `BenchmarkCreatePage.tsx` 只能从空白表单填,不支持从模板预填
+- 模板列表页 `TemplateCard.tsx` 没有"使用此模板"CTA
+
+后端契约已经支持闭环:`CreateBenchmarkRequest.templateId`(`packages/contracts/src/benchmark.ts:82`)是可选字段,`benchmark.service.ts:164` 在 create 时验证并落库。本 issue 只补前端入口。
+
+## Goals
+
+1. 详情页 / 列表页 `completed` benchmark 看到"保存为模板"
+2. 列表页 dialog 能改 name / description / tags(逗号分隔),提交后 toast 成功
+3. 新建页支持从模板预填(popover 选择 + URL `?templateId` 直接预填)
+4. 模板列表页卡片有"使用此模板"按钮 → 跳到新建页自动预填
+5. 提交时 `templateId` 落库,即便用户改了 params(provenance 始终保留)
+
+## Non-Goals
+
+- 三 tab Drawer 创建模态(原 #97)
+- 从历史 benchmark 复用 (`parentBenchmarkId`)
+- Admin seed 5 个官方模板(ops 步骤,不是工程任务)
+- Vegeta legacy params 在预填时迁移(模板 create 时已走 ToolParamsForm,config 应已合规)
+
+## Architecture
+
+### 新增组件(均位于 `apps/web/src/features/benchmarks/`)
+
+#### 1. `SaveAsTemplateDialog.tsx`
+
+受控 Dialog,列表页 + 详情页共用。
+
+**Props:**
+```ts
+interface SaveAsTemplateDialogProps {
+  benchmark: Benchmark | null;       // null 关闭
+  onOpenChange: (open: boolean) => void;
+}
+```
+
+**字段:**
+- `name`(默认 `${benchmark.name} (template)`,trimmed to ≤90 chars 后再加后缀,max 100 chars 总长)
+- `description`(可选,Textarea 2 行)
+- `tags`(可选,Input;提交时按 `,` split + trim + filter empty)
+
+**提交:**
+```ts
+useCreateTemplate().mutateAsync({
+  name,
+  description,
+  scenario: benchmark.scenario,
+  tool: benchmark.tool,
+  config: benchmark.params as Record<string, unknown>,
+  tags,
+  isOfficial: false,
+})
+```
+
+**反馈:**
+- 成功:`toast.success(t("rowActions.saveAsTemplate.success", { name }))`,关闭 dialog,留在原页
+- 失败:dialog 内 inline `Alert`,不关闭
+
+**不做 vegeta 参数迁移** —— 模板存原始 config,运行时(rerun / 新建)才迁移,与现有 `BenchmarkListShell.handleSaveAsTemplate` 行为一致。
+
+#### 2. `PrefillFromTemplatePopover.tsx`
+
+新建页专用,不复用。
+
+**Props:**
+```ts
+interface PrefillFromTemplatePopoverProps {
+  scenario: ScenarioId;
+  onPick: (template: BenchmarkTemplate) => void;
+}
+```
+
+**触发器:** `Button variant="outline" size="sm"`,内含 `Layers` icon + `从模板预填 ▾` label。
+
+**Popover 内容(~360px 宽):**
+- 顶部 `Input`:本地搜索(300ms debounce 不必,client-side filter 直接同步即可,因为最多 50 条)
+- 列表:`useTemplates({ scenario, limit: 50 })`,每条用 `button` 渲染:
+  - 左:`name`(truncate)+ 第二行 `tool` badge + tags badges + 官方 `ShieldCheck` icon
+  - 整行 click → `onPick(template)` + 关闭 popover
+- 空态(无模板 / 搜索无结果):提示文案 + "→ 去模板库管理" 链接到 `/benchmark-templates?scenario=${scenario}`
+- 底部固定一行:"→ 去模板库管理"
+
+**焦点管理:** 用 shadcn `Popover` 默认行为,无需手工处理。
+
+### 改动
+
+#### 3. `BenchmarkListShell.tsx`
+
+- 删除 `handleSaveAsTemplate`(行 154-171)
+- 新增 `const [saveTplBenchmark, setSaveTplBenchmark] = useState<Benchmark | null>(null)`
+- DropdownMenuItem(行 393-400):
+  - `disabled = benchmark.status !== "completed"`(`status === "completed"` 才可点击)
+  - 包 `Tooltip` 解释 `t("rowActions.saveAsTemplate.disabledTooltip")`
+  - `onClick: () => setSaveTplBenchmark(benchmark)`
+- 在 `<AlertDialog>` 同级渲染 `<SaveAsTemplateDialog benchmark={saveTplBenchmark} onOpenChange={(o) => !o && setSaveTplBenchmark(null)} />`
+
+#### 4. `BenchmarkDetailPage.tsx`
+
+- 在 rerun 按钮(行 218-241)之后、delete 按钮(行 247)之前插入:
+  ```tsx
+  {isTerminal && benchmark.status === "completed" && (
+    <Button variant="outline" size="sm" onClick={() => setSaveTplOpen(true)}>
+      <Copy className="mr-1 h-4 w-4" />
+      {t("detail.saveAsTemplate.button")}
+    </Button>
+  )}
+  ```
+- 新增 state `const [saveTplOpen, setSaveTplOpen] = useState(false)`
+- 文件底部加 `<SaveAsTemplateDialog benchmark={saveTplOpen ? benchmark : null} onOpenChange={setSaveTplOpen} />`
+
+#### 5. `BenchmarkCreatePage.tsx`
+
+- `PageHeader` 加 `rightSlot={<PrefillFromTemplatePopover scenario={scenario} onPick={applyTemplate} />}`
+- `defaultValues` 加 `templateId: undefined`(form schema 已包含此字段)
+- 新增 `applyTemplate(template)`:
+  ```ts
+  function applyTemplate(template: BenchmarkTemplate) {
+    if (template.scenario !== scenario) {
+      toast.warning(t("create.prefillFromTemplate.scenarioMismatch", {
+        scenario: template.scenario,
+      }));
+    }
+    form.reset({
+      tool: template.tool,
+      scenario: template.scenario,                 // 模板 wins
+      connectionId: form.getValues("connectionId"), // 保留当前
+      name: template.name,
+      description: template.description ?? undefined,
+      params: template.config,
+      templateId: template.id,
+    });
+    toast.info(t("create.prefillFromTemplate.applied", { name: template.name }));
+  }
+  ```
+- 读 URL `?templateId`,用 `useTemplate(templateIdFromQuery)` 获取后通过 `useEffect + ref` 单次预填:
+  ```ts
+  const templateIdParam = params.get("templateId");
+  const { data: prefillTemplate } = useTemplate(templateIdParam ?? undefined);
+  const hasAppliedRef = useRef(false);
+  useEffect(() => {
+    if (prefillTemplate && !hasAppliedRef.current) {
+      applyTemplate(prefillTemplate);
+      hasAppliedRef.current = true;
+    }
+  }, [prefillTemplate]);
+  ```
+- 当 `form.watch("templateId")` truthy 时,在 `<Form>` 内、第一个 `<Card>` 之前(也即 `space-y-6` 容器的第一项)展示 banner:
+  ```
+  ┌ 已从模板「{{name}}」预填 ────────────────[ ✕ 清除关联 ]
+  ```
+  点 ✕ 调 `form.setValue("templateId", undefined)`,**不清** params(已可见的内容不要无声消失)
+- Banner 文本需要 template name —— 此时 `useTemplate(form.watch("templateId"))` 已 ready,直接复用其 `data.name`(与 prefill effect 共用同一个 hook 调用,`react-query` 缓存命中)
+- URL `?templateId` 不存在时的兜底:
+  ```ts
+  const tplQuery = useTemplate(templateIdParam ?? undefined);
+  useEffect(() => {
+    if (templateIdParam && tplQuery.isError) {
+      toast.error(t("create.prefillFromTemplate.notFound"));
+      const next = new URLSearchParams(params);
+      next.delete("templateId");
+      setParams(next, { replace: true });
+    }
+  }, [templateIdParam, tplQuery.isError]);
+  ```
+
+#### 6. `TemplateCard.tsx`
+
+- 卡片底部新增主色按钮 `使用此模板`,跳到 `/benchmarks/new?scenario=${template.scenario}&templateId=${template.id}`
+- 当前实现是整张卡片 `<Link>` 包裹(行 24-52),嵌套 `<a>` 不合法。重构为:
+  - 外层改 `<div>`,移除 Link 包裹
+  - 卡片**头部+元数据区**(name / badges / description / updatedAt)整体仍可点 → 包一个透明 `<Link>` 占满该区域(用 `absolute inset-0` 技巧或将整块作为可点击 div + `useNavigate`)
+  - 卡片**底部**新增 `<div className="mt-3 flex justify-end">`,内含 `<Button asChild size="sm"><Link to={...}>使用此模板</Link></Button>`
+  - `canEdit` 的 absolute-positioned dropdown menu 不动
+
+## Data Flow
+
+### 触发路径 A:Popover 预填
+
+```
+PrefillFromTemplatePopover.onPick(template)
+  → BenchmarkCreatePage.applyTemplate(template)
+      form.reset({ tool, scenario, connectionId(保留), name, description, params, templateId })
+      toast.info "已从模板「X」预填"
+```
+
+### 触发路径 B:URL `?templateId=xxx`
+
+```
+BenchmarkCreatePage mount + URL 含 templateId
+  → useTemplate(templateId) 加载
+  → useEffect 单次触发(ref guard)applyTemplate(template)
+  → 后续用户编辑不会被覆盖
+```
+
+### 提交
+
+`form.handleSubmit` 已经把 `templateId` 一并提交;`benchmark.service.ts:164-194` 验证并落到 `Benchmark.templateId`。
+
+### Banner 清除
+
+```
+banner [✕]
+  → form.setValue("templateId", undefined)
+  → banner 消失,params 保持
+  → 提交时不带 templateId
+```
+
+## Edge Cases
+
+1. **`?templateId=不存在`** — `useTemplate` 返回 404,`useEffect` 因 `template` falsy 不触发预填;额外 `useEffect` 监听 query error,toast 报错并 `params.delete("templateId")` 清掉 URL
+2. **Scenario 不一致**(URL `?scenario=inference&templateId={gateway-tpl}`)— `applyTemplate` 模板 wins,`form.reset` 改 scenario,toast.warning 提示;**不做** 路由重定向(避免 effect 重跑)
+3. **预填后用户切换 scenario** — 现有 `useEffect([scenario])`(行 82-91)会 `form.reset` 清掉所有字段,**包括 templateId**,这是预期行为(切场景 = 弃用模板)
+4. **Vegeta 参数迁移** — 不在本 issue 范围;模板 config 应在 template create 时就合规
+5. **`?templateId=xxx` + `?scenario=` 都没有** — 预填 effect 不跑,正常空表单流程
+6. **`saveTplBenchmark` 切换为新 benchmark 时** — Dialog 用 `benchmark.id` 作 key,确保表单字段被重新初始化
+
+## i18n
+
+### `apps/web/src/locales/{zh-CN,en-US}/benchmarks.json`
+
+```
+rowActions.saveAsTemplate.disabledTooltip   "仅已完成的 benchmark 可保存为模板"
+detail.saveAsTemplate.button                "保存为模板"
+
+saveAsTemplateDialog.title                  "保存为模板"
+saveAsTemplateDialog.description            "把当前参数固化为可复用的模板"
+saveAsTemplateDialog.fields.name            "模板名称"
+saveAsTemplateDialog.fields.description     "描述"
+saveAsTemplateDialog.fields.tags            "标签"
+saveAsTemplateDialog.fields.tagsPlaceholder "用逗号分隔多个标签"
+saveAsTemplateDialog.actions.submit         "保存"
+saveAsTemplateDialog.errors.generic         "保存失败,请稍后重试"
+
+create.prefillFromTemplate.button           "从模板预填"
+create.prefillFromTemplate.search           "搜索模板…"
+create.prefillFromTemplate.empty            "还没有此场景的模板"
+create.prefillFromTemplate.manage           "→ 去模板库管理"
+create.prefillFromTemplate.applied          "已从模板「{{name}}」预填,可继续修改"
+create.prefillFromTemplate.scenarioMismatch "模板属于 {{scenario}},已切换 scenario"
+create.prefillFromTemplate.notFound         "模板不存在或已删除"
+create.prefilledBanner.label                "已从模板「{{name}}」预填"
+create.prefilledBanner.clear                "清除关联"
+```
+
+### `apps/web/src/locales/{zh-CN,en-US}/benchmark-templates.json`
+
+```
+list.cards.useThisTemplate                  "使用此模板"
+```
+
+## Tests
+
+| 文件 | 关键 case |
+|---|---|
+| `SaveAsTemplateDialog.test.tsx`(新) | 默认 name 含 `(template)` 后缀;tags `"a, b, c"` → payload `["a","b","c"]`;空 description 不带 description;mutation 失败 inline error 不关闭;成功 toast |
+| `PrefillFromTemplatePopover.test.tsx`(新) | `useTemplates` mock 3 个时全部显示;搜索 "vLLM" 仅显示匹配项;空态显示链接;点击 item 调 `onPick` 带完整 template |
+| `BenchmarkListShell.test.tsx`(已存,加 case) | `status="failed"` 行的菜单项 `aria-disabled`;`status="completed"` 点击打开 dialog |
+| `BenchmarkDetailPage.test.tsx`(已存,加 case) | `status="completed"` 看到"保存为模板"按钮;`status="failed"` / `status="running"` 看不到 |
+| `BenchmarkCreatePage.test.tsx`(已存,加 case) | URL `?templateId=tpl-1` 进入,`useTemplate` resolve 后字段被填;hidden `templateId` 出现在提交 payload;banner ✕ 后 templateId 不在 payload 但 params 保留 |
+| `TemplateCard.test.tsx`(若无则建) | "使用此模板" `href` 包含 `scenario=` 与 `templateId=` |
+
+## Acceptance
+
+- [ ] 详情页 / 列表页:`completed` benchmark 看到"保存为模板",非 `completed` disabled+tooltip
+- [ ] Dialog 能改 name / description / tags,提交后 toast,在 `/benchmark-templates` 看到新模板
+- [ ] 新建页"从模板预填" popover 仅显示当前 scenario 模板,选中后表单按模板预填,可继续改
+- [ ] 模板列表页"使用此模板" → 跳到 `/benchmarks/new?scenario=...&templateId=...` 自动预填
+- [ ] 提交后 `Benchmark.templateId` 正确落库;banner ✕ 后不落库
+- [ ] `pnpm -r test` / `type-check` / `lint` 全绿
+
+## Out of Scope (反留 issue)
+
+实现完成后,在 #138 评论列出尚未做的相关项,以便下个迭代起 issue:
+
+- TemplateCard CTA 仅限 `/benchmarks/new`,没考虑从详情页"以此模板再开一次新 benchmark"的反向入口
+- 详情页未来可显示"派生自模板 X"信息(目前后端有 templateId 字段但 UI 不显示)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2
         version: 2.1.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popover':
+        specifier: ^1
+        version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-progress':
         specifier: ^1
         version: 1.1.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1389,6 +1392,19 @@ packages:
 
   '@radix-ui/react-menu@2.1.16':
     resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.15':
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6128,6 +6144,29 @@ snapshots:
       '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.28)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)


### PR DESCRIPTION
## Summary

Closes the loop between `benchmark_templates` and the benchmark main flow, frontend-only — backend `Benchmark.templateId` provenance was already in place.

- **Save as template** on list + detail pages, gated to `completed` status (list disables menu item with tooltip; detail hides the header button outright). Both reuse a new shared `SaveAsTemplateDialog` with name / description / comma-tags fields.
- **Prefill from template** on the create page via a new `PrefillFromTemplatePopover` (search + scenario-filtered list) AND via URL `?templateId=...` — a "prefilled from template X [✕ clear]" banner lets users drop the link without losing the params they're staring at.
- **"Use this template" CTA** on each `TemplateCard` → `/benchmarks/new?scenario=...&templateId=...`. Card was restructured to avoid nested `<a>` (only the name + the CTA are links now).
- `templateId` flows through the form on submit so the resulting benchmark records its provenance; banner ✕ strips it without touching params.

Tooling: adds `@radix-ui/react-popover` + a shadcn `popover.tsx` primitive (mirrors `dialog.tsx` / `dropdown-menu.tsx`). Adds 17 i18n keys × 2 locales.

Tests: 13 new cases across 5 files (5 dialog, 4 popover, 2 list, 3 detail, 3 create-page incl. submit-payload assertions for `templateId` set/cleared, plus 2 new TemplateCard cases). 638/638 passing locally.

Spec: `docs/superpowers/specs/2026-05-07-issue-138-benchmark-template-loop-design.md`
Plan: `docs/superpowers/plans/2026-05-07-issue-138-benchmark-template-loop.md`

Closes #138.

## Test plan

- [ ] `/benchmarks/inference` — open more-menu on a `running` row → "保存为模板" disabled with tooltip
- [ ] Same row when `completed` → menu opens dialog → submit → toast → new entry in `/benchmark-templates`
- [ ] `/benchmarks/{completed-id}` (detail) — header shows "保存为模板" → opens same dialog
- [ ] `/benchmarks/{failed-id}` and `{running-id}` — no "保存为模板" button
- [ ] `/benchmark-templates` — each card has "使用此模板" → routes to `/benchmarks/new?scenario=...&templateId=...` with form prefilled and banner visible
- [ ] On the create page, click "从模板预填" → popover lists scenario-matched templates → search filters → click prefills + toast
- [ ] Banner ✕ clears the link, params stay; submit → benchmark created without `templateId`
- [ ] Submit a benchmark from a prefilled form → resulting `Benchmark.templateId` matches the source template id

## Out of scope (follow-ups)

- Detail page does not yet display "派生自模板 X" provenance even though `Benchmark.templateId` is now consistently set.
- No reverse "以此模板再开一次新 benchmark" entry from the detail page (only TemplateCard CTA).
- No backfill of `templateId` on existing benchmarks created before this change — provenance is forward-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)