### PR TITLE
feat(notifications): Feishu + DingTalk bot adapters

### DIFF
--- a/apps/api/prisma/migrations/20260511154810_add_feishu_dingtalk_channel_types/migration.sql
+++ b/apps/api/prisma/migrations/20260511154810_add_feishu_dingtalk_channel_types/migration.sql
@@ -1,0 +1,10 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "ChannelType" ADD VALUE 'feishu';
+ALTER TYPE "ChannelType" ADD VALUE 'dingtalk';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -261,6 +261,8 @@ model LlmJudgeProvider {
 enum ChannelType {
   slack
   webhook
+  feishu
+  dingtalk
 }
 
 enum DeliveryStatus {

--- a/apps/api/src/modules/notifications/adapters/dingtalk.adapter.spec.ts
+++ b/apps/api/src/modules/notifications/adapters/dingtalk.adapter.spec.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../connection/discovery/ssrf-guard.js", () => ({
+  assertSafeUrl: vi.fn(async (url: string) => ({
+    safeUrl: new URL(url),
+    resolvedIp: "10.0.0.1",
+  })),
+}));
+
+import { sendDingtalk } from "./dingtalk.adapter.js";
+import { NotificationDeliveryError } from "./index.js";
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+afterEach(() => fetchMock.mockReset());
+
+describe("sendDingtalk", () => {
+  it("POSTs DingTalk schema with [ModelDoctor]-prefixed content", async () => {
+    fetchMock.mockResolvedValueOnce(new Response('{"errcode":0,"errmsg":"ok"}', { status: 200 }));
+    await sendDingtalk("https://oapi.dingtalk.com/robot/send?access_token=xxx", {
+      eventType: "diagnostics.failed",
+      payload: { runId: "r-1", connectionId: "c1" },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const parsed = JSON.parse(init.body as string) as {
+      msgtype: string;
+      text: { content: string };
+    };
+    expect(parsed.msgtype).toBe("text");
+    expect(parsed.text.content.startsWith("[ModelDoctor]")).toBe(true);
+    expect(parsed.text.content).toContain("diagnostics.failed");
+  });
+
+  it("throws when DingTalk returns non-zero errcode in body", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('{"errcode":310000,"errmsg":"keywords not in content"}', { status: 200 }),
+    );
+    await expect(
+      sendDingtalk("https://oapi.dingtalk.com/robot/send?access_token=x", {
+        eventType: "x",
+        payload: {},
+      }),
+    ).rejects.toBeInstanceOf(NotificationDeliveryError);
+  });
+
+  it("throws on 4xx HTTP status", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("", { status: 404 }));
+    await expect(
+      sendDingtalk("https://oapi.dingtalk.com/robot/send?access_token=x", {
+        eventType: "x",
+        payload: {},
+      }),
+    ).rejects.toBeInstanceOf(NotificationDeliveryError);
+  });
+});

