### PR TITLE
feat: kv-cache-stress tool + vllm-ascend LMCache/YRCache recipes + KV cache official templates

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -56,6 +56,7 @@ RUNNER_IMAGE_GUIDELLM=<replace via ./tools/build-runner-images.sh>
 RUNNER_IMAGE_VEGETA=<replace via ./tools/build-runner-images.sh>
 RUNNER_IMAGE_GENAI_PERF=<replace via ./tools/build-runner-images.sh>
 RUNNER_IMAGE_PREFIX_CACHE_PROBE=<replace via ./tools/build-runner-images.sh>
+RUNNER_IMAGE_KV_CACHE_STRESS=<replace via ./tools/build-runner-images.sh>
 
 # Optional kubeconfig override for out-of-cluster local dev. Leave unset in
 # production (the API runs as a pod and uses its in-cluster ServiceAccount).

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -28,6 +28,7 @@ import {
   applyScenarioConstraints,
   genaiPerfParamsSchema,
   guidellmParamsSchema,
+  kvCacheStressParamsSchema,
 } from "@modeldoctor/tool-adapters";
 import { Prisma, PrismaClient } from "@prisma/client";
 
@@ -178,12 +179,13 @@ const EVALUATION_PROFILES: EvaluationProfileSeed[] = [
 //   - applyScenarioConstraints("inference", tool)  (narrows rateType etc.)
 // ---------------------------------------------------------------------------
 
-type Tool = "guidellm" | "genai-perf";
+type Tool = "guidellm" | "genai-perf" | "kv-cache-stress";
+type SeedScenario = "inference" | "kv-cache-stress";
 interface BenchmarkTemplateSeed {
   id: string;
   name: string;
   description: string;
-  scenario: "inference";
+  scenario: SeedScenario;
   tool: Tool;
   config: unknown;
   tags: string[];
@@ -388,6 +390,49 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
     },
     tags: ["agent", "tool-use", "production-trace", "mooncake", "long-input"],
   },
