### PR TITLE
fix(web/deployment-recipes): i18n + align with PageHeader / page body convention

### DIFF
--- a/apps/web/src/features/deployment-recipes/DeploymentRecipesPage.tsx
+++ b/apps/web/src/features/deployment-recipes/DeploymentRecipesPage.tsx
@@ -253,13 +253,16 @@ export function DeploymentRecipesPage() {
   const selectedRecipe =
     selectedModel && selected ? (getRecipe(selectedModel, selected.engineId) ?? null) : null;
 
-  const tabs: { id: CategoryFilter; label: string }[] = [
-    { id: "all", label: t("filters.all") },
-    ...CATEGORY_ORDER.map((id) => ({
-      id: id as CategoryFilter,
-      label: t(`categories.${id}.label`),
-    })),
-  ];
+  const tabs = useMemo<{ id: CategoryFilter; label: string }[]>(
+    () => [
+      { id: "all", label: t("filters.all") },
+      ...CATEGORY_ORDER.map((id) => ({
+        id: id as CategoryFilter,
+        label: t(`categories.${id}.label`),
+      })),
+    ],
+    [t],
+  );
 
   return (
     <>
@@ -306,7 +309,10 @@ export function DeploymentRecipesPage() {
           {groupedModels.length === 0 ? (
             <EmptyState icon={SearchX} title={t("empty.title")} body={t("empty.body")} />
           ) : (
-            <div className="overflow-auto rounded-lg border border-border bg-card">
+            // The matrix wrapper owns its own scroll context so the sticky
+            // <thead> stays pinned. The max-h subtracts PageHeader + toolbar +
+            // page padding + legend from the dynamic viewport height.
+            <div className="max-h-[calc(100dvh-15rem)] overflow-auto rounded-lg border border-border bg-card">
               <table className="min-w-full border-collapse text-sm">
                 <thead className="sticky top-0 z-20 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80">
                   <tr className="border-b border-border">

--- a/apps/web/src/features/deployment-recipes/DeploymentRecipesPage.tsx
+++ b/apps/web/src/features/deployment-recipes/DeploymentRecipesPage.tsx
@@ -1,13 +1,16 @@
+import { EmptyState } from "@/components/common/empty-state";
 import { PageHeader } from "@/components/common/page-header";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { Check, Filter, Search } from "lucide-react";
+import { Check, Filter, Search, SearchX } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { RecipeDrawer } from "./RecipeDrawer";
-import { CATEGORIES, ENGINES, MODELS, getRecipe } from "./data";
+import { ENGINES, MODELS, getRecipe } from "./data";
+import { CATEGORY_ORDER } from "./types";
 import type { CategoryId, EngineId, EngineMeta, ModelEntry, RecipeStatus } from "./types";
 
 type CategoryFilter = "all" | CategoryId;
@@ -26,11 +29,13 @@ function StatusPill({
   active,
   highlight,
   onClick,
+  ariaLabel,
 }: {
   status: RecipeStatus;
   active: boolean;
   highlight: boolean;
   onClick?: () => void;
+  ariaLabel: string;
 }) {
   const base =
     "flex h-7 w-9 items-center justify-center rounded-md text-sm font-medium transition-colors";
@@ -40,7 +45,7 @@ function StatusPill({
       <button
         type="button"
         onClick={onClick}
-        aria-label="原生支持,点击查看详情"
+        aria-label={ariaLabel}
         className={cn(
           base,
           "border border-emerald-200/70 bg-emerald-50 text-emerald-700",
@@ -60,7 +65,7 @@ function StatusPill({
       <button
         type="button"
         onClick={onClick}
-        aria-label="部分支持,点击查看详情"
+        aria-label={ariaLabel}
         className={cn(
           base,
           "border border-amber-200/70 bg-amber-50 text-amber-700",
@@ -77,7 +82,7 @@ function StatusPill({
 
   return (
     <span
-      aria-label="不支持"
+      aria-label={ariaLabel}
       className={cn(
         base,
         "cursor-not-allowed border border-transparent bg-muted/40 text-muted-foreground/50",
@@ -99,13 +104,14 @@ function EngineToggle({
   visible: Set<EngineId>;
   onChange: (next: Set<EngineId>) => void;
 }) {
+  const { t } = useTranslation("deployment-recipes");
   const allOn = visible.size === ENGINES.length;
   return (
     <Popover>
       <PopoverTrigger asChild>
         <Button variant="outline" size="sm" className="gap-1.5">
           <Filter className="h-3.5 w-3.5" />
-          引擎列
+          {t("filters.engineToggle")}
           <span className="text-xs text-muted-foreground">
             {visible.size}/{ENGINES.length}
           </span>
@@ -113,7 +119,9 @@ function EngineToggle({
       </PopoverTrigger>
       <PopoverContent align="end" className="w-56 p-2">
         <div className="mb-2 flex items-center justify-between px-1">
-          <span className="text-xs font-medium text-muted-foreground">显示列</span>
+          <span className="text-xs font-medium text-muted-foreground">
+            {t("filters.visibleColumns")}
+          </span>
           <Button
             type="button"
             variant="ghost"
@@ -121,7 +129,7 @@ function EngineToggle({
             className="h-6 px-1.5 text-xs"
             onClick={() => onChange(allOn ? new Set() : new Set(ENGINES.map((e) => e.id)))}
           >
-            {allOn ? "全部隐藏" : "全部显示"}
+            {allOn ? t("filters.hideAll") : t("filters.showAll")}
           </Button>
         </div>
         <div className="space-y-0.5">
@@ -158,6 +166,7 @@ function EngineToggle({
 // ---------------------------------------------------------------------------
 
 export function DeploymentRecipesPage() {
+  const { t } = useTranslation("deployment-recipes");
   const [category, setCategory] = useState<CategoryFilter>("all");
   const [query, setQuery] = useState("");
   const [visibleEngines, setVisibleEngines] = useState<Set<EngineId>>(
@@ -229,9 +238,9 @@ export function DeploymentRecipesPage() {
       list.push(m);
       map.set(m.category, list);
     }
-    return CATEGORIES.flatMap((c) => {
-      const list = map.get(c.id) ?? [];
-      return list.length > 0 ? [{ category: c, models: list }] : [];
+    return CATEGORY_ORDER.flatMap((id) => {
+      const list = map.get(id) ?? [];
+      return list.length > 0 ? [{ id, models: list }] : [];
     });
   }, [filteredModels]);
 
@@ -244,56 +253,60 @@ export function DeploymentRecipesPage() {
   const selectedRecipe =
     selectedModel && selected ? (getRecipe(selectedModel, selected.engineId) ?? null) : null;
 
-  const totalCount = MODELS.length;
+  const tabs: { id: CategoryFilter; label: string }[] = [
+    { id: "all", label: t("filters.all") },
+    ...CATEGORY_ORDER.map((id) => ({
+      id: id as CategoryFilter,
+      label: t(`categories.${id}.label`),
+    })),
+  ];
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <>
       <PageHeader
-        title="部署示例"
-        subtitle={`推理引擎 × 开源模型权重兼容性矩阵 · 共 ${totalCount} 个模型 / ${ENGINES.length} 个引擎`}
+        title={t("title")}
+        subtitle={t("subtitle", { models: MODELS.length, engines: ENGINES.length })}
       />
-
-      <div className="flex-1 overflow-hidden">
-        <div className="flex h-full flex-col gap-4 px-8 py-6">
-          {/* Toolbar ------------------------------------------------------- */}
-          <div className="flex flex-wrap items-center gap-3">
-            <div className="flex flex-wrap items-center gap-1.5">
-              {[
-                { id: "all" as CategoryFilter, label: "全部" },
-                ...CATEGORIES.map((c) => ({ id: c.id as CategoryFilter, label: c.label })),
-              ].map((tab) => (
-                <button
-                  key={tab.id}
-                  type="button"
-                  onClick={() => setCategory(tab.id)}
-                  className={cn(
-                    "rounded-md border px-3 py-1.5 text-xs font-medium transition-colors",
-                    category === tab.id
-                      ? "border-primary/30 bg-primary/10 text-primary"
-                      : "border-border bg-background text-muted-foreground hover:border-foreground/20 hover:text-foreground",
-                  )}
-                >
-                  {tab.label}
-                </button>
-              ))}
-            </div>
-
-            <div className="relative ml-auto w-full max-w-xs">
-              <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="搜索模型或引擎名…"
-                className="h-9 pl-8 text-sm"
-              />
-            </div>
-
-            <EngineToggle visible={visibleEngines} onChange={setVisibleEngines} />
+      <div className="space-y-6 px-8 py-6">
+        {/* Toolbar -------------------------------------------------------- */}
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="flex flex-wrap items-center gap-1.5">
+            {tabs.map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => setCategory(tab.id)}
+                className={cn(
+                  "rounded-md border px-3 py-1.5 text-xs font-medium transition-colors",
+                  category === tab.id
+                    ? "border-primary/30 bg-primary/10 text-primary"
+                    : "border-border bg-background text-muted-foreground hover:border-foreground/20 hover:text-foreground",
+                )}
+              >
+                {tab.label}
+              </button>
+            ))}
           </div>
 
-          {/* Matrix table ------------------------------------------------- */}
-          <TooltipProvider delayDuration={200}>
-            <div className="min-h-0 flex-1 overflow-auto rounded-lg border border-border bg-card">
+          <div className="relative ml-auto w-full max-w-xs">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={t("filters.searchPlaceholder")}
+              className="h-9 pl-8 text-sm"
+            />
+          </div>
+
+          <EngineToggle visible={visibleEngines} onChange={setVisibleEngines} />
+        </div>
+
+        {/* Matrix table -------------------------------------------------- */}
+        <TooltipProvider delayDuration={200}>
+          {groupedModels.length === 0 ? (
+            <EmptyState icon={SearchX} title={t("empty.title")} body={t("empty.body")} />
+          ) : (
+            <div className="overflow-auto rounded-lg border border-border bg-card">
               <table className="min-w-full border-collapse text-sm">
                 <thead className="sticky top-0 z-20 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80">
                   <tr className="border-b border-border">
@@ -301,7 +314,7 @@ export function DeploymentRecipesPage() {
                       scope="col"
                       className="sticky left-0 z-30 min-w-[260px] bg-card/95 px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground"
                     >
-                      模型 / 权重
+                      {t("table.modelHeader")}
                     </th>
                     {visibleEngineList.map((eng) => (
                       <th
@@ -325,61 +338,67 @@ export function DeploymentRecipesPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {groupedModels.length === 0 ? (
-                    <tr>
-                      <td
-                        colSpan={visibleEngineList.length + 1}
-                        className="px-4 py-12 text-center text-sm text-muted-foreground"
-                      >
-                        没有匹配的模型。试试清空搜索或切换分类。
-                      </td>
-                    </tr>
-                  ) : (
-                    groupedModels.map(({ category: cat, models }) => (
-                      <CategorySection
-                        key={cat.id}
-                        label={`${cat.label}(${cat.description})`}
-                        colSpan={visibleEngineList.length + 1}
-                      >
-                        {models.map((model) => (
-                          <ModelRow
-                            key={model.id}
-                            model={model}
-                            engines={visibleEngineList}
-                            selected={selected}
-                            hoveredEngine={hoveredEngine}
-                            onHoverEngine={setHoveredEngine}
-                            onSelect={handleSelect}
-                          />
-                        ))}
-                      </CategorySection>
-                    ))
-                  )}
+                  {groupedModels.map(({ id, models }) => (
+                    <CategorySection
+                      key={id}
+                      label={t("categoryRow", {
+                        label: t(`categories.${id}.label`),
+                        description: t(`categories.${id}.description`),
+                      })}
+                      colSpan={visibleEngineList.length + 1}
+                    >
+                      {models.map((model) => (
+                        <ModelRow
+                          key={model.id}
+                          model={model}
+                          engines={visibleEngineList}
+                          selected={selected}
+                          hoveredEngine={hoveredEngine}
+                          onHoverEngine={setHoveredEngine}
+                          onSelect={handleSelect}
+                        />
+                      ))}
+                    </CategorySection>
+                  ))}
                 </tbody>
               </table>
             </div>
-          </TooltipProvider>
+          )}
+        </TooltipProvider>
 
-          {/* Legend ------------------------------------------------------- */}
-          <footer className="flex flex-wrap items-center gap-x-6 gap-y-2 px-1 text-xs text-muted-foreground">
-            <div className="flex items-center gap-1.5">
-              <StatusPill status="native" active={false} highlight={false} />
-              <span>原生支持</span>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <StatusPill status="partial" active={false} highlight={false} />
-              <span>部分 / 实验</span>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <StatusPill status="none" active={false} highlight={false} />
-              <span>不支持</span>
-            </div>
-            <span className="ml-auto text-[11px] text-muted-foreground/70">
-              数据基线:vLLM 0.7+ · SGLang 0.4+ · TRT-LLM 0.13+ · MindIE 1.0.RC3 · LMDeploy 0.6+ ·
-              TEI 1.5+ · Infinity 0.0.7x
-            </span>
-          </footer>
-        </div>
+        {/* Legend -------------------------------------------------------- */}
+        <footer className="flex flex-wrap items-center gap-x-6 gap-y-2 px-1 text-xs text-muted-foreground">
+          <div className="flex items-center gap-1.5">
+            <StatusPill
+              status="native"
+              active={false}
+              highlight={false}
+              ariaLabel={t("status.ariaNative")}
+            />
+            <span>{t("status.native")}</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <StatusPill
+              status="partial"
+              active={false}
+              highlight={false}
+              ariaLabel={t("status.ariaPartial")}
+            />
+            <span>{t("status.partial")}</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <StatusPill
+              status="none"
+              active={false}
+              highlight={false}
+              ariaLabel={t("status.ariaNone")}
+            />
+            <span>{t("status.none")}</span>
+          </div>
+          <span className="ml-auto text-[11px] text-muted-foreground/70">
+            {t("legend.baseline")}
+          </span>
+        </footer>
       </div>
 
       <RecipeDrawer
@@ -389,7 +408,7 @@ export function DeploymentRecipesPage() {
         engine={selectedEngineMeta}
         recipe={selectedRecipe}
       />
-    </div>
+    </>
   );
 }
 
@@ -436,6 +455,7 @@ function ModelRow({
   onHoverEngine: (id: EngineId | null) => void;
   onSelect: (modelId: string, engineId: EngineId) => void;
 }) {
+  const { t } = useTranslation("deployment-recipes");
   return (
     <tr className="group border-b border-border/60 last:border-b-0 hover:bg-accent/30">
       <th
@@ -452,12 +472,19 @@ function ModelRow({
         const isColHighlighted = hoveredEngine === eng.id;
         const cellClickable = status !== "none";
         const tooltipText = recipe?.tooltip ?? recipe?.notes ?? null;
+        const ariaLabel =
+          status === "native"
+            ? t("status.ariaNative")
+            : status === "partial"
+              ? t("status.ariaPartial")
+              : t("status.ariaNone");
 
         const cell = (
           <StatusPill
             status={status}
             active={isActive}
             highlight={isColHighlighted}
+            ariaLabel={ariaLabel}
             onClick={cellClickable ? () => onSelect(model.id, eng.id) : undefined}
           />
         );

--- a/apps/web/src/features/deployment-recipes/RecipeDrawer.tsx
+++ b/apps/web/src/features/deployment-recipes/RecipeDrawer.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { Check, Copy, ExternalLink, X } from "lucide-react";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import type { EngineMeta, EngineRecipe, ModelEntry } from "./types";
 
@@ -15,38 +16,40 @@ interface RecipeDrawerProps {
 }
 
 function StatusBadge({ status }: { status: EngineRecipe["status"] }) {
+  const { t } = useTranslation("deployment-recipes");
   if (status === "native") {
     return (
       <span className="inline-flex items-center gap-1 rounded-md border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-400">
-        <Check className="h-3 w-3" /> 原生支持
+        <Check className="h-3 w-3" /> {t("status.native")}
       </span>
     );
   }
   if (status === "partial") {
     return (
       <span className="inline-flex items-center gap-1 rounded-md border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-400">
-        部分 / 实验
+        {t("status.partial")}
       </span>
     );
   }
   return (
     <span className="inline-flex items-center gap-1 rounded-md border border-border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-      不支持
+      {t("status.none")}
     </span>
   );
 }
 
 function CodeBlock({ code, label }: { code: string; label: string }) {
+  const { t } = useTranslation("deployment-recipes");
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(code);
       setCopied(true);
-      toast.success("已复制到剪贴板");
+      toast.success(t("drawer.copyToast"));
       setTimeout(() => setCopied(false), 1600);
     } catch {
-      toast.error("复制失败");
+      toast.error(t("drawer.copyFailed"));
     }
   };
 
@@ -62,7 +65,7 @@ function CodeBlock({ code, label }: { code: string; label: string }) {
           className="h-7 gap-1.5 px-2 text-xs"
         >
           {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-          {copied ? "已复制" : "复制"}
+          {copied ? t("drawer.copied") : t("drawer.copy")}
         </Button>
       </div>
       <pre className="overflow-x-auto rounded-md border border-border bg-muted/60 p-3 font-mono text-xs leading-relaxed text-foreground">
@@ -82,6 +85,8 @@ function FieldRow({ label, value }: { label: string; value: React.ReactNode }) {
 }
 
 export function RecipeDrawer({ open, onOpenChange, model, engine, recipe }: RecipeDrawerProps) {
+  const { t } = useTranslation("deployment-recipes");
+
   // Bail out entirely when the URL hash points to a non-existent (or unsupported)
   // model/engine combo — rendering a Root with only a Portal would otherwise
   // leave a ghost overlay that swallows clicks.
@@ -126,7 +131,7 @@ export function RecipeDrawer({ open, onOpenChange, model, engine, recipe }: Reci
                 variant="ghost"
                 size="icon"
                 className="h-8 w-8 shrink-0"
-                aria-label="关闭"
+                aria-label={t("drawer.close")}
               >
                 <X className="h-4 w-4" />
               </Button>
@@ -137,29 +142,31 @@ export function RecipeDrawer({ open, onOpenChange, model, engine, recipe }: Reci
             <section className="space-y-2.5">
               {recipe.image ? (
                 <FieldRow
-                  label="推荐镜像"
+                  label={t("drawer.image")}
                   value={<code className="font-mono text-xs">{recipe.image}</code>}
                 />
               ) : null}
               {recipe.minVersion ? (
                 <FieldRow
-                  label="最低版本"
+                  label={t("drawer.minVersion")}
                   value={<code className="font-mono text-xs">{recipe.minVersion}</code>}
                 />
               ) : null}
-              {recipe.resource ? <FieldRow label="资源建议" value={recipe.resource} /> : null}
+              {recipe.resource ? (
+                <FieldRow label={t("drawer.resource")} value={recipe.resource} />
+              ) : null}
             </section>
 
             {recipe.command ? (
               <section className="mt-6">
-                <CodeBlock code={recipe.command} label="启动命令" />
+                <CodeBlock code={recipe.command} label={t("drawer.command")} />
               </section>
             ) : null}
 
             {recipe.params && recipe.params.length > 0 ? (
               <section className="mt-6">
                 <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  关键参数
+                  {t("drawer.params")}
                 </h3>
                 <div className="overflow-hidden rounded-md border border-border">
                   <table className="w-full text-sm">
@@ -183,7 +190,7 @@ export function RecipeDrawer({ open, onOpenChange, model, engine, recipe }: Reci
             {recipe.notes ? (
               <section className="mt-6">
                 <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  注意事项
+                  {t("drawer.notes")}
                 </h3>
                 <p className="rounded-md border-l-2 border-amber-400 bg-amber-50/40 px-3 py-2 text-sm leading-relaxed text-foreground/90 dark:bg-amber-950/20">
                   {recipe.notes}
@@ -200,14 +207,14 @@ export function RecipeDrawer({ open, onOpenChange, model, engine, recipe }: Reci
                   className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
                 >
                   <ExternalLink className="h-3.5 w-3.5" />
-                  官方文档
+                  {t("drawer.docs")}
                 </a>
               </section>
             ) : null}
 
             {!recipe.command && !recipe.image && !recipe.notes ? (
               <section className="mt-6 rounded-md border border-dashed border-border px-4 py-6 text-center text-sm text-muted-foreground">
-                {recipe.tooltip ?? "该组合暂未填充详细配置,欢迎补充。"}
+                {recipe.tooltip ?? t("drawer.emptyFallback")}
               </section>
             ) : null}
           </div>

--- a/apps/web/src/features/deployment-recipes/data.ts
+++ b/apps/web/src/features/deployment-recipes/data.ts
@@ -1,7 +1,15 @@
-import type { CategoryMeta, EngineMeta, EngineRecipe, ModelEntry, RecipeStatus } from "./types";
+import type { EngineMeta, EngineRecipe, ModelEntry, RecipeStatus } from "./types";
 
 // ---------------------------------------------------------------------------
 // Static metadata
+//
+// NOTE — UI chrome (page title, tab labels, table headers, drawer field
+// labels) flows through i18n at apps/web/src/locales/*/deployment-recipes.json.
+// The descriptive payload below (model meta, tooltip, notes, resource, params)
+// is intentionally zh-CN-first for V1, mirroring the AI-narrative convention
+// in CLAUDE.md ("AI narrative is zh-CN only for V1"). When we localise the
+// recipe payload, lift these strings into the locale bundle keyed by the
+// model id + engine id.
 // ---------------------------------------------------------------------------
 
 export const ENGINES: EngineMeta[] = [
@@ -15,15 +23,6 @@ export const ENGINES: EngineMeta[] = [
   { id: "infinity", name: "Infinity", vendor: "Michael Feil" },
   { id: "llamacpp", name: "llama.cpp", vendor: "ggml.ai" },
   { id: "comfyui", name: "ComfyUI / Diffusers", vendor: "comfyanonymous · HF" },
-];
-
-export const CATEGORIES: CategoryMeta[] = [
-  { id: "dense", label: "稠密 LLM", description: "Llama / Qwen / Mistral 系" },
-  { id: "moe", label: "MoE 大模型", description: "DeepSeek / Llama4 / GPT-OSS / Qwen3-MoE" },
-  { id: "vlm", label: "多模态 / VLM", description: "Vision-Language Models" },
-  { id: "embedding", label: "Embedding", description: "向量召回 / 检索" },
-  { id: "rerank", label: "Rerank", description: "二阶段重排" },
-  { id: "diffusion", label: "文生图", description: "Diffusion · Image" },
 ];
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/features/deployment-recipes/types.ts
+++ b/apps/web/src/features/deployment-recipes/types.ts
@@ -20,11 +20,19 @@ export interface EngineMeta {
   vendor: string;
 }
 
-export interface CategoryMeta {
-  id: CategoryId;
-  label: string;
-  description: string;
-}
+/**
+ * Categories are referenced by id only — labels and descriptions live in
+ * `apps/web/src/locales/{zh-CN,en-US}/deployment-recipes.json` under
+ * `categories.<id>.{label,description}`.
+ */
+export const CATEGORY_ORDER: CategoryId[] = [
+  "dense",
+  "moe",
+  "vlm",
+  "embedding",
+  "rerank",
+  "diffusion",
+];
 
 export interface RecipeParam {
   key: string;

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -8,6 +8,7 @@ import enCommands from "@/locales/en-US/commands.json";
 import enCommon from "@/locales/en-US/common.json";
 import enConnections from "@/locales/en-US/connections.json";
 import enDebug from "@/locales/en-US/debug.json";
+import enDeploymentRecipes from "@/locales/en-US/deployment-recipes.json";
 import enDiagnostics from "@/locales/en-US/diagnostics.json";
 import enInsights from "@/locales/en-US/insights.json";
 import enPlayground from "@/locales/en-US/playground.json";
@@ -19,6 +20,7 @@ import zhCommands from "@/locales/zh-CN/commands.json";
 import zhCommon from "@/locales/zh-CN/common.json";
 import zhConnections from "@/locales/zh-CN/connections.json";
 import zhDebug from "@/locales/zh-CN/debug.json";
+import zhDeploymentRecipes from "@/locales/zh-CN/deployment-recipes.json";
 import zhDiagnostics from "@/locales/zh-CN/diagnostics.json";
 import zhInsights from "@/locales/zh-CN/insights.json";
 import zhPlayground from "@/locales/zh-CN/playground.json";
@@ -39,6 +41,7 @@ void i18n.use(initReactI18next).init({
       playground: enPlayground,
       insights: enInsights,
       commands: enCommands,
+      "deployment-recipes": enDeploymentRecipes,
     },
     "zh-CN": {
       common: zhCommon,
@@ -52,6 +55,7 @@ void i18n.use(initReactI18next).init({
       playground: zhPlayground,
       insights: zhInsights,
       commands: zhCommands,
+      "deployment-recipes": zhDeploymentRecipes,
     },
   },
   // `lng` is set by main.tsx from the locale store before first render.
@@ -69,6 +73,7 @@ void i18n.use(initReactI18next).init({
     "playground",
     "insights",
     "commands",
+    "deployment-recipes",
   ],
   interpolation: { escapeValue: false },
   returnNull: false,

--- a/apps/web/src/locales/en-US/deployment-recipes.json
+++ b/apps/web/src/locales/en-US/deployment-recipes.json
@@ -1,0 +1,54 @@
+{
+  "title": "Deployment Recipes",
+  "subtitle": "Inference engine × open-weight model compatibility matrix · {{models}} models / {{engines}} engines",
+  "filters": {
+    "all": "All",
+    "searchPlaceholder": "Search model or engine…",
+    "engineToggle": "Engines",
+    "visibleColumns": "Visible columns",
+    "hideAll": "Hide all",
+    "showAll": "Show all"
+  },
+  "categories": {
+    "dense": { "label": "Dense LLM", "description": "Llama / Qwen / Mistral family" },
+    "moe": { "label": "MoE", "description": "DeepSeek / Llama4 / GPT-OSS / Qwen3-MoE" },
+    "vlm": { "label": "Multimodal / VLM", "description": "Vision-Language models" },
+    "embedding": { "label": "Embedding", "description": "Retrieval / dense vectors" },
+    "rerank": { "label": "Rerank", "description": "Second-stage reranking" },
+    "diffusion": { "label": "Text-to-Image", "description": "Diffusion · image" }
+  },
+  "categoryRow": "{{label}} ({{description}})",
+  "table": {
+    "modelHeader": "Model / Weights"
+  },
+  "status": {
+    "native": "Native",
+    "partial": "Partial / experimental",
+    "none": "Not supported",
+    "ariaNative": "Native support · click for details",
+    "ariaPartial": "Partial support · click for details",
+    "ariaNone": "Not supported"
+  },
+  "empty": {
+    "title": "No matching models",
+    "body": "Try clearing the search or switching the category."
+  },
+  "legend": {
+    "baseline": "Baseline: vLLM 0.7+ · SGLang 0.4+ · TRT-LLM 0.13+ · MindIE 1.0.RC3 · LMDeploy 0.6+ · TEI 1.5+ · Infinity 0.0.7x"
+  },
+  "drawer": {
+    "image": "Image",
+    "minVersion": "Min version",
+    "resource": "Resources",
+    "command": "Launch command",
+    "params": "Key parameters",
+    "notes": "Notes",
+    "docs": "Docs",
+    "close": "Close",
+    "copy": "Copy",
+    "copied": "Copied",
+    "copyToast": "Copied to clipboard",
+    "copyFailed": "Copy failed",
+    "emptyFallback": "This combination is not yet documented. Contributions welcome."
+  }
+}

--- a/apps/web/src/locales/zh-CN/deployment-recipes.json
+++ b/apps/web/src/locales/zh-CN/deployment-recipes.json
@@ -1,0 +1,54 @@
+{
+  "title": "部署示例",
+  "subtitle": "推理引擎 × 开源模型权重兼容性矩阵 · 共 {{models}} 个模型 / {{engines}} 个引擎",
+  "filters": {
+    "all": "全部",
+    "searchPlaceholder": "搜索模型或引擎名…",
+    "engineToggle": "引擎列",
+    "visibleColumns": "显示列",
+    "hideAll": "全部隐藏",
+    "showAll": "全部显示"
+  },
+  "categories": {
+    "dense": { "label": "稠密 LLM", "description": "Llama / Qwen / Mistral 系" },
+    "moe": { "label": "MoE 大模型", "description": "DeepSeek / Llama4 / GPT-OSS / Qwen3-MoE" },
+    "vlm": { "label": "多模态 / VLM", "description": "Vision-Language Models" },
+    "embedding": { "label": "Embedding", "description": "向量召回 / 检索" },
+    "rerank": { "label": "Rerank", "description": "二阶段重排" },
+    "diffusion": { "label": "文生图", "description": "Diffusion · Image" }
+  },
+  "categoryRow": "{{label}}({{description}})",
+  "table": {
+    "modelHeader": "模型 / 权重"
+  },
+  "status": {
+    "native": "原生支持",
+    "partial": "部分 / 实验",
+    "none": "不支持",
+    "ariaNative": "原生支持,点击查看详情",
+    "ariaPartial": "部分支持,点击查看详情",
+    "ariaNone": "不支持"
+  },
+  "empty": {
+    "title": "没有匹配的模型",
+    "body": "试试清空搜索或切换分类。"
+  },
+  "legend": {
+    "baseline": "数据基线:vLLM 0.7+ · SGLang 0.4+ · TRT-LLM 0.13+ · MindIE 1.0.RC3 · LMDeploy 0.6+ · TEI 1.5+ · Infinity 0.0.7x"
+  },
+  "drawer": {
+    "image": "推荐镜像",
+    "minVersion": "最低版本",
+    "resource": "资源建议",
+    "command": "启动命令",
+    "params": "关键参数",
+    "notes": "注意事项",
+    "docs": "官方文档",
+    "close": "关闭",
+    "copy": "复制",
+    "copied": "已复制",
+    "copyToast": "已复制到剪贴板",
+    "copyFailed": "复制失败",
+    "emptyFallback": "该组合暂未填充详细配置,欢迎补充。"
+  }
+}


### PR DESCRIPTION
## Summary

针对 #146 在 review 后发现的两类不合规问题做收尾:

### 1. UI chrome 接入 i18n
原本所有页面文案硬编码中文,语言切到 en-US 时仍显示中文。这次:

- 新建 `apps/web/src/locales/{zh-CN,en-US}/deployment-recipes.json` 命名空间并注册到 `apps/web/src/lib/i18n.ts`
- `DeploymentRecipesPage` / `RecipeDrawer` 全部用户可见文案改为 `useTranslation("deployment-recipes")` + `t(...)`:
  - 页面标题 / 副标题(带 `models` / `engines` 插值)
  - 类别 tab(`全部 / 稠密 LLM / MoE / ...` ↔ `All / Dense LLM / MoE / ...`)
  - 搜索框 placeholder、引擎列切换 popover(`显示列 / 全部隐藏 / 全部显示`)
  - 表头 `模型 / 权重` ↔ `Model / Weights`
  - 状态 pill 的 `aria-label`(`原生支持,点击查看详情` ↔ `Native support · click for details`)
  - 抽屉字段标签(`推荐镜像 / 最低版本 / 资源建议 / 启动命令 / 关键参数 / 注意事项 / 官方文档`)
  - 复制按钮文案、复制 toast、关闭按钮 `aria-label`、空数据 fallback
  - 图例(`原生支持 / 部分 / 实验 / 不支持`)、footer 数据基线
- `CategoryMeta.label/description` 从 `data.ts` 移除,改用 `categories.<id>.{label,description}` 的 i18n key;`data.ts` 仅保留按 id 排序的 `CATEGORY_ORDER`

`data.ts` 内的 model `meta` / engine 单元格的 `tooltip` / `notes` / `resource` / `params.desc` 暂保持 zh-CN-first(对齐 CLAUDE.md `AI narrative is zh-CN only for V1`),头部加了注释说明。后续按需把这层数据也搬到 locale bundle。

### 2. 页面 wrapper 对齐 `## Page body layout`
原本结构是:

```jsx
<div className="flex h-full min-h-0 flex-col">
  <PageHeader ... />
  <div className="flex-1 overflow-hidden">
    <div className="flex h-full flex-col gap-4 px-8 py-6">...</div>
  </div>
</div>
```

偏离了 CLAUDE.md 的标准:

> **Wrapper:** `<div className="px-8 py-6 space-y-6">` ... Reference: `apps/web/src/features/diagnostics/DiagnosticsPage.tsx`

改成 fragment + PageHeader + `<div className="space-y-6 px-8 py-6">`,与 `DiagnosticsPage` / `EndpointReportsPage` 一致。Section spacing 从 `gap-4` 改为 `space-y-6`。

### 3. 复用 EmptyState
原本 `没有匹配的模型` 是 inline `<td colspan>` 单元格,改用 `<EmptyState icon={SearchX} title body>` 共享组件(zh / en 都走 i18n)。

## Test plan

- [x] `pnpm -F @modeldoctor/web type-check` 通过
- [x] `pnpm -F @modeldoctor/web exec biome check` 通过
- [x] `pnpm -r build` 通过
- [x] 浏览器实跑,en-US 显示 `Deployment Recipes` / `Inference engine × …` / `Dense LLM (Llama / Qwen / Mistral family)` 等英文 chrome
- [x] 切到 zh-CN 后页面 chrome 全部中文化(`部署示例` / `模型 / 权重` / `稠密 LLM(Llama / Qwen / Mistral 系)`)
- [ ] data.ts 内 model 描述层 i18n 留作后续(本 PR 不做)

🤖 Generated with [Claude Code](https://claude.com/claude-code)