### PR TITLE
fix(web/notifications): /api prefix + Dialog→Sheet + autofill suppression

### DIFF
--- a/apps/web/src/features/notifications/ChannelSheet.tsx
+++ b/apps/web/src/features/notifications/ChannelSheet.tsx
@@ -1,13 +1,6 @@
 import { FormActions } from "@/components/common/form-actions";
 import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
   Form,
   FormControl,
   FormField,
@@ -23,9 +16,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { Channel } from "@modeldoctor/contracts";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -38,12 +32,13 @@ interface Props {
   channel: Channel | null;
 }
 
-export function ChannelDialog({ open, onOpenChange, channel }: Props): JSX.Element {
+export function ChannelSheet({ open, onOpenChange, channel }: Props): JSX.Element {
   const { t } = useTranslation("notifications");
   const { t: tc } = useTranslation("common");
   const create = useCreateChannel();
   const update = useUpdateChannel();
   const testCh = useTestChannel();
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const form = useForm<ChannelForm>({
     mode: "onTouched",
@@ -51,9 +46,9 @@ export function ChannelDialog({ open, onOpenChange, channel }: Props): JSX.Eleme
     defaultValues: { type: "slack", name: "", url: "" },
   });
 
-  // Reset form when the channel being edited changes (or new channel mode).
   useEffect(() => {
     if (open) {
+      setSubmitError(null);
       form.reset({
         type: channel?.type ?? "slack",
         name: channel?.name ?? "",
@@ -63,26 +58,31 @@ export function ChannelDialog({ open, onOpenChange, channel }: Props): JSX.Eleme
   }, [open, channel, form]);
 
   const onSubmit = form.handleSubmit(async (values) => {
-    if (channel) {
-      await update.mutateAsync({
-        id: channel.id,
-        body: { name: values.name, url: values.url || undefined },
-      });
-    } else {
-      await create.mutateAsync(values);
+    setSubmitError(null);
+    try {
+      if (channel) {
+        await update.mutateAsync({
+          id: channel.id,
+          body: { name: values.name, url: values.url || undefined },
+        });
+      } else {
+        await create.mutateAsync(values);
+      }
+      onOpenChange(false);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : tc("errors.unknown");
+      setSubmitError(msg);
     }
-    onOpenChange(false);
   });
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{channel ? t("channel.editButton") : t("channel.newButton")}</DialogTitle>
-          <DialogDescription>{t("channel.form.url")}</DialogDescription>
-        </DialogHeader>
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-[640px]">
+        <SheetHeader>
+          <SheetTitle>{channel ? t("channel.editButton") : t("channel.newButton")}</SheetTitle>
+        </SheetHeader>
         <Form {...form}>
-          <form onSubmit={onSubmit} className="space-y-4">
+          <form onSubmit={onSubmit} autoComplete="off" className="mt-4 space-y-4">
             <FormField
               control={form.control}
               name="type"
@@ -111,7 +111,7 @@ export function ChannelDialog({ open, onOpenChange, channel }: Props): JSX.Eleme
                 <FormItem>
                   <FormLabel required>{t("channel.form.name")}</FormLabel>
                   <FormControl>
-                    <Input {...field} />
+                    <Input {...field} autoComplete="off" data-1p-ignore data-lpignore="true" />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -124,12 +124,25 @@ export function ChannelDialog({ open, onOpenChange, channel }: Props): JSX.Eleme
                 <FormItem>
                   <FormLabel required={!channel}>{t("channel.form.url")}</FormLabel>
                   <FormControl>
-                    <Input {...field} placeholder={t("channel.form.urlPlaceholder")} />
+                    <Input
+                      {...field}
+                      placeholder={t("channel.form.urlPlaceholder")}
+                      autoComplete="off"
+                      data-1p-ignore
+                      data-lpignore="true"
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
               )}
             />
+
+            {submitError ? (
+              <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {submitError}
+              </div>
+            ) : null}
+
             <FormActions
               onCancel={() => onOpenChange(false)}
               cancelLabel={tc("actions.cancel")}
@@ -154,7 +167,7 @@ export function ChannelDialog({ open, onOpenChange, channel }: Props): JSX.Eleme
             />
           </form>
         </Form>
-      </DialogContent>
-    </Dialog>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/apps/web/src/features/notifications/ChannelsSection.tsx
+++ b/apps/web/src/features/notifications/ChannelsSection.tsx
@@ -22,7 +22,7 @@ import type { Channel } from "@modeldoctor/contracts";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-import { ChannelDialog } from "./ChannelDialog";
+import { ChannelSheet } from "./ChannelSheet";
 import { useChannels, useDeleteChannel, useTestChannel } from "./queries";
 
 export function ChannelsSection(): JSX.Element {
@@ -82,7 +82,7 @@ export function ChannelsSection(): JSX.Element {
         <Button onClick={() => setEditing(null)}>{t("channel.newButton")}</Button>
       </div>
 
-      <ChannelDialog
+      <ChannelSheet
         open={editing !== undefined}
         onOpenChange={(open) => !open && setEditing(undefined)}
         channel={editing ?? null}

--- a/apps/web/src/features/notifications/SubscriptionSheet.tsx
+++ b/apps/web/src/features/notifications/SubscriptionSheet.tsx
@@ -1,6 +1,5 @@
 import { FormActions } from "@/components/common/form-actions";
 import { ConnectionPicker } from "@/components/connection/ConnectionPicker";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import {
   Form,
   FormControl,
@@ -16,8 +15,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useChannels, useCreateSubscription } from "./queries";
@@ -28,11 +28,12 @@ interface Props {
   onOpenChange: (v: boolean) => void;
 }
 
-export function SubscriptionDialog({ open, onOpenChange }: Props): JSX.Element {
+export function SubscriptionSheet({ open, onOpenChange }: Props): JSX.Element {
   const { t } = useTranslation("notifications");
   const { t: tc } = useTranslation("common");
   const { data: channels = [] } = useChannels();
   const create = useCreateSubscription();
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const form = useForm<SubscriptionForm>({
     mode: "onTouched",
@@ -42,6 +43,7 @@ export function SubscriptionDialog({ open, onOpenChange }: Props): JSX.Element {
 
   useEffect(() => {
     if (open) {
+      setSubmitError(null);
       form.reset({
         channelId: "",
         eventType: "benchmark.completed",
@@ -51,22 +53,28 @@ export function SubscriptionDialog({ open, onOpenChange }: Props): JSX.Element {
   }, [open, form]);
 
   const onSubmit = form.handleSubmit(async (values) => {
-    await create.mutateAsync({
-      channelId: values.channelId,
-      eventType: values.eventType,
-      connectionId: values.connectionId || undefined,
-    });
-    onOpenChange(false);
+    setSubmitError(null);
+    try {
+      await create.mutateAsync({
+        channelId: values.channelId,
+        eventType: values.eventType,
+        connectionId: values.connectionId || undefined,
+      });
+      onOpenChange(false);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : tc("errors.unknown");
+      setSubmitError(msg);
+    }
   });
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{t("subscription.newButton")}</DialogTitle>
-        </DialogHeader>
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-[640px]">
+        <SheetHeader>
+          <SheetTitle>{t("subscription.newButton")}</SheetTitle>
+        </SheetHeader>
         <Form {...form}>
-          <form onSubmit={onSubmit} className="space-y-4">
+          <form onSubmit={onSubmit} className="mt-4 space-y-4">
             <FormField
               control={form.control}
               name="channelId"
@@ -136,6 +144,13 @@ export function SubscriptionDialog({ open, onOpenChange }: Props): JSX.Element {
                 </FormItem>
               )}
             />
+
+            {submitError ? (
+              <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {submitError}
+              </div>
+            ) : null}
+
             <FormActions
               onCancel={() => onOpenChange(false)}
               cancelLabel={tc("actions.cancel")}
@@ -144,7 +159,7 @@ export function SubscriptionDialog({ open, onOpenChange }: Props): JSX.Element {
             />
           </form>
         </Form>
-      </DialogContent>
-    </Dialog>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/apps/web/src/features/notifications/SubscriptionsSection.tsx
+++ b/apps/web/src/features/notifications/SubscriptionsSection.tsx
@@ -21,7 +21,7 @@ import {
 import type { Subscription } from "@modeldoctor/contracts";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { SubscriptionDialog } from "./SubscriptionDialog";
+import { SubscriptionSheet } from "./SubscriptionSheet";
 import { useDeleteSubscription, useSubscriptions } from "./queries";
 
 export function SubscriptionsSection(): JSX.Element {
@@ -66,7 +66,7 @@ export function SubscriptionsSection(): JSX.Element {
         <Button onClick={() => setCreating(true)}>{t("subscription.newButton")}</Button>
       </div>
 
-      <SubscriptionDialog open={creating} onOpenChange={setCreating} />
+      <SubscriptionSheet open={creating} onOpenChange={setCreating} />
 
       <AlertDialog open={!!toDelete} onOpenChange={(open) => !open && setToDelete(null)}>
         <AlertDialogContent>

--- a/apps/web/src/features/notifications/queries.ts
+++ b/apps/web/src/features/notifications/queries.ts
@@ -15,14 +15,15 @@ const subscriptionsKey = ["notifications", "subscriptions"] as const;
 export function useChannels() {
   return useQuery({
     queryKey: channelsKey,
-    queryFn: () => api.get<Channel[]>("/notifications/channels"),
+    queryFn: () => api.get<Channel[]>("/api/notifications/channels"),
   });
 }
 
 export function useCreateChannel() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (body: CreateChannelRequest) => api.post<Channel>("/notifications/channels", body),
+    mutationFn: (body: CreateChannelRequest) =>
+      api.post<Channel>("/api/notifications/channels", body),
     onSuccess: () => qc.invalidateQueries({ queryKey: channelsKey }),
   });
 }
@@ -31,7 +32,7 @@ export function useUpdateChannel() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id, body }: { id: string; body: UpdateChannelRequest }) =>
-      api.patch<Channel>(`/notifications/channels/${id}`, body),
+      api.patch<Channel>(`/api/notifications/channels/${id}`, body),
     onSuccess: () => qc.invalidateQueries({ queryKey: channelsKey }),
   });
 }
@@ -39,7 +40,7 @@ export function useUpdateChannel() {
 export function useDeleteChannel() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => api.del<void>(`/notifications/channels/${id}`),
+    mutationFn: (id: string) => api.del<void>(`/api/notifications/channels/${id}`),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: channelsKey });
       qc.invalidateQueries({ queryKey: subscriptionsKey });
@@ -50,14 +51,14 @@ export function useDeleteChannel() {
 export function useTestChannel() {
   return useMutation({
     mutationFn: (id: string) =>
-      api.post<TestChannelResponse>(`/notifications/channels/${id}/test`, {}),
+      api.post<TestChannelResponse>(`/api/notifications/channels/${id}/test`, {}),
   });
 }
 
 export function useSubscriptions() {
   return useQuery({
     queryKey: subscriptionsKey,
-    queryFn: () => api.get<Subscription[]>("/notifications/subscriptions"),
+    queryFn: () => api.get<Subscription[]>("/api/notifications/subscriptions"),
   });
 }
 
@@ -65,7 +66,7 @@ export function useCreateSubscription() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (body: CreateSubscriptionRequest) =>
-      api.post<Subscription>("/notifications/subscriptions", body),
+      api.post<Subscription>("/api/notifications/subscriptions", body),
     onSuccess: () => qc.invalidateQueries({ queryKey: subscriptionsKey }),
   });
 }
@@ -73,7 +74,7 @@ export function useCreateSubscription() {
 export function useDeleteSubscription() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => api.del<void>(`/notifications/subscriptions/${id}`),
+    mutationFn: (id: string) => api.del<void>(`/api/notifications/subscriptions/${id}`),
     onSuccess: () => qc.invalidateQueries({ queryKey: subscriptionsKey }),
   });
 }


### PR DESCRIPTION
## Summary

Follow-up to #168 — three issues discovered post-merge while smoke-testing channel creation:

- **`/api` prefix missing on all CRUD paths** — `apiClient` does not auto-prepend `/api`; callers must pass full paths (other features do `/api/connections`, `/api/benchmarks`, etc.). My `notifications/queries.ts` used bare `/notifications/*`, so every CRUD silently 404'd against the vite dev server (vite only proxies `/api/*` to the api). E2E didn't catch this because supertest hits the api directly without proxy.
- **Convention drift: Dialog → Sheet** — project's create/edit primitive is `Sheet` (cf. `ConnectionSheet.tsx`). The "ConnectionDialog" reference text in `CLAUDE.md` is stale; the actual file has always been `ConnectionSheet`. Converted `ChannelDialog` → `ChannelSheet` and `SubscriptionDialog` → `SubscriptionSheet`, right-side 640px panels matching the rest of the app.
- **Browser password manager autofill** — Chrome / 1Password / LastPass were filling the "Name" field with the user's saved login (plus dropping their `-webkit-autofill` yellow background through dark theme). Added `autoComplete="off"` on `<form>` and `data-1p-ignore` / `data-lpignore="true"` on the name + URL inputs.
- **Surface mutation errors** — `mutateAsync` failures were silently swallowed (dialog stayed open, user saw nothing). Added inline submit-error rendering inside both sheets so backend errors (e.g. the 404s above, or future SSRF rejections) are visible.

Addresses #152.

## Test plan
- [ ] `/notifications` → "+ 新建通道" opens a right-side Sheet (not centered Dialog).
- [ ] Create Slack channel with a real `hooks.slack.com/services/...` URL → row appears, no 404.
- [ ] On failure, the error message renders in red inside the Sheet (e.g. paste a junk URL `https://example.test/bad` → backend's `slack webhook returned 404` shown inline).
- [ ] Name field stays blank when sheet opens (no autofill from password manager).
- [ ] Subscription Sheet same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)