+  // -------------------------------------------------------------------------
+  // KV cache stress · 2 个官方 baseline 模板
+  //
+  // 锚定 theriseunion/repots 2026-05-10(LMCache)/ 2026-05-11(YRCache) 实测:
+  // Qwen3-32B + Atlas 800I A2 / 8×910B4。两个模板的 `config` 故意完全一致 ——
+  // 同一工作负载 / 不同后端的"控制变量"对比方法论,用户跑两次后直接走 Compare
+  // 视图看 delta。本模板**只**包含 kv-cache-stress adapter 的 params,
+  // backend 切换由 deployment-recipes 文档化,本模板假设 backend 已部署。
+  // -------------------------------------------------------------------------
+  {
+    id: "tpl_official_kv_cache_lmcache_cpu_baseline",
+    name: "KV Cache · LMCache CPU baseline",
+    description:
+      "对齐 2026-05-10 实测:Qwen3-32B + LMCache CPU 100 GB,200 sessions × 4 轮多轮对话,工作集 ~400K token 强制驱逐 HBM。预期 QPS ~3.75 / TTFT p90 ~2.3 s / Prefix Cache Savings 85% / err 0%(Atlas 800I A2 · 8×910B4)。",
+    scenario: "kv-cache-stress",
+    tool: "kv-cache-stress",
+    config: {
+      numSessions: 200,
+      turns: 4,
+      concurrency: 25,
+      maxTokens: 50,
+      durationSec: 600,
+      systemPromptSeed: "scn",
+    },
+    tags: ["kv-cache", "lmcache", "baseline", "multi-turn", "qwen3-32b"],
+  },
+  {
+    id: "tpl_official_kv_cache_yrcache_full_baseline",
+    name: "KV Cache · YRCache 三层缓存 baseline",
+    description:
+      "对齐 2026-05-11 实测:Qwen3-32B + YRCache(CPU 100 GB + Local Disk + Redis 元数据 + NFS 数据),200 sessions × 4 轮。预期 QPS ~3.39 / TTFT p90 ~2.1 s / Prefix Cache Savings 89% / err 9-13%(Atlas 800I A2 · 8×910B4)。接受 err 率 trade-off 才推荐使用;生产强烈建议先跑 LMCache baseline 对比。",
+    scenario: "kv-cache-stress",
+    tool: "kv-cache-stress",
+    config: {
+      numSessions: 200,
+      turns: 4,
+      concurrency: 25,
+      maxTokens: 50,
+      durationSec: 600,
+      systemPromptSeed: "scn",
+    },
+    tags: ["kv-cache", "yrcache", "baseline", "multi-turn", "qwen3-32b", "shared-tier"],
+  },
   {
     id: "tpl_official_embeddings_high_throughput",
     name: "嵌入服务高吞吐",
@@ -448,15 +493,23 @@ async function seedEvaluationProfiles(): Promise<void> {
 
 async function seedBenchmarkTemplates(): Promise<void> {
   for (const t of BENCHMARK_TEMPLATES) {
-    const base = t.tool === "guidellm" ? guidellmParamsSchema : genaiPerfParamsSchema;
+    // Pick the per-tool zod base schema. Each adapter owns its own
+    // params schema; we route by tool name (not scenario) because some
+    // tools are scenario-polymorphic.
+    const base =
+      t.tool === "guidellm"
+        ? guidellmParamsSchema
+        : t.tool === "genai-perf"
+          ? genaiPerfParamsSchema
+          : kvCacheStressParamsSchema;
     const validatedBase = base.parse(t.config);
     // Apply scenario-level constraints uniformly across tools. For
-    // (inference, genai-perf) this is a no-op — the scenario's
-    // paramsConstraints map has no genai-perf entry, so
-    // applyScenarioConstraints returns the bare adapter schema and
-    // re-parses the same shape. We still call it so the invariant
-    // "all official templates round-trip through scenario constraints"
-    // holds regardless of tool.
+    // (inference, genai-perf) and (kv-cache-stress, kv-cache-stress)
+    // this is a no-op — those scenarios' paramsConstraints maps have
+    // no entry for the given tool, so applyScenarioConstraints returns
+    // the bare adapter schema and re-parses the same shape. We still
+    // call it so the invariant "all official templates round-trip
+    // through scenario constraints" holds regardless of tool.
     const validatedConfig = applyScenarioConstraints(t.scenario, t.tool).parse(validatedBase);
     await prisma.benchmarkTemplate.upsert({
       where: { id: t.id },

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -65,6 +65,7 @@ export const EnvSchema = z
     RUNNER_IMAGE_GENAI_PERF: z.string().min(1).optional(),
     RUNNER_IMAGE_VEGETA: z.string().min(1).optional(),
     RUNNER_IMAGE_PREFIX_CACHE_PROBE: z.string().min(1).optional(),
+    RUNNER_IMAGE_KV_CACHE_STRESS: z.string().min(1).optional(),
     BENCHMARK_DEFAULT_MAX_DURATION_SECONDS: z.coerce.number().int().positive().default(1800),
     // Optional HuggingFace tokenizer id for guidellm synthetic prompt token
     // counting (passed as --processor). Set this when the target gateway
@@ -137,6 +138,7 @@ export const EnvSchema = z
         "RUNNER_IMAGE_VEGETA",
         "RUNNER_IMAGE_GENAI_PERF",
         "RUNNER_IMAGE_PREFIX_CACHE_PROBE",
+        "RUNNER_IMAGE_KV_CACHE_STRESS",
       ] as const;
       for (const key of perToolImages) {
         if (!env[key]) {

--- a/apps/api/src/config/env.spec.ts
+++ b/apps/api/src/config/env.spec.ts
@@ -51,6 +51,7 @@ describe("validateEnv", () => {
       RUNNER_IMAGE_VEGETA: "md-runner-vegeta:test",
       RUNNER_IMAGE_GENAI_PERF: "md-runner-genai-perf:test",
       RUNNER_IMAGE_PREFIX_CACHE_PROBE: "md-runner-prefix-cache-probe:test",
+      RUNNER_IMAGE_KV_CACHE_STRESS: "md-runner-kv-cache-stress:test",
     });
     expect(env.DATABASE_URL).toBe("postgresql://u:p@h:5432/d");
   });
@@ -84,6 +85,7 @@ describe("validateEnv", () => {
       RUNNER_IMAGE_VEGETA: "md-runner-vegeta:test",
       RUNNER_IMAGE_GENAI_PERF: "md-runner-genai-perf:test",
       RUNNER_IMAGE_PREFIX_CACHE_PROBE: "md-runner-prefix-cache-probe:test",
+      RUNNER_IMAGE_KV_CACHE_STRESS: "md-runner-kv-cache-stress:test",
     });
     expect(env.JWT_ACCESS_SECRET).toBe("a".repeat(32));
   });
@@ -184,6 +186,7 @@ describe("validateEnv", () => {
       RUNNER_IMAGE_VEGETA: "md-runner-vegeta:test",
       RUNNER_IMAGE_GENAI_PERF: "md-runner-genai-perf:test",
       RUNNER_IMAGE_PREFIX_CACHE_PROBE: "md-runner-prefix-cache-probe:test",
+      RUNNER_IMAGE_KV_CACHE_STRESS: "md-runner-kv-cache-stress:test",
     };
 
     it("requires RUNNER_IMAGE_GUIDELLM outside test mode", () => {
@@ -201,18 +204,24 @@ describe("validateEnv", () => {
       expect(() => validateEnv(rest)).toThrow(/RUNNER_IMAGE_GENAI_PERF/);
     });
 
-    it("accepts a fully-configured dev env with all four RUNNER_IMAGE_* set", () => {
+    it("accepts a fully-configured dev env with all RUNNER_IMAGE_* set", () => {
       const env = validateEnv(baseDev);
       expect(env.BENCHMARK_K8S_NAMESPACE).toBe("modeldoctor-benchmarks");
       expect(env.RUNNER_IMAGE_GUIDELLM).toBe("md-runner-guidellm:test");
       expect(env.RUNNER_IMAGE_VEGETA).toBe("md-runner-vegeta:test");
       expect(env.RUNNER_IMAGE_GENAI_PERF).toBe("md-runner-genai-perf:test");
       expect(env.RUNNER_IMAGE_PREFIX_CACHE_PROBE).toBe("md-runner-prefix-cache-probe:test");
+      expect(env.RUNNER_IMAGE_KV_CACHE_STRESS).toBe("md-runner-kv-cache-stress:test");
     });
 
     it("requires RUNNER_IMAGE_PREFIX_CACHE_PROBE outside test mode", () => {
       const { RUNNER_IMAGE_PREFIX_CACHE_PROBE: _omitted, ...rest } = baseDev;
       expect(() => validateEnv(rest)).toThrow(/RUNNER_IMAGE_PREFIX_CACHE_PROBE/);
+    });
+
+    it("requires RUNNER_IMAGE_KV_CACHE_STRESS outside test mode", () => {
+      const { RUNNER_IMAGE_KV_CACHE_STRESS: _omitted, ...rest } = baseDev;
+      expect(() => validateEnv(rest)).toThrow(/RUNNER_IMAGE_KV_CACHE_STRESS/);
     });
 
     it("defaults BENCHMARK_DEFAULT_MAX_DURATION_SECONDS to 1800", () => {

--- a/apps/api/src/modules/benchmark/benchmark.repository.ts
+++ b/apps/api/src/modules/benchmark/benchmark.repository.ts
@@ -14,7 +14,7 @@ export type CreateBenchmarkInput = {
   userId?: string | null;
   connectionId?: string | null;
   scenario: string;
-  tool: "guidellm" | "genai-perf" | "vegeta" | "prefix-cache-probe";
+  tool: "guidellm" | "genai-perf" | "vegeta" | "prefix-cache-probe" | "kv-cache-stress";
   params: Prisma.InputJsonValue;
   name: string;
   description?: string | null;

--- a/apps/api/src/modules/benchmark/k8s/runner-images.ts
+++ b/apps/api/src/modules/benchmark/k8s/runner-images.ts
@@ -7,6 +7,7 @@ const TOOL_TO_IMAGE_ENV: Record<ToolName, keyof Env> = {
   "genai-perf": "RUNNER_IMAGE_GENAI_PERF",
   vegeta: "RUNNER_IMAGE_VEGETA",
   "prefix-cache-probe": "RUNNER_IMAGE_PREFIX_CACHE_PROBE",
+  "kv-cache-stress": "RUNNER_IMAGE_KV_CACHE_STRESS",
 };
 
 /**

--- a/apps/benchmark-runner/images/kv-cache-stress.Dockerfile
+++ b/apps/benchmark-runner/images/kv-cache-stress.Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.6
+
+# kv-cache-stress runner image. Multi-turn dialog stress that measures
+# KV cache backend performance (LMCache / YRCache / vanilla vLLM). See
+# packages/tool-adapters/src/kv-cache-stress/runtime.ts and
+# apps/benchmark-runner/scripts/kv_cache_stress.py for the contract.
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Same dependency pins as prefix-cache-probe — both probes only need httpx
+# and requests; staying aligned keeps the layer cacheable across images.
+RUN pip install --no-cache-dir \
+        'httpx>=0.27,<1' \
+        'requests>=2.31,<3'
+
+WORKDIR /app
+
+COPY runner runner
+COPY scripts/kv_cache_stress.py /app/probe.py
+
+# Non-root user (matches sibling Dockerfiles).
+RUN useradd --create-home --shell /sbin/nologin runner \
+    && chown -R runner:runner /app
+USER runner
+
+# Generic wrapper; argv produced by
+# packages/tool-adapters/src/kv-cache-stress/runtime.ts is
+# python /app/probe.py ...
+ENTRYPOINT ["python", "-m", "runner"]

--- a/apps/benchmark-runner/scripts/kv_cache_stress.py
+++ b/apps/benchmark-runner/scripts/kv_cache_stress.py
@@ -83,14 +83,10 @@ async def session_run(
     max_tokens: int,
     seed: str,
 ) -> list[tuple]:
-    history: list[dict[str, str]] = [
-        {"role": "system", "content": make_scenario(sess_id, seed)}
-    ]
+    history: list[dict[str, str]] = [{"role": "system", "content": make_scenario(sess_id, seed)}]
     rows: list[tuple] = []
     for turn in range(turns):
-        history.append(
-            {"role": "user", "content": QUESTIONS[turn % len(QUESTIONS)]}
-        )
+        history.append({"role": "user", "content": QUESTIONS[turn % len(QUESTIONS)]})
         body = {
             "model": model,
             "messages": history,
@@ -105,9 +101,7 @@ async def session_run(
         pt = 0
         ct = 0
         try:
-            async with client.stream(
-                "POST", base_path, json=body, timeout=120
-            ) as resp:
+            async with client.stream("POST", base_path, json=body, timeout=120) as resp:
                 if resp.status_code != 200:
                     rows.append(
                         (
@@ -133,10 +127,7 @@ async def session_run(
                     except Exception:
                         continue
                     if d.get("choices"):
-                        delta = (
-                            d["choices"][0].get("delta", {}).get("content", "")
-                            or ""
-                        )
+                        delta = d["choices"][0].get("delta", {}).get("content", "") or ""
                         if delta and ttft is None:
                             ttft = time.time() - t0
                         content += delta
@@ -145,9 +136,7 @@ async def session_run(
                         ct = d["usage"].get("completion_tokens", ct)
             elapsed = time.time() - t0
             history.append({"role": "assistant", "content": content})
-            rows.append(
-                ("ok", sess_id, turn, pt, ct, ttft or 0.0, elapsed)
-            )
+            rows.append(("ok", sess_id, turn, pt, ct, ttft or 0.0, elapsed))
         except Exception as e:
             elapsed = time.time() - t0
             rows.append(
@@ -186,9 +175,7 @@ async def worker(
         path = "/v1/chat/completions"
         while time.time() < deadline:
             sess_id = random.randrange(num_sessions)
-            rows = await session_run(
-                client, path, model, sess_id, turns, max_tokens, seed
-            )
+            rows = await session_run(client, path, model, sess_id, turns, max_tokens, seed)
             async with lock:
                 results.extend(rows)
 
@@ -253,9 +240,7 @@ async def snapshot_prom_all(prom: str | None, model: str) -> dict[str, int]:
     return out
 
 
-async def scrape_backend_counters(
-    base_url: str, api_key: str
-) -> tuple[str, dict[str, float]]:
+async def scrape_backend_counters(base_url: str, api_key: str) -> tuple[str, dict[str, float]]:
     """Scrape vLLM /metrics and pull lmcache:* / yrcache_* counters.
     Returns (nameGuess, {metric_name_with_labels: value}). Aggregates across
     label sets per metric name (summing) to match the diff scripts shipped
@@ -308,13 +293,9 @@ async def scrape_backend_counters(
 async def main_async(args: argparse.Namespace) -> int:
     api_key = os.environ.get("OPENAI_API_KEY", "")
     if not api_key:
-        print("[stress] WARN: OPENAI_API_KEY not set; sending unauthenticated",
-              file=sys.stderr)
+        print("[stress] WARN: OPENAI_API_KEY not set; sending unauthenticated", file=sys.stderr)
 
-    print(
-        f"BASE_URL={args.base_url}  MODEL={args.model}  API_KEY="
-        f"{'set' if api_key else 'unset'}"
-    )
+    print(f"BASE_URL={args.base_url}  MODEL={args.model}  API_KEY={'set' if api_key else 'unset'}")
     print(
         f"NUM_SESSIONS={args.num_sessions}  TURNS={args.turns}  "
         f"CONCURRENCY={args.concurrency}  MAX_TOKENS={args.max_tokens}  "
@@ -356,9 +337,7 @@ async def main_async(args: argparse.Namespace) -> int:
     # Optional post-bench Prom snapshot.
     prom_after = await snapshot_prom_all(args.prom_url, args.model)
 
-    backend_name, backend_counters = await scrape_backend_counters(
-        args.base_url, api_key
-    )
+    backend_name, backend_counters = await scrape_backend_counters(args.base_url, api_key)
 
     ok_rows = [r for r in results if r[0] == "ok"]
     err_count = len(results) - len(ok_rows)
@@ -382,8 +361,7 @@ async def main_async(args: argparse.Namespace) -> int:
         )
         delta_pt = max(
             0,
-            prom_after.get("prompt_tokens_total", 0)
-            - prom_before.get("prompt_tokens_total", 0),
+            prom_after.get("prompt_tokens_total", 0) - prom_before.get("prompt_tokens_total", 0),
         )
         delta_cached = max(
             0,
@@ -398,9 +376,7 @@ async def main_async(args: argparse.Namespace) -> int:
         if delta_q > 0:
             prom_block["hbmHitRatePct"] = round(100.0 * delta_h / delta_q, 2)
         if delta_pt > 0:
-            prom_block["prefixCacheSavingsPct"] = round(
-                100.0 * delta_cached / delta_pt, 2
-            )
+            prom_block["prefixCacheSavingsPct"] = round(100.0 * delta_cached / delta_pt, 2)
         prom_block["promptTokensTotalDelta"] = delta_pt
         prom_block["generationTokensTotalDelta"] = delta_gen
 
@@ -449,27 +425,24 @@ async def main_async(args: argparse.Namespace) -> int:
     )
     print(f"backend.nameGuess  = {report['backend']['nameGuess']}")
     if prom_block.get("prefixCacheSavingsPct") is not None:
-        print(
-            f"prefix_cache_savings_pct = {prom_block['prefixCacheSavingsPct']}"
-        )
+        print(f"prefix_cache_savings_pct = {prom_block['prefixCacheSavingsPct']}")
 
     return 0
 
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--base-url", required=True,
-                   help="OpenAI-compatible base URL (no /v1/...)")
+    p.add_argument("--base-url", required=True, help="OpenAI-compatible base URL (no /v1/...)")
     p.add_argument("--model", required=True)
     p.add_argument("--num-sessions", type=int, required=True)
     p.add_argument("--turns", type=int, required=True)
     p.add_argument("--concurrency", type=int, required=True)
     p.add_argument("--max-tokens", type=int, required=True)
-    p.add_argument("--duration", type=int, required=True,
-                   help="bench wall-clock seconds")
+    p.add_argument("--duration", type=int, required=True, help="bench wall-clock seconds")
     p.add_argument("--system-prompt-seed", required=True)
-    p.add_argument("--prom-url", default=None,
-                   help="Optional Prometheus base URL for delta snapshot")
+    p.add_argument(
+        "--prom-url", default=None, help="Optional Prometheus base URL for delta snapshot"
+    )
     p.add_argument("--out", default="result.json")
     args = p.parse_args()
     return asyncio.run(main_async(args))

--- a/apps/benchmark-runner/scripts/kv_cache_stress.py
+++ b/apps/benchmark-runner/scripts/kv_cache_stress.py
@@ -124,7 +124,7 @@ async def session_run(
                         break
                     try:
                         d = json.loads(p)
-                    except Exception:
+                    except json.JSONDecodeError:
                         continue
                     if d.get("choices"):
                         delta = d["choices"][0].get("delta", {}).get("content", "") or ""
@@ -138,7 +138,15 @@ async def session_run(
             history.append({"role": "assistant", "content": content})
             rows.append(("ok", sess_id, turn, pt, ct, ttft or 0.0, elapsed))
         except Exception as e:
+            # Session-level safety net: a 600s bench must not die because
+            # one turn raised an unexpected exception. We deliberately
+            # keep the catch wide so the worker keeps producing rows for
+            # the remaining sessions, but log the type for forensics.
             elapsed = time.time() - t0
+            print(
+                f"[session_run] sess={sess_id} turn={turn} caught {type(e).__name__}: {e}",
+                file=sys.stderr,
+            )
             rows.append(
                 (
                     f"err_exc:{type(e).__name__}",
@@ -217,7 +225,14 @@ async def snapshot_prom_counter(prom: str, metric: str, model: str) -> int:
         if not result:
             return 0
         return int(float(result[0]["value"][1]))
-    except Exception as e:
+    except (
+        httpx.RequestError,
+        httpx.HTTPStatusError,
+        json.JSONDecodeError,
+        IndexError,
+        KeyError,
+        ValueError,
+    ) as e:
         print(f"[prom] failed to query {metric}: {e}", file=sys.stderr)
         return 0
 
@@ -252,7 +267,7 @@ async def scrape_backend_counters(base_url: str, api_key: str) -> tuple[str, dic
             r = await client.get(url)
             r.raise_for_status()
         body = r.text
-    except Exception as e:
+    except (httpx.RequestError, httpx.HTTPStatusError) as e:
         print(f"[backend] failed to scrape /metrics: {e}", file=sys.stderr)
         return "unknown", {}
 

--- a/apps/benchmark-runner/scripts/kv_cache_stress.py
+++ b/apps/benchmark-runner/scripts/kv_cache_stress.py
@@ -1,0 +1,479 @@
+"""KV-cache backend stress benchmark.
+
+Multi-turn dialog workload that forces prefix-cache evictions so different
+KV cache backends (LMCache / YRCache / vanilla) produce comparable
+QPS / TTFT / Prefix-Cache-Savings deltas.
+
+Workload methodology (adapted from theriseunion/repots:2026-05-10 + 2026-05-11):
+- NUM_SESSIONS unique sessions, each with a ~2000-token system prompt
+  derived deterministically from sha256(systemPromptSeed + session-id).
+  Same input across runs → reproducible prefix-cache hits.
+- TURNS multi-turn dialog per session, history accumulates so turns 2+
+  hit prefix cache.
+- CONCURRENCY async workers, each pick a random session per request.
+- Per-request streaming + stream_options.include_usage so we capture
+  TTFT from the FIRST content delta (not the SSE role chunk).
+
+Output: --out is a JSON file matching kvCacheStressReportSchema in
+packages/tool-adapters/src/kv-cache-stress/schema.ts.
+
+CLI: see argparse below. OPENAI_API_KEY env var carries the bearer token.
+
+Prometheus integration (optional, --prom-url):
+- Before/after counter snapshot of vllm:prefix_cache_hits_total,
+  vllm:prefix_cache_queries_total, vllm:prompt_tokens_total,
+  vllm:prompt_tokens_cached_total, vllm:generation_tokens_total.
+- Handles V0 (vllm:gpu_*) and V1 (vllm:*) metric names like
+  prefix_cache_probe.py does.
+
+Backend native counters (scraped via the same vLLM /metrics endpoint that
+already aggregates lmcache:* / yrcache_* through PROMETHEUS_MULTIPROC_DIR):
+- Heuristic detects whether lmcache:* or yrcache_* counters appear and
+  reports `backend.nameGuess`. Both counter families dumped as a flat
+  record so the FE can show them without per-backend knowledge.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import random
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+QUESTIONS = [
+    "State your analysis.",
+    "Continue your reasoning.",
+    "What is the conclusion?",
+    "What are the next steps?",
+    "Summarise the key points.",
+    "Highlight the trade-offs.",
+    "Propose follow-up actions.",
+    "Identify open questions.",
+]
+
+
+def make_scenario(idx: int, seed: str) -> str:
+    seed_bytes = hashlib.sha256(f"{seed}-{idx}".encode()).hexdigest()[:16]
+    head = (
+        f"You are senior expert {seed_bytes}. Provide concise structured "
+        f"analysis. Each response should be brief and direct."
+    )
+    refs = "\n".join(
+        f"REF[{seed_bytes}-{j:03d}] context: data point #{j} about scenario "
+        f"{idx} domain detail elaboration here."
+        for j in range(150)
+    )
+    return f"{head}\n\n{refs}"
+
+
+async def session_run(
+    client: httpx.AsyncClient,
+    base_path: str,
+    model: str,
+    sess_id: int,
+    turns: int,
+    max_tokens: int,
+    seed: str,
+) -> list[tuple]:
+    history: list[dict[str, str]] = [
+        {"role": "system", "content": make_scenario(sess_id, seed)}
+    ]
+    rows: list[tuple] = []
+    for turn in range(turns):
+        history.append(
+            {"role": "user", "content": QUESTIONS[turn % len(QUESTIONS)]}
+        )
+        body = {
+            "model": model,
+            "messages": history,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "max_tokens": max_tokens,
+            "chat_template_kwargs": {"enable_thinking": False},
+        }
+        t0 = time.time()
+        ttft: float | None = None
+        content = ""
+        pt = 0
+        ct = 0
+        try:
+            async with client.stream(
+                "POST", base_path, json=body, timeout=120
+            ) as resp:
+                if resp.status_code != 200:
+                    rows.append(
+                        (
+                            "err_http",
+                            resp.status_code,
+                            sess_id,
+                            turn,
+                            0,
+                            0,
+                            0.0,
+                            time.time() - t0,
+                        )
+                    )
+                    return rows
+                async for line in resp.aiter_lines():
+                    if not line.startswith("data:"):
+                        continue
+                    p = line[5:].strip()
+                    if p == "[DONE]":
+                        break
+                    try:
+                        d = json.loads(p)
+                    except Exception:
+                        continue
+                    if d.get("choices"):
+                        delta = (
+                            d["choices"][0].get("delta", {}).get("content", "")
+                            or ""
+                        )
+                        if delta and ttft is None:
+                            ttft = time.time() - t0
+                        content += delta
+                    if d.get("usage"):
+                        pt = d["usage"].get("prompt_tokens", pt)
+                        ct = d["usage"].get("completion_tokens", ct)
+            elapsed = time.time() - t0
+            history.append({"role": "assistant", "content": content})
+            rows.append(
+                ("ok", sess_id, turn, pt, ct, ttft or 0.0, elapsed)
+            )
+        except Exception as e:
+            elapsed = time.time() - t0
+            rows.append(
+                (
+                    f"err_exc:{type(e).__name__}",
+                    sess_id,
+                    turn,
+                    0,
+                    0,
+                    0.0,
+                    elapsed,
+                )
+            )
+            break
+    return rows
+
+
+async def worker(
+    base_url: str,
+    api_key: str,
+    model: str,
+    num_sessions: int,
+    turns: int,
+    max_tokens: int,
+    seed: str,
+    deadline: float,
+    results: list,
+    lock: asyncio.Lock,
+) -> None:
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        timeout=httpx.Timeout(120.0, connect=10.0),
+    ) as client:
+        path = "/v1/chat/completions"
+        while time.time() < deadline:
+            sess_id = random.randrange(num_sessions)
+            rows = await session_run(
+                client, path, model, sess_id, turns, max_tokens, seed
+            )
+            async with lock:
+                results.extend(rows)
+
+
+async def progress_loop(start: float, deadline: float, results: list) -> None:
+    while time.time() < deadline:
+        await asyncio.sleep(15)
+        ok = sum(1 for r in results if r[0] == "ok")
+        err = len(results) - ok
+        ct = sum(r[4] for r in results if r[0] == "ok")
+        elapsed = int(time.time() - start)
+        # Format matches the regex in kv-cache-stress/runtime.ts parseProgress.
+        print(
+            f"  +{elapsed:>3}s  ok={ok}  err={err}  completion_tokens={ct}",
+            flush=True,
+        )
+
+
+def percentile(arr: list[float], p: float) -> float:
+    if not arr:
+        return 0.0
+    idx = min(len(arr) - 1, int(len(arr) * p / 100))
+    return arr[idx]
+
+
+async def snapshot_prom_counter(prom: str, metric: str, model: str) -> int:
+    """Sum a vllm:* counter across all series with the matching model_name.
+    Falls back to V0 vllm:gpu_<metric>* if V1 returns nothing.
+    """
+    query = (
+        f'sum(vllm:{metric}{{model_name="{model}"}}) '
+        f'or sum(vllm:gpu_{metric}{{model_name="{model}"}})'
+    )
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            r = await client.get(f"{prom}/api/v1/query", params={"query": query})
+            r.raise_for_status()
+            result = r.json().get("data", {}).get("result", [])
+        if not result:
+            return 0
+        return int(float(result[0]["value"][1]))
+    except Exception as e:
+        print(f"[prom] failed to query {metric}: {e}", file=sys.stderr)
+        return 0
+
+
+async def snapshot_prom_all(prom: str | None, model: str) -> dict[str, int]:
+    """Returns delta-source counters: {metric_name: value}. {} when prom URL
+    is empty or scrape failed entirely (caller treats as no-Prom-data)."""
+    if not prom:
+        return {}
+    metrics = [
+        "prefix_cache_hits_total",
+        "prefix_cache_queries_total",
+        "prompt_tokens_total",
+        "prompt_tokens_cached_total",
+        "generation_tokens_total",
+    ]
+    out: dict[str, int] = {}
+    for m in metrics:
+        out[m] = await snapshot_prom_counter(prom.rstrip("/"), m, model)
+    return out
+
+
+async def scrape_backend_counters(
+    base_url: str, api_key: str
+) -> tuple[str, dict[str, float]]:
+    """Scrape vLLM /metrics and pull lmcache:* / yrcache_* counters.
+    Returns (nameGuess, {metric_name_with_labels: value}). Aggregates across
+    label sets per metric name (summing) to match the diff scripts shipped
+    in theriseunion/repots."""
+    url = base_url.rstrip("/") + "/metrics"
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    try:
+        async with httpx.AsyncClient(timeout=15, headers=headers) as client:
+            r = await client.get(url)
+            r.raise_for_status()
+        body = r.text
+    except Exception as e:
+        print(f"[backend] failed to scrape /metrics: {e}", file=sys.stderr)
+        return "unknown", {}
+
+    lmcache: dict[str, float] = {}
+    yrcache: dict[str, float] = {}
+    for raw in body.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Family-detect by prefix; strip labels for aggregation key.
+        if line.startswith("lmcache:") or line.startswith("yrcache_"):
+            try:
+                name, value = line.rsplit(" ", 1)
+            except ValueError:
+                continue
+            base = name.split("{", 1)[0]
+            try:
+                v = float(value)
+            except ValueError:
+                continue
+            target = lmcache if line.startswith("lmcache:") else yrcache
+            target[base] = target.get(base, 0.0) + v
+
+    if lmcache and not yrcache:
+        return "lmcache", lmcache
+    if yrcache and not lmcache:
+        return "yrcache", yrcache
+    if yrcache and lmcache:
+        # Both present (e.g. images shipping both libs); pick the one with
+        # more activity. Tie-break favours yrcache because lmcache_*
+        # registers ~30 zero gauges that always count.
+        if sum(yrcache.values()) >= sum(lmcache.values()):
+            return "yrcache", yrcache
+        return "lmcache", lmcache
+    return "unknown", {}
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    api_key = os.environ.get("OPENAI_API_KEY", "")
+    if not api_key:
+        print("[stress] WARN: OPENAI_API_KEY not set; sending unauthenticated",
+              file=sys.stderr)
+
+    print(
+        f"BASE_URL={args.base_url}  MODEL={args.model}  API_KEY="
+        f"{'set' if api_key else 'unset'}"
+    )
+    print(
+        f"NUM_SESSIONS={args.num_sessions}  TURNS={args.turns}  "
+        f"CONCURRENCY={args.concurrency}  MAX_TOKENS={args.max_tokens}  "
+        f"DURATION={args.duration}s"
+    )
+    print(f"OUT={args.out}")
+    print()
+
+    # Optional pre-bench Prom snapshot.
+    prom_before = await snapshot_prom_all(args.prom_url, args.model)
+
+    start = time.time()
+    deadline = start + args.duration
+    results: list[tuple] = []
+    lock = asyncio.Lock()
+    workers = [
+        asyncio.create_task(
+            worker(
+                args.base_url,
+                api_key,
+                args.model,
+                args.num_sessions,
+                args.turns,
+                args.max_tokens,
+                args.system_prompt_seed,
+                deadline,
+                results,
+                lock,
+            )
+        )
+        for _ in range(args.concurrency)
+    ]
+    progress = asyncio.create_task(progress_loop(start, deadline, results))
+    await asyncio.gather(*workers, return_exceptions=True)
+    progress.cancel()
+
+    wall = time.time() - start
+
+    # Optional post-bench Prom snapshot.
+    prom_after = await snapshot_prom_all(args.prom_url, args.model)
+
+    backend_name, backend_counters = await scrape_backend_counters(
+        args.base_url, api_key
+    )
+
+    ok_rows = [r for r in results if r[0] == "ok"]
+    err_count = len(results) - len(ok_rows)
+    total = len(results)
+    ttfts = sorted(r[5] * 1000.0 for r in ok_rows)
+    elapsed = sorted(r[6] * 1000.0 for r in ok_rows)
+    pt_sum = sum(r[3] for r in ok_rows)
+    ct_sum = sum(r[4] for r in ok_rows)
+
+    prom_block: dict[str, Any] = {}
+    if prom_before and prom_after:
+        delta_q = max(
+            0,
+            prom_after.get("prefix_cache_queries_total", 0)
+            - prom_before.get("prefix_cache_queries_total", 0),
+        )
+        delta_h = max(
+            0,
+            prom_after.get("prefix_cache_hits_total", 0)
+            - prom_before.get("prefix_cache_hits_total", 0),
+        )
+        delta_pt = max(
+            0,
+            prom_after.get("prompt_tokens_total", 0)
+            - prom_before.get("prompt_tokens_total", 0),
+        )
+        delta_cached = max(
+            0,
+            prom_after.get("prompt_tokens_cached_total", 0)
+            - prom_before.get("prompt_tokens_cached_total", 0),
+        )
+        delta_gen = max(
+            0,
+            prom_after.get("generation_tokens_total", 0)
+            - prom_before.get("generation_tokens_total", 0),
+        )
+        if delta_q > 0:
+            prom_block["hbmHitRatePct"] = round(100.0 * delta_h / delta_q, 2)
+        if delta_pt > 0:
+            prom_block["prefixCacheSavingsPct"] = round(
+                100.0 * delta_cached / delta_pt, 2
+            )
+        prom_block["promptTokensTotalDelta"] = delta_pt
+        prom_block["generationTokensTotalDelta"] = delta_gen
+
+    report: dict[str, Any] = {
+        "qps": round(len(ok_rows) / wall, 3) if wall > 0 else 0.0,
+        "outputTps": round(ct_sum / wall, 2) if wall > 0 else 0.0,
+        "requestsOk": len(ok_rows),
+        "requestsErr": err_count,
+        "errRatePct": round(100.0 * err_count / total, 2) if total else 0.0,
+        "ttftMs": {
+            "p50": round(percentile(ttfts, 50), 1),
+            "p90": round(percentile(ttfts, 90), 1),
+            "p99": round(percentile(ttfts, 99), 1),
+        },
+        "e2eMs": {
+            "p50": round(percentile(elapsed, 50), 1),
+            "p90": round(percentile(elapsed, 90), 1),
+            "p99": round(percentile(elapsed, 99), 1),
+        },
+        "prom": prom_block,
+        "backend": {
+            "nameGuess": backend_name,
+            "counters": backend_counters,
+        },
+    }
+
+    Path(args.out).write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    print()
+    print("=== SUMMARY ===")
+    print(f"requests_ok        = {report['requestsOk']}")
+    print(f"requests_err       = {report['requestsErr']}")
+    print(f"sum_prompt_tokens  = {pt_sum}")
+    print(f"sum_completion_tok = {ct_sum}")
+    print(f"qps                = {report['qps']}")
+    print(f"output_tps         = {report['outputTps']}")
+    print(
+        "ttft_ms p50/p90/p99 = "
+        f"{report['ttftMs']['p50']:.0f}/{report['ttftMs']['p90']:.0f}/"
+        f"{report['ttftMs']['p99']:.0f}"
+    )
+    print(
+        "e2e_ms  p50/p90/p99 = "
+        f"{report['e2eMs']['p50']:.0f}/{report['e2eMs']['p90']:.0f}/"
+        f"{report['e2eMs']['p99']:.0f}"
+    )
+    print(f"backend.nameGuess  = {report['backend']['nameGuess']}")
+    if prom_block.get("prefixCacheSavingsPct") is not None:
+        print(
+            f"prefix_cache_savings_pct = {prom_block['prefixCacheSavingsPct']}"
+        )
+
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--base-url", required=True,
+                   help="OpenAI-compatible base URL (no /v1/...)")
+    p.add_argument("--model", required=True)
+    p.add_argument("--num-sessions", type=int, required=True)
+    p.add_argument("--turns", type=int, required=True)
+    p.add_argument("--concurrency", type=int, required=True)
+    p.add_argument("--max-tokens", type=int, required=True)
+    p.add_argument("--duration", type=int, required=True,
+                   help="bench wall-clock seconds")
+    p.add_argument("--system-prompt-seed", required=True)
+    p.add_argument("--prom-url", default=None,
+                   help="Optional Prometheus base URL for delta snapshot")
+    p.add_argument("--out", default="result.json")
+    args = p.parse_args()
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/web/src/components/sidebar/sidebar-config.tsx
+++ b/apps/web/src/components/sidebar/sidebar-config.tsx
@@ -59,6 +59,11 @@ export const sidebarGroups: SidebarGroup[] = [
         icon: Layers,
         labelKey: "items.benchmarkPrefixCache",
       },
+      {
+        to: "/benchmarks/kv-cache-stress",
+        icon: Database,
+        labelKey: "items.benchmarkKvCacheStress",
+      },
       { to: "/benchmarks/reports", icon: BarChart3, labelKey: "items.endpointReports" },
       { to: "/benchmark-templates", icon: Layers, labelKey: "items.benchmarkTemplates" },
     ],

--- a/apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx
@@ -172,6 +172,7 @@ export function BenchmarkCreatePage() {
     capacity: "benchmarkCapacity",
     gateway: "benchmarkGateway",
     "prefix-cache-validation": "benchmarkPrefixCache",
+    "kv-cache-stress": "benchmarkKvCacheStress",
   };
   const breadcrumbs = [
     { label: tSidebar("groups.benchmarks") },

--- a/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
@@ -20,6 +20,7 @@ import { EngineMetricsSection } from "@/features/engine-metrics/EngineMetricsSec
 import type { Benchmark, ConnectionPublic } from "@modeldoctor/contracts";
 import type { ScenarioId } from "@modeldoctor/contracts";
 import {
+  kvCacheStressReportSchema,
   migrateVegetaParams,
   prefixCacheProbeReportSchema,
 } from "@modeldoctor/tool-adapters/schemas";
@@ -48,6 +49,7 @@ import { BenchmarkChartsSection } from "./reports/BenchmarkChartsSection";
 import { CapacityReport } from "./reports/CapacityReport";
 import { GatewayReport } from "./reports/GatewayReport";
 import { InferenceReport } from "./reports/InferenceReport";
+import { KvCacheStressReport } from "./reports/KvCacheStressReport";
 import { PrefixCacheProbeReport } from "./reports/PrefixCacheProbeReport";
 import { UnknownReport } from "./reports/UnknownReport";
 
@@ -107,6 +109,13 @@ function ReportSection({ benchmark }: { benchmark: Benchmark }) {
       const parsed = prefixCacheProbeReportSchema.safeParse(candidate);
       if (!parsed.success) return <UnknownReport benchmark={benchmark} />;
       return <PrefixCacheProbeReport data={parsed.data} />;
+    }
+    case "kv-cache-stress": {
+      const tagged = benchmark.summaryMetrics as { tool?: string; data?: unknown } | null;
+      const candidate = tagged && "data" in tagged ? tagged.data : tagged;
+      const parsed = kvCacheStressReportSchema.safeParse(candidate);
+      if (!parsed.success) return <UnknownReport benchmark={benchmark} />;
+      return <KvCacheStressReport data={parsed.data} />;
     }
     default:
       return <UnknownReport benchmark={benchmark} />;
@@ -184,6 +193,7 @@ const SCENARIO_SIDEBAR_KEY: Record<ScenarioId, string> = {
   capacity: "benchmarkCapacity",
   gateway: "benchmarkGateway",
   "prefix-cache-validation": "benchmarkPrefixCache",
+  "kv-cache-stress": "benchmarkKvCacheStress",
 };
 
 export function BenchmarkDetailPage() {

--- a/apps/web/src/features/benchmarks/BenchmarkKvCacheStressPage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkKvCacheStressPage.tsx
@@ -1,0 +1,5 @@
+import { BenchmarkListShell } from "./BenchmarkListShell";
+
+export function BenchmarkKvCacheStressPage() {
+  return <BenchmarkListShell scenario="kv-cache-stress" />;
+}

--- a/apps/web/src/features/benchmarks/BenchmarkListShell.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkListShell.tsx
@@ -72,6 +72,7 @@ const SCENARIO_SIDEBAR_KEY: Record<ScenarioId, string> = {
   capacity: "benchmarkCapacity",
   gateway: "benchmarkGateway",
   "prefix-cache-validation": "benchmarkPrefixCache",
+  "kv-cache-stress": "benchmarkKvCacheStress",
 };
 
 export function BenchmarkListShell({ scenario }: BenchmarkListShellProps) {

--- a/apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
+++ b/apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
@@ -35,6 +35,7 @@ const SCENARIO_SIDEBAR_KEY: Record<ScenarioId, string> = {
   capacity: "benchmarkCapacity",
   gateway: "benchmarkGateway",
   "prefix-cache-validation": "benchmarkPrefixCache",
+  "kv-cache-stress": "benchmarkKvCacheStress",
 };
 
 function parseIds(searchParams: URLSearchParams): string[] {

--- a/apps/web/src/features/benchmarks/forms/KvCacheStressParamsForm.tsx
+++ b/apps/web/src/features/benchmarks/forms/KvCacheStressParamsForm.tsx
@@ -1,0 +1,88 @@
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+
+interface KvCacheStressParamsFormProps {
+  fieldPrefix?: "params" | "config";
+}
+
+export function KvCacheStressParamsForm({
+  fieldPrefix = "params",
+}: KvCacheStressParamsFormProps = {}) {
+  const { control } = useFormContext();
+  const { t } = useTranslation("benchmarks");
+
+  const numberField = (name: string, labelKey: string, helpKey?: string) => (
+    <FormField
+      control={control}
+      name={`${fieldPrefix}.${name}`}
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>{t(labelKey)}</FormLabel>
+          <FormControl>
+            <Input
+              type="number"
+              {...field}
+              value={field.value ?? ""}
+              onChange={(e) =>
+                field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
+              }
+            />
+          </FormControl>
+          {helpKey && <FormDescription>{t(helpKey)}</FormDescription>}
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+
+  const stringField = (name: string, labelKey: string, helpKey?: string) => (
+    <FormField
+      control={control}
+      name={`${fieldPrefix}.${name}`}
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>{t(labelKey)}</FormLabel>
+          <FormControl>
+            <Input {...field} value={field.value ?? ""} />
+          </FormControl>
+          {helpKey && <FormDescription>{t(helpKey)}</FormDescription>}
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {numberField(
+          "numSessions",
+          "forms.kvCacheStress.numSessions",
+          "forms.kvCacheStress.numSessionsHelp",
+        )}
+        {numberField("turns", "forms.kvCacheStress.turns", "forms.kvCacheStress.turnsHelp")}
+        {numberField("concurrency", "forms.kvCacheStress.concurrency")}
+        {numberField("maxTokens", "forms.kvCacheStress.maxTokens")}
+        {numberField(
+          "durationSec",
+          "forms.kvCacheStress.durationSec",
+          "forms.kvCacheStress.durationSecHelp",
+        )}
+        {stringField(
+          "systemPromptSeed",
+          "forms.kvCacheStress.systemPromptSeed",
+          "forms.kvCacheStress.systemPromptSeedHelp",
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/benchmarks/forms/ToolParamsEditor.tsx
+++ b/apps/web/src/features/benchmarks/forms/ToolParamsEditor.tsx
@@ -12,10 +12,12 @@ import type { ScenarioId } from "@modeldoctor/contracts";
 import {
   GENAI_PERF_CATEGORY_DEFAULTS,
   GUIDELLM_CATEGORY_DEFAULTS,
+  KV_CACHE_STRESS_CATEGORY_DEFAULTS,
   PREFIX_CACHE_PROBE_CATEGORY_DEFAULTS,
   VEGETA_CATEGORY_DEFAULTS,
   genaiPerfParamDefaults,
   guidellmParamDefaults,
+  kvCacheStressParamDefaults,
   prefixCacheProbeParamDefaults,
   vegetaParamDefaults,
 } from "@modeldoctor/tool-adapters/schemas";
@@ -30,9 +32,11 @@ const TOOL_CATEGORY_DEFAULTS = {
   guidellm: GUIDELLM_CATEGORY_DEFAULTS,
   "genai-perf": GENAI_PERF_CATEGORY_DEFAULTS,
   "prefix-cache-probe": PREFIX_CACHE_PROBE_CATEGORY_DEFAULTS,
+  "kv-cache-stress": KV_CACHE_STRESS_CATEGORY_DEFAULTS,
 } as const;
 import { GenaiPerfParamsForm } from "./GenaiPerfParamsForm";
 import { GuidellmParamsForm } from "./GuidellmParamsForm";
+import { KvCacheStressParamsForm } from "./KvCacheStressParamsForm";
 import { PrefixCacheProbeParamsForm } from "./PrefixCacheProbeParamsForm";
 import { ToolUnsupportedNotice } from "./ToolUnsupportedNotice";
 import { VegetaParamsForm } from "./VegetaParamsForm";
@@ -42,6 +46,7 @@ export const TOOL_DEFAULTS: Record<ToolName, unknown> = {
   vegeta: vegetaParamDefaults,
   "genai-perf": genaiPerfParamDefaults,
   "prefix-cache-probe": prefixCacheProbeParamDefaults,
+  "kv-cache-stress": kvCacheStressParamDefaults,
 };
 
 export interface ToolEditorProps {
@@ -234,7 +239,9 @@ export function ToolParamsForm({
         ? VegetaParamsForm
         : tool === "prefix-cache-probe"
           ? PrefixCacheProbeParamsForm
-          : GenaiPerfParamsForm;
+          : tool === "kv-cache-stress"
+            ? KvCacheStressParamsForm
+            : GenaiPerfParamsForm;
   return <ParamsForm fieldPrefix={paramsFieldName} />;
 }
 

--- a/apps/web/src/features/benchmarks/reports/KvCacheStressReport.tsx
+++ b/apps/web/src/features/benchmarks/reports/KvCacheStressReport.tsx
@@ -1,0 +1,166 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { KvCacheStressReport as Data } from "@modeldoctor/tool-adapters/schemas";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  data: Data;
+}
+
+function statCard(label: string, value: string, hint?: string) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm text-muted-foreground">{label}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-3xl font-semibold">{value}</div>
+        {hint && <div className="mt-1 text-xs text-muted-foreground">{hint}</div>}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function KvCacheStressReport({ data }: Props) {
+  const { t } = useTranslation("benchmarks");
+  const { qps, outputTps, requestsOk, requestsErr, errRatePct, ttftMs, e2eMs, prom, backend } =
+    data;
+
+  const sortedCounters = Object.entries(backend.counters).sort(([a], [b]) => a.localeCompare(b));
+
+  // delta in percentage points between HBM hit rate and full savings — same
+  // "hidden gain" framing used in the theriseunion/repots reports.
+  const hiddenGainPp =
+    prom.hbmHitRatePct !== undefined && prom.prefixCacheSavingsPct !== undefined
+      ? prom.prefixCacheSavingsPct - prom.hbmHitRatePct
+      : null;
+
+  return (
+    <div className="space-y-4">
+      {/* Top-line stats */}
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        {statCard(t("reports.kvCacheStress.qps"), qps.toFixed(2))}
+        {statCard(t("reports.kvCacheStress.outputTps"), `${outputTps.toFixed(0)} tps`)}
+        {statCard(
+          t("reports.kvCacheStress.requests"),
+          `${requestsOk} / ${requestsOk + requestsErr}`,
+          `${requestsErr} err`,
+        )}
+        {statCard(t("reports.kvCacheStress.errRate"), `${errRatePct.toFixed(1)}%`)}
+      </div>
+
+      {/* Latency percentiles */}
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("reports.kvCacheStress.latency")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t("reports.kvCacheStress.latencyMetric")}</TableHead>
+                <TableHead className="text-right">p50 (ms)</TableHead>
+                <TableHead className="text-right">p90 (ms)</TableHead>
+                <TableHead className="text-right">p99 (ms)</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow>
+                <TableCell>TTFT</TableCell>
+                <TableCell className="text-right">{ttftMs.p50.toFixed(0)}</TableCell>
+                <TableCell className="text-right">{ttftMs.p90.toFixed(0)}</TableCell>
+                <TableCell className="text-right">{ttftMs.p99.toFixed(0)}</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>e2e</TableCell>
+                <TableCell className="text-right">{e2eMs.p50.toFixed(0)}</TableCell>
+                <TableCell className="text-right">{e2eMs.p90.toFixed(0)}</TableCell>
+                <TableCell className="text-right">{e2eMs.p99.toFixed(0)}</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      {/* Prefix cache savings — only shown when Prom URL was set */}
+      {(prom.hbmHitRatePct !== undefined || prom.prefixCacheSavingsPct !== undefined) && (
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("reports.kvCacheStress.savingsTitle")}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+              <div>
+                <div className="text-muted-foreground">{t("reports.kvCacheStress.hbmHitRate")}</div>
+                <div className="text-2xl font-semibold">
+                  {prom.hbmHitRatePct !== undefined ? `${prom.hbmHitRatePct.toFixed(1)}%` : "—"}
+                </div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">
+                  {t("reports.kvCacheStress.prefixCacheSavings")}
+                </div>
+                <div className="text-2xl font-semibold">
+                  {prom.prefixCacheSavingsPct !== undefined
+                    ? `${prom.prefixCacheSavingsPct.toFixed(1)}%`
+                    : "—"}
+                </div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">{t("reports.kvCacheStress.hiddenGain")}</div>
+                <div className="text-2xl font-semibold">
+                  {hiddenGainPp !== null ? `+${hiddenGainPp.toFixed(1)} pp` : "—"}
+                </div>
+              </div>
+            </div>
+            <p className="text-muted-foreground">{t("reports.kvCacheStress.savingsExplainer")}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Backend native counters */}
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            {t("reports.kvCacheStress.backendTitle", { name: backend.nameGuess })}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {sortedCounters.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {t("reports.kvCacheStress.backendEmpty")}
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("reports.kvCacheStress.counterName")}</TableHead>
+                  <TableHead className="text-right">
+                    {t("reports.kvCacheStress.counterValue")}
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sortedCounters.map(([name, value]) => (
+                  <TableRow key={name}>
+                    <TableCell className="font-mono text-xs">{name}</TableCell>
+                    <TableCell className="text-right font-mono text-xs">
+                      {typeof value === "number" ? value.toLocaleString() : value}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/features/benchmarks/scenarios.ts
+++ b/apps/web/src/features/benchmarks/scenarios.ts
@@ -1,5 +1,5 @@
 import { SCENARIOS, type ScenarioId } from "@modeldoctor/tool-adapters/schemas";
-import { Activity, Gauge, Layers, type LucideIcon, Network } from "lucide-react";
+import { Activity, Database, Gauge, Layers, type LucideIcon, Network } from "lucide-react";
 
 /**
  * Lucide icon for each scenario, consumed by the sidebar in Phase 14.
@@ -10,6 +10,7 @@ export const SCENARIO_ICONS: Record<ScenarioId, LucideIcon> = {
   capacity: Activity,
   gateway: Network,
   "prefix-cache-validation": Layers,
+  "kv-cache-stress": Database,
 };
 
 export { SCENARIOS, type ScenarioId };

--- a/apps/web/src/features/deployment-recipes/DeploymentRecipesPage.tsx
+++ b/apps/web/src/features/deployment-recipes/DeploymentRecipesPage.tsx
@@ -80,6 +80,26 @@ function StatusPill({
     );
   }
 
+  if (status === "community") {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label={ariaLabel}
+        className={cn(
+          base,
+          "border border-indigo-200/70 bg-indigo-50 text-indigo-700",
+          "hover:border-indigo-300 hover:bg-indigo-100",
+          "dark:border-indigo-900/60 dark:bg-indigo-950/30 dark:text-indigo-400 dark:hover:bg-indigo-950/60",
+          (active || highlight) &&
+            "ring-2 ring-indigo-400/60 ring-offset-1 ring-offset-background dark:ring-indigo-500/60",
+        )}
+      >
+        ★
+      </button>
+    );
+  }
+
   return (
     <span
       aria-label={ariaLabel}
@@ -226,7 +246,7 @@ export function DeploymentRecipesPage() {
         const matches = eng.name.toLowerCase().includes(q) || eng.vendor.toLowerCase().includes(q);
         if (!matches) return false;
         const status = getRecipe(m, eng.id)?.status;
-        return status === "native" || status === "partial";
+        return status === "native" || status === "partial" || status === "community";
       });
     });
   }, [category, query, visibleEngines]);
@@ -394,6 +414,15 @@ export function DeploymentRecipesPage() {
           </div>
           <div className="flex items-center gap-1.5">
             <StatusPill
+              status="community"
+              active={false}
+              highlight={false}
+              ariaLabel={t("status.ariaCommunity")}
+            />
+            <span>{t("status.community")}</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <StatusPill
               status="none"
               active={false}
               highlight={false}
@@ -483,7 +512,9 @@ function ModelRow({
             ? t("status.ariaNative")
             : status === "partial"
               ? t("status.ariaPartial")
-              : t("status.ariaNone");
+              : status === "community"
+                ? t("status.ariaCommunity")
+                : t("status.ariaNone");
 
         const cell = (
           <StatusPill

--- a/apps/web/src/features/deployment-recipes/RecipeDrawer.tsx
+++ b/apps/web/src/features/deployment-recipes/RecipeDrawer.tsx
@@ -31,6 +31,13 @@ function StatusBadge({ status }: { status: EngineRecipe["status"] }) {
       </span>
     );
   }
+  if (status === "community") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-md border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700 dark:border-indigo-900 dark:bg-indigo-950/40 dark:text-indigo-400">
+        ★ {t("status.community")}
+      </span>
+    );
+  }
   return (
     <span className="inline-flex items-center gap-1 rounded-md border border-border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
       {t("status.none")}

--- a/apps/web/src/features/deployment-recipes/data.ts
+++ b/apps/web/src/features/deployment-recipes/data.ts
@@ -18,6 +18,7 @@ import type { EngineMeta, EngineRecipe, ModelEntry, RecipeStatus } from "./types
 
 export const ENGINES: EngineMeta[] = [
   { id: "vllm", name: "vLLM", vendor: "UC Berkeley" },
+  { id: "vllm-ascend", name: "vLLM-Ascend", vendor: "Huawei Ascend × vLLM" },
   { id: "sglang", name: "SGLang", vendor: "LMSYS" },
   { id: "trtllm", name: "TensorRT-LLM", vendor: "NVIDIA" },
   { id: "mindie", name: "MindIE", vendor: "Huawei Ascend" },
@@ -35,6 +36,12 @@ export const ENGINES: EngineMeta[] = [
 
 const native = (r: Omit<EngineRecipe, "status">): EngineRecipe => ({ status: "native", ...r });
 const partial = (r: Omit<EngineRecipe, "status">): EngineRecipe => ({ status: "partial", ...r });
+// `community` = 非官方上游发布。内部构建镜像 + hot-patch / 厂商发布但需自维护
+// 的搭配走这条。本仓 vllm-ascend × {LMCache, YRCache} 两份方案即此例。
+const community = (r: Omit<EngineRecipe, "status">): EngineRecipe => ({
+  status: "community",
+  ...r,
+});
 
 // Common HF cache volume snippet — single source of truth.
 const HF_VOL = "-v $HOME/.cache/huggingface:/root/.cache/huggingface";
@@ -145,6 +152,127 @@ export const MODELS: ModelEntry[] = [
         tooltip: "GGUF 量化版本,本地 CPU/Metal/ROCm 都行",
         notes: "70B 推荐 Q4_K_M(~40GB)+ mmap;长上下文用 -c 32768。",
         docUrl: "https://github.com/ggml-org/llama.cpp",
+      }),
+    },
+  },
+  // -------- KV cache offload 实战配方 ----------------------------------------
+  // 这两行是同一个底层模型(Qwen3-32B)+ 同一引擎(vllm-ascend)+ 不同 KV
+  // cache 后端的对比配方。源自 theriseunion/repots 2026-05-10/05-11 在
+  // Atlas 800I A2 / 8×910B4 实测得出的两套生产可用方案,作 `kv-cache-stress`
+  // benchmark scenario 的目标参考。两条 recipe 都是 `community` 状态:镜像内部
+  // 构建 + vLLM 0.18 / yrcache 1.5.0 兼容性 hot-patch,不在上游 release。
+  {
+    id: "qwen3-32b-lmcache",
+    name: "Qwen3-32B + LMCache CPU offload",
+    category: "dense",
+    meta: "阿里 · 单 pod KV 卸载(生产推荐)",
+    engines: {
+      "vllm-ascend": community({
+        minVersion: "0.18.0rc1",
+        image: "swr.cn-north-4.myhuaweicloud.com/inference-engines/vllm-ascend:v0.18.0rc1-lmcache",
+        tooltip: "vllm-ascend 0.18 + LMCache 0.4.2 · CPU 100GB 卸载 · QPS 3.75 / TTFT p90 2.3s",
+        command: `# StatefulSet 关键 args / env / volumeMounts:
+# vLLM 启动参数:
+#   --kv-transfer-config '{"kv_connector":"LMCacheAscendConnectorV1Dynamic", ...}'
+#   --disable-hybrid-kv-cache-manager     # HMA 与 KV connector 不兼容,必加
+# 环境变量:
+#   PROMETHEUS_MULTIPROC_DIR=/tmp/lmcache_prometheus   # 必须,否则 lmcache:* 指标看不见
+#   LMCACHE_CHUNK_SIZE=256
+#   LMCACHE_LOCAL_CPU=True
+#   LMCACHE_MAX_LOCAL_CPU_SIZE=100                     # GB,建议 25-50% 主机内存
+# Volume:
+#   prom-multiproc (emptyDir) -> /tmp/lmcache_prometheus
+#     LMCache 不会自己 mkdir,目录必须由 K8s 预挂载
+# 完整 yaml: theriseunion/repots:2026-05-10-qwen3-lmcache-ascend-benchmark/patches/03-c-on-cpu.yaml`,
+        params: [
+          {
+            key: "PROMETHEUS_MULTIPROC_DIR",
+            value: "/tmp/lmcache_prometheus",
+            desc: "必须,跨 TP worker 聚合 metrics;LMCache 不自建目录",
+          },
+          {
+            key: "LMCACHE_MAX_LOCAL_CPU_SIZE",
+            value: "100 (GB)",
+            desc: "建议 25-50% 主机内存,1 TB 内存机器经验值 100",
+          },
+          {
+            key: "LMCACHE_CHUNK_SIZE",
+            value: "256",
+            desc: "block 粒度,与 vLLM block_size 协调",
+          },
+          {
+            key: "--disable-hybrid-kv-cache-manager",
+            value: "(flag)",
+            desc: "HMA 与 KV connector 不兼容,必加,否则启动直接 panic",
+          },
+        ],
+        resource: "Atlas 800I A2 · 8×910B4 / TP=4 · 32 GB HBM × 4 · 100 GB host RAM",
+        notes:
+          "实测 QPS 3.75 / TTFT p90 2.3 s / err 0% / Prefix Cache Savings 85% — 单 pod 场景综合最优。如需跨 pod 共享 KV,见 Qwen3-32B + YRCache 行。",
+        docUrl:
+          "https://github.com/theriseunion/repots/tree/main/2026-05-10-qwen3-lmcache-ascend-benchmark",
+      }),
+    },
+  },
+  {
+    id: "qwen3-32b-yrcache",
+    name: "Qwen3-32B + YRCache 三层缓存",
+    category: "dense",
+    meta: "阿里 · 跨 pod KV 共享(CPU + Disk + NFS)",
+    engines: {
+      "vllm-ascend": community({
+        minVersion: "0.18.0rc1",
+        image:
+          "swr.cn-north-4.myhuaweicloud.com/inference-engines/vllm-ascend:v0.18.0rc1-yrcache-1.5.0",
+        tooltip:
+          "vllm-ascend 0.18 + YRCache 1.5.0 三层(CPU/Disk/Redis 元数据/NFS)· QPS 3.39 / err 9-13%",
+        command: `# YRCache 跑通有 3 个前置:
+# 1) 部署专用无认证 Redis(YRCache wheel 无 redis_password 字段,接不上生产 Redis):
+#    Deployment yrcache-redis · image quanzhenglong.com/camp/redis:8.2.0 · '--protected-mode no'
+# 2) 准备数据后端(任选):hostPath 大盘 /apps/yrcache,或 NFS PVC /mnt/yrfs
+# 3) **hot-patch yrcache 1.5.0 的 vLLM 0.18 兼容性 bug**(KVConnectorFactory.create_connector
+#    第 3 参数 vLLM 0.18 改成 kv_cache_config,yrcache 1.5.0 仍按 local_rank 解析):
+#    ConfigMap yrcache-connector-fix,subPath 挂修复版 yrcache_connector.py 覆盖镜像内 buggy 版本
+#    修复源:theriseunion/repots:2026-05-11-qwen3-yrcache-ascend-benchmark/patches/yrcache_connector_patched.py
+#
+# StatefulSet 关键 args / env / volumeMounts:
+#   --kv-transfer-config '{"kv_connector":"YRCacheConnector", ...}'
+#   --disable-hybrid-kv-cache-manager
+# 环境变量:
+#   YRCACHE_CONFIG_FILE=/etc/yrcache.yaml
+# Volume:
+#   yrcache-config (ConfigMap)  -> /etc/yrcache.yaml         # 注意 log_level=2 必加
+#   yrcache-disk (hostPath)     -> /apps/yrcache             # 本地盘 tier
+#   yrcache-shared (NFS PVC)    -> /mnt/yrfs                 # 可选,跨 pod 共享 tier
+#   yrcache-connector-fix       -> 镜像内 yrcache_connector.py (subPath)`,
+        params: [
+          {
+            key: "log_level (yrcache.yaml)",
+            value: "2 (warning)",
+            desc: "**必调**:默认 3 INFO 把 worker 打死,err 率额外 +5 pp",
+          },
+          {
+            key: "metric_level (yrcache.yaml)",
+            value: "1 (batch only)",
+            desc: "默认 3 太细,会拖慢请求",
+          },
+          {
+            key: "shared_storage_cache_config.redis_host",
+            value: "yrcache-redis.<ns>.svc",
+            desc: "**必须无认证 Redis**;wheel 没 redis_password 字段",
+          },
+          {
+            key: "shared_storage_cache_config.storage_path",
+            value: "/apps/yrcache 或 /mnt/yrfs",
+            desc: "本地盘或 NFS;NFS 走跨 pod 共享场景",
+          },
+        ],
+        resource:
+          "Atlas 800I A2 · 8×910B4 / TP=4 · 100 GB host RAM · 300+ GB disk · (可选)500 GB NFS",
+        notes:
+          "Y-FULL 实测 QPS 3.39 / TTFT p90 2.06 s / Prefix Cache Savings 89% · err 率 9-13%(LMCache 0%)。接受 err 率 trade-off 才推荐;唯一支持跨 pod 共享 KV 的方案。yrcache 1.5.0 wheel 与 vLLM 0.18 KVConnectorFactory 不兼容,部署前必须打 hot-patch。",
+        docUrl:
+          "https://github.com/theriseunion/repots/tree/main/2026-05-11-qwen3-yrcache-ascend-benchmark",
       }),
     },
   },

--- a/apps/web/src/features/deployment-recipes/types.ts
+++ b/apps/web/src/features/deployment-recipes/types.ts
@@ -2,7 +2,18 @@ import type { EngineId } from "@modeldoctor/contracts";
 
 export type { EngineId };
 
-export type RecipeStatus = "native" | "partial" | "none";
+/**
+ * Recipe support status.
+ *
+ * - `native`    upstream-supported, ships in the engine vendor's release
+ * - `partial`   upstream supports the model but with caveats (kernel
+ *               compatibility, slower path, etc.)
+ * - `community` not upstream — the recipe ships an internally-built image,
+ *               a hot-patch, or both. The UI labels these clearly so
+ *               operators know the maintenance burden falls on us
+ * - `none`     known not to work; the cell stays empty / dimmed
+ */
+export type RecipeStatus = "native" | "partial" | "community" | "none";
 
 export type CategoryId = "dense" | "moe" | "vlm" | "embedding" | "rerank" | "diffusion";
 

--- a/apps/web/src/features/insights/__tests__/ScoreBanner.test.tsx
+++ b/apps/web/src/features/insights/__tests__/ScoreBanner.test.tsx
@@ -13,7 +13,13 @@ describe("ScoreBanner", () => {
     r(
       <ScoreBanner
         composite={87}
-        perScenario={{ inference: 92, capacity: 75, gateway: 82, "prefix-cache-validation": null }}
+        perScenario={{
+          inference: 92,
+          capacity: 75,
+          gateway: 82,
+          "prefix-cache-validation": null,
+          "kv-cache-stress": null,
+        }}
         totalChecks={18}
         totalRuns={25}
         rangeDays={30}
@@ -34,6 +40,7 @@ describe("ScoreBanner", () => {
           capacity: null,
           gateway: null,
           "prefix-cache-validation": null,
+          "kv-cache-stress": null,
         }}
         totalChecks={0}
         totalRuns={0}
@@ -52,6 +59,7 @@ describe("ScoreBanner", () => {
           capacity: null,
           gateway: null,
           "prefix-cache-validation": null,
+          "kv-cache-stress": null,
         }}
         totalChecks={7}
         totalRuns={5}

--- a/apps/web/src/features/insights/__tests__/evaluate.test.ts
+++ b/apps/web/src/features/insights/__tests__/evaluate.test.ts
@@ -89,13 +89,20 @@ describe("compositeScore", () => {
         capacity: null,
         gateway: null,
         "prefix-cache-validation": null,
+        "kv-cache-stress": null,
       }),
     ).toBeNull();
   });
 
   it("equal-weight average over present scenarios, rounded", () => {
     expect(
-      compositeScore({ inference: 90, capacity: 70, gateway: 80, "prefix-cache-validation": null }),
+      compositeScore({
+        inference: 90,
+        capacity: 70,
+        gateway: 80,
+        "prefix-cache-validation": null,
+        "kv-cache-stress": null,
+      }),
     ).toBe(80);
   });
 
@@ -106,6 +113,7 @@ describe("compositeScore", () => {
         capacity: null,
         gateway: 70,
         "prefix-cache-validation": null,
+        "kv-cache-stress": null,
       }),
     ).toBe(80);
   });

--- a/apps/web/src/locales/en-US/benchmarks.json
+++ b/apps/web/src/locales/en-US/benchmarks.json
@@ -31,7 +31,8 @@
       "guidellm": "guidellm",
       "vegeta": "vegeta",
       "genai-perf": "genai-perf",
-      "prefix-cache-probe": "prefix-cache-probe"
+      "prefix-cache-probe": "prefix-cache-probe",
+      "kv-cache-stress": "kv-cache-stress"
     },
     "toolDescriptions": {
       "guidellm": "Text-generation benchmark (chat / completion); inference perf + capacity planning",
@@ -387,6 +388,18 @@
       "promBackoffSec": "Prom scrape wait (s)",
       "promBackoffSecHelp": "Prometheus default scrape is 15s; keep at least 18s of buffer",
       "missingPromUrl": "This connection has no Prometheus URL — cannot run prefix-cache validation. Edit the connection to add one."
+    },
+    "kvCacheStress": {
+      "numSessions": "Sessions",
+      "numSessionsHelp": "Number of independent sessions; each gets a ~2000-token deterministic system prompt. 200 forces HBM eviction on 8x910B4.",
+      "turns": "Turns per session",
+      "turnsHelp": "Conversation depth — first turn is cold, later turns hit prefix cache.",
+      "concurrency": "Concurrency",
+      "maxTokens": "Max tokens",
+      "durationSec": "Duration (s)",
+      "durationSecHelp": "Recommend ≥ 600s for stable Prometheus counter deltas.",
+      "systemPromptSeed": "System prompt seed",
+      "systemPromptSeedHelp": "sha256-derived prefix. Reuse the same seed across runs to compare cache backends fairly."
     }
   },
   "reports": {
@@ -396,7 +409,12 @@
       "deterministicYes": "Yes",
       "deterministicNo": "No",
       "perPodTitle": "Per-Pod Counts",
-      "perPodCols": { "pod": "Pod", "queries": "Queries", "hits": "Hits", "hitRate": "Hit rate" },
+      "perPodCols": {
+        "pod": "Pod",
+        "queries": "Queries",
+        "hits": "Hits",
+        "hitRate": "Hit rate"
+      },
       "promptSetsTitle": "Routing per Prompt Set",
       "promptSetsCols": {
         "label": "Set",
@@ -466,6 +484,23 @@
         "title": "Connection not found",
         "body": "It may have been deleted"
       }
+    },
+    "kvCacheStress": {
+      "qps": "QPS",
+      "outputTps": "Output tokens/sec",
+      "requests": "OK / Total",
+      "errRate": "Error rate",
+      "latency": "Latency distribution",
+      "latencyMetric": "Metric",
+      "savingsTitle": "Prefix cache savings (two views)",
+      "hbmHitRate": "HBM hit rate (vLLM counter)",
+      "prefixCacheSavings": "Full savings (incl. LMCache/YRCache)",
+      "hiddenGain": "Hidden backend gain",
+      "savingsExplainer": "HBM hit rate counts only vLLM HBM hits; full savings = 1 − actual prefill / total prompt, including chunks reloaded from LMCache/YRCache. The delta is the backend's invisible contribution.",
+      "backendTitle": "Backend native counters (nameGuess: {{name}})",
+      "backendEmpty": "No lmcache:* or yrcache_* counter scraped. The backend may not be enabled, or PROMETHEUS_MULTIPROC_DIR may be unset.",
+      "counterName": "Counter",
+      "counterValue": "Value"
     }
   }
 }

--- a/apps/web/src/locales/en-US/deployment-recipes.json
+++ b/apps/web/src/locales/en-US/deployment-recipes.json
@@ -24,9 +24,11 @@
   "status": {
     "native": "Native",
     "partial": "Partial / experimental",
+    "community": "Community build",
     "none": "Not supported",
     "ariaNative": "Native support · click for details",
     "ariaPartial": "Partial support · click for details",
+    "ariaCommunity": "Community build (not upstream) · click for details",
     "ariaNone": "Not supported"
   },
   "empty": {

--- a/apps/web/src/locales/en-US/sidebar.json
+++ b/apps/web/src/locales/en-US/sidebar.json
@@ -24,6 +24,7 @@
     "profile": "Profile",
     "logout": "Logout",
     "devCharts": "Dev Charts",
-    "deploymentRecipes": "Deployment Recipes"
+    "deploymentRecipes": "Deployment Recipes",
+    "benchmarkKvCacheStress": "KV Cache Stress"
   }
 }

--- a/apps/web/src/locales/zh-CN/benchmarks.json
+++ b/apps/web/src/locales/zh-CN/benchmarks.json
@@ -31,7 +31,8 @@
       "guidellm": "guidellm",
       "vegeta": "vegeta",
       "genai-perf": "genai-perf",
-      "prefix-cache-probe": "prefix-cache-probe"
+      "prefix-cache-probe": "prefix-cache-probe",
+      "kv-cache-stress": "kv-cache-stress"
     },
     "toolDescriptions": {
       "guidellm": "文本生成基准（chat / completion），用于推理性能与容量评估",
@@ -387,6 +388,18 @@
       "promBackoffSec": "Prometheus 抓取等待秒数",
       "promBackoffSecHelp": "Prom 默认 15s 抓一次；最少留 18s 缓冲",
       "missingPromUrl": "该连接未配置 Prometheus URL，无法运行 prefix-cache 验证。请在连接编辑里补上。"
+    },
+    "kvCacheStress": {
+      "numSessions": "Session 数",
+      "numSessionsHelp": "独立会话数。每个 session 一份 ~2000 token 的 deterministic system prompt（200 是 8x910B4 强制驱逐 HBM 的甜点）",
+      "turns": "对话轮数",
+      "turnsHelp": "history 累积,首轮冷启,后续轮命中 prefix cache",
+      "concurrency": "并发数",
+      "maxTokens": "Max tokens",
+      "durationSec": "时长(秒)",
+      "durationSecHelp": "建议 ≥ 600s 让 Prom counter delta 稳定",
+      "systemPromptSeed": "System prompt seed",
+      "systemPromptSeedHelp": "sha256 派生 prefix。不同 run 用同一个 seed 才能跨 run 比 prefix cache 收益"
     }
   },
   "reports": {
@@ -396,7 +409,12 @@
       "deterministicYes": "是",
       "deterministicNo": "否",
       "perPodTitle": "每副本计数",
-      "perPodCols": { "pod": "Pod", "queries": "查询数", "hits": "命中数", "hitRate": "命中率" },
+      "perPodCols": {
+        "pod": "Pod",
+        "queries": "查询数",
+        "hits": "命中数",
+        "hitRate": "命中率"
+      },
       "promptSetsTitle": "每组路由结果",
       "promptSetsCols": {
         "label": "组",
@@ -466,6 +484,23 @@
         "title": "未找到此连接",
         "body": "它可能已被删除"
       }
+    },
+    "kvCacheStress": {
+      "qps": "QPS",
+      "outputTps": "Output tokens/sec",
+      "requests": "完成 / 总请求",
+      "errRate": "错误率",
+      "latency": "延迟分布",
+      "latencyMetric": "指标",
+      "savingsTitle": "Prefix Cache Savings（两套口径）",
+      "hbmHitRate": "HBM hit rate（vLLM 自家 counter）",
+      "prefixCacheSavings": "全口径 Savings（含 LMCache/YRCache）",
+      "hiddenGain": "后端隐形增益",
+      "savingsExplainer": "HBM hit rate 只统计 vLLM HBM 命中；全口径 Savings = 1 − 实际 prefill / 总 prompt,包括 LMCache 从 CPU/disk 救回的 chunk。两者之差就是后端的隐形贡献。",
+      "backendTitle": "后端 native counter (nameGuess: {{name}})",
+      "backendEmpty": "没抓到 lmcache:* 或 yrcache_* counter。可能后端没启用或 PROMETHEUS_MULTIPROC_DIR 没配。",
+      "counterName": "Counter",
+      "counterValue": "值"
     }
   }
 }