--- a/apps/api/src/modules/notifications/adapters/dingtalk.adapter.ts
+++ b/apps/api/src/modules/notifications/adapters/dingtalk.adapter.ts
@@ -1,0 +1,40 @@
+import { safeFetch } from "../../connection/discovery/safe-fetch.js";
+import { formatText } from "./format.js";
+import { type DeliveryPayload, NotificationDeliveryError } from "./index.js";
+
+/**
+ * 钉钉 custom robot. Payload shape:
+ *   { msgtype: "text", text: { content: "<message>" } }
+ *
+ * Same security model as Feishu: the bot must be configured with at least
+ * one of: 自定义关键词 / IP 白名单 / 加签. We always prefix the message
+ * with `[ModelDoctor]` so users can set that as the keyword. HMAC signing
+ * (加签) requires a per-channel secret and is deferred to V2.
+ *
+ * DingTalk also returns HTTP 200 on logical errors with `{ errcode: <non-zero>, errmsg: ... }`.
+ */
+export async function sendDingtalk(url: string, body: DeliveryPayload): Promise<void> {
+  const text = formatText(body);
+  const res = await safeFetch(url, {
+    method: "POST",
+    body: JSON.stringify({ msgtype: "text", text: { content: text } }),
+    extraHeaders: { "content-type": "application/json" },
+    timeoutMs: 5000,
+  });
+  if (!res.ok) {
+    throw new NotificationDeliveryError(`dingtalk webhook returned ${res.status}`);
+  }
+  const raw = await res.text();
+  if (!raw) return;
+  try {
+    const parsed = JSON.parse(raw) as { errcode?: number; errmsg?: string };
+    if (typeof parsed.errcode === "number" && parsed.errcode !== 0) {
+      throw new NotificationDeliveryError(
+        `dingtalk webhook errcode=${parsed.errcode} errmsg=${parsed.errmsg ?? ""}`,
+      );
+    }
+  } catch (e) {
+    if (e instanceof NotificationDeliveryError) throw e;
+    // Non-JSON body treated as success.
+  }
+}

