### PR TITLE
feat(web/deployment-recipes): inference engine × open-weight model compatibility matrix

### DIFF
--- a/apps/web/src/components/sidebar/sidebar-config.tsx
+++ b/apps/web/src/components/sidebar/sidebar-config.tsx
@@ -14,6 +14,7 @@ import {
   MessageSquare,
   Mic,
   Network,
+  Rocket,
   Settings,
 } from "lucide-react";
 
@@ -74,6 +75,11 @@ export const sidebarGroups: SidebarGroup[] = [
         icon: LineChart,
         labelKey: "items.devCharts",
         devOnly: true,
+      },
+      {
+        to: "/dev/deployments",
+        icon: Rocket,
+        labelKey: "items.deploymentRecipes",
       },
     ],
   },

--- a/apps/web/src/features/deployment-recipes/DeploymentRecipesPage.tsx
+++ b/apps/web/src/features/deployment-recipes/DeploymentRecipesPage.tsx
@@ -175,11 +175,13 @@ export function DeploymentRecipesPage() {
         return;
       }
       const [modelId, engineId] = raw.split("/");
-      if (!modelId || !engineId) return;
-      const model = MODELS.find((m) => m.id === modelId);
-      const recipe = model ? getRecipe(model, engineId) : null;
-      if (model && recipe && recipe.status !== "none") {
-        setSelected({ modelId, engineId: engineId as EngineId });
+      const model = modelId ? MODELS.find((m) => m.id === modelId) : null;
+      const engine = engineId ? ENGINES.find((e) => e.id === engineId) : null;
+      const recipe = model && engine ? getRecipe(model, engine.id) : null;
+      if (model && engine && recipe && recipe.status !== "none") {
+        setSelected({ modelId: model.id, engineId: engine.id });
+      } else {
+        setSelected(null);
       }
     };
     parseHash();
@@ -208,10 +210,15 @@ export function DeploymentRecipesPage() {
       if (!q) return true;
       if (m.name.toLowerCase().includes(q)) return true;
       if (m.meta.toLowerCase().includes(q)) return true;
-      // Engine name match: keep all rows where any visible engine name matches.
-      return ENGINES.some(
-        (eng) => visibleEngines.has(eng.id) && eng.name.toLowerCase().includes(q),
-      );
+      // Engine match: only keep rows that actually support a matching engine
+      // (status native or partial). Match on display name and vendor.
+      return ENGINES.some((eng) => {
+        if (!visibleEngines.has(eng.id)) return false;
+        const matches = eng.name.toLowerCase().includes(q) || eng.vendor.toLowerCase().includes(q);
+        if (!matches) return false;
+        const status = getRecipe(m, eng.id)?.status;
+        return status === "native" || status === "partial";
+      });
     });
   }, [category, query, visibleEngines]);
 