--- a/apps/web/src/locales/zh-CN/deployment-recipes.json
+++ b/apps/web/src/locales/zh-CN/deployment-recipes.json
@@ -24,9 +24,11 @@
   "status": {
     "native": "原生支持",
     "partial": "部分 / 实验",
+    "community": "社区构建",
     "none": "不支持",
     "ariaNative": "原生支持,点击查看详情",
     "ariaPartial": "部分支持,点击查看详情",
+    "ariaCommunity": "社区构建(非上游官方),点击查看详情",
     "ariaNone": "不支持"
   },
   "empty": {

--- a/apps/web/src/locales/zh-CN/sidebar.json
+++ b/apps/web/src/locales/zh-CN/sidebar.json
@@ -24,6 +24,7 @@
     "profile": "个人中心",
     "logout": "退出登录",
     "devCharts": "图表调试",
-    "deploymentRecipes": "部署示例"
+    "deploymentRecipes": "部署示例",
+    "benchmarkKvCacheStress": "KV cache 压测"
   }
 }

--- a/apps/web/src/router/index.tsx
+++ b/apps/web/src/router/index.tsx
@@ -9,6 +9,7 @@ import { BenchmarkCreatePage } from "@/features/benchmarks/BenchmarkCreatePage";
 import { BenchmarkDetailPage } from "@/features/benchmarks/BenchmarkDetailPage";
 import { BenchmarkGatewayPage } from "@/features/benchmarks/BenchmarkGatewayPage";
 import { BenchmarkInferencePage } from "@/features/benchmarks/BenchmarkInferencePage";