--- a/apps/api/src/modules/notifications/adapters/feishu.adapter.spec.ts
+++ b/apps/api/src/modules/notifications/adapters/feishu.adapter.spec.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../connection/discovery/ssrf-guard.js", () => ({
+  assertSafeUrl: vi.fn(async (url: string) => ({
+    safeUrl: new URL(url),
+    resolvedIp: "10.0.0.1",
+  })),
+}));
+
+import { sendFeishu } from "./feishu.adapter.js";
+import { NotificationDeliveryError } from "./index.js";
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+afterEach(() => fetchMock.mockReset());
+
+describe("sendFeishu", () => {
+  it("POSTs Feishu schema with [ModelDoctor]-prefixed text", async () => {
+    fetchMock.mockResolvedValueOnce(new Response('{"code":0,"msg":"ok"}', { status: 200 }));
+    await sendFeishu("https://open.feishu.cn/open-apis/bot/v2/hook/abcd", {
+      eventType: "benchmark.completed",
+      payload: { name: "bench-1", status: "completed", connectionId: "c1" },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const parsed = JSON.parse(init.body as string) as {
+      msg_type: string;
+      content: { text: string };
+    };
+    expect(parsed.msg_type).toBe("text");
+    expect(parsed.content.text.startsWith("[ModelDoctor]")).toBe(true);
+    expect(parsed.content.text).toContain("benchmark.completed");
+    expect(parsed.content.text).toContain("bench-1");
+  });
+
+  it("throws when Feishu returns non-zero code in body", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('{"code":9499,"msg":"param invalid"}', { status: 200 }),
+    );
+    await expect(
+      sendFeishu("https://open.feishu.cn/open-apis/bot/v2/hook/x", {
+        eventType: "x",
+        payload: {},
+      }),
+    ).rejects.toBeInstanceOf(NotificationDeliveryError);
+  });
+
+  it("throws on 5xx HTTP status", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("", { status: 503 }));
+    await expect(
+      sendFeishu("https://open.feishu.cn/open-apis/bot/v2/hook/x", {
+        eventType: "x",
+        payload: {},
+      }),
+    ).rejects.toBeInstanceOf(NotificationDeliveryError);
+  });
+
+  it("treats non-JSON 200 body as success", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    await expect(
+      sendFeishu("https://open.feishu.cn/open-apis/bot/v2/hook/x", {
+        eventType: "x",
+        payload: {},
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/modules/notifications/adapters/feishu.adapter.ts
+++ b/apps/api/src/modules/notifications/adapters/feishu.adapter.ts
@@ -1,0 +1,42 @@
+import { safeFetch } from "../../connection/discovery/safe-fetch.js";
+import { formatText } from "./format.js";
+import { type DeliveryPayload, NotificationDeliveryError } from "./index.js";
+
+/**
+ * 飞书 (Lark) custom robot. Payload shape:
+ *   { msg_type: "text", content: { text: "<message>" } }
+ *
+ * The bot must be configured with at least one of: 自定义关键字 / IP 白名单 /
+ * 签名校验. We always prefix the message with `[ModelDoctor]` so users can
+ * set that as the keyword (the simplest security mode). HMAC signing
+ * (加签) requires a per-channel secret and is deferred to V2.
+ *
+ * Feishu returns HTTP 200 even on logical errors (e.g. invalid token) and
+ * encodes the failure in the JSON response body as `{ code: <non-zero>, msg: ... }`.
+ * We check both the HTTP status and the body's `code` field.
+ */
+export async function sendFeishu(url: string, body: DeliveryPayload): Promise<void> {
+  const text = formatText(body);
+  const res = await safeFetch(url, {
+    method: "POST",
+    body: JSON.stringify({ msg_type: "text", content: { text } }),
+    extraHeaders: { "content-type": "application/json" },
+    timeoutMs: 5000,
+  });
+  if (!res.ok) {
+    throw new NotificationDeliveryError(`feishu webhook returned ${res.status}`);
+  }
+  const raw = await res.text();
+  if (!raw) return;
+  try {
+    const parsed = JSON.parse(raw) as { code?: number; msg?: string };
+    if (typeof parsed.code === "number" && parsed.code !== 0) {
+      throw new NotificationDeliveryError(
+        `feishu webhook error code=${parsed.code} msg=${parsed.msg ?? ""}`,
+      );
+    }
+  } catch (e) {
+    if (e instanceof NotificationDeliveryError) throw e;
+    // Non-JSON body is treated as success — Feishu sometimes returns plain "ok".
+  }
+}

--- a/apps/api/src/modules/notifications/adapters/format.ts
+++ b/apps/api/src/modules/notifications/adapters/format.ts
@@ -1,0 +1,19 @@
+import type { DeliveryPayload } from "./index.js";
+
+/**
+ * One-line summary used as the message body by all simple-text adapters
+ * (Slack / Feishu / DingTalk). Starts with `[ModelDoctor]` so users can
+ * configure that as the security keyword on bot webhooks that require it
+ * (Feishu 自定义关键字 / DingTalk 自定义关键词).
+ *
+ * Shape: `[ModelDoctor] <eventType> <name> [status=<s>] [connection=<id>]`
+ */
+export function formatText(body: DeliveryPayload): string {
+  const tag = `[ModelDoctor] ${body.eventType}`;
+  const p = body.payload as Record<string, unknown>;
+  const name =
+    typeof p.name === "string" ? p.name : ((p.runId as string | undefined) ?? "(unknown)");
+  const status = typeof p.status === "string" ? ` status=${p.status}` : "";
+  const conn = typeof p.connectionId === "string" ? ` connection=${p.connectionId}` : "";
+  return `${tag} ${name}${status}${conn}`;
+}

--- a/apps/api/src/modules/notifications/adapters/index.ts
+++ b/apps/api/src/modules/notifications/adapters/index.ts
@@ -1,4 +1,6 @@
 import type { ChannelType } from "@prisma/client";
+import { sendDingtalk } from "./dingtalk.adapter.js";
+import { sendFeishu } from "./feishu.adapter.js";
 import { sendSlack } from "./slack.adapter.js";
 import { sendWebhook } from "./webhook.adapter.js";
 
@@ -21,6 +23,8 @@ export async function dispatchToChannel(
 ): Promise<void> {
   if (type === "slack") return sendSlack(url, body);
   if (type === "webhook") return sendWebhook(url, body);
+  if (type === "feishu") return sendFeishu(url, body);
+  if (type === "dingtalk") return sendDingtalk(url, body);
   const _exhaustive: never = type;
   throw new Error(`Unsupported channel type: ${String(_exhaustive)}`);
 }

--- a/apps/api/src/modules/notifications/adapters/slack.adapter.ts
+++ b/apps/api/src/modules/notifications/adapters/slack.adapter.ts
@@ -1,4 +1,5 @@
 import { safeFetch } from "../../connection/discovery/safe-fetch.js";
+import { formatText } from "./format.js";
 import { type DeliveryPayload, NotificationDeliveryError } from "./index.js";
 
 export async function sendSlack(url: string, body: DeliveryPayload): Promise<void> {
@@ -12,14 +13,4 @@ export async function sendSlack(url: string, body: DeliveryPayload): Promise<voi
   if (!res.ok) {
     throw new NotificationDeliveryError(`slack webhook returned ${res.status}`);
   }
-}
-
-function formatText(body: DeliveryPayload): string {
-  const tag = `[ModelDoctor] ${body.eventType}`;
-  const p = body.payload as Record<string, unknown>;
-  const name =
-    typeof p.name === "string" ? p.name : ((p.runId as string | undefined) ?? "(unknown)");
-  const status = typeof p.status === "string" ? ` status=${p.status}` : "";
-  const conn = typeof p.connectionId === "string" ? ` connection=${p.connectionId}` : "";
-  return `${tag} ${name}${status}${conn}`;
 }

--- a/apps/api/src/modules/notifications/notifications.dto.ts
+++ b/apps/api/src/modules/notifications/notifications.dto.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const channelTypeSchema = z.enum(["slack", "webhook"]);
+export const channelTypeSchema = z.enum(["slack", "webhook", "feishu", "dingtalk"]);
 export const eventTypeSchema = z.enum([
   "benchmark.completed",
   "benchmark.failed",

--- a/apps/web/src/features/notifications/ChannelSheet.tsx
+++ b/apps/web/src/features/notifications/ChannelSheet.tsx
@@ -48,6 +48,7 @@ export function ChannelSheet({ open, onOpenChange, channel }: Props): JSX.Elemen
 
   const currentType = form.watch("type");
   const needsKeywordTip = currentType === "feishu" || currentType === "dingtalk";
+  const showWebhookTip = currentType === "webhook";
 
   useEffect(() => {
     if (open) {
@@ -145,6 +146,25 @@ export function ChannelSheet({ open, onOpenChange, channel }: Props): JSX.Elemen
             {needsKeywordTip ? (
               <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
                 {t("channel.form.keywordTip")}
+              </div>
+            ) : null}
+
+            {showWebhookTip ? (
+              <div className="space-y-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+                <div>{t("channel.form.webhookTip")}</div>
+                <div className="font-mono text-[11px]">{t("channel.form.webhookPayloadHint")}</div>
+                <pre className="overflow-x-auto rounded bg-background/60 p-2 font-mono text-[11px] leading-relaxed">{`{
+  "eventType": "benchmark.completed",
+  "payload": {
+    "benchmarkId": "ckxxx...",
+    "name": "...",
+    "status": "completed",
+    "scenario": "inference",
+    "tool": "guidellm",
+    "connectionId": "ckyyy...",
+    "summaryMetrics": { ... }
+  }
+}`}</pre>
               </div>
             ) : null}
 

--- a/apps/web/src/features/notifications/ChannelSheet.tsx
+++ b/apps/web/src/features/notifications/ChannelSheet.tsx
@@ -46,6 +46,9 @@ export function ChannelSheet({ open, onOpenChange, channel }: Props): JSX.Elemen
     defaultValues: { type: "slack", name: "", url: "" },
   });
 
+  const currentType = form.watch("type");
+  const needsKeywordTip = currentType === "feishu" || currentType === "dingtalk";
+
   useEffect(() => {
     if (open) {
       setSubmitError(null);
@@ -96,6 +99,8 @@ export function ChannelSheet({ open, onOpenChange, channel }: Props): JSX.Elemen
                       </SelectTrigger>
                       <SelectContent>
                         <SelectItem value="slack">{t("channel.form.typeSlack")}</SelectItem>
+                        <SelectItem value="feishu">{t("channel.form.typeFeishu")}</SelectItem>
+                        <SelectItem value="dingtalk">{t("channel.form.typeDingtalk")}</SelectItem>
                         <SelectItem value="webhook">{t("channel.form.typeWebhook")}</SelectItem>
                       </SelectContent>
                     </Select>
@@ -136,6 +141,12 @@ export function ChannelSheet({ open, onOpenChange, channel }: Props): JSX.Elemen
                 </FormItem>
               )}
             />
+
+            {needsKeywordTip ? (
+              <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+                {t("channel.form.keywordTip")}
+              </div>
+            ) : null}
 
             {submitError ? (
               <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">

--- a/apps/web/src/features/notifications/schemas.ts
+++ b/apps/web/src/features/notifications/schemas.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const channelFormSchema = z.object({
-  type: z.enum(["slack", "webhook"]),
+  type: z.enum(["slack", "webhook", "feishu", "dingtalk"]),
   name: z.string().min(1).max(100),
   url: z.string().url(),
 });

--- a/apps/web/src/locales/en-US/notifications.json
+++ b/apps/web/src/locales/en-US/notifications.json
@@ -24,7 +24,9 @@
       "name": "Name",
       "url": "Webhook URL",
       "urlPlaceholder": "https://hooks.slack.com/services/...",
-      "keywordTip": "Feishu / DingTalk bots require at least one security mode. Simplest: set \"ModelDoctor\" as the custom keyword (every message we send is prefixed with [ModelDoctor]). HMAC signing is deferred to V2."
+      "keywordTip": "Feishu / DingTalk bots require at least one security mode. Simplest: set \"ModelDoctor\" as the custom keyword (every message we send is prefixed with [ModelDoctor]). HMAC signing is deferred to V2.",
+      "webhookTip": "Posts ModelDoctor's native JSON to any HTTP endpoint. Good for webhook.site debugging, Zapier / n8n / self-hosted bridge services.",
+      "webhookPayloadHint": "POST Content-Type: application/json"
     },
     "testSuccess": "Test message sent",
     "testFailure": "Test failed: {{error}}"

--- a/apps/web/src/locales/en-US/notifications.json
+++ b/apps/web/src/locales/en-US/notifications.json
@@ -18,10 +18,13 @@
     "form": {
       "type": "Type",
       "typeSlack": "Slack",
+      "typeFeishu": "Feishu (Lark)",
+      "typeDingtalk": "DingTalk",
       "typeWebhook": "Generic Webhook",
       "name": "Name",
       "url": "Webhook URL",
-      "urlPlaceholder": "https://hooks.slack.com/services/..."
+      "urlPlaceholder": "https://hooks.slack.com/services/...",
+      "keywordTip": "Feishu / DingTalk bots require at least one security mode. Simplest: set \"ModelDoctor\" as the custom keyword (every message we send is prefixed with [ModelDoctor]). HMAC signing is deferred to V2."
     },
     "testSuccess": "Test message sent",
     "testFailure": "Test failed: {{error}}"

--- a/apps/web/src/locales/zh-CN/notifications.json
+++ b/apps/web/src/locales/zh-CN/notifications.json
@@ -18,10 +18,13 @@
     "form": {
       "type": "类型",
       "typeSlack": "Slack",
+      "typeFeishu": "飞书",
+      "typeDingtalk": "钉钉",
       "typeWebhook": "通用 Webhook",
       "name": "名称",
       "url": "Webhook URL",
-      "urlPlaceholder": "https://hooks.slack.com/services/..."
+      "urlPlaceholder": "https://hooks.slack.com/services/...",
+      "keywordTip": "飞书/钉钉机器人需要至少一种安全设置。最简单是将「ModelDoctor」配置为自定义关键字（消息内容会带 [ModelDoctor] 前缀）。HMAC 加签留待 V2。"
     },
     "testSuccess": "测试发送成功",
     "testFailure": "测试发送失败：{{error}}"

--- a/apps/web/src/locales/zh-CN/notifications.json
+++ b/apps/web/src/locales/zh-CN/notifications.json
@@ -24,7 +24,9 @@
       "name": "名称",
       "url": "Webhook URL",
       "urlPlaceholder": "https://hooks.slack.com/services/...",
-      "keywordTip": "飞书/钉钉机器人需要至少一种安全设置。最简单是将「ModelDoctor」配置为自定义关键字（消息内容会带 [ModelDoctor] 前缀）。HMAC 加签留待 V2。"
+      "keywordTip": "飞书/钉钉机器人需要至少一种安全设置。最简单是将「ModelDoctor」配置为自定义关键字（消息内容会带 [ModelDoctor] 前缀）。HMAC 加签留待 V2。",
+      "webhookTip": "发送 ModelDoctor 原生 JSON 到任意 HTTP 端点。适合 webhook.site 调试、Zapier / n8n / 自建桥接服务。",
+      "webhookPayloadHint": "POST Content-Type: application/json"
     },
     "testSuccess": "测试发送成功",
     "testFailure": "测试发送失败：{{error}}"

--- a/packages/contracts/src/notifications.ts
+++ b/packages/contracts/src/notifications.ts
@@ -1,4 +1,4 @@
-export type ChannelType = "slack" | "webhook";
+export type ChannelType = "slack" | "webhook" | "feishu" | "dingtalk";
 export type NotificationEventType =
   | "benchmark.completed"
   | "benchmark.failed"


### PR DESCRIPTION
## Summary

Closes the V1 honesty gap from #168 — Roadmap B's stated success criterion was "5-min Feishu bot push", but V1 only natively spoke Slack + raw JSON. Feishu/DingTalk custom robots require their own payload schemas, so this PR adds dedicated adapters.

- **`feishu` adapter** — `POST { msg_type: "text", content: { text } }` to Feishu/Lark bot webhook
- **`dingtalk` adapter** — `POST { msgtype: "text", text: { content } }` to DingTalk bot webhook
- Both check vendor error codes in the JSON body (Feishu's `code`, DingTalk's `errcode`) in addition to HTTP status — both APIs return 200 on logical failures
- Shared `formatText()` helper extracted from `slack.adapter.ts` so all three text-channel formats stay in sync
- Messages always prefixed with `[ModelDoctor]` — users configure that as the bot's `自定义关键字` (the simplest of the three security modes both vendors require)

## Security mode note

Feishu and DingTalk bots require **at least one** of:
- 自定义关键字 (custom keyword) — **what V1 supports**: set "ModelDoctor" as the keyword
- IP 白名单
- 加签 (HMAC signing) — deferred to V2 (needs per-channel secret storage)

The ChannelSheet's Type dropdown shows an inline tip when Feishu/DingTalk is selected, explaining this.

## Files

- Prisma: `ChannelType` enum grows `slack | webhook` → `slack | webhook | feishu | dingtalk` (auto-generated migration)
- `apps/api/src/modules/notifications/adapters/{feishu,dingtalk}.adapter.ts` + specs (7 new tests)
- `apps/api/src/modules/notifications/adapters/format.ts` — shared text formatter
- Contracts type + zod DTO + web schema bumped
- `ChannelSheet`: 4 type options + keyword tip
- i18n: `typeFeishu` / `typeDingtalk` / `keywordTip`

addresses #152

## Test plan
- [ ] `/notifications` → New channel → Feishu, paste your bot webhook URL → save → keyword tip visible
- [ ] In Feishu group bot settings: set "ModelDoctor" as 自定义关键字
- [ ] Click 测试 → bot posts `[ModelDoctor] test (unknown)` in the group
- [ ] Same with DingTalk
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)