--- a/apps/web/src/features/deployment-recipes/DeploymentRecipesPage.tsx
+++ b/apps/web/src/features/deployment-recipes/DeploymentRecipesPage.tsx
@@ -1,0 +1,485 @@
+import { PageHeader } from "@/components/common/page-header";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { Check, Filter, Search } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { RecipeDrawer } from "./RecipeDrawer";
+import { CATEGORIES, ENGINES, MODELS, getRecipe } from "./data";
+import type { CategoryId, EngineId, EngineMeta, ModelEntry, RecipeStatus } from "./types";
+
+type CategoryFilter = "all" | CategoryId;
+
+interface SelectedCell {
+  modelId: string;
+  engineId: EngineId;
+}
+
+// ---------------------------------------------------------------------------
+// Cell pill — small visual indicator inside the matrix.
+// ---------------------------------------------------------------------------
+
+function StatusPill({
+  status,
+  active,
+  highlight,
+  onClick,
+}: {
+  status: RecipeStatus;
+  active: boolean;
+  highlight: boolean;
+  onClick?: () => void;
+}) {
+  const base =
+    "flex h-7 w-9 items-center justify-center rounded-md text-sm font-medium transition-colors";
+
+  if (status === "native") {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label="原生支持,点击查看详情"
+        className={cn(
+          base,
+          "border border-emerald-200/70 bg-emerald-50 text-emerald-700",
+          "hover:border-emerald-300 hover:bg-emerald-100",
+          "dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-400 dark:hover:bg-emerald-950/70",
+          (active || highlight) &&
+            "ring-2 ring-emerald-400/60 ring-offset-1 ring-offset-background dark:ring-emerald-500/60",
+        )}
+      >
+        ✓
+      </button>
+    );
+  }
+
+  if (status === "partial") {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label="部分支持,点击查看详情"
+        className={cn(
+          base,
+          "border border-amber-200/70 bg-amber-50 text-amber-700",
+          "hover:border-amber-300 hover:bg-amber-100",
+          "dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-400 dark:hover:bg-amber-950/60",
+          (active || highlight) &&
+            "ring-2 ring-amber-400/60 ring-offset-1 ring-offset-background dark:ring-amber-500/60",
+        )}
+      >
+        ~
+      </button>
+    );
+  }
+
+  return (
+    <span
+      aria-label="不支持"
+      className={cn(
+        base,
+        "cursor-not-allowed border border-transparent bg-muted/40 text-muted-foreground/50",
+      )}
+    >
+      ·
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Engine column visibility popover
+// ---------------------------------------------------------------------------
+
+function EngineToggle({
+  visible,
+  onChange,
+}: {
+  visible: Set<EngineId>;
+  onChange: (next: Set<EngineId>) => void;
+}) {
+  const allOn = visible.size === ENGINES.length;
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-1.5">
+          <Filter className="h-3.5 w-3.5" />
+          引擎列
+          <span className="text-xs text-muted-foreground">
+            {visible.size}/{ENGINES.length}
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-56 p-2">
+        <div className="mb-2 flex items-center justify-between px-1">
+          <span className="text-xs font-medium text-muted-foreground">显示列</span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-6 px-1.5 text-xs"
+            onClick={() => onChange(allOn ? new Set() : new Set(ENGINES.map((e) => e.id)))}
+          >
+            {allOn ? "全部隐藏" : "全部显示"}
+          </Button>
+        </div>
+        <div className="space-y-0.5">
+          {ENGINES.map((eng) => {
+            const checked = visible.has(eng.id);
+            return (
+              <button
+                key={eng.id}
+                type="button"
+                className={cn(
+                  "flex w-full items-center justify-between rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+                  "hover:bg-accent hover:text-accent-foreground",
+                )}
+                onClick={() => {
+                  const next = new Set(visible);
+                  if (checked) next.delete(eng.id);
+                  else next.add(eng.id);
+                  onChange(next);
+                }}
+              >
+                <span className="font-medium">{eng.name}</span>
+                {checked ? <Check className="h-3.5 w-3.5 text-primary" /> : null}
+              </button>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
+export function DeploymentRecipesPage() {
+  const [category, setCategory] = useState<CategoryFilter>("all");
+  const [query, setQuery] = useState("");
+  const [visibleEngines, setVisibleEngines] = useState<Set<EngineId>>(
+    () => new Set(ENGINES.map((e) => e.id)),
+  );
+  const [selected, setSelected] = useState<SelectedCell | null>(null);
+  const [hoveredEngine, setHoveredEngine] = useState<EngineId | null>(null);
+
+  // ---- Hash routing: #model-id/engine-id ----
+  useEffect(() => {
+    const parseHash = () => {
+      const raw = window.location.hash.replace(/^#/, "");
+      if (!raw) {
+        setSelected(null);
+        return;
+      }
+      const [modelId, engineId] = raw.split("/");
+      if (!modelId || !engineId) return;
+      const model = MODELS.find((m) => m.id === modelId);
+      const recipe = model ? getRecipe(model, engineId) : null;
+      if (model && recipe && recipe.status !== "none") {
+        setSelected({ modelId, engineId: engineId as EngineId });
+      }
+    };
+    parseHash();
+    window.addEventListener("hashchange", parseHash);
+    return () => window.removeEventListener("hashchange", parseHash);
+  }, []);
+
+  const handleSelect = (modelId: string, engineId: EngineId) => {
+    window.location.hash = `${modelId}/${engineId}`;
+    setSelected({ modelId, engineId });
+  };
+
+  const handleCloseDrawer = (open: boolean) => {
+    if (!open) {
+      // Strip the hash without leaving "#" behind, so re-opening triggers hashchange.
+      history.replaceState(null, "", window.location.pathname + window.location.search);
+      setSelected(null);
+    }
+  };
+
+  // ---- Derived data ----
+  const filteredModels = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return MODELS.filter((m) => {
+      if (category !== "all" && m.category !== category) return false;
+      if (!q) return true;
+      if (m.name.toLowerCase().includes(q)) return true;
+      if (m.meta.toLowerCase().includes(q)) return true;
+      // Engine name match: keep all rows where any visible engine name matches.
+      return ENGINES.some(
+        (eng) => visibleEngines.has(eng.id) && eng.name.toLowerCase().includes(q),
+      );
+    });
+  }, [category, query, visibleEngines]);
+
+  const groupedModels = useMemo(() => {
+    const map = new Map<CategoryId, ModelEntry[]>();
+    for (const m of filteredModels) {
+      const list = map.get(m.category) ?? [];
+      list.push(m);
+      map.set(m.category, list);
+    }
+    return CATEGORIES.flatMap((c) => {
+      const list = map.get(c.id) ?? [];
+      return list.length > 0 ? [{ category: c, models: list }] : [];
+    });
+  }, [filteredModels]);
+
+  const visibleEngineList: EngineMeta[] = ENGINES.filter((e) => visibleEngines.has(e.id));
+
+  const selectedModel = selected ? (MODELS.find((m) => m.id === selected.modelId) ?? null) : null;
+  const selectedEngineMeta = selected
+    ? (ENGINES.find((e) => e.id === selected.engineId) ?? null)
+    : null;
+  const selectedRecipe =
+    selectedModel && selected ? (getRecipe(selectedModel, selected.engineId) ?? null) : null;
+
+  const totalCount = MODELS.length;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <PageHeader
+        title="部署示例"
+        subtitle={`推理引擎 × 开源模型权重兼容性矩阵 · 共 ${totalCount} 个模型 / ${ENGINES.length} 个引擎`}
+      />
+
+      <div className="flex-1 overflow-hidden">
+        <div className="flex h-full flex-col gap-4 px-8 py-6">
+          {/* Toolbar ------------------------------------------------------- */}
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="flex flex-wrap items-center gap-1.5">
+              {[
+                { id: "all" as CategoryFilter, label: "全部" },
+                ...CATEGORIES.map((c) => ({ id: c.id as CategoryFilter, label: c.label })),
+              ].map((tab) => (
+                <button
+                  key={tab.id}
+                  type="button"
+                  onClick={() => setCategory(tab.id)}
+                  className={cn(
+                    "rounded-md border px-3 py-1.5 text-xs font-medium transition-colors",
+                    category === tab.id
+                      ? "border-primary/30 bg-primary/10 text-primary"
+                      : "border-border bg-background text-muted-foreground hover:border-foreground/20 hover:text-foreground",
+                  )}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+
+            <div className="relative ml-auto w-full max-w-xs">
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="搜索模型或引擎名…"
+                className="h-9 pl-8 text-sm"
+              />
+            </div>
+
+            <EngineToggle visible={visibleEngines} onChange={setVisibleEngines} />
+          </div>
+
+          {/* Matrix table ------------------------------------------------- */}
+          <TooltipProvider delayDuration={200}>
+            <div className="min-h-0 flex-1 overflow-auto rounded-lg border border-border bg-card">
+              <table className="min-w-full border-collapse text-sm">
+                <thead className="sticky top-0 z-20 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80">
+                  <tr className="border-b border-border">
+                    <th
+                      scope="col"
+                      className="sticky left-0 z-30 min-w-[260px] bg-card/95 px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                    >
+                      模型 / 权重
+                    </th>
+                    {visibleEngineList.map((eng) => (
+                      <th
+                        key={eng.id}
+                        scope="col"
+                        onMouseEnter={() => setHoveredEngine(eng.id)}
+                        onMouseLeave={() => setHoveredEngine(null)}
+                        className={cn(
+                          "min-w-[96px] px-2 py-3 text-center text-xs font-semibold tracking-wide transition-colors",
+                          hoveredEngine === eng.id ? "text-foreground" : "text-muted-foreground",
+                        )}
+                      >
+                        <div className="flex flex-col items-center gap-0.5">
+                          <span>{eng.name}</span>
+                          <span className="text-[10px] font-normal text-muted-foreground/70">
+                            {eng.vendor}
+                          </span>
+                        </div>
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {groupedModels.length === 0 ? (
+                    <tr>
+                      <td
+                        colSpan={visibleEngineList.length + 1}
+                        className="px-4 py-12 text-center text-sm text-muted-foreground"
+                      >
+                        没有匹配的模型。试试清空搜索或切换分类。
+                      </td>
+                    </tr>
+                  ) : (
+                    groupedModels.map(({ category: cat, models }) => (
+                      <CategorySection
+                        key={cat.id}
+                        label={`${cat.label}(${cat.description})`}
+                        colSpan={visibleEngineList.length + 1}
+                      >
+                        {models.map((model) => (
+                          <ModelRow
+                            key={model.id}
+                            model={model}
+                            engines={visibleEngineList}
+                            selected={selected}
+                            hoveredEngine={hoveredEngine}
+                            onHoverEngine={setHoveredEngine}
+                            onSelect={handleSelect}
+                          />
+                        ))}
+                      </CategorySection>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </TooltipProvider>
+
+          {/* Legend ------------------------------------------------------- */}
+          <footer className="flex flex-wrap items-center gap-x-6 gap-y-2 px-1 text-xs text-muted-foreground">
+            <div className="flex items-center gap-1.5">
+              <StatusPill status="native" active={false} highlight={false} />
+              <span>原生支持</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <StatusPill status="partial" active={false} highlight={false} />
+              <span>部分 / 实验</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <StatusPill status="none" active={false} highlight={false} />
+              <span>不支持</span>
+            </div>
+            <span className="ml-auto text-[11px] text-muted-foreground/70">
+              数据基线:vLLM 0.7+ · SGLang 0.4+ · TRT-LLM 0.13+ · MindIE 1.0.RC3 · LMDeploy 0.6+ ·
+              TEI 1.5+ · Infinity 0.0.7x
+            </span>
+          </footer>
+        </div>
+      </div>
+
+      <RecipeDrawer
+        open={selected !== null}
+        onOpenChange={handleCloseDrawer}
+        model={selectedModel}
+        engine={selectedEngineMeta}
+        recipe={selectedRecipe}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Category section row + model row
+// ---------------------------------------------------------------------------
+
+function CategorySection({
+  label,
+  colSpan,
+  children,
+}: {
+  label: string;
+  colSpan: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <tr>
+        <td
+          colSpan={colSpan}
+          className="sticky left-0 bg-muted/40 px-4 py-2 text-xs font-semibold tracking-wide text-foreground/80"
+        >
+          {label}
+        </td>
+      </tr>
+      {children}
+    </>
+  );
+}
+
+function ModelRow({
+  model,
+  engines,
+  selected,
+  hoveredEngine,
+  onHoverEngine,
+  onSelect,
+}: {
+  model: ModelEntry;
+  engines: EngineMeta[];
+  selected: SelectedCell | null;
+  hoveredEngine: EngineId | null;
+  onHoverEngine: (id: EngineId | null) => void;
+  onSelect: (modelId: string, engineId: EngineId) => void;
+}) {
+  return (
+    <tr className="group border-b border-border/60 last:border-b-0 hover:bg-accent/30">
+      <th
+        scope="row"
+        className="sticky left-0 z-10 bg-card px-4 py-3 text-left align-top group-hover:bg-accent/50"
+      >
+        <div className="font-medium text-foreground">{model.name}</div>
+        <div className="mt-0.5 text-xs text-muted-foreground">{model.meta}</div>
+      </th>
+      {engines.map((eng) => {
+        const recipe = getRecipe(model, eng.id);
+        const status = recipe?.status ?? "none";
+        const isActive = selected?.modelId === model.id && selected?.engineId === eng.id;
+        const isColHighlighted = hoveredEngine === eng.id;
+        const cellClickable = status !== "none";
+        const tooltipText = recipe?.tooltip ?? recipe?.notes ?? null;
+
+        const cell = (
+          <StatusPill
+            status={status}
+            active={isActive}
+            highlight={isColHighlighted}
+            onClick={cellClickable ? () => onSelect(model.id, eng.id) : undefined}
+          />
+        );
+
+        return (
+          <td
+            key={eng.id}
+            onMouseEnter={() => onHoverEngine(eng.id)}
+            onMouseLeave={() => onHoverEngine(null)}
+            className={cn(
+              "px-2 py-2 text-center align-middle transition-colors",
+              isColHighlighted && "bg-accent/20",
+            )}
+          >
+            <div className="flex justify-center">
+              {tooltipText ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>{cell}</TooltipTrigger>
+                  <TooltipContent side="top" className="max-w-xs text-xs">
+                    {tooltipText}
+                  </TooltipContent>
+                </Tooltip>
+              ) : (
+                cell
+              )}
+            </div>
+          </td>
+        );
+      })}
+    </tr>
+  );
+}

--- a/apps/web/src/features/deployment-recipes/RecipeDrawer.tsx
+++ b/apps/web/src/features/deployment-recipes/RecipeDrawer.tsx
@@ -82,13 +82,10 @@ function FieldRow({ label, value }: { label: string; value: React.ReactNode }) {
 }
 
 export function RecipeDrawer({ open, onOpenChange, model, engine, recipe }: RecipeDrawerProps) {
-  if (!model || !engine || !recipe) {
-    return (
-      <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
-        <DialogPrimitive.Portal />
-      </DialogPrimitive.Root>
-    );
-  }
+  // Bail out entirely when the URL hash points to a non-existent (or unsupported)
+  // model/engine combo — rendering a Root with only a Portal would otherwise
+  // leave a ghost overlay that swallows clicks.
+  if (!model || !engine || !recipe) return null;
 
   return (
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>

--- a/apps/web/src/features/deployment-recipes/RecipeDrawer.tsx
+++ b/apps/web/src/features/deployment-recipes/RecipeDrawer.tsx
@@ -1,0 +1,221 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Check, Copy, ExternalLink, X } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import type { EngineMeta, EngineRecipe, ModelEntry } from "./types";
+
+interface RecipeDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  model: ModelEntry | null;
+  engine: EngineMeta | null;
+  recipe: EngineRecipe | null;
+}
+
+function StatusBadge({ status }: { status: EngineRecipe["status"] }) {
+  if (status === "native") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-md border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-400">
+        <Check className="h-3 w-3" /> 原生支持
+      </span>
+    );
+  }
+  if (status === "partial") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-md border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-400">
+        部分 / 实验
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-md border border-border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+      不支持
+    </span>
+  );
+}
+
+function CodeBlock({ code, label }: { code: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      toast.success("已复制到剪贴板");
+      setTimeout(() => setCopied(false), 1600);
+    } catch {
+      toast.error("复制失败");
+    }
+  };
+
+  return (
+    <div className="group relative">
+      <div className="mb-1.5 flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground">{label}</span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleCopy}
+          className="h-7 gap-1.5 px-2 text-xs"
+        >
+          {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+          {copied ? "已复制" : "复制"}
+        </Button>
+      </div>
+      <pre className="overflow-x-auto rounded-md border border-border bg-muted/60 p-3 font-mono text-xs leading-relaxed text-foreground">
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}
+
+function FieldRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-[7rem_1fr] gap-3 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-medium">{value}</span>
+    </div>
+  );
+}
+
+export function RecipeDrawer({ open, onOpenChange, model, engine, recipe }: RecipeDrawerProps) {
+  if (!model || !engine || !recipe) {
+    return (
+      <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+        <DialogPrimitive.Portal />
+      </DialogPrimitive.Root>
+    );
+  }
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay
+          className={cn(
+            "fixed inset-0 z-50 bg-black/40 backdrop-blur-[1px]",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out",
+            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          )}
+        />
+        <DialogPrimitive.Content
+          className={cn(
+            "fixed inset-y-0 right-0 z-50 flex w-full max-w-[640px] flex-col border-l border-border bg-background shadow-2xl",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out",
+            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
+            "duration-200",
+          )}
+        >
+          <header className="flex items-start justify-between gap-4 border-b border-border px-6 py-4">
+            <div className="min-w-0 flex-1">
+              <DialogPrimitive.Title className="text-base font-semibold leading-snug">
+                {model.name}
+                <span className="mx-2 text-muted-foreground/60">×</span>
+                <span className="text-primary">{engine.name}</span>
+              </DialogPrimitive.Title>
+              <DialogPrimitive.Description className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+                <span>{model.meta}</span>
+                <span>·</span>
+                <span>{engine.vendor}</span>
+                <span>·</span>
+                <StatusBadge status={recipe.status} />
+              </DialogPrimitive.Description>
+            </div>
+            <DialogPrimitive.Close asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 shrink-0"
+                aria-label="关闭"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </DialogPrimitive.Close>
+          </header>
+
+          <div className="flex-1 overflow-y-auto px-6 py-5">
+            <section className="space-y-2.5">
+              {recipe.image ? (
+                <FieldRow
+                  label="推荐镜像"
+                  value={<code className="font-mono text-xs">{recipe.image}</code>}
+                />
+              ) : null}
+              {recipe.minVersion ? (
+                <FieldRow
+                  label="最低版本"
+                  value={<code className="font-mono text-xs">{recipe.minVersion}</code>}
+                />
+              ) : null}
+              {recipe.resource ? <FieldRow label="资源建议" value={recipe.resource} /> : null}
+            </section>
+
+            {recipe.command ? (
+              <section className="mt-6">
+                <CodeBlock code={recipe.command} label="启动命令" />
+              </section>
+            ) : null}
+
+            {recipe.params && recipe.params.length > 0 ? (
+              <section className="mt-6">
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  关键参数
+                </h3>
+                <div className="overflow-hidden rounded-md border border-border">
+                  <table className="w-full text-sm">
+                    <tbody>
+                      {recipe.params.map((p, idx) => (
+                        <tr
+                          key={p.key}
+                          className={cn(idx > 0 && "border-t border-border", "align-top")}
+                        >
+                          <td className="w-56 bg-muted/40 px-3 py-2 font-mono text-xs">{p.key}</td>
+                          <td className="px-3 py-2 font-mono text-xs text-primary">{p.value}</td>
+                          <td className="px-3 py-2 text-xs text-muted-foreground">{p.desc}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+            ) : null}
+
+            {recipe.notes ? (
+              <section className="mt-6">
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  注意事项
+                </h3>
+                <p className="rounded-md border-l-2 border-amber-400 bg-amber-50/40 px-3 py-2 text-sm leading-relaxed text-foreground/90 dark:bg-amber-950/20">
+                  {recipe.notes}
+                </p>
+              </section>
+            ) : null}
+
+            {recipe.docUrl ? (
+              <section className="mt-6">
+                <a
+                  href={recipe.docUrl}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+                >
+                  <ExternalLink className="h-3.5 w-3.5" />
+                  官方文档
+                </a>
+              </section>
+            ) : null}
+
+            {!recipe.command && !recipe.image && !recipe.notes ? (
+              <section className="mt-6 rounded-md border border-dashed border-border px-4 py-6 text-center text-sm text-muted-foreground">
+                {recipe.tooltip ?? "该组合暂未填充详细配置,欢迎补充。"}
+              </section>
+            ) : null}
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/apps/web/src/features/deployment-recipes/data.ts
+++ b/apps/web/src/features/deployment-recipes/data.ts
@@ -1,0 +1,1062 @@
+import type { CategoryMeta, EngineMeta, EngineRecipe, ModelEntry, RecipeStatus } from "./types";
+
+// ---------------------------------------------------------------------------
+// Static metadata
+// ---------------------------------------------------------------------------
+
+export const ENGINES: EngineMeta[] = [
+  { id: "vllm", name: "vLLM", vendor: "UC Berkeley" },
+  { id: "sglang", name: "SGLang", vendor: "LMSYS" },
+  { id: "trtllm", name: "TensorRT-LLM", vendor: "NVIDIA" },
+  { id: "mindie", name: "MindIE", vendor: "Huawei Ascend" },
+  { id: "lmdeploy", name: "LMDeploy", vendor: "InternLM" },
+  { id: "tgi", name: "TGI", vendor: "HuggingFace" },
+  { id: "tei", name: "TEI", vendor: "HuggingFace" },
+  { id: "infinity", name: "Infinity", vendor: "Michael Feil" },
+  { id: "llamacpp", name: "llama.cpp", vendor: "ggml.ai" },
+  { id: "comfyui", name: "ComfyUI / Diffusers", vendor: "comfyanonymous · HF" },
+];
+
+export const CATEGORIES: CategoryMeta[] = [
+  { id: "dense", label: "稠密 LLM", description: "Llama / Qwen / Mistral 系" },
+  { id: "moe", label: "MoE 大模型", description: "DeepSeek / Llama4 / GPT-OSS / Qwen3-MoE" },
+  { id: "vlm", label: "多模态 / VLM", description: "Vision-Language Models" },
+  { id: "embedding", label: "Embedding", description: "向量召回 / 检索" },
+  { id: "rerank", label: "Rerank", description: "二阶段重排" },
+  { id: "diffusion", label: "文生图", description: "Diffusion · Image" },
+];
+
+// ---------------------------------------------------------------------------
+// Recipe builders
+// ---------------------------------------------------------------------------
+
+const native = (r: Omit<EngineRecipe, "status">): EngineRecipe => ({ status: "native", ...r });
+const partial = (r: Omit<EngineRecipe, "status">): EngineRecipe => ({ status: "partial", ...r });
+
+// Common HF cache volume snippet — single source of truth.
+const HF_VOL = "-v $HOME/.cache/huggingface:/root/.cache/huggingface";
+
+// ---------------------------------------------------------------------------
+// MODELS
+// ---------------------------------------------------------------------------
+
+export const MODELS: ModelEntry[] = [
+  // =========================================================================
+  // A. 稠密 LLM
+  // =========================================================================
+  {
+    id: "llama-3",
+    name: "Llama 3.1 / 3.3 (8B/70B)",
+    category: "dense",
+    meta: "Meta · 通用基线",
+    engines: {
+      vllm: native({
+        minVersion: "0.5.4",
+        image: "vllm/vllm-openai:v0.7.3",
+        tooltip: "vLLM ≥ 0.5.4,70B 推荐 TP=4",
+        command: `docker run --gpus all --shm-size 16g \\
+  -p 8000:8000 ${HF_VOL} \\
+  vllm/vllm-openai:v0.7.3 \\
+  --model meta-llama/Llama-3.3-70B-Instruct \\
+  --tensor-parallel-size 4 \\
+  --max-model-len 32768 \\
+  --gpu-memory-utilization 0.92`,
+        params: [
+          { key: "--tensor-parallel-size", value: "4", desc: "70B 推荐 4 卡 TP" },
+          {
+            key: "--max-model-len",
+            value: "32768",
+            desc: "上下文长度,Llama 3.3 原生 128k 可酌情拉满",
+          },
+          { key: "--gpu-memory-utilization", value: "0.92", desc: "KV cache 预算" },
+        ],
+        resource: "70B: 4× H100 80GB / A100 80GB · 8B: 1× L20 / A100",
+        notes: "Llama 3.3 模板新增 toolcalls,客户端需走 OpenAI tool-use 协议。",
+        docUrl: "https://docs.vllm.ai/en/latest/models/supported_models.html",
+      }),
+      sglang: native({
+        minVersion: "0.4.0",
+        image: "lmsysorg/sglang:v0.4.3-cu124",
+        tooltip: "SGLang ≥ 0.4.0,RadixAttention 默认开",
+        command: `docker run --gpus all --shm-size 16g \\
+  -p 30000:30000 ${HF_VOL} \\
+  lmsysorg/sglang:v0.4.3-cu124 \\
+  python -m sglang.launch_server \\
+    --model-path meta-llama/Llama-3.3-70B-Instruct \\
+    --tp 4 \\
+    --host 0.0.0.0 --port 30000`,
+        params: [
+          { key: "--tp", value: "4", desc: "70B 推荐 4 卡 TP" },
+          { key: "--mem-fraction-static", value: "0.85", desc: "缓存比例,过高易 OOM" },
+        ],
+        resource: "70B: 4× H100 / A100 80GB",
+        docUrl: "https://docs.sglang.ai/backend/server_arguments.html",
+      }),
+      trtllm: native({
+        minVersion: "0.10.0",
+        image: "nvcr.io/nvidia/tritonserver:24.10-trtllm-python-py3",
+        tooltip: "需要预先 trtllm-build 转引擎",
+        notes: "需先 trtllm-build 把 HF 权重编为 .engine,推荐 FP8 / W4A16 量化提升吞吐。",
+        docUrl: "https://nvidia.github.io/TensorRT-LLM/llm-api/index.html",
+      }),
+      mindie: native({
+        minVersion: "1.0.RC3",
+        image: "swr.cn-south-1.myhuaweicloud.com/ascendhub/mindie:1.0.RC3-800I-A2",
+        tooltip: "Atlas 800I A2 / 910B,FP16 直跑",
+        notes:
+          "需预下载权重到 /workspace/models;config.json 配 Llama 模板。Ascend 设备 socket 须挂载。",
+        docUrl: "https://www.hiascend.com/document/detail/zh/mindie/10RC3/index/index.html",
+      }),
+      lmdeploy: native({
+        minVersion: "0.6.0",
+        image: "openmmlab/lmdeploy:v0.6.4",
+        tooltip: "TurboMind 后端,W4A16 加速明显",
+        command: `docker run --gpus all --shm-size 16g \\
+  -p 23333:23333 ${HF_VOL} \\
+  openmmlab/lmdeploy:v0.6.4 \\
+  lmdeploy serve api_server \\
+    meta-llama/Llama-3.3-70B-Instruct \\
+    --backend turbomind --tp 4 \\
+    --server-port 23333`,
+        params: [
+          {
+            key: "--backend",
+            value: "turbomind",
+            desc: "首选 turbomind;PyTorch 后端用 --backend pytorch",
+          },
+          { key: "--tp", value: "4", desc: "70B 推荐 4 卡 TP" },
+        ],
+        resource: "70B: 4× A100 80GB",
+        docUrl: "https://lmdeploy.readthedocs.io/",
+      }),
+      tgi: native({
+        minVersion: "2.3",
+        image: "ghcr.io/huggingface/text-generation-inference:2.3.0",
+        tooltip: "Llama 3.x 一等公民支持",
+        notes: "shm-size ≥ 1g 否则多卡 NCCL 报错;HF token 通过 -e HF_TOKEN 注入。",
+        docUrl: "https://huggingface.co/docs/text-generation-inference/index",
+      }),
+      llamacpp: native({
+        minVersion: "b3300",
+        image: "ghcr.io/ggerganov/llama.cpp:server",
+        tooltip: "GGUF 量化版本,本地 CPU/Metal/ROCm 都行",
+        notes: "70B 推荐 Q4_K_M(~40GB)+ mmap;长上下文用 -c 32768。",
+        docUrl: "https://github.com/ggml-org/llama.cpp",
+      }),
+    },
+  },
+  {
+    id: "qwen-2-5",
+    name: "Qwen2.5 / Qwen3 (0.5B–72B)",
+    category: "dense",
+    meta: "阿里 · 中文首选",
+    engines: {
+      vllm: native({
+        minVersion: "0.6.3",
+        image: "vllm/vllm-openai:v0.7.3",
+        tooltip: "Qwen2.5/3 全规格,72B 推荐 TP=4",
+        command: `docker run --gpus all --shm-size 16g \\
+  -p 8000:8000 ${HF_VOL} \\
+  vllm/vllm-openai:v0.7.3 \\
+  --model Qwen/Qwen2.5-72B-Instruct \\
+  --tensor-parallel-size 4 \\
+  --max-model-len 32768 \\
+  --enforce-eager`,
+        params: [
+          { key: "--tensor-parallel-size", value: "4", desc: "72B 推荐 4 卡 TP" },
+          { key: "--rope-scaling", value: "yarn", desc: "需要 128k 时配 YARN" },
+        ],
+        resource: "72B: 4× A100/H100 80GB · 7B: 1 卡",
+        docUrl: "https://qwen.readthedocs.io/en/latest/deployment/vllm.html",
+      }),
+      sglang: native({
+        minVersion: "0.4.0",
+        image: "lmsysorg/sglang:v0.4.3-cu124",
+        tooltip: "Qwen2.5 一等公民,prefix cache 命中率高",
+        command: `docker run --gpus all --shm-size 16g \\
+  -p 30000:30000 ${HF_VOL} \\
+  lmsysorg/sglang:v0.4.3-cu124 \\
+  python -m sglang.launch_server \\
+    --model-path Qwen/Qwen2.5-72B-Instruct \\
+    --tp 4 --host 0.0.0.0 --port 30000`,
+        params: [{ key: "--tp", value: "4", desc: "72B 推荐 4 卡 TP" }],
+        resource: "72B: 4× A100/H100 80GB",
+        docUrl: "https://docs.sglang.ai/",
+      }),
+      trtllm: native({
+        minVersion: "0.13.0",
+        image: "nvcr.io/nvidia/tritonserver:24.10-trtllm-python-py3",
+        tooltip: "Qwen2 系列需 0.13+",
+        notes:
+          "Qwen2.5 需要 trtllm 0.13+;Qwen3 建议 1.0+。先 trtllm-build,后用 trtllm-serve 启动。",
+        docUrl: "https://nvidia.github.io/TensorRT-LLM/",
+      }),
+      mindie: native({
+        minVersion: "1.0.RC3",
+        image: "swr.cn-south-1.myhuaweicloud.com/ascendhub/mindie:1.0.RC3-800I-A2",
+        tooltip: "国产场景首选,Qwen2.5 模板内置",
+        docUrl: "https://www.hiascend.com/document/detail/zh/mindie/",
+      }),
+      lmdeploy: native({
+        minVersion: "0.6.0",
+        image: "openmmlab/lmdeploy:v0.6.4",
+        tooltip: "TurboMind + AWQ 量化跑得最快",
+        command: `docker run --gpus all --shm-size 16g \\
+  -p 23333:23333 ${HF_VOL} \\
+  openmmlab/lmdeploy:v0.6.4 \\
+  lmdeploy serve api_server \\
+    Qwen/Qwen2.5-72B-Instruct-AWQ \\
+    --backend turbomind --tp 2 \\
+    --model-format awq --quant-policy 4`,
+        notes: "AWQ 版本可压到 2 卡 80GB。",
+        docUrl: "https://lmdeploy.readthedocs.io/",
+      }),
+      tgi: native({
+        minVersion: "2.3",
+        image: "ghcr.io/huggingface/text-generation-inference:2.3.0",
+        tooltip: "Qwen2.5 / Qwen3 主线支持",
+        docUrl: "https://huggingface.co/docs/text-generation-inference/",
+      }),
+      llamacpp: native({
+        minVersion: "b3500",
+        image: "ghcr.io/ggerganov/llama.cpp:server",
+        tooltip: "GGUF 中文表现稳",
+        notes: "Qwen3-Thinking 类模型需用 b4300+ 才能正确处理 <think> 标签。",
+        docUrl: "https://github.com/ggml-org/llama.cpp",
+      }),
+    },
+  },
+  {
+    id: "mistral",
+    name: "Mistral 7B / Nemo / Small",
+    category: "dense",
+    meta: "Mistral AI",
+    engines: {
+      vllm: native({
+        minVersion: "0.5.0",
+        image: "vllm/vllm-openai:v0.7.3",
+        tooltip: "Mistral / Nemo / Small 全系列",
+        notes: "Mistral 模板不带 system role,客户端需自行拼装。",
+        docUrl: "https://docs.vllm.ai/",
+      }),
+      sglang: native({
+        minVersion: "0.4.0",
+        image: "lmsysorg/sglang:v0.4.3-cu124",
+        tooltip: "Mistral 系列原生支持",
+      }),
+      trtllm: native({
+        minVersion: "0.10.0",
+        image: "nvcr.io/nvidia/tritonserver:24.10-trtllm-python-py3",
+        tooltip: "需 trtllm-build 转引擎",
+      }),
+      mindie: partial({
+        tooltip: "Mistral 7B 走通用 Llama 模板,Nemo / Small 需自行验证",
+        notes: "// TODO: Nemo tokenizer 兼容性待验证。",
+      }),
+      lmdeploy: native({
+        minVersion: "0.6.0",
+        image: "openmmlab/lmdeploy:v0.6.4",
+        tooltip: "TurboMind 支持 Mistral",
+      }),
+      tgi: native({
+        minVersion: "2.0",
+        image: "ghcr.io/huggingface/text-generation-inference:2.3.0",
+        tooltip: "TGI 长期 first-class 支持",
+      }),
+      llamacpp: native({
+        minVersion: "b3000",
+        image: "ghcr.io/ggerganov/llama.cpp:server",
+        tooltip: "GGUF 量化版本广泛可用",
+      }),
+    },
+  },
+  {
+    id: "gemma",
+    name: "Gemma 2 / 3",
+    category: "dense",
+    meta: "Google",
+    engines: {
+      vllm: native({
+        minVersion: "0.5.4",
+        image: "vllm/vllm-openai:v0.7.3",
+        tooltip: "Gemma 2/3 文本部分;Gemma 3 多模态见 VLM 行",
+      }),
+      sglang: native({
+        minVersion: "0.4.1",
+        image: "lmsysorg/sglang:v0.4.3-cu124",
+        tooltip: "Gemma 2/3-text 支持",
+      }),
+      trtllm: partial({
+        tooltip: "Gemma 2 部分支持,Gemma 3 等 trtllm 1.x",
+        notes: "// TODO: Gemma 3 trtllm-build 兼容性待 NVIDIA 1.x 路线图确认。",
+      }),
+      lmdeploy: native({
+        minVersion: "0.6.2",
+        image: "openmmlab/lmdeploy:v0.6.4",
+        tooltip: "Gemma 2/3 原生",
+      }),
+      tgi: native({
+        minVersion: "2.2",
+        image: "ghcr.io/huggingface/text-generation-inference:2.3.0",
+        tooltip: "Google + HF 共建",
+      }),
+      llamacpp: native({
+        minVersion: "b3300",
+        image: "ghcr.io/ggerganov/llama.cpp:server",
+        tooltip: "GGUF 已上 ggml-org",
+      }),
+    },
+  },
+  {
+    id: "phi",
+    name: "Phi-3 / Phi-4",
+    category: "dense",
+    meta: "Microsoft",
+    engines: {
+      vllm: native({
+        minVersion: "0.6.4",
+        image: "vllm/vllm-openai:v0.7.3",
+        tooltip: "Phi-3.5 / Phi-4 14B 直接跑",
+      }),
+      sglang: native({
+        minVersion: "0.4.0",
+        image: "lmsysorg/sglang:v0.4.3-cu124",
+        tooltip: "Phi-3 / Phi-4 主线支持",
+      }),
+      trtllm: native({
+        minVersion: "0.13.0",
+        image: "nvcr.io/nvidia/tritonserver:24.10-trtllm-python-py3",
+        tooltip: "Phi-3 ✓,Phi-4 需 trtllm 1.0+",
+      }),
+      lmdeploy: native({
+        minVersion: "0.6.0",
+        image: "openmmlab/lmdeploy:v0.6.4",
+        tooltip: "TurboMind 支持",
+      }),
+      tgi: native({
+        minVersion: "2.2",
+        image: "ghcr.io/huggingface/text-generation-inference:2.3.0",
+      }),
+      llamacpp: native({
+        minVersion: "b3300",
+        image: "ghcr.io/ggerganov/llama.cpp:server",
+      }),
+    },
+  },
+  {
+    id: "internlm",
+    name: "InternLM3",
+    category: "dense",
+    meta: "上海 AI Lab",
+    engines: {
+      vllm: native({
+        minVersion: "0.6.0",
+        image: "vllm/vllm-openai:v0.7.3",
+        tooltip: "InternLM3 8B 文本",
+      }),
+      sglang: partial({
+        tooltip: "通过通用 LlamaForCausalLM 路径加载,部分模板需自定",
+      }),
+      lmdeploy: native({
+        minVersion: "0.6.4",
+        image: "openmmlab/lmdeploy:v0.6.4",
+        tooltip: "InternLM 自家引擎,首选",
+        command: `docker run --gpus all --shm-size 16g \\
+  -p 23333:23333 ${HF_VOL} \\
+  openmmlab/lmdeploy:v0.6.4 \\
+  lmdeploy serve api_server internlm/internlm3-8b-instruct \\
+    --backend turbomind --tp 1`,
+        docUrl: "https://lmdeploy.readthedocs.io/",
+      }),
+      tgi: partial({ tooltip: "可加载,模板需手动配置" }),
+      llamacpp: native({
+        minVersion: "b3500",
+        image: "ghcr.io/ggerganov/llama.cpp:server",
+      }),
+    },
+  },
+  {
+    id: "glm-4",
+    name: "GLM-4",
+    category: "dense",
+    meta: "智谱",
+    engines: {
+      vllm: native({
+        minVersion: "0.6.0",
+        image: "vllm/vllm-openai:v0.7.3",
+        tooltip: "GLM-4 9B/Air 文本",
+        notes: "GLM-4 需 --trust-remote-code。",
+      }),
+      sglang: native({
+        minVersion: "0.4.0",
+        image: "lmsysorg/sglang:v0.4.3-cu124",
+        tooltip: "GLM-4 主线支持",
+      }),
+      lmdeploy: native({
+        minVersion: "0.6.2",
+        image: "openmmlab/lmdeploy:v0.6.4",
+        tooltip: "TurboMind + GLM-4 模板",
+      }),
+      mindie: partial({ tooltip: "通过通用模板可跑,需自行验证 chat template" }),
+      llamacpp: native({
+        minVersion: "b3700",
+        image: "ghcr.io/ggerganov/llama.cpp:server",
+      }),
+    },
+  },
+  {
+    id: "yi",
+    name: "Yi-1.5",
+    category: "dense",
+    meta: "零一万物",
+    engines: {
+      vllm: native({
+        minVersion: "0.5.0",
+        image: "vllm/vllm-openai:v0.7.3",
+      }),
+      sglang: native({
+        minVersion: "0.4.0",
+        image: "lmsysorg/sglang:v0.4.3-cu124",
+      }),
+      lmdeploy: native({
+        minVersion: "0.6.0",
+        image: "openmmlab/lmdeploy:v0.6.4",
+      }),
+      tgi: native({
+        minVersion: "2.0",
+        image: "ghcr.io/huggingface/text-generation-inference:2.3.0",
+      }),
+      llamacpp: native({
+        minVersion: "b3000",
+        image: "ghcr.io/ggerganov/llama.cpp:server",
+      }),
+    },
+  },
+
+  // =========================================================================
+  // B. MoE 大模型
+  // =========================================================================
+  {
+    id: "deepseek-v3",
+    name: "DeepSeek-V3 / R1 (671B)",
+    category: "moe",
+    meta: "DeepSeek · MLA + MoE",
+    engines: {
+      vllm: native({
+        minVersion: "0.7.0",
+        image: "vllm/vllm-openai:v0.7.3",
+        tooltip: "vLLM ≥ 0.7 完整支持 MLA + MoE 路由",
+        command: `docker run --gpus all --shm-size 32g \\
+  -p 8000:8000 ${HF_VOL} \\
+  vllm/vllm-openai:v0.7.3 \\
+  --model deepseek-ai/DeepSeek-V3 \\
+  --tensor-parallel-size 8 \\
+  --max-model-len 65536 \\
+  --trust-remote-code \\
+  --enable-expert-parallel \\
+  --gpu-memory-utilization 0.92`,
+        params: [
+          { key: "--tensor-parallel-size", value: "8", desc: "MLA 友好,8 卡 TP" },
+          { key: "--enable-expert-parallel", value: "(flag)", desc: "启用 EP 提升 MoE 吞吐" },
+          { key: "--max-model-len", value: "65536", desc: "默认上下文 64k,可拉满 128k" },
+          { key: "--trust-remote-code", value: "(flag)", desc: "DeepSeek 自定义 attn 实现" },
+        ],
+        resource: "8× H100 80GB / H800 · 启用 EP",
+        notes: "shm-size 必须 ≥ 32g;FP8 量化版本需 vLLM 0.7.3+。",
+        docUrl: "https://docs.vllm.ai/en/latest/models/supported_models.html",
+      }),
+      sglang: native({
+        minVersion: "0.4.0",
+        image: "lmsysorg/sglang:v0.4.3-cu124",
+        tooltip: "SGLang 0.4 起官方推 DSV3 优化",
+        command: `docker run --gpus all --shm-size 32g \\
+  -p 30000:30000 ${HF_VOL} \\
+  lmsysorg/sglang:v0.4.3-cu124 \\
+  python -m sglang.launch_server \\
+    --model-path deepseek-ai/DeepSeek-V3 \\
+    --tp 8 --trust-remote-code \\
+    --enable-dp-attention \\
+    --host 0.0.0.0 --port 30000`,
+        params: [
+          { key: "--tp", value: "8", desc: "8 卡 TP" },
+          {
+            key: "--enable-dp-attention",
+            value: "(flag)",
+            desc: "DP-attention 提升长 context 吞吐",
+          },
+        ],
+        resource: "8× H100 / H800 80GB",
+        docUrl: "https://docs.sglang.ai/references/deepseek.html",
+      }),
+      trtllm: partial({
+        minVersion: "1.0.0",
+        tooltip: "trtllm 1.0+ 起加 MLA / DSV3 路径",
+        notes: "DSV3 + FP8 在 trtllm 上还在打磨,生产建议先用 vLLM/SGLang。",
+      }),
+      mindie: native({
+        minVersion: "1.0.RC3",
+        image: "swr.cn-south-1.myhuaweicloud.com/ascendhub/mindie:1.0.RC3-800I-A2",
+        tooltip: "Atlas 800I A2 / 910B,DSV3 已对接",
+        notes: "需 16 卡 910B 跑 671B 全量;Lite 版本下放到 8 卡。",
+        docUrl: "https://www.hiascend.com/document/detail/zh/mindie/",
+      }),
+      lmdeploy: partial({
+        tooltip: "PyTorch 后端可加载,turbomind 暂未优化 MLA",
+        notes: "// TODO: 等 LMDeploy 0.7+ 给 MLA 加官方路径。",
+      }),
+      llamacpp: partial({
+        tooltip: "社区 fork 有 GGUF,Q4_K 量化勉强可推理",
+        notes: "上下游分歧大,生产不建议。",
+      }),
+    },
+  },
+  {
+    id: "deepseek-v2",
+    name: "DeepSeek-V2 (236B)",
+    category: "moe",
+    meta: "DeepSeek · MoE",
+    engines: {
+      vllm: native({
+        minVersion: "0.5.4",
+        image: "vllm/vllm-openai:v0.7.3",
+        tooltip: "DSV2 / V2-Lite 支持完善",
+      }),
+      sglang: native({
+        minVersion: "0.3.0",
+        image: "lmsysorg/sglang:v0.4.3-cu124",
+      }),
+      mindie: native({
+        minVersion: "1.0.RC3",
+        image: "swr.cn-south-1.myhuaweicloud.com/ascendhub/mindie:1.0.RC3-800I-A2",
+      }),
+      lmdeploy: partial({ tooltip: "PyTorch 后端可跑,turbomind 不支持" }),
+    },
+  },
+  {
+    id: "qwen3-moe",
+    name: "Qwen3-MoE (30B-A3B / 235B-A22B)",
+    category: "moe",
+    meta: "阿里 · MoE",
+    engines: {
+      vllm: native({
+        minVersion: "0.7.0",
+        image: "vllm/vllm-openai:v0.7.3",
+        tooltip: "Qwen3-MoE 235B 推荐 8 卡 TP + EP",
+        command: `docker run --gpus all --shm-size 32g \\
+  -p 8000:8000 ${HF_VOL} \\
+  vllm/vllm-openai:v0.7.3 \\
+  --model Qwen/Qwen3-235B-A22B-Instruct-2507 \\
+  --tensor-parallel-size 8 \\
+  --enable-expert-parallel \\
+  --max-model-len 32768 \\
+  --trust-remote-code`,
+        resource: "235B: 8× H100 80GB · 30B-A3B: 2× A100",
+        docUrl: "https://qwen.readthedocs.io/",
+      }),
+      sglang: native({
+        minVersion: "0.4.3",
+        image: "lmsysorg/sglang:v0.4.3-cu124",
+        tooltip: "Qwen3-MoE 已合并主线",
+      }),
+      trtllm: partial({ tooltip: "30B-A3B 部分支持,235B 待验证" }),
+      mindie: partial({
+        tooltip: "30B-A3B 已对接,235B 待昇腾 1.0.RC4 路线图",
+        notes: "// TODO: 235B-A22B on Ascend 待 1.0.RC4 release notes 确认。",
+      }),
+    },
+  },
+  {
+    id: "llama4",
+    name: "Llama 4 Scout / Maverick",
+    category: "moe",
+    meta: "Meta · 多模态 MoE",
+    engines: {
+      vllm: native({
+        minVersion: "0.8.0",
+        image: "vllm/vllm-openai:v0.8.4",
+        tooltip: "Llama 4 需 vLLM 0.8+",
+        notes:
+          "Scout/Maverick 都是 MoE 多模态,启动加 --limit-mm-per-prompt 与 --enable-expert-parallel。",
+      }),
+      sglang: native({
+        minVersion: "0.4.5",
+        image: "lmsysorg/sglang:v0.4.5-cu124",
+        tooltip: "Llama 4 第一波支持引擎之一",
+      }),
+      trtllm: partial({ tooltip: "trtllm 1.0+ 加入,持续打磨" }),
+    },
+  },
+  {
+    id: "gpt-oss",
+    name: "GPT-OSS-120B / 20B",
+    category: "moe",
+    meta: "OpenAI · 开源 MoE",
+    engines: {
+      vllm: native({
+        minVersion: "0.10.0",
+        image: "vllm/vllm-openai:v0.10.0",
+        tooltip: "vLLM 官方对接,FP8 推理",
+        notes: "120B 推荐 8× H100;20B 单机 1×H100 即可。",
+      }),
+      sglang: native({
+        minVersion: "0.4.6",
+        image: "lmsysorg/sglang:v0.4.6-cu124",
+        tooltip: "SGLang 紧跟 OpenAI 开源",
+      }),
+      trtllm: partial({ tooltip: "trtllm 1.0+ 路径 in flight" }),
+    },
+  },
+  {
+    id: "mixtral-moe",
+    name: "Mixtral 8x7B / 8x22B",
+    category: "moe",
+    meta: "Mistral AI · 经典 MoE",
+    engines: {
+      vllm: native({
+        minVersion: "0.4.0",
+        image: "vllm/vllm-openai:v0.7.3",
+        tooltip: "Mixtral 8x22B 推荐 4-8 卡 TP",
+      }),
+      sglang: native({
+        minVersion: "0.3.0",
+        image: "lmsysorg/sglang:v0.4.3-cu124",
+      }),
+      trtllm: native({
+        minVersion: "0.10.0",
+        image: "nvcr.io/nvidia/tritonserver:24.10-trtllm-python-py3",
+        tooltip: "Mixtral 是 TRT-LLM MoE 第一公民",
+      }),
+      mindie: partial({ tooltip: "8x7B 通用模板可跑,8x22B 需自行验证" }),
+      lmdeploy: native({
+        minVersion: "0.6.0",
+        image: "openmmlab/lmdeploy:v0.6.4",
+      }),
+      tgi: native({
+        minVersion: "1.4",
+        image: "ghcr.io/huggingface/text-generation-inference:2.3.0",
+        tooltip: "Mixtral 是 TGI MoE 主线",
+      }),
+      llamacpp: native({
+        minVersion: "b3500",
+        image: "ghcr.io/ggerganov/llama.cpp:server",
+        tooltip: "GGUF 8x7B Q4_K_M ~24GB",
+      }),
+    },
+  },
+
+  // =========================================================================
+  // C. 多模态 / VLM
+  // =========================================================================
+  {
+    id: "qwen-vl",
+    name: "Qwen2.5-VL / Qwen3-VL",
+    category: "vlm",
+    meta: "阿里 · 视觉语言",
+    engines: {
+      vllm: native({
+        minVersion: "0.7.0",
+        image: "vllm/vllm-openai:v0.7.3",
+        tooltip: "Qwen2.5-VL 7B/72B 主线",
+        command: `docker run --gpus all --shm-size 16g \\
+  -p 8000:8000 ${HF_VOL} \\
+  vllm/vllm-openai:v0.7.3 \\
+  --model Qwen/Qwen2.5-VL-7B-Instruct \\
+  --max-model-len 32768 \\
+  --limit-mm-per-prompt image=4 \\
+  --trust-remote-code`,
+        params: [
+          { key: "--limit-mm-per-prompt", value: "image=4", desc: "单 prompt 最多 4 图" },
+          { key: "--max-num-seqs", value: "8", desc: "并发降低显存压力" },
+        ],
+        docUrl:
+          "https://docs.vllm.ai/en/latest/models/supported_models.html#multimodal-language-models",
+      }),
+      sglang: native({
+        minVersion: "0.4.2",
+        image: "lmsysorg/sglang:v0.4.3-cu124",
+        tooltip: "Qwen-VL 视觉编码器 + 语言塔",
+      }),
+      lmdeploy: native({
+        minVersion: "0.6.0",
+        image: "openmmlab/lmdeploy:v0.6.4",
+        tooltip: "TurboMind VLM 路径,支持图文",
+      }),
+      mindie: partial({ tooltip: "Qwen2-VL 模板已就绪,Qwen2.5/3-VL 持续完善" }),
+      tgi: partial({ tooltip: "通过 multimodal 路径,部分图像分辨率限制" }),
+    },
+  },
+  {
+    id: "internvl",
+    name: "InternVL3",
+    category: "vlm",
+    meta: "上海 AI Lab · VLM",
+    engines: {
+      vllm: native({
+        minVersion: "0.7.0",
+        image: "vllm/vllm-openai:v0.7.3",
+        tooltip: "InternVL3 8B/38B 主线支持",
+      }),
+      sglang: partial({ tooltip: "需要 0.4.3+,部分 chat template 自定义" }),
+      lmdeploy: native({
+        minVersion: "0.6.0",
+        image: "openmmlab/lmdeploy:v0.6.4",
+        tooltip: "InternVL 系列首选",
+      }),
+    },
+  },
+  {
+    id: "llava-next",
+    name: "LLaVA-Next",
+    category: "vlm",
+    meta: "UW · LLaVA 系列",
+    engines: {
+      vllm: native({
+        minVersion: "0.5.0",
+        image: "vllm/vllm-openai:v0.7.3",
+        tooltip: "LLaVA-Next-Video 也支持",
+      }),
+      sglang: native({
+        minVersion: "0.4.0",
+        image: "lmsysorg/sglang:v0.4.3-cu124",
+      }),
+      lmdeploy: native({
+        minVersion: "0.6.0",
+        image: "openmmlab/lmdeploy:v0.6.4",
+      }),
+      tgi: partial({ tooltip: "LLaVA-Next 走 messages API,需 multimodal flag" }),
+    },
+  },
+  {
+    id: "minicpm-v",
+    name: "MiniCPM-V 2.6 / o2.6",
+    category: "vlm",
+    meta: "面壁智能",
+    engines: {
+      vllm: native({
+        minVersion: "0.6.0",
+        image: "vllm/vllm-openai:v0.7.3",
+        tooltip: "MiniCPM-V 2.6 / o2.6 全模态",
+      }),
+      sglang: partial({ tooltip: "通过通用 VLM 路径加载" }),
+      lmdeploy: native({
+        minVersion: "0.6.0",
+        image: "openmmlab/lmdeploy:v0.6.4",
+      }),
+      llamacpp: partial({ tooltip: "GGUF 量化 + clip vision encoder 走 minicpmv-cli" }),
+    },
+  },
+  {
+    id: "pixtral",
+    name: "Pixtral 12B",
+    category: "vlm",
+    meta: "Mistral · VLM",
+    engines: {
+      vllm: native({
+        minVersion: "0.6.2",
+        image: "vllm/vllm-openai:v0.7.3",
+        tooltip: "Mistral 官方推荐用 vLLM",
+      }),
+      sglang: native({
+        minVersion: "0.4.0",
+        image: "lmsysorg/sglang:v0.4.3-cu124",
+      }),
+      lmdeploy: partial({ tooltip: "PyTorch 后端可跑" }),
+    },
+  },
+  {
+    id: "gemma-3-mm",
+    name: "Gemma 3 (multimodal)",
+    category: "vlm",
+    meta: "Google · 多模态",
+    engines: {
+      vllm: native({
+        minVersion: "0.8.0",
+        image: "vllm/vllm-openai:v0.8.4",
+        tooltip: "Gemma 3 视觉部分需 0.8+",
+      }),
+      sglang: native({
+        minVersion: "0.4.4",
+        image: "lmsysorg/sglang:v0.4.4-cu124",
+      }),
+      lmdeploy: partial({ tooltip: "0.7+ 路线图" }),
+    },
+  },
+
+  // =========================================================================
+  // D. Embedding
+  // =========================================================================
+  {
+    id: "bge-m3",
+    name: "BGE-M3",
+    category: "embedding",
+    meta: "BAAI · 多语言密集 + 稀疏",
+    engines: {
+      tei: native({
+        minVersion: "1.5",
+        image: "ghcr.io/huggingface/text-embeddings-inference:1.5",
+        tooltip: "TEI 是 BGE 系列首选",
+        command: `docker run --gpus all -p 8080:80 ${HF_VOL} \\
+  ghcr.io/huggingface/text-embeddings-inference:1.5 \\
+  --model-id BAAI/bge-m3 \\
+  --max-batch-tokens 16384`,
+        params: [
+          { key: "--model-id", value: "BAAI/bge-m3", desc: "HF 仓库 id" },
+          { key: "--max-batch-tokens", value: "16384", desc: "批量 token 上限" },
+        ],
+        resource: "1× T4 / L4 / A10G",
+        docUrl: "https://huggingface.co/docs/text-embeddings-inference/index",
+      }),
+      infinity: native({
+        minVersion: "0.0.70",
+        image: "michaelf34/infinity:0.0.75",
+        tooltip: "Infinity 跑多模型多并发友好",
+        command: `docker run --gpus all -p 7997:7997 ${HF_VOL} \\
+  michaelf34/infinity:0.0.75 \\
+  v2 --model-id BAAI/bge-m3 --port 7997`,
+        docUrl: "https://github.com/michaelfeil/infinity",
+      }),
+      vllm: partial({
+        minVersion: "0.6.0",
+        tooltip: "vLLM 0.6+ 实验性 embeddings endpoint",
+        notes: "用 --task embed 启动;sparse 输出走 ColBERT 路径需自行实现。",
+      }),
+      llamacpp: native({
+        minVersion: "b3500",
+        image: "ghcr.io/ggerganov/llama.cpp:server",
+        tooltip: "llama-server --embedding,GGUF",
+      }),
+      mindie: partial({ tooltip: "MindIE Service 1.0.RC3+ 提供 embedding endpoint" }),
+    },
+  },
+  {
+    id: "qwen3-embed",
+    name: "Qwen3-Embedding (0.6B / 4B / 8B)",
+    category: "embedding",
+    meta: "阿里 · 通用嵌入",
+    engines: {
+      tei: native({
+        minVersion: "1.6",
+        image: "ghcr.io/huggingface/text-embeddings-inference:1.6",
+        tooltip: "Qwen3-Embedding 走 LLM-style embedding",
+        notes: "Qwen3-Embedding 模型用 TEI 的 --pooling lasttoken。",
+      }),
+      infinity: native({
+        minVersion: "0.0.74",
+        image: "michaelf34/infinity:0.0.75",
+        tooltip: "Infinity 自动识别 lasttoken pooling",
+      }),
+      vllm: partial({
+        tooltip: '需 --task embed + --override-generation-config \'{"pooling":"lasttoken"}\'',
+      }),
+    },
+  },
+  {
+    id: "gte-e5",
+    name: "GTE / E5",
+    category: "embedding",
+    meta: "阿里 · 微软",
+    engines: {
+      tei: native({
+        minVersion: "1.5",
+        image: "ghcr.io/huggingface/text-embeddings-inference:1.5",
+      }),
+      infinity: native({
+        minVersion: "0.0.70",
+        image: "michaelf34/infinity:0.0.75",
+      }),
+      vllm: partial({ tooltip: "通过 --task embed 加载,默认 mean pooling" }),
+      llamacpp: native({
+        minVersion: "b3500",
+        image: "ghcr.io/ggerganov/llama.cpp:server",
+      }),
+    },
+  },
+  {
+    id: "jina-embed-v3",
+    name: "Jina Embeddings v3",
+    category: "embedding",
+    meta: "Jina AI",
+    engines: {
+      tei: native({
+        minVersion: "1.5",
+        image: "ghcr.io/huggingface/text-embeddings-inference:1.5",
+        tooltip: "Jina v3 LoRA adapters 走 task 路径",
+        notes: "需要传 task=retrieval.query/passage 切换 LoRA。",
+      }),
+      infinity: native({
+        minVersion: "0.0.70",
+        image: "michaelf34/infinity:0.0.75",
+      }),
+    },
+  },
+  {
+    id: "nomic-embed",
+    name: "Nomic Embed v1.5",
+    category: "embedding",
+    meta: "Nomic · 长文本",
+    engines: {
+      tei: native({
+        minVersion: "1.5",
+        image: "ghcr.io/huggingface/text-embeddings-inference:1.5",
+      }),
+      infinity: native({
+        minVersion: "0.0.70",
+        image: "michaelf34/infinity:0.0.75",
+      }),
+      llamacpp: native({
+        minVersion: "b3500",
+        image: "ghcr.io/ggerganov/llama.cpp:server",
+      }),
+    },
+  },
+
+  // =========================================================================
+  // E. Rerank
+  // =========================================================================
+  {
+    id: "bge-rerank-v2",
+    name: "BGE-Reranker-v2-M3",
+    category: "rerank",
+    meta: "BAAI · 多语言重排",
+    engines: {
+      tei: native({
+        minVersion: "1.5",
+        image: "ghcr.io/huggingface/text-embeddings-inference:1.5",
+        tooltip: "TEI 1.5 起原生支持 cross-encoder",
+        command: `docker run --gpus all -p 8080:80 ${HF_VOL} \\
+  ghcr.io/huggingface/text-embeddings-inference:1.5 \\
+  --model-id BAAI/bge-reranker-v2-m3 \\
+  --max-batch-tokens 16384`,
+        notes: "调用 /rerank,与 embedding endpoint 同实例可分模型部署。",
+        docUrl: "https://huggingface.co/docs/text-embeddings-inference/",
+      }),
+      infinity: native({
+        minVersion: "0.0.70",
+        image: "michaelf34/infinity:0.0.75",
+        tooltip: "Infinity 同时跑 embedding + rerank",
+      }),
+      vllm: partial({
+        minVersion: "0.7.0",
+        tooltip: "vLLM 0.7+ 实验 score endpoint(/v1/score)",
+      }),
+    },
+  },
+  {
+    id: "qwen3-rerank",
+    name: "Qwen3-Reranker (0.6B / 4B / 8B)",
+    category: "rerank",
+    meta: "阿里 · 重排",
+    engines: {
+      tei: native({
+        minVersion: "1.6",
+        image: "ghcr.io/huggingface/text-embeddings-inference:1.6",
+        tooltip: "Qwen3-Reranker 是 LLM-as-reranker 路径",
+        notes: "需要 --pooling cls + classifier head;某些版本走 generative scorer。",
+      }),
+      infinity: native({
+        minVersion: "0.0.74",
+        image: "michaelf34/infinity:0.0.75",
+      }),
+      vllm: partial({ tooltip: "通过 /v1/score 路径,生产前请压测" }),
+    },
+  },
+  {
+    id: "jina-rerank-v2",
+    name: "Jina Reranker v2",
+    category: "rerank",
+    meta: "Jina AI",
+    engines: {
+      tei: native({
+        minVersion: "1.5",
+        image: "ghcr.io/huggingface/text-embeddings-inference:1.5",
+      }),
+      infinity: native({
+        minVersion: "0.0.70",
+        image: "michaelf34/infinity:0.0.75",
+      }),
+    },
+  },
+
+  // =========================================================================
+  // F. 文生图(Diffusion)
+  // =========================================================================
+  {
+    id: "sdxl",
+    name: "Stable Diffusion XL / 3.5",
+    category: "diffusion",
+    meta: "Stability AI",
+    engines: {
+      comfyui: native({
+        minVersion: "v0.3.0",
+        image: "yanwk/comfyui-boot:cu124-megapak",
+        tooltip: "ComfyUI 是 SD/SDXL 生态首选",
+        command: `docker run --gpus all -p 8188:8188 \\
+  -v $PWD/models:/root/ComfyUI/models \\
+  -v $PWD/output:/root/ComfyUI/output \\
+  yanwk/comfyui-boot:cu124-megapak`,
+        params: [
+          {
+            key: "models",
+            value: "checkpoints/sd_xl_base_1.0.safetensors",
+            desc: "需提前下载 ckpt 到 models/checkpoints/",
+          },
+        ],
+        resource: "1× 12GB+ 显存,SDXL 1024² 约 8GB",
+        docUrl: "https://docs.comfy.org/",
+      }),
+    },
+  },
+  {
+    id: "flux",
+    name: "FLUX.1 (dev / schnell)",
+    category: "diffusion",
+    meta: "Black Forest Labs",
+    engines: {
+      comfyui: native({
+        minVersion: "v0.3.0",
+        image: "yanwk/comfyui-boot:cu124-megapak",
+        tooltip: "FLUX schnell 4 步出图,dev 20 步",
+        notes: "FLUX 需要单独的 t5xxl_fp8 + clip_l 文件,放到 models/clip/。",
+        docUrl: "https://comfyanonymous.github.io/ComfyUI_examples/flux/",
+      }),
+    },
+  },
+  {
+    id: "qwen-image",
+    name: "Qwen-Image",
+    category: "diffusion",
+    meta: "阿里 · 文生图",
+    engines: {
+      comfyui: partial({
+        tooltip: "社区节点已支持,官方 workflow 待完善",
+        notes: "// TODO: 待官方 ComfyUI workflow 发布,补充镜像与节点 hash。",
+      }),
+    },
+  },
+  {
+    id: "hunyuan-dit",
+    name: "HunyuanDiT",
+    category: "diffusion",
+    meta: "腾讯 · 中文文生图",
+    engines: {
+      comfyui: native({
+        minVersion: "v0.2.0",
+        image: "yanwk/comfyui-boot:cu124-megapak",
+        tooltip: "ComfyUI 自带 HunyuanDiT 节点",
+      }),
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+export function getRecipeStatus(model: ModelEntry, engineId: string): RecipeStatus {
+  const recipe = model.engines[engineId as keyof typeof model.engines];
+  return recipe?.status ?? "none";
+}
+
+export function getRecipe(model: ModelEntry, engineId: string): EngineRecipe | undefined {
+  return model.engines[engineId as keyof typeof model.engines];
+}

--- a/apps/web/src/features/deployment-recipes/index.ts
+++ b/apps/web/src/features/deployment-recipes/index.ts
@@ -1,0 +1,1 @@
+export { DeploymentRecipesPage } from "./DeploymentRecipesPage";

--- a/apps/web/src/features/deployment-recipes/types.ts
+++ b/apps/web/src/features/deployment-recipes/types.ts
@@ -1,0 +1,55 @@
+export type RecipeStatus = "native" | "partial" | "none";
+
+export type EngineId =
+  | "vllm"
+  | "sglang"
+  | "trtllm"
+  | "mindie"
+  | "lmdeploy"
+  | "tgi"
+  | "tei"
+  | "infinity"
+  | "llamacpp"
+  | "comfyui";
+
+export type CategoryId = "dense" | "moe" | "vlm" | "embedding" | "rerank" | "diffusion";
+
+export interface EngineMeta {
+  id: EngineId;
+  name: string;
+  vendor: string;
+}
+
+export interface CategoryMeta {
+  id: CategoryId;
+  label: string;
+  description: string;
+}
+
+export interface RecipeParam {
+  key: string;
+  value: string;
+  desc: string;
+}
+
+export interface EngineRecipe {
+  status: RecipeStatus;
+  minVersion?: string;
+  image?: string;
+  command?: string;
+  params?: RecipeParam[];
+  resource?: string;
+  notes?: string;
+  docUrl?: string;
+  /** Short tooltip shown on hover over the matrix cell. */
+  tooltip?: string;
+}
+
+export interface ModelEntry {
+  id: string;
+  name: string;
+  category: CategoryId;
+  /** "vendor · short tag" — rendered under the model name in the first column. */
+  meta: string;
+  engines: Partial<Record<EngineId, EngineRecipe>>;
+}

--- a/apps/web/src/locales/en-US/sidebar.json
+++ b/apps/web/src/locales/en-US/sidebar.json
@@ -20,6 +20,7 @@
     "diagnostics": "Endpoint Health",
     "connections": "Connections",
     "settings": "Settings",
-    "devCharts": "Dev Charts"
+    "devCharts": "Dev Charts",
+    "deploymentRecipes": "Deployment Recipes"
   }
 }

--- a/apps/web/src/locales/zh-CN/sidebar.json
+++ b/apps/web/src/locales/zh-CN/sidebar.json
@@ -20,6 +20,7 @@
     "diagnostics": "端点检测",
     "connections": "连接",
     "settings": "设置",
-    "devCharts": "图表调试"
+    "devCharts": "图表调试",
+    "deploymentRecipes": "部署示例"
   }
 }

--- a/apps/web/src/router/index.tsx
+++ b/apps/web/src/router/index.tsx
@@ -12,6 +12,7 @@ import { BenchmarkInferencePage } from "@/features/benchmarks/BenchmarkInference
 import { EndpointReportsPage } from "@/features/benchmarks/EndpointReportsPage";
 import { BenchmarkCompareGate } from "@/features/benchmarks/compare/BenchmarkCompareGate";
 import { ConnectionsPage } from "@/features/connections/ConnectionsPage";
+import { DeploymentRecipesPage } from "@/features/deployment-recipes";
 import { DevChartsPage } from "@/features/dev-charts";
 import { DiagnosticsPage } from "@/features/diagnostics/DiagnosticsPage";
 import { ErrorPage } from "@/features/error/ErrorPage";
@@ -77,6 +78,7 @@ export const routes: RouteObject[] = [
           { path: "playground/embeddings", element: <EmbeddingsPage /> },
           { path: "playground/rerank", element: <RerankPage /> },
           { path: "dev/charts", element: <DevChartsPage /> },
+          { path: "dev/deployments", element: <DeploymentRecipesPage /> },
           { path: "*", element: <NotFoundPage /> },
         ],
       },


### PR DESCRIPTION
## Summary

新增 **`/dev/deployments`** 页面,作为团队内部「某个开源模型用哪个推理引擎跑、镜像版本、启动命令」的快速参考矩阵。入口挂在 sidebar 的 Developer 组、DevCharts 下方。

- **数据**:32 个开源模型权重(稠密 LLM / MoE / VLM / Embedding / Rerank / 文生图 6 类) × 10 个推理引擎(vLLM · SGLang · TensorRT-LLM · MindIE · LMDeploy · TGI · TEI · Infinity · llama.cpp · ComfyUI)
- **状态**:绿 ✓ 原生支持 / 黄 ~ 部分实验 / 灰 · 不支持
- **详情抽屉**:点击 ✓ / ~ 单元格从右侧滑入,展示推荐镜像、最低引擎版本、完整 `docker run` 命令(等宽 + 一键复制 + sonner toast)、关键参数表、资源建议、注意事项、官方文档链接
- **交互**:类别 tab 过滤 · 模糊搜索(模型 / 引擎名) · 引擎列可见性切换 · 单元格 hover tooltip · `#model-id/engine-id` 哈希路由直链分享 · ESC / 点击外部关闭抽屉
- **视觉**:沿用项目 PageHeader / token 体系,深色 / 浅色主题自适应,粘性表头 + 粘性首列横向滚动

主流组合(Llama × vLLM、Qwen × SGLang、DeepSeek-V3 × vLLM/SGLang/MindIE、BGE-M3 × TEI、FLUX × ComfyUI 等)给出真实可用的启动命令;冷门组合标 `partial` 并附 `// TODO` 注释,后续按需在 `apps/web/src/features/deployment-recipes/data.ts` 的 `MODELS` 数组追加即可。

## Test plan

- [x] `pnpm -F @modeldoctor/web type-check` 通过
- [x] `pnpm -F @modeldoctor/web lint`(新增文件)通过
- [x] `pnpm -r build` 通过(packages/contracts · tool-adapters · api · web 全绿)
- [x] 浏览器实跑:浅色 / 深色主题 · 类别过滤 · 哈希路由(`#deepseek-v3/vllm`、`#deepseek-v3/sglang`)直接弹抽屉
- [ ] PR 合并前再过一遍 `pnpm test`(目前未引入新单测,矩阵数据仅静态字面量)

🤖 Generated with [Claude Code](https://claude.com/claude-code)