+import { BenchmarkKvCacheStressPage } from "@/features/benchmarks/BenchmarkKvCacheStressPage";
 import { BenchmarkPrefixCachePage } from "@/features/benchmarks/BenchmarkPrefixCachePage";
 import { EndpointReportsPage } from "@/features/benchmarks/EndpointReportsPage";
 import { BenchmarkCompareGate } from "@/features/benchmarks/compare/BenchmarkCompareGate";
@@ -67,6 +68,10 @@ export const routes: RouteObject[] = [
           {
             path: "benchmarks/prefix-cache-validation",
             element: <BenchmarkPrefixCachePage />,
+          },
+          {
+            path: "benchmarks/kv-cache-stress",
+            element: <BenchmarkKvCacheStressPage />,
           },
           { path: "benchmarks/compare", element: <BenchmarkCompareGate /> },
           { path: "benchmarks/compare/saved", element: <SavedComparesListPage /> },

--- a/docs/superpowers/specs/2026-05-12-kv-cache-stress-tool-design.md
+++ b/docs/superpowers/specs/2026-05-12-kv-cache-stress-tool-design.md
@@ -1,0 +1,596 @@
+# KV cache stress tool + deployment recipes (vllm-ascend × LMCache / YRCache) — 设计
+
+**Status:** Draft · 2026-05-12 · 用户已批准全 3 个决策点(新 scenario、新 recipe status `community`、官方模板入库)
+**Branch:** `feat-kv-cache-tool`(已 rebase 到 main @ 6d2fc38)
+**Driver:** 2026-05-10 / 2026-05-11 在 [theriseunion/repots](https://github.com/theriseunion/repots) 仓里跑了三轮压测（LMCache 4 档 + YRCache 3 档 + 网关 1 档）对比 KV cache 卸载后端,所有动作都靠 `/tmp/bench_qwen3.py` + `kubectl patch` 串档手干。两份报告都成型了,但**每次想重跑或换工作负载,得人工再走一遍 5 个 stage**——没有产品化沉淀。本文档把这套工作流接进 modeldoctor 现有的 benchmark / tool-adapter / deployment-recipes 框架,以便未来:
+- 新硬件或新引擎落地时**3 分钟在 UI 里跑出 LMCache CPU vs YRCache CPU 的对比**,不用碰 kubectl
+- 把 yrcache 1.5.0 的 vLLM 0.18 兼容 patch + 无认证 Redis 这两个**已踩过的坑**固化进 deployment recipe,下一个工程师不重蹈
+
+---
+
+## 1. Why
+
+### 1.1 表面问题
+
+现在 modeldoctor 5 个 benchmark tool (`guidellm` / `genai-perf` / `vegeta` / `prefix-cache-probe` + 一个 placeholder)**没一个能压 prefix-cache 性能**:
+
+- **`guidellm`** / `genai-perf`:无状态、单轮、不会把同一 prompt 重复送到目标。**prefix cache 命中率 ≈ 0**——上游官方 benchmark 也明说 RandomDataset 是合成数据,跟 prefix cache 收益无关([guidellm random dataset](https://github.com/vllm-project/guidellm))。
+- **`prefix-cache-probe`**(已存在的同名工具)做的是**Higress AI Load Balancer sticky routing 验证**——读 Prom delta 判断哪个 pod 服务了请求,**不测延迟/吞吐**,不是性能 benchmark。
+- **`vegeta`**:HTTP 层压测,跟 KV cache 没关系。
+
+结果:用户想知道"我这台机器开 LMCache CPU 后 TTFT 能改善多少",**没有任何现成工具可以回答**。
+
+### 1.2 深层问题
+
+我们 2026-05-10 ~ 2026-05-11 在生产环境验证了:
+
+| 配置 | QPS | TTFT p90 (ms) | Prefix Cache Savings | err 率 |
+|---|---|---|---|---|
+| 无 cache offload(A baseline) | 2.79 | 3663 | 76.4% | 0% |
+| LMCache CPU 100 GB | **3.75** | **2315** | 85.1% | **0%** |
+| LMCache CPU + Disk | 3.76 | 2729 | 84.0% | 0.09% |
+| YRCache CPU 100 GB | 3.53 | 2291 | **89.4%** | 8.4% |
+| YRCache CPU + Disk | 3.36 | **1821** | 89.2% | 13.1% |
+| YRCache CPU + Disk + NFS shared | 3.39 | 2060 | 89.1% | 9.4% |
+
+**结论是**:LMCache CPU 在本硬件上是综合最优,**但要做出这个结论必须横跑这 6 档,每档约 25 分钟**(pod 重建 5 min + 600 s bench + 间隙)。手干不可持续。
+
+同时,这一轮还固化下来这些**部署知识**,目前散落在 `/tmp/yrcache-*.yaml` 和报告里:
+
+- **YRCache 1.5.0 wheel 与 vLLM 0.18 不兼容**——`KVConnectorFactory.create_connector` 第 3 参数 vLLM 0.18 改成 `kv_cache_config`,yrcache 还是按 `local_rank` 解析,导致拼出 `npu:KVCacheConfig(...)` 崩溃。修复方法:用 ConfigMap + `subPath` 挂自定义 `yrcache_connector.py` 覆盖镜像内的 buggy 版本。
+- **YRCache wheel 没有 Redis 认证字段**(`yrcache.yaml`、`SharedStorageCacheConfig` dataclass、`c_ops.so` 全部无 `redis_password`),无法接生产 Redis,必须起专用无认证 Redis。
+- **LMCache 0.4.x 指标暴露**:必须设 `PROMETHEUS_MULTIPROC_DIR` + emptyDir 挂到该路径(LMCache 只在 env 未设时才 mkdir,我们预设了 env 反而要自己提供目录)。
+- **YRCache 必调**:`log_level: 2`、`metric_level: 1`,否则 INFO 日志把 worker 打死,err 率额外 +4-5 pp。
+
+这些都不写进 `deployment-recipes/data.ts`,下一个工程师必然重踩。
+
+### 1.3 还要回答的二阶问题
+
+- **谁来执行 KV cache 后端切换?**——我们这次手 `kubectl patch statefulset`,但 modeldoctor 已有 K8sJobDriver / SubprocessDriver。**短期答案**:tool 只负责跑流量;backend 切换让用户手动完成(或参考 recipe 自行 patch)。**长期 v2**:加 "Backend Provisioner" 模块,modeldoctor 自己负责 patch + rollout + readiness。本 PR 不做。
+- **Prom delta 怎么读?**——已有 `prefix_cache_probe.py` 提供模板(`vllm:prefix_cache_queries_total` V0/V1 兼容查询)。我们复用同样的策略,只是多读几个 metric 名。
+
+---
+
+## 2. Scope
+
+**In(本 PR / 本 worktree 实施)**:
+
+- **新 scenario**:`kv-cache-stress`(`packages/tool-adapters/src/scenarios.ts` 加一行)
+- **新 tool adapter**:`packages/tool-adapters/src/kv-cache-stress/` —— schema、runtime、tests、fixtures
+- **新 runner image**:`apps/benchmark-runner/images/kv-cache-stress.Dockerfile` + `scripts/kv_cache_stress.py`
+- **新 web 页面**:`apps/web/src/features/benchmarks/BenchmarkKvCacheStressPage.tsx`(表单 + 结果展示)
+- **i18n**:`apps/web/src/locales/{zh-CN,en-US}/benchmarks.json` 加 kv-cache-stress 字段
+- **2 个 deployment recipes**:`apps/web/src/features/deployment-recipes/data.ts` 新增 `vllm-ascend` 引擎条目(目前只有 `vllm` / `sglang` / `mindie` 等通用引擎),挂到 Qwen3-32B 模型下;同时给出 `lmcache-cpu` 和 `yrcache-shared` 两个 image 变体的 docker run 命令 + 关键参数 + 已知坑提示
+- **新 RecipeStatus 值 `community`**:`types.ts` 加 `community` 状态,区分"官方上游发布"(native)、"上游部分支持"(partial)、"内部构建 / 第三方 hot-patch"(community)。本 PR 的两个 vllm-ascend recipe 用此状态
+- **2 个官方 baseline benchmark templates 入库**(seed.ts):基于本仓 2026-05-10 / 2026-05-11 实测数据,沉淀成 `kv-cache-stress` scenario 的官方推荐参数。这条原本规划在 v2,本次按用户要求一步到位
+- 配套:`runner-images.ts`、`category-defaults.ts`、`scenarios.spec.ts` 等"加 tool 时必须改的地方"
+- 数据库 schema:**不动**(benchmark 模块的 generic `params`/`report` 字段是 JSON,新 tool 自动落库;templates 通过 `prisma db seed` 而非 schema migration 落库,follow #172 已确立的 seed 模式)
+- 验收:`pnpm type-check / lint / test` 全过
+
+**Out(本 PR 不做,挂 §11 v2 清单)**:
+
+- 自动化 backend switching(模仿"换镜像 + patch StatefulSet"流程)——这是 v2 的 Backend Provisioner 模块
+- 把 YRCache hot-patch 工件(`yrcache_connector_patched.py`、ConfigMap、PV)做成一键 `kubectl apply` 的 release artifact
+- 跨 pod 共享场景(多副本共用 YRCache shared tier)的测试——本 PR 假定 1 pod
+- Grafana 面板模板(`lmcache:*` / `yrcache_*` 现成大盘):另起 PR 走 `deploy/k8s` 路径
+
+---
+
+## 3. 现有 `prefix-cache-probe` vs 新 `kv-cache-stress` ——为何不复用
+
+```
+现有 prefix-cache-probe (scenarios.ts: 'prefix-cache-validation'):
+  目的:验证 Higress ai-load-balancer 把同 prefix 请求是否粘到同一 pod
+  做法:同 prefix N 轮请求 → 读 Prom delta 判断哪个 pod 服务
+  指标:stickinessPct(stickiness 百分比)
+  → 路由 / 网关层验证
+
+新 kv-cache-stress (scenarios.ts: 'kv-cache-stress'):
+  目的:压测后端 KV cache 性能(LMCache / YRCache / 等)
+  做法:200 sessions × 4 turns 多轮对话,工作集 ~2× HBM 强制驱逐
+  指标:QPS / TTFT p50/p90/p99 / e2e / Prefix Cache Savings / 后端 native counter delta
+  → 计算 / 存储层 benchmark
+```
+
+**两者方法论完全不同**:`prefix-cache-probe` 关注"调度命中是不是稳定",`kv-cache-stress` 关注"命中之后的性能收益是多少"。强行合并会让 schema 既要 stickinessPct 又要 ttft p99,不健康。
+
+---
+
+## 4. 架构与文件清单
+
+```
+feat-kv-cache-tool/
+├── apps/benchmark-runner/
+│   ├── images/
+│   │   └── kv-cache-stress.Dockerfile          [新增]
+│   └── scripts/
+│       └── kv_cache_stress.py                  [新增,基于 /tmp/bench_qwen3.py + Prom delta 集成]
+├── apps/api/
+│   ├── src/modules/benchmark/k8s/runner-images.ts  [改:加 kv-cache-stress image tag 映射]
+│   └── prisma/seed.ts                          [改:widen Tool/scenario union;增加 2 个 kv-cache-stress 模板]
+├── packages/tool-adapters/src/
+│   ├── kv-cache-stress/
+│   │   ├── index.ts                            [新增,adapter export]
+│   │   ├── schema.ts                           [新增,Zod params + report]
+│   │   ├── schema.spec.ts                      [新增]
+│   │   ├── runtime.ts                          [新增,buildCommand / parseProgress / parseFinalReport]
+│   │   ├── runtime.spec.ts                     [新增]
+│   │   └── __fixtures__/                       [新增,sample stdout & report]
+│   ├── scenarios.ts                            [改:SCENARIOS 增加 'kv-cache-stress']
+│   ├── schemas-entry.ts                        [改:export 新 types]
+│   ├── core/registry.ts                        [改:注册 adapter]
+│   ├── category-defaults.ts                    [改:默认参数]
+│   └── index.ts                                [改:export]
+├── apps/web/src/
+│   ├── features/benchmarks/
+│   │   ├── BenchmarkKvCacheStressPage.tsx      [新增]
+│   │   ├── scenarios.ts                        [改:icon 映射]
+│   │   └── reports/
+│   │       └── KvCacheStressReport.tsx         [新增,可视化展示]
+│   └── locales/
+│       ├── zh-CN/benchmarks.json               [改]
+│       ├── en-US/benchmarks.json               [改]
+│       ├── zh-CN/deployment-recipes.json       [改:增加 community 状态翻译]
+│       └── en-US/deployment-recipes.json       [改]
+└── apps/web/src/features/deployment-recipes/
+    ├── data.ts                                 [改:加 'vllm-ascend' 引擎 + 2 个 Qwen3-32B recipe]
+    └── types.ts                                [改:RecipeStatus union 加 'community']
+```
+
+**预估净增**:**~1100-1200 行**(Python ~250 + TypeScript adapter ~280 + Web page ~250 + i18n ~70 + recipes ~80 + Dockerfile/runner-images ~30 + scenarios/registry 改动 ~50 + **seed.ts 2 模板 + 类型加宽 ~80**)。
+
+---
+
+## 5. Runner script:`scripts/kv_cache_stress.py`
+
+基于 `bench_qwen3.py`(已在 `theriseunion/repots:2026-05-10-qwen3-lmcache-ascend-benchmark/scripts/`)改造。**核心改动 4 点**:
+
+1. **CLI 参数化**(不再走 env var)——modeldoctor 约定 argv,因为 K8s Job spec 难传 env
+2. **集成 Prometheus delta**(前后快照),计算 Prefix Cache Savings——参考 `scripts/prefix_cache_probe.py:_build_prom_query` 处理 V0/V1 metric 名
+3. **(可选)拉 LMCache `lmcache:*` 和 YRCache `yrcache_*` counter**——从同一个 vLLM `/metrics` 拉(因为 `PROMETHEUS_MULTIPROC_DIR` 让它们 multiproc 聚合到同端口)
+4. **结构化输出**:final JSON 通过 stdout 末行 + `--report-file` 双写(modeldoctor `parseFinalReport` 约定)
+
+CLI:
+
+```bash
+python /app/probe.py \
+    --base-url <openai-compatible endpoint> \
+    --api-key <bearer> \
+    --model <served-model-name> \
+    --num-sessions 200 \
+    --turns 4 \
+    --concurrency 25 \
+    --max-tokens 50 \
+    --duration 600 \
+    --prom-url <prom NodePort URL>            # optional, 没设跳过 prom delta
+    --report-file /run/report.json
+```
+
+输出 final JSON(摘录):
+
+```json
+{
+  "qps": 3.75,
+  "output_tps": 187.0,
+  "requests_ok": 2312,
+  "requests_err": 0,
+  "err_rate_pct": 0.0,
+  "ttft_ms_p50": 757,
+  "ttft_ms_p90": 2315,
+  "ttft_ms_p99": 7729,
+  "e2e_ms_p50": 5254,
+  "e2e_ms_p90": 10424,
+  "e2e_ms_p99": 22265,
+  "prom": {
+    "hbm_hit_rate_pct": 76.9,
+    "prefix_cache_savings_pct": 85.1,
+    "prompt_tokens_total_delta": 14070000,
+    "generation_tokens_total_delta": 115000
+  },
+  "backend": {
+    "name_guess": "lmcache",        // 由 "看到 lmcache:* 还是 yrcache_* counter" 启发式推断
+    "counters": { ... }              // 透传原始 counter 增量,UI 自己排版
+  },
+  "config": { ... }                  // echo 一下 CLI 入参,便于 audit
+}
+```
+
+**已知不做(out of scope)**:
+- 不读 `bench_qwen3.py` 里 sha256 deterministic 工作集——保留同样的算法(系统提示词 + 4 轮历史),但客户端 token 数允许配置
+- 不算 lookup_hit_rate / retrieve_hit_rate(`yrcache_num_lookup_*`):太 yrcache-specific,放在 `backend.counters` 里透传,UI 端展示
+
+---
+
+## 6. Tool adapter:`packages/tool-adapters/src/kv-cache-stress/`
+
+### 6.1 `schema.ts` — Zod
+
+复用 `prefix-cache-probe/schema.ts` 的两段式结构:
+
+```ts
+export const kvCacheStressParamsSchema = z.object({
+  numSessions:     z.number().int().min(1).max(2000).default(200),
+  turns:           z.number().int().min(1).max(16).default(4),
+  concurrency:     z.number().int().min(1).max(256).default(25),
+  maxTokens:       z.number().int().min(1).max(2048).default(50),
+  durationSec:     z.number().int().min(30).max(7200).default(600),
+  systemPromptSeed:z.string().default("scn"),     // sha256 prefix seed
+  promUrl:         z.string().url().optional(),    // 留空则跳过 prom delta
+});
+
+export const kvCacheStressReportSchema = z.object({
+  qps:                      z.number(),
+  outputTps:                z.number(),
+  requestsOk:               z.number().int().nonnegative(),
+  requestsErr:              z.number().int().nonnegative(),
+  errRatePct:               z.number(),
+  ttftMs:                   z.object({ p50: z.number(), p90: z.number(), p99: z.number() }),
+  e2eMs:                    z.object({ p50: z.number(), p90: z.number(), p99: z.number() }),
+  prom: z.object({
+    hbmHitRatePct:          z.number().optional(),
+    prefixCacheSavingsPct:  z.number().optional(),
+    promptTokensTotalDelta: z.number().int().optional(),
+    generationTokensTotalDelta: z.number().int().optional(),
+  }).partial(),
+  backend: z.object({
+    nameGuess:              z.enum(["lmcache","yrcache","unknown"]),
+    counters:               z.record(z.union([z.number(), z.string()])),
+  }),
+});
+```
+
+约束:`durationSec ≥ 30` 让用户必须自觉跑足够长(短了 Prom delta 没意义),`≤ 7200` 防意外 24h 大单。
+
+### 6.2 `runtime.ts` — argv + 解析
+
+```ts
+export function buildCommand(p: KvCacheStressParams, runtime: RuntimeContext): string[] {
+  return [
+    "python", "/app/probe.py",
+    "--base-url", runtime.apiUrl,
+    "--api-key", runtime.apiKey,
+    "--model",   runtime.model,
+    "--num-sessions",   String(p.numSessions),
+    "--turns",          String(p.turns),
+    "--concurrency",    String(p.concurrency),
+    "--max-tokens",     String(p.maxTokens),
+    "--duration",       String(p.durationSec),
+    "--system-prompt-seed", p.systemPromptSeed,
+    ...(p.promUrl ? ["--prom-url", p.promUrl] : []),
+    "--report-file", "/run/report.json",
+  ];
+}
+
+export function getMaxDurationSeconds(p: KvCacheStressParams): number {
+  // 600s bench + 60s warmup grace + 60s post-snapshot ≈ duration + 120
+  return p.durationSec + 120;
+}
+```
+
+`parseProgress` / `parseFinalReport` 模仿 `prefix-cache-probe/runtime.ts:parseProgress`:增量 stdout 解析 `+ 15s  ok=N  err=M` 行作 progress event。
+
+### 6.3 `index.ts` — export
+
+```ts
+export const kvCacheStressAdapter: ToolAdapter = {
+  name: "kv-cache-stress",
+  scenarios: ["kv-cache-stress"] as const,
+  paramsSchema:  kvCacheStressParamsSchema,
+  reportSchema:  kvCacheStressReportSchema,
+  paramDefaults: kvCacheStressParamDefaults,
+  buildCommand,
+  parseProgress,
+  parseFinalReport,
+  getMaxDurationSeconds,
+};
+```
+
+注册:`core/registry.ts` 加 import + register。`scenarios.ts` 加:
+
+```ts
+"kv-cache-stress": {
+  label: "KV cache 压测",
+  description: "多轮对话压测,触发 prefix-cache 驱逐,对比不同 KV 卸载后端(LMCache / YRCache / etc.)",
+  tools: ["kv-cache-stress"],
+  paramsConstraints: {},
+  reportComponent: "KvCacheStressReport",
+},
+```
+
+并在 `ScenarioId` union、`scenarioIdSchema`、reportComponent union 三处对应增补。
+
+---
+
+## 7. Web UI
+
+### 7.1 BenchmarkKvCacheStressPage.tsx
+
+参考 `BenchmarkPrefixCachePage.tsx`,字段:
+
+| 字段 | 类型 | 默认 | 说明 |
+|---|---|---|---|
+| Name | text | 必填 | run name |
+| Connection | dropdown | 用户已配的 connection | 取 model + apiUrl + apiKey |
+| Num sessions | number | 200 | 工作集 size driver |
+| Turns | number | 4 | 多轮深度 |
+| Concurrency | number | 25 | async worker |
+| Max tokens | number | 50 | per-request 限 |
+| Duration (s) | number | 600 | bench 时长 |
+| Prom URL | url(可选)| 空 | 不填跳过 Prom delta 计算 |
+
+### 7.2 `reports/KvCacheStressReport.tsx`
+
+展示 4 个分组:
+
+1. **Top-line**(QPS / output_tps / err rate / requests_ok)—— 4 个 stat card
+2. **Latency percentiles**(TTFT p50/p90/p99 + e2e p50/p90/p99)—— 2 行 grouped bar
+3. **Prefix Cache Savings**(HBM hit % vs Savings % delta 显示在两个 progress bar 上)
+4. **Backend counters**(`backend.counters` 表格,key/value,自适应展示 lmcache:* 或 yrcache_* 任一)
+
+样式跟现有 `InferenceReport` / `PrefixCacheProbeReport` 对齐。
+
+### 7.3 i18n
+
+```json
+// zh-CN/benchmarks.json 新增
+{
+  "kvCacheStress": {
+    "title": "KV cache 压测",
+    "description": "多轮对话压测,触发 prefix-cache 驱逐,对比不同 KV 卸载后端",
+    "fields": {
+      "numSessions": "Session 数",
+      "turns": "对话轮数",
+      "concurrency": "并发数",
+      "maxTokens": "Max tokens",
+      "durationSec": "时长(秒)",
+      "promUrl": "Prometheus URL(可选)"
+    },
+    "report": {
+      "topLine": "Top-line",
+      "latency": "延迟分布",
+      "savings": "Prefix Cache Savings",
+      "backendCounters": "后端原生 counter"
+    }
+  }
+}
+```
+
+en-US 平行。
+
+---
+
+## 8. Deployment recipes
+
+### 8.1 新引擎:`vllm-ascend`
+
+`data.ts` 现有 `ENGINES` 表里有 `vllm`、`sglang`、`mindie` 等,**没有 `vllm-ascend`**。LMCache / YRCache 都是基于 `vllm-ascend` 镜像,所以先加引擎条目:
+
+```ts
+{ id: "vllm-ascend", name: "vLLM-Ascend", vendor: "Huawei Ascend × vLLM" },
+```
+
+### 8.1.1 新 RecipeStatus:`community`
+
+`types.ts` 现有的 `RecipeStatus` 枚举只有 `"native" | "partial"`(根据 data.ts 用法推断)。我们的两个镜像都是**内部构建 + hot-patch**,既不是上游官方(`native`),也不是上游部分支持(`partial`),而是"社区/内部维护"——加新值 `community`:
+
+```ts
+// types.ts
+export type RecipeStatus = "native" | "partial" | "community";
+
+// data.ts 加 helper
+const community = (r: Omit<EngineRecipe, "status">): EngineRecipe => ({ status: "community", ...r });
+```
+
+i18n 同步:`deployment-recipes.json` 加 `status.community: "社区构建"` / `"Community build"`。
+
+### 8.2 Recipe 1:`Qwen3-32B + vllm-ascend + LMCache CPU`
+
+```ts
+{
+  id: "qwen3-32b",
+  // ...其他字段 ...
+  engines: {
+    "vllm-ascend": community({
+      minVersion: "0.18.0rc1",
+      image: "swr.cn-north-4.myhuaweicloud.com/inference-engines/vllm-ascend:v0.18.0rc1-lmcache",
+      tooltip: "vllm-ascend 0.18 + LMCache 0.4.2(CPU 100GB 卸载,生产推荐)",
+      command: `kubectl apply -f - <<EOF
+# StatefulSet 关键 args:
+# - --kv-transfer-config '{"kv_connector":"LMCacheAscendConnectorV1Dynamic", ...}'
+# - --disable-hybrid-kv-cache-manager
+# env:
+# - PROMETHEUS_MULTIPROC_DIR=/tmp/lmcache_prometheus        # 必须,否则 lmcache:* 看不见
+# - LMCACHE_CHUNK_SIZE=256
+# - LMCACHE_LOCAL_CPU=True
+# - LMCACHE_MAX_LOCAL_CPU_SIZE=100                          # GB
+# volumeMounts: prom-multiproc:/tmp/lmcache_prometheus (emptyDir 必须,LMCache 不自己 mkdir)
+EOF`,
+      params: [
+        { key: "PROMETHEUS_MULTIPROC_DIR", value: "/tmp/lmcache_prometheus", desc: "必须,跨 TP worker 聚合 metrics" },
+        { key: "LMCACHE_MAX_LOCAL_CPU_SIZE", value: "100 GB", desc: "建议 25-50% 主机内存,本机 1 TB → 100 GB 经验值" },
+        { key: "--disable-hybrid-kv-cache-manager", value: "", desc: "HMA 与 KV connector 不兼容,必加" },
+      ],
+      resource: "Atlas 800I A2 8×910B4 / TP=4 / 32 GB HBM × 4",
+      notes: [
+        "实测 QPS 3.75 / TTFT p90 2.3 s / 0% err。生产推荐档。",
+        "完整 yaml 见 theriseunion/repots:2026-05-10-qwen3-lmcache-ascend-benchmark/patches/03-c-on-cpu.yaml",
+      ].join(" "),
+      docUrl: "https://github.com/theriseunion/repots/tree/main/2026-05-10-qwen3-lmcache-ascend-benchmark",
+    }),
+    // ... 其他引擎(如果该 model 在别处也有)
+  },
+}
+```
+
+### 8.3 Recipe 2:`Qwen3-32B + vllm-ascend + YRCache CPU+DISK+Shared`
+
+```ts
+"vllm-ascend-yrcache": community({
+  minVersion: "0.18.0rc1",
+  image: "swr.cn-north-4.myhuaweicloud.com/inference-engines/vllm-ascend:v0.18.0rc1-yrcache-1.5.0",
+  tooltip: "vllm-ascend 0.18 + YRCache 1.5.0 三层缓存(CPU + Local Disk + Redis 元数据 + NFS 数据)",
+  command: `# YRCache 跑通需要 3 个前置:
+# 1. 部署专用无认证 Redis(YRCache 没 redis_password 字段,生产 Redis 接不上):
+#    Deployment yrcache-redis,image quanzhenglong.com/camp/redis:8.2.0,'--protected-mode no'
+# 2. 准备 NFS PVC(/mnt/yrfs),或 hostPath 大盘
+# 3. hot-patch yrcache 1.5.0 的 vLLM 0.18 兼容性 bug(KVConnectorFactory 第 3 参数已改名):
+#    ConfigMap yrcache-connector-fix,subPath 挂修复后的 yrcache_connector.py 覆盖镜像内的版本
+#    完整修复源:theriseunion/repots:2026-05-11-...../patches/yrcache_connector_patched.py
+kubectl apply -f - <<EOF
+# StatefulSet 关键 args:
+# - --kv-transfer-config '{"kv_connector":"YRCacheConnector", ...}'
+# - --disable-hybrid-kv-cache-manager
+# env:
+# - YRCACHE_CONFIG_FILE=/etc/yrcache.yaml
+# volumeMounts:
+# - yrcache-config:/etc/yrcache.yaml      (ConfigMap 含 yrcache.yaml,log_level=2 必加)
+# - yrcache-disk:/apps/yrcache            (hostPath)
+# - yrcache-shared:/mnt/yrfs              (NFS PVC,可选)
+# - yrcache-connector-fix:...             (subPath,hot-patch)
+EOF`,
+  params: [
+    { key: "log_level (yrcache.yaml)", value: "2 (warning)", desc: "**必调**:默认 3 INFO 把 worker 打死,err 率额外 +5 pp" },
+    { key: "metric_level (yrcache.yaml)", value: "1 (batch only)", desc: "默认 3 太细" },
+    { key: "shared_storage_cache_config.redis_host", value: "yrcache-redis.<ns>.svc", desc: "必须无认证 Redis,yrcache wheel 没 redis_password 字段" },
+  ],
+  resource: "Atlas 800I A2 8×910B4 / TP=4 + 100 GB host RAM + 300+ GB disk + (可选)500 GB NFS",
+  notes: [
+    "yrcache 1.5.0 wheel 与 vLLM 0.18 KVConnectorFactory 不兼容,部署前必须打 hot-patch。",
+    "Y-FULL 实测 QPS 3.39 / TTFT p90 2.06 s / err 率 9.4%(比 LMCache 高,但跨 pod 共享 KV 是唯一场景)。",
+    "完整方案见 theriseunion/repots:2026-05-11-qwen3-yrcache-ascend-benchmark/。",
+  ].join(" "),
+  docUrl: "https://github.com/theriseunion/repots/tree/main/2026-05-11-qwen3-yrcache-ascend-benchmark",
+})
+```
+
+**注**:用新加的 `status: "community"` 状态——这两个 image 都不是上游(vLLM-Ascend 官方)发布的,是我们内部构建并附加 hot-patch。如果未来 YRCache 厂商修了 vLLM 0.18 兼容性,可以升到 `native`。
+
+### 8.4 i18n 注意
+
+`deployment-recipes/data.ts` 注释里写了"V1 zh-CN-only,字符串保留中文"。我们加的 `tooltip`、`notes` 用中文。新加的 `community` 状态在 `deployment-recipes.json` 里加翻译 key(zh-CN + en-US)。
+
+---
+
+## 9. 官方 baseline benchmark templates(seed.ts 入库)
+
+### 9.1 现状
+
+#172(`2026-05-12-official-benchmark-templates-design.md`)已经把 10 个 inference scenario 官方模板通过 `apps/api/prisma/seed.ts` 落库,采用 industry-standard 模式(schema migration + 数据 seed 分离)。`BenchmarkTemplateSeed` 接口当前**硬编码** `scenario: "inference"` 且 `tool: "guidellm" | "genai-perf"`,需要**加宽**才能容纳 `kv-cache-stress` 模板。
+
+### 9.2 类型加宽
+
+```ts
+// apps/api/prisma/seed.ts
+type Tool = "guidellm" | "genai-perf" | "kv-cache-stress";
+interface BenchmarkTemplateSeed {
+  id: string;
+  name: string;
+  description: string;
+  scenario: "inference" | "kv-cache-stress";
+  tool: Tool;
+  config: unknown;
+  tags: string[];
+}
+```
+
+并把 `seedBenchmarkTemplates()` 内的 zod 校验路径扩展,根据 `template.scenario` 走对应的 `applyScenarioConstraints(scenario, tool)`。
+
+### 9.3 两个 KV cache 官方模板
+
+锚定 2026-05-10 / 2026-05-11 实测数据。每条模板**只包含 `kv-cache-stress` adapter 的 params**,不包含 backend 配置(backend 切换走 deployment-recipes,本模板假设 backend 已部署好)。
+
+#### 9.3.1 LMCache CPU baseline
+
+```ts
+{
+  id: "tpl_official_kv_cache_lmcache_cpu_baseline",
+  name: "KV Cache · LMCache CPU baseline",
+  description:
+    "对齐 2026-05-10 实测:Qwen3-32B + LMCache CPU 100 GB,200 sessions × 4 轮多轮对话,工作集 ~400K token 强制驱逐 HBM。预期 QPS ~3.75 / TTFT p90 ~2.3 s / Prefix Cache Savings 85%。",
+  scenario: "kv-cache-stress",
+  tool: "kv-cache-stress",
+  config: {
+    numSessions: 200,
+    turns: 4,
+    concurrency: 25,
+    maxTokens: 50,
+    durationSec: 600,
+    systemPromptSeed: "scn",
+    // promUrl 留空,用户在 UI 填(可选)
+  },
+  tags: ["kv-cache", "lmcache", "baseline", "multi-turn", "qwen3-32b"],
+},
+```
+
+#### 9.3.2 YRCache 三层缓存 baseline
+
+```ts
+{
+  id: "tpl_official_kv_cache_yrcache_full_baseline",
+  name: "KV Cache · YRCache 三层缓存 baseline",
+  description:
+    "对齐 2026-05-11 实测:Qwen3-32B + YRCache (CPU 100 GB + Local Disk + Redis 元数据 + NFS 数据),200 sessions × 4 轮。预期 QPS ~3.39 / TTFT p90 ~2.1 s / Prefix Cache Savings 89%。**err 率 9-13%**,接受这个 trade-off 才推荐使用,生产强烈建议先跑 LMCache baseline 模板对比。",
+  scenario: "kv-cache-stress",
+  tool: "kv-cache-stress",
+  config: {
+    numSessions: 200,
+    turns: 4,
+    concurrency: 25,
+    maxTokens: 50,
+    durationSec: 600,
+    systemPromptSeed: "scn",
+  },
+  tags: ["kv-cache", "yrcache", "baseline", "multi-turn", "qwen3-32b", "shared-tier"],
+},
+```
+
+> **两个模板的 `config` 完全一致**:这是有意为之——同一工作负载、不同后端的"控制变量"对比方法论。期望用户跑过两次后,在 Compare 视图里直接看两个 run 的 delta。
+
+### 9.4 ID 命名规则
+
+`tpl_official_kv_cache_<backend>_<variant>_baseline`,跟 #172 既定的 `tpl_official_<scenario>_<descriptor>` 模式一致。
+
+### 9.5 seed 校验
+
+`seedBenchmarkTemplates()` 现有逻辑会走 `applyScenarioConstraints(scenario, tool)`。我们的 `kv-cache-stress` scenario 在 `scenarios.ts` 已添加,`paramsConstraints` 为空(没有 sweep 等额外约束),所以 zod 校验天然通过。两个模板的 `config` 都必须通过 `kvCacheStressParamsSchema.parse()` —— 这条会在 seed.ts 单测里加 case 验证。
+
+---
+
+## 10. 测试与验收
+
+| Phase | 命令 | 覆盖 |
+|---|---|---|
+| Tool-adapter unit | `pnpm -F @modeldoctor/tool-adapters test -- kv-cache-stress` | schema parse + buildCommand + parseProgress + parseFinalReport |
+| Type check | `pnpm type-check` | 全 monorepo 类型一致 |
+| Lint | `pnpm lint` | biome 通过 |
+| Web component | `pnpm -F @modeldoctor/web test` | KvCacheStressReport rendering |
+| Prisma seed | `pnpm -F @modeldoctor/api db:seed`(本地)| 2 个 KV cache 模板 zod 校验通过、upsert 成功 |
+| 端到端(可选) | `pnpm test:e2e` | 创建 benchmark run → 收 callback → 报告渲染 |
+| 手工验收 | `pnpm dev` + 真实压一次 | 在我们已有的 Qwen3-32B 环境上跑 60s 短试,验证 final report 字段 |
+
+**deployment-recipes 验收**:Web `pnpm dev` 进 deployment-recipes 页,看 Qwen3-32B 行下 `vllm-ascend` 两个 recipe 卡片都显示出来,RecipeDrawer 里能正确渲染 command + params + notes,顶部状态徽章显示 `社区构建` / `Community build`(取决于语言)。
+
+**官方模板验收**:Benchmark 创建页选 `kv-cache-stress` scenario,顶部"官方模板"下拉里应该看到 2 个 KV cache baseline 模板;选中后表单字段自动填充。
+
+---
+
+## 11. v2 / 后续清单
+
+- [x] ~~**官方 baseline 模板入库**~~ 已在本 PR §9 完成(2 个 KV cache 官方模板入 seed.ts)
+- [ ] **Backend Provisioner 模块**:modeldoctor 自己 patch StatefulSet 切换 backend → readiness → 跑 bench → 切回,链路全自动
+- [ ] **跨 pod 共享场景**:多副本共连 YRCache shared tier 的 bench,验证跨 pod KV 命中率
+- [ ] **Grafana dashboard 模板**:`lmcache:*` 和 `yrcache_*` 大盘,接入 `deploy/k8s` 现成 prometheus stack
+- [ ] **`yrcache_connector_patched.py` 作为 release artifact**:打 yrcache 厂商兼容版,或上游 fix
+- [ ] **stickiness × stress 联合验证**:启用现有 `prefix-cache-probe` + `kv-cache-stress` 串跑,验证 sticky 路由下 cache 命中率提升
+
+---
+
+## 12. 已知风险
+
+| 风险 | 缓解 |
+|---|---|
+| 我们的 `bench_qwen3.py` 用户态行为(sha256 deterministic prompt)在公网会被某些上游限流/拒掉 | tool 文档明确"仅在内网 / 自管 LLM endpoint 使用",modeldoctor 已有 connection 模型只暴露给登录用户 |
+| `parseProgress` 增量解析依赖 `+ Ns  ok=N  err=M` 输出格式,bench_qwen3.py 改输出格式会破 | 把 progress 行格式 pin 在 spec §5,改格式同步改 adapter 单测 |
+| `community` recipe status 是新概念,UI 端要给配色 + i18n,否则徽章 fallback 难看 | 在 `RecipeDrawer.tsx` 加新 status 的视觉样式;i18n key 必须 V1 就有 |
+| YRCache hot-patch 是 hack,后续 wheel 升级可能 stale | recipe notes 写明 hot-patch 来源(theriseunion/repots commit hash),升级时核对 |
+| 官方 KV cache 模板的预期数字(QPS 3.75 / 3.39 等)只在 8×910B4 一种硬件上测过,UI 上展示给其它硬件用户会误导 | 模板 description 显式说明"对齐 Atlas 800I A2 / 8×910B4 实测数据";UI 端考虑未来加 `expected_hardware` 字段(v2) |

--- a/packages/contracts/src/benchmark.ts
+++ b/packages/contracts/src/benchmark.ts
@@ -8,6 +8,7 @@ export const scenarioIdSchema = z.enum([
   "capacity",
   "gateway",
   "prefix-cache-validation",
+  "kv-cache-stress",
 ]);
 export type ScenarioId = z.infer<typeof scenarioIdSchema>;
 
@@ -16,6 +17,7 @@ export const benchmarkToolSchema = z.enum([
   "genai-perf",
   "vegeta",
   "prefix-cache-probe",
+  "kv-cache-stress",
 ]);
 export type BenchmarkTool = z.infer<typeof benchmarkToolSchema>;
 

--- a/packages/contracts/src/engine.spec.ts
+++ b/packages/contracts/src/engine.spec.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import { ENGINE_CAPABILITY, ENGINE_DISPLAY_NAME, ENGINE_IDS, type EngineId } from "./engine.js";
 
 describe("engine SSOT", () => {
-  it("declares all 10 engines exactly once", () => {
+  it("declares all 11 engines exactly once", () => {
     expect(new Set(ENGINE_IDS).size).toBe(ENGINE_IDS.length);
-    expect(ENGINE_IDS).toHaveLength(10);
+    expect(ENGINE_IDS).toHaveLength(11);
   });
 
   it("has display name for every engine id", () => {

--- a/packages/contracts/src/engine.ts
+++ b/packages/contracts/src/engine.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
  */
 export const ENGINE_IDS = [
   "vllm",
+  "vllm-ascend",
   "sglang",
   "trtllm",
   "mindie",
@@ -33,6 +34,7 @@ export type EngineId = (typeof ENGINE_IDS)[number];
  */
 export const ENGINE_DISPLAY_NAME: Record<EngineId, string> = {
   vllm: "vLLM",
+  "vllm-ascend": "vLLM-Ascend",
   sglang: "SGLang",
   trtllm: "TensorRT-LLM",
   mindie: "MindIE",
@@ -56,6 +58,7 @@ export type EngineCapability = "generative" | "embedding";
  */
 export const ENGINE_CAPABILITY: Record<EngineId, EngineCapability> = {
   vllm: "generative",
+  "vllm-ascend": "generative",
   sglang: "generative",
   trtllm: "generative",
   mindie: "generative",

--- a/packages/tool-adapters/src/category-defaults.ts
+++ b/packages/tool-adapters/src/category-defaults.ts
@@ -56,3 +56,18 @@ export const PREFIX_CACHE_PROBE_CATEGORY_DEFAULTS = {
   rerank: {},
   image: {},
 } as const satisfies Record<ModalityCategory, Record<string, never>>;
+
+/**
+ * kv-cache-stress only makes sense against OpenAI-compatible chat endpoints —
+ * the workload is a multi-turn dialog stress. Embeddings / rerank / images /
+ * audio endpoints don't have prefix cache semantics to measure. The other
+ * categories are explicit `unsupported` markers so the form renders the same
+ * blocking warning users see for genai-perf / guidellm.
+ */
+export const KV_CACHE_STRESS_CATEGORY_DEFAULTS = {
+  chat: {},
+  audio: { unsupported: true },
+  embeddings: { unsupported: true },
+  rerank: { unsupported: true },
+  image: { unsupported: true },
+} as const satisfies Record<ModalityCategory, Record<string, never> | { unsupported: true }>;

--- a/packages/tool-adapters/src/core/interface.ts
+++ b/packages/tool-adapters/src/core/interface.ts
@@ -4,7 +4,12 @@ import type { z } from "zod";
 // superset (additionally `'e2e'` and `'custom'`) — those don't go through
 // ToolAdapter and follow their own codepaths. ToolName covers exactly the
 // adapters the registry knows about.
-export type ToolName = "guidellm" | "genai-perf" | "vegeta" | "prefix-cache-probe";
+export type ToolName =
+  | "guidellm"
+  | "genai-perf"
+  | "vegeta"
+  | "prefix-cache-probe"
+  | "kv-cache-stress";
 
 // ── Progress events (uniform across tools) ────────────────────────────
 export type ProgressEvent =
@@ -16,6 +21,7 @@ import type { GenaiPerfReport } from "../genai-perf/schema.js";
 // We use type-only imports to break a circular dep concern: schema files
 // don't import from interface.ts; interface.ts imports their inferred types.
 import type { GuidellmReport } from "../guidellm/schema.js";
+import type { KvCacheStressReport } from "../kv-cache-stress/schema.js";
 import type { PrefixCacheProbeReport } from "../prefix-cache-probe/schema.js";
 import type { VegetaReport } from "../vegeta/schema.js";
 
@@ -24,7 +30,8 @@ export type ToolReport =
   | { tool: "guidellm"; data: GuidellmReport }
   | { tool: "genai-perf"; data: GenaiPerfReport }
   | { tool: "vegeta"; data: VegetaReport }
-  | { tool: "prefix-cache-probe"; data: PrefixCacheProbeReport };
+  | { tool: "prefix-cache-probe"; data: PrefixCacheProbeReport }
+  | { tool: "kv-cache-stress"; data: KvCacheStressReport };
 
 // ── buildCommand inputs ───────────────────────────────────────────────
 export interface BuildCommandPlan<TParams = unknown> {

--- a/packages/tool-adapters/src/core/registry.spec.ts
+++ b/packages/tool-adapters/src/core/registry.spec.ts
@@ -16,11 +16,15 @@ describe("registry", () => {
     expect(byTool("genai-perf").name).toBe("genai-perf");
   });
 
-  it("allAdapters returns four adapters", () => {
+  it("byTool('kv-cache-stress') returns the kv-cache-stress adapter", () => {
+    expect(byTool("kv-cache-stress").name).toBe("kv-cache-stress");
+  });
+
+  it("allAdapters returns five adapters", () => {
     const all = allAdapters();
-    expect(all).toHaveLength(4);
+    expect(all).toHaveLength(5);
     expect(all.map((a) => a.name).sort()).toEqual(
-      ["genai-perf", "guidellm", "prefix-cache-probe", "vegeta"].sort(),
+      ["genai-perf", "guidellm", "kv-cache-stress", "prefix-cache-probe", "vegeta"].sort(),
     );
   });
 });

--- a/packages/tool-adapters/src/core/registry.ts
+++ b/packages/tool-adapters/src/core/registry.ts
@@ -1,5 +1,6 @@
 import { genaiPerfAdapter } from "../genai-perf/index.js";
 import { guidellmAdapter } from "../guidellm/index.js";
+import { kvCacheStressAdapter } from "../kv-cache-stress/index.js";
 import { prefixCacheProbeAdapter } from "../prefix-cache-probe/index.js";
 import type { ScenarioId } from "../scenarios.js";
 import { vegetaAdapter } from "../vegeta/index.js";
@@ -10,6 +11,7 @@ const ADAPTERS: Readonly<Record<ToolName, ToolAdapter>> = {
   "genai-perf": genaiPerfAdapter,
   vegeta: vegetaAdapter,
   "prefix-cache-probe": prefixCacheProbeAdapter,
+  "kv-cache-stress": kvCacheStressAdapter,
 };
 
 export function byTool(tool: ToolName): ToolAdapter {

--- a/packages/tool-adapters/src/index.ts
+++ b/packages/tool-adapters/src/index.ts
@@ -8,6 +8,7 @@ export { guidellmAdapter } from "./guidellm/index.js";
 export { vegetaAdapter } from "./vegeta/index.js";
 export { genaiPerfAdapter } from "./genai-perf/index.js";
 export { prefixCacheProbeAdapter } from "./prefix-cache-probe/index.js";
+export { kvCacheStressAdapter } from "./kv-cache-stress/index.js";
 
 // Re-export schemas + types for convenience (so `apps/api` doesn't need to
 // reach into subpaths to validate `req.params`).

--- a/packages/tool-adapters/src/kv-cache-stress/__fixtures__/result.json
+++ b/packages/tool-adapters/src/kv-cache-stress/__fixtures__/result.json
@@ -1,0 +1,24 @@
+{
+  "qps": 3.75,
+  "outputTps": 187.0,
+  "requestsOk": 2312,
+  "requestsErr": 0,
+  "errRatePct": 0.0,
+  "ttftMs": { "p50": 757, "p90": 2315, "p99": 7729 },
+  "e2eMs": { "p50": 5254, "p90": 10424, "p99": 22265 },
+  "prom": {
+    "hbmHitRatePct": 76.9,
+    "prefixCacheSavingsPct": 85.1,
+    "promptTokensTotalDelta": 14070000,
+    "generationTokensTotalDelta": 115000
+  },
+  "backend": {
+    "nameGuess": "lmcache",
+    "counters": {
+      "lmcache:num_retrieve_requests_total": 1368,
+      "lmcache:num_hit_tokens_total": 7949312,
+      "lmcache:num_store_requests_total": 4120,
+      "lmcache:retrieve_speed_avg_tps": 318824
+    }
+  }
+}

--- a/packages/tool-adapters/src/kv-cache-stress/index.ts
+++ b/packages/tool-adapters/src/kv-cache-stress/index.ts
@@ -1,0 +1,21 @@
+import type { ToolAdapter } from "../core/interface.js";
+import { buildCommand, getMaxDurationSeconds, parseFinalReport, parseProgress } from "./runtime.js";
+import {
+  kvCacheStressParamDefaults,
+  kvCacheStressParamsSchema,
+  kvCacheStressReportSchema,
+} from "./schema.js";
+
+export const kvCacheStressAdapter: ToolAdapter = {
+  name: "kv-cache-stress",
+  scenarios: ["kv-cache-stress"] as const,
+  paramsSchema: kvCacheStressParamsSchema,
+  reportSchema: kvCacheStressReportSchema,
+  paramDefaults: kvCacheStressParamDefaults,
+  buildCommand,
+  parseProgress,
+  parseFinalReport,
+  getMaxDurationSeconds,
+};
+
+export type { KvCacheStressParams, KvCacheStressReport } from "./schema.js";

--- a/packages/tool-adapters/src/kv-cache-stress/runtime.spec.ts
+++ b/packages/tool-adapters/src/kv-cache-stress/runtime.spec.ts
@@ -1,0 +1,138 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { buildCommand, getMaxDurationSeconds, parseFinalReport, parseProgress } from "./runtime.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixtureBuf = fs.readFileSync(path.join(__dirname, "__fixtures__/result.json"));
+
+const baseConn = {
+  baseUrl: "http://10.100.121.67:31700",
+  apiKey: "sk-test",
+  model: "Qwen/Qwen3-32B",
+  customHeaders: "",
+  queryParams: "",
+  tokenizerHfId: null,
+  prometheusUrl: "http://10.100.121.67:30121",
+};
+
+const baseParams = {
+  numSessions: 200,
+  turns: 4,
+  concurrency: 25,
+  maxTokens: 50,
+  durationSec: 600,
+  systemPromptSeed: "scn",
+};
+
+describe("kv-cache-stress.buildCommand", () => {
+  it("argv is python /app/probe.py with required flags", () => {
+    const r = buildCommand({
+      runId: "r1",
+      params: baseParams,
+      connection: baseConn,
+      callback: { url: "http://api/", token: "tk" },
+    });
+    expect(r.argv[0]).toBe("python");
+    expect(r.argv[1]).toBe("/app/probe.py");
+    const flat = r.argv.join(" ");
+    expect(flat).toContain("--base-url http://10.100.121.67:31700");
+    expect(flat).toContain("--model Qwen/Qwen3-32B");
+    expect(flat).toContain("--num-sessions 200");
+    expect(flat).toContain("--turns 4");
+    expect(flat).toContain("--concurrency 25");
+    expect(flat).toContain("--max-tokens 50");
+    expect(flat).toContain("--duration 600");
+    expect(flat).toContain("--system-prompt-seed scn");
+    expect(flat).toContain("--out result.json");
+  });
+
+  it("includes --prom-url when connection.prometheusUrl is set", () => {
+    const r = buildCommand({
+      runId: "r1",
+      params: baseParams,
+      connection: baseConn,
+      callback: { url: "http://api/", token: "tk" },
+    });
+    expect(r.argv.join(" ")).toContain("--prom-url http://10.100.121.67:30121");
+  });
+
+  it("omits --prom-url when connection.prometheusUrl is null", () => {
+    const conn = { ...baseConn, prometheusUrl: null };
+    const r = buildCommand({
+      runId: "r1",
+      params: baseParams,
+      connection: conn,
+      callback: { url: "http://api/", token: "tk" },
+    });
+    expect(r.argv.join(" ")).not.toContain("--prom-url");
+  });
+
+  it("apiKey ships via secretEnv.OPENAI_API_KEY (never argv)", () => {
+    const r = buildCommand({
+      runId: "r1",
+      params: baseParams,
+      connection: baseConn,
+      callback: { url: "http://api/", token: "tk" },
+    });
+    expect(r.argv.join(" ")).not.toContain("sk-test");
+    expect(r.secretEnv.OPENAI_API_KEY).toBe("sk-test");
+  });
+
+  it("outputFiles.result is result.json", () => {
+    const r = buildCommand({
+      runId: "r1",
+      params: baseParams,
+      connection: baseConn,
+      callback: { url: "http://api/", token: "tk" },
+    });
+    expect(r.outputFiles.result).toBe("result.json");
+  });
+});
+
+describe("kv-cache-stress.parseProgress", () => {
+  it("parses '  + 15s  ok=100  err=2  completion_tokens=4830' into progress event", () => {
+    const evt = parseProgress("  + 15s  ok=100  err=2  completion_tokens=4830");
+    expect(evt).not.toBeNull();
+    if (!evt || evt.kind !== "progress") throw new Error("expected progress event");
+    expect(evt.currentRequests).toBe(102);
+    expect(evt.message).toBe("ok=100 err=2");
+  });
+
+  it("parses progress without completion_tokens suffix (early ticks)", () => {
+    const evt = parseProgress("  + 16s  ok=0  err=5");
+    expect(evt).not.toBeNull();
+    if (!evt || evt.kind !== "progress") throw new Error("expected progress event");
+    expect(evt.currentRequests).toBe(5);
+  });
+
+  it("returns null for unrelated lines (warnings, banners, SUMMARY block)", () => {
+    expect(parseProgress("BASE_URL=http://x  MODEL=y  API_KEY=set")).toBeNull();
+    expect(parseProgress("=== SUMMARY ===")).toBeNull();
+    expect(parseProgress("")).toBeNull();
+  });
+});
+
+describe("kv-cache-stress.parseFinalReport", () => {
+  it("parses LMCache fixture into typed report", () => {
+    const r = parseFinalReport("", { result: fixtureBuf });
+    expect(r.tool).toBe("kv-cache-stress");
+    if (r.tool !== "kv-cache-stress") throw new Error("type narrowing");
+    expect(r.data.qps).toBe(3.75);
+    expect(r.data.backend.nameGuess).toBe("lmcache");
+    expect(r.data.prom.prefixCacheSavingsPct).toBe(85.1);
+  });
+
+  it("throws when files.result is missing", () => {
+    expect(() => parseFinalReport("", {})).toThrow(/missing 'result'/);
+  });
+});
+
+describe("kv-cache-stress.getMaxDurationSeconds", () => {
+  it("returns durationSec + 120 (pre/post snapshot + warmup grace)", () => {
+    expect(getMaxDurationSeconds(baseParams)).toBe(720);
+    expect(getMaxDurationSeconds({ ...baseParams, durationSec: 300 })).toBe(420);
+    expect(getMaxDurationSeconds({ ...baseParams, durationSec: 7200 })).toBe(7320);
+  });
+});

--- a/packages/tool-adapters/src/kv-cache-stress/runtime.ts
+++ b/packages/tool-adapters/src/kv-cache-stress/runtime.ts
@@ -1,0 +1,91 @@
+import type {
+  BuildCommandPlan,
+  BuildCommandResult,
+  ProgressEvent,
+  ToolReport,
+} from "../core/interface.js";
+import { type KvCacheStressParams, kvCacheStressReportSchema } from "./schema.js";
+
+// Progress lines from kv_cache_stress.py look like:
+//   "  + 15s  ok=100  err=2  completion_tokens=4830"
+// (anchored on the leading two spaces + `+`, integer seconds, then key=val pairs)
+//
+// The script also emits a final SUMMARY block which parseFinalReport reads from
+// the captured result file, not from this stream.
+const PROGRESS_LINE = /^\s*\+\s*(\d+)s\s+ok=(\d+)\s+err=(\d+)(?:\s+completion_tokens=(\d+))?/;
+
+export function buildCommand(plan: BuildCommandPlan<KvCacheStressParams>): BuildCommandResult {
+  const { params, connection } = plan;
+
+  // Argv only carries non-secret strings. The bearer token rides via env
+  // (OPENAI_API_KEY) so it never enters Job spec / ps aux.
+  const argv = [
+    "python",
+    "/app/probe.py",
+    "--base-url",
+    connection.baseUrl,
+    "--model",
+    connection.model,
+    "--num-sessions",
+    String(params.numSessions),
+    "--turns",
+    String(params.turns),
+    "--concurrency",
+    String(params.concurrency),
+    "--max-tokens",
+    String(params.maxTokens),
+    "--duration",
+    String(params.durationSec),
+    "--system-prompt-seed",
+    params.systemPromptSeed,
+    "--out",
+    "result.json",
+  ];
+
+  // Prom URL is optional — when present the script captures vllm:* counter
+  // deltas before/after the bench and computes Prefix Cache Savings.
+  if (connection.prometheusUrl) {
+    argv.push("--prom-url", connection.prometheusUrl);
+  }
+
+  return {
+    argv,
+    env: {},
+    secretEnv: {
+      OPENAI_API_KEY: connection.apiKey,
+    },
+    outputFiles: {
+      result: "result.json",
+    },
+  };
+}
+
+export function parseProgress(line: string): ProgressEvent | null {
+  const m = PROGRESS_LINE.exec(line);
+  if (!m) return null;
+  const [, _elapsedStr, okStr, errStr] = m;
+  const ok = Number.parseInt(okStr, 10);
+  const err = Number.parseInt(errStr, 10);
+  return {
+    kind: "progress",
+    pct: 0, // duration-relative pct lives in the driver; we just emit absolute counts
+    currentRequests: ok + err,
+    message: `ok=${ok} err=${err}`,
+  };
+}
+
+export function parseFinalReport(_stdout: string, files: Record<string, Buffer>): ToolReport {
+  const buf = files.result;
+  if (!buf) {
+    throw new Error("kv-cache-stress.parseFinalReport: missing 'result' output file");
+  }
+  const data = kvCacheStressReportSchema.parse(JSON.parse(buf.toString("utf8")));
+  return { tool: "kv-cache-stress", data };
+}
+
+export function getMaxDurationSeconds(params: KvCacheStressParams): number {
+  // bench wall-clock + warmup grace + pre/post Prom snapshot + report-file write.
+  // 90s buffer matches the worst case observed in the 2026-05-11 runs where
+  // pod readiness lag pushed start time ~60s past invocation.
+  return params.durationSec + 120;
+}

--- a/packages/tool-adapters/src/kv-cache-stress/schema.spec.ts
+++ b/packages/tool-adapters/src/kv-cache-stress/schema.spec.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { kvCacheStressParamsSchema, kvCacheStressReportSchema } from "./schema.js";
+
+describe("kvCacheStressParamsSchema", () => {
+  it("applies defaults when no fields provided", () => {
+    const parsed = kvCacheStressParamsSchema.parse({});
+    expect(parsed.numSessions).toBe(200);
+    expect(parsed.turns).toBe(4);
+    expect(parsed.concurrency).toBe(25);
+    expect(parsed.maxTokens).toBe(50);
+    expect(parsed.durationSec).toBe(600);
+    expect(parsed.systemPromptSeed).toBe("scn");
+  });
+
+  it("rejects durationSec below 30 (Prom counter delta too noisy)", () => {
+    expect(() => kvCacheStressParamsSchema.parse({ durationSec: 10 })).toThrow();
+  });
+
+  it("rejects durationSec above 7200 (matches BENCHMARK_DEFAULT_MAX_DURATION ceiling)", () => {
+    expect(() => kvCacheStressParamsSchema.parse({ durationSec: 9000 })).toThrow();
+  });
+
+  it("rejects numSessions above 2000 (memory pressure cliff)", () => {
+    expect(() => kvCacheStressParamsSchema.parse({ numSessions: 5000 })).toThrow();
+  });
+
+  it("rejects concurrency above 256", () => {
+    expect(() => kvCacheStressParamsSchema.parse({ concurrency: 512 })).toThrow();
+  });
+
+  it("rejects turns above 16 (context window blow-out)", () => {
+    expect(() => kvCacheStressParamsSchema.parse({ turns: 32 })).toThrow();
+  });
+
+  it("accepts custom systemPromptSeed for reproducibility across runs", () => {
+    const parsed = kvCacheStressParamsSchema.parse({ systemPromptSeed: "qwen3-32b-tier1" });
+    expect(parsed.systemPromptSeed).toBe("qwen3-32b-tier1");
+  });
+});
+
+describe("kvCacheStressReportSchema", () => {
+  it("parses a full report (LMCache CPU baseline shape)", () => {
+    const parsed = kvCacheStressReportSchema.parse({
+      qps: 3.75,
+      outputTps: 187.0,
+      requestsOk: 2312,
+      requestsErr: 0,
+      errRatePct: 0.0,
+      ttftMs: { p50: 757, p90: 2315, p99: 7729 },
+      e2eMs: { p50: 5254, p90: 10424, p99: 22265 },
+      prom: {
+        hbmHitRatePct: 76.9,
+        prefixCacheSavingsPct: 85.1,
+      },
+      backend: {
+        nameGuess: "lmcache",
+        counters: { "lmcache:num_retrieve_requests_total": 1368 },
+      },
+    });
+    expect(parsed.qps).toBe(3.75);
+    expect(parsed.prom.prefixCacheSavingsPct).toBe(85.1);
+    expect(parsed.backend.nameGuess).toBe("lmcache");
+  });
+
+  it("accepts empty prom block (when prometheusUrl wasn't set)", () => {
+    const parsed = kvCacheStressReportSchema.parse({
+      qps: 3.5,
+      outputTps: 175,
+      requestsOk: 2000,
+      requestsErr: 0,
+      errRatePct: 0,
+      ttftMs: { p50: 650, p90: 2300, p99: 7000 },
+      e2eMs: { p50: 5000, p90: 10000, p99: 22000 },
+      prom: {},
+      backend: { nameGuess: "unknown", counters: {} },
+    });
+    expect(parsed.prom).toEqual({});
+  });
+
+  it("accepts backend nameGuess=yrcache with yrcache_* counters", () => {
+    const parsed = kvCacheStressReportSchema.parse({
+      qps: 3.39,
+      outputTps: 168,
+      requestsOk: 2087,
+      requestsErr: 217,
+      errRatePct: 9.4,
+      ttftMs: { p50: 644, p90: 2060, p99: 8384 },
+      e2eMs: { p50: 5953, p90: 9084, p99: 24324 },
+      prom: { prefixCacheSavingsPct: 89.1 },
+      backend: {
+        nameGuess: "yrcache",
+        counters: {
+          yrcache_num_retrieve_requests_total: 642,
+          yrcache_num_hit_tokens_total: 3798592,
+        },
+      },
+    });
+    expect(parsed.backend.nameGuess).toBe("yrcache");
+  });
+
+  it("rejects errRatePct outside [0, 100]", () => {
+    expect(() =>
+      kvCacheStressReportSchema.parse({
+        qps: 1,
+        outputTps: 1,
+        requestsOk: 1,
+        requestsErr: 0,
+        errRatePct: 150,
+        ttftMs: { p50: 1, p90: 1, p99: 1 },
+        e2eMs: { p50: 1, p90: 1, p99: 1 },
+        prom: {},
+        backend: { nameGuess: "unknown", counters: {} },
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/tool-adapters/src/kv-cache-stress/schema.ts
+++ b/packages/tool-adapters/src/kv-cache-stress/schema.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+
+// ── Params ────────────────────────────────────────────────────────────
+//
+// Workload anchored to the 2026-05-10 / 2026-05-11 reports in
+// theriseunion/repots: a multi-turn dialog stress that forces prefix-cache
+// evictions so different KV cache backends (LMCache / YRCache / vanilla)
+// produce comparable QPS / TTFT / Prefix Cache Savings deltas.
+//
+// Bounds rationale:
+//   - numSessions max 2000 — beyond that the deterministic prompt set
+//     generation in kv_cache_stress.py thrashes Python memory (~2 KB per
+//     session × N) without adding signal.
+//   - turns max 16 — vLLM `max-model-len` typically 16-32k tokens, deeper
+//     turns blow past that for a 2K-token system prompt.
+//   - concurrency max 256 — vLLM `max-num-seqs` default 128-256; going
+//     higher is queue-bound, not informative.
+//   - durationSec min 30 — Prom counter delta is noisy below ~30s and the
+//     warmup window dominates. min 60 recommended in production.
+//   - durationSec max 7200 — 2h ceiling matches Phase 3's
+//     BENCHMARK_DEFAULT_MAX_DURATION_SECONDS default; longer runs should
+//     be split.
+export const kvCacheStressParamsSchema = z.object({
+  numSessions: z.number().int().min(1).max(2000).default(200),
+  turns: z.number().int().min(1).max(16).default(4),
+  concurrency: z.number().int().min(1).max(256).default(25),
+  maxTokens: z.number().int().min(1).max(2048).default(50),
+  durationSec: z.number().int().min(30).max(7200).default(600),
+  systemPromptSeed: z.string().min(1).max(64).default("scn"),
+});
+export type KvCacheStressParams = z.infer<typeof kvCacheStressParamsSchema>;
+
+export const kvCacheStressParamDefaults: Partial<KvCacheStressParams> = {
+  numSessions: 200,
+  turns: 4,
+  concurrency: 25,
+  maxTokens: 50,
+  durationSec: 600,
+  systemPromptSeed: "scn",
+};
+
+// ── Report ────────────────────────────────────────────────────────────
+
+const latencyTriple = z.object({
+  p50: z.number().nonnegative(),
+  p90: z.number().nonnegative(),
+  p99: z.number().nonnegative(),
+});
+
+// Optional block — populated only when connection.prometheusUrl was set
+// AND the snapshot succeeded. Missing fields signal "couldn't compute".
+const promBlock = z
+  .object({
+    hbmHitRatePct: z.number().min(0).max(100).optional(),
+    prefixCacheSavingsPct: z.number().min(0).max(100).optional(),
+    promptTokensTotalDelta: z.number().int().nonnegative().optional(),
+    generationTokensTotalDelta: z.number().int().nonnegative().optional(),
+  })
+  .partial();
+
+// Backend-specific counters surface as a flat record so we can show
+// `lmcache:num_retrieve_requests_total` or `yrcache_num_retrieve_requests_total`
+// without the adapter needing to know which is which.
+//
+// `nameGuess` is a heuristic the runner emits based on which counter family
+// it saw in /metrics. "unknown" means neither lmcache:* nor yrcache_* showed
+// up, which usually means the backend isn't actually wired in.
+const backendBlock = z.object({
+  nameGuess: z.enum(["lmcache", "yrcache", "unknown"]),
+  counters: z.record(z.union([z.number(), z.string()])),
+});
+
+export const kvCacheStressReportSchema = z.object({
+  qps: z.number().nonnegative(),
+  outputTps: z.number().nonnegative(),
+  requestsOk: z.number().int().nonnegative(),
+  requestsErr: z.number().int().nonnegative(),
+  errRatePct: z.number().min(0).max(100),
+  ttftMs: latencyTriple,
+  e2eMs: latencyTriple,
+  prom: promBlock,
+  backend: backendBlock,
+});
+export type KvCacheStressReport = z.infer<typeof kvCacheStressReportSchema>;

--- a/packages/tool-adapters/src/scenarios.spec.ts
+++ b/packages/tool-adapters/src/scenarios.spec.ts
@@ -9,13 +9,18 @@ import {
 } from "./scenarios.js";
 
 describe("SCENARIOS constant", () => {
-  it("declares inference, capacity, gateway, prefix-cache-validation", () => {
+  it("declares all known scenarios", () => {
     expect(Object.keys(SCENARIOS).sort()).toEqual([
       "capacity",
       "gateway",
       "inference",
+      "kv-cache-stress",
       "prefix-cache-validation",
     ]);
+  });
+
+  it("kv-cache-stress scenario lists kv-cache-stress only", () => {
+    expect(SCENARIOS["kv-cache-stress"].tools).toEqual(["kv-cache-stress"]);
   });
 
   it("inference scenario lists guidellm and genai-perf", () => {

--- a/packages/tool-adapters/src/scenarios.ts
+++ b/packages/tool-adapters/src/scenarios.ts
@@ -2,13 +2,19 @@ import { z } from "zod";
 import type { ToolName } from "./core/interface.js";
 import { allAdapters, byTool } from "./core/registry.js";
 
-export type ScenarioId = "inference" | "capacity" | "gateway" | "prefix-cache-validation";
+export type ScenarioId =
+  | "inference"
+  | "capacity"
+  | "gateway"
+  | "prefix-cache-validation"
+  | "kv-cache-stress";
 
 export const scenarioIdSchema = z.enum([
   "inference",
   "capacity",
   "gateway",
   "prefix-cache-validation",
+  "kv-cache-stress",
 ]);
 
 export interface ScenarioConfig {
@@ -20,7 +26,8 @@ export interface ScenarioConfig {
     | "InferenceReport"
     | "CapacityReport"
     | "GatewayReport"
-    | "PrefixCacheProbeReport";
+    | "PrefixCacheProbeReport"
+    | "KvCacheStressReport";
 }
 
 export const SCENARIOS: Record<ScenarioId, ScenarioConfig> = {
@@ -60,6 +67,14 @@ export const SCENARIOS: Record<ScenarioId, ScenarioConfig> = {
     tools: ["prefix-cache-probe"],
     paramsConstraints: {},
     reportComponent: "PrefixCacheProbeReport",
+  },
+  "kv-cache-stress": {
+    label: "KV cache 后端压测",
+    description:
+      "多轮对话压测,触发 prefix-cache 驱逐,对比不同 KV 卸载后端(LMCache / YRCache / etc.)的 QPS、TTFT、Prefix Cache Savings",
+    tools: ["kv-cache-stress"],
+    paramsConstraints: {},
+    reportComponent: "KvCacheStressReport",
   },
 };
 

--- a/packages/tool-adapters/src/schemas-entry.ts
+++ b/packages/tool-adapters/src/schemas-entry.ts
@@ -39,6 +39,14 @@ export {
   type PrefixCacheProbeReport,
 } from "./prefix-cache-probe/schema.js";
 
+export {
+  kvCacheStressParamsSchema,
+  kvCacheStressReportSchema,
+  kvCacheStressParamDefaults,
+  type KvCacheStressParams,
+  type KvCacheStressReport,
+} from "./kv-cache-stress/schema.js";
+
 export type { ToolName, ProgressEvent, ToolReport } from "./core/interface.js";
 export { progressEventSchema } from "./core/progress-event.js";
 
@@ -59,4 +67,5 @@ export {
   GUIDELLM_CATEGORY_DEFAULTS,
   VEGETA_CATEGORY_DEFAULTS,
   PREFIX_CACHE_PROBE_CATEGORY_DEFAULTS,
+  KV_CACHE_STRESS_CATEGORY_DEFAULTS,
 } from "./category-defaults.js";

--- a/tools/build-runner-images.sh
+++ b/tools/build-runner-images.sh
@@ -40,7 +40,7 @@ fi
 
 echo "==> Building runner images at tag :$TAG"
 
-for tool in guidellm vegeta genai-perf prefix-cache-probe; do
+for tool in guidellm vegeta genai-perf prefix-cache-probe kv-cache-stress; do
   image="md-runner-${tool}:${TAG}"
   echo "==> docker build $image"
   docker build \
@@ -56,6 +56,7 @@ if [[ "$IMPORT" == "true" ]]; then
     "md-runner-vegeta:${TAG}" \
     "md-runner-genai-perf:${TAG}" \
     "md-runner-prefix-cache-probe:${TAG}" \
+    "md-runner-kv-cache-stress:${TAG}" \
     -c "$K3D_CLUSTER"
 fi
 
@@ -65,3 +66,4 @@ echo "RUNNER_IMAGE_GUIDELLM=md-runner-guidellm:${TAG}"
 echo "RUNNER_IMAGE_VEGETA=md-runner-vegeta:${TAG}"
 echo "RUNNER_IMAGE_GENAI_PERF=md-runner-genai-perf:${TAG}"
 echo "RUNNER_IMAGE_PREFIX_CACHE_PROBE=md-runner-prefix-cache-probe:${TAG}"
+echo "RUNNER_IMAGE_KV_CACHE_STRESS=md-runner-kv-cache-stress:${TAG}"


### PR DESCRIPTION
## Summary

Three coordinated changes driven by the 2026-05-10 / 2026-05-11 KV cache backend benchmarks in [theriseunion/repots](https://github.com/theriseunion/repots) on Atlas 800I A2 / 8×910B4:

- **New benchmark tool & scenario `kv-cache-stress`** — multi-turn deterministic workload (sha256-seeded prompts × N sessions × T turns) sized to force HBM eviction; reads Prom `vllm:prefix_cache_queries_total` delta + heuristic `lmcache:*` / `yrcache_*` counter scrape. Fills the gap that guidellm/genai-perf (random unique prompts → cache hit ≈ 0%) and the existing prefix-cache-probe (routing stickiness, not perf) can't cover. → `7eac2ac`
- **2 production deployment recipes for Qwen3-32B × vllm-ascend** with the new `community` `RecipeStatus` value (internal builds + hot-patches that aren't upstream). Covers LMCache CPU 100GB (QPS 3.75 / err 0%) and YRCache 3-tier CPU+Disk+Redis+NFS (QPS 3.39 / err 9-13%, cross-pod KV sharing). Includes the `PROMETHEUS_MULTIPROC_DIR` emptyDir requirement and the yrcache-1.5.0 vs vLLM-0.18 `KVConnectorFactory` compat hot-patch. → `67a929d`
- **2 official `kv-cache-stress` baseline templates in `seed.ts`** anchored to the measured numbers so the next operator can reproduce the comparison in 3 minutes from the UI instead of 6 stages × 25 minutes of kubectl-patching. Identical configs on purpose (controlled-variable methodology). → `9a8ec76`

Net change: 50 files (+2305 / -35), spec at `docs/superpowers/specs/2026-05-12-kv-cache-stress-tool-design.md`.

## Test plan

- [x] `pnpm type-check` — clean across contracts / tool-adapters / api / web
- [x] `pnpm lint` — exit 0 (remaining 42 warnings are pre-existing `any` in test files)
- [x] `pnpm test` — 1598 passed (contracts 110 + tool-adapters 162 + web 769 + api 557)
- [ ] Manual smoke: `pnpm dev` → benchmarks/kv-cache-stress page renders, form validates, template dropdown shows the 2 new official templates
- [ ] Manual smoke: `dev/deployments` page shows Qwen3-32B + vLLM-Ascend matrix cells with indigo ★ community badge, drawer renders command + params + notes correctly
- [ ] (optional) `pnpm -F @modeldoctor/api db:seed` on a dev DB — both new templates upsert without zod errors
- [ ] (optional) Real run: build the runner image via `tools/build-runner-images.sh` and trigger one short bench against an existing Qwen3-32B endpoint, verify final report shape matches `kvCacheStressReportSchema`

🤖 Generated with [Claude Code](https://claude.com/claude-code)