### PR TITLE
feat: evalscope+aiperf followup — air-gap baking + exhaustiveness refactor + polish

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -598,6 +598,27 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
     },
     tags: ["inference", "evalscope", "long-context"],
   },
+  {
+    id: "tpl_inf_aiperf_baseline",
+    name: "AIPerf · 综合基线",
+    description:
+      "AIPerf 通用基线:concurrency=8, 200 requests, synthetic 输入均值 1024 tokens / 输出均值 256 tokens。一发就有,适合横评。",
+    scenario: "inference",
+    tool: "aiperf",
+    config: {
+      concurrency: 8,
+      requestCount: 200,
+      inputTokensMean: 1024,
+      inputTokensStddev: 128,
+      outputTokensMean: 256,
+      outputTokensStddev: 64,
+      endpointType: "chat",
+      streaming: true,
+      dataset: "synthetic",
+      seed: 42,
+    },
+    tags: ["inference", "aiperf", "baseline", "synthetic"],
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/modules/benchmark/benchmark.service.spec.ts
+++ b/apps/api/src/modules/benchmark/benchmark.service.spec.ts
@@ -43,6 +43,19 @@ vi.mock("@modeldoctor/tool-adapters", async (orig) => {
       parseProgress: () => null,
       parseFinalReport: () => ({ tool: "guidellm", data: {} }),
       getMaxDurationSeconds: () => 1800,
+      // Minimal readMetric stub: just walk the shapes the report-summary
+      // tests below construct (`data.e2eLatency.p95`, `data.latencies.p95`).
+      // BenchmarkService.getByConnectionReports calls `byTool(tool).readMetric`
+      // via `readP95LatencyMs`, so the stub has to honor that contract.
+      readMetric: (kind: string, data: Record<string, unknown>) => {
+        if (kind === "e2e.p95") {
+          const e = (data.e2eLatency as { p95?: number } | undefined)?.p95;
+          if (typeof e === "number" && Number.isFinite(e)) return e;
+          const l = (data.latencies as { p95?: number } | undefined)?.p95;
+          return typeof l === "number" && Number.isFinite(l) ? l : null;
+        }
+        return null;
+      },
     }),
   };
 });

--- a/apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.spec.ts
+++ b/apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.spec.ts
@@ -175,6 +175,7 @@ describe("BenchmarkCallbackController", () => {
       parseProgress: () => null,
       parseFinalReport,
       getMaxDurationSeconds: () => 60,
+      readMetric: () => null,
     });
 
     repo.setup("benchmark-1", { id: "benchmark-1", tool: "guidellm", status: "running" });

--- a/apps/api/src/modules/benchmark/metrics.ts
+++ b/apps/api/src/modules/benchmark/metrics.ts
@@ -1,36 +1,17 @@
-import { type MetricKind, type ToolName, byTool } from "@modeldoctor/tool-adapters";
+import { readMetricSafe } from "@modeldoctor/tool-adapters";
 import type { Prisma } from "@prisma/client";
 
 /**
  * Backend twin of the FE `readP95Latency` reader
  * (apps/web/src/features/benchmarks/compare/metrics.ts). The per-tool field
  * paths live in each adapter's `readMetric(kind, data)` — this module just
- * picks a `MetricKind` and delegates. Adding a new tool only requires
- * registering its adapter; this file is tool-agnostic.
+ * picks a `MetricKind` and delegates via the shared `readMetricSafe`. Adding
+ * a new tool only requires registering its adapter; this file is
+ * tool-agnostic.
  *
  * Returns null whenever the metric is missing or non-finite. The reports
  * service treats null as "no data point in this run".
  */
-type Tagged = { tool?: unknown; data?: Record<string, unknown> };
-
-function asTagged(metrics: Prisma.JsonValue | null): Tagged | null {
-  if (!metrics || typeof metrics !== "object" || Array.isArray(metrics)) return null;
-  const m = metrics as Tagged;
-  return m.data && typeof m.data === "object" && !Array.isArray(m.data) ? m : null;
-}
-
-function readByKind(kind: MetricKind, metrics: Prisma.JsonValue | null): number | null {
-  const m = asTagged(metrics);
-  if (!m?.data || typeof m.tool !== "string") return null;
-  try {
-    return byTool(m.tool as ToolName).readMetric(kind, m.data);
-  } catch {
-    // byTool throws on unknown tool names; tolerate stale rows whose tool
-    // is no longer registered (e.g. a Run from a deleted-tool migration).
-    return null;
-  }
-}
-
 export function readP95LatencyMs(metrics: Prisma.JsonValue | null): number | null {
-  return readByKind("e2e.p95", metrics);
+  return readMetricSafe("e2e.p95", metrics as { tool?: unknown; data?: unknown } | null);
 }

--- a/apps/api/src/modules/benchmark/metrics.ts
+++ b/apps/api/src/modules/benchmark/metrics.ts
@@ -1,13 +1,12 @@
+import { type MetricKind, type ToolName, byTool } from "@modeldoctor/tool-adapters";
 import type { Prisma } from "@prisma/client";
 
 /**
  * Backend twin of the FE `readP95Latency` reader
- * (apps/web/src/features/benchmarks/compare/metrics.ts). Kept in sync
- * with the tool-adapter parseFinalReport shapes:
- *   guidellm           → data.e2eLatency.p95   (ms)
- *   vegeta             → data.latencies.p95    (ms; runtime normalizes from
- *                                                Go-duration units before persist)
- *   evalscope / aiperf → data.e2eLatency.p95   (ms; shared shape)
+ * (apps/web/src/features/benchmarks/compare/metrics.ts). The per-tool field
+ * paths live in each adapter's `readMetric(kind, data)` — this module just
+ * picks a `MetricKind` and delegates. Adding a new tool only requires
+ * registering its adapter; this file is tool-agnostic.
  *
  * Returns null whenever the metric is missing or non-finite. The reports
  * service treats null as "no data point in this run".
@@ -20,27 +19,18 @@ function asTagged(metrics: Prisma.JsonValue | null): Tagged | null {
   return m.data && typeof m.data === "object" && !Array.isArray(m.data) ? m : null;
 }
 
-function asFiniteNumber(v: unknown): number | null {
-  return typeof v === "number" && Number.isFinite(v) ? v : null;
-}
-
-function fromDist(data: Record<string, unknown>, key: string, field: string): number | null {
-  const dist = data[key] as Record<string, unknown> | undefined;
-  return asFiniteNumber(dist?.[field]);
+function readByKind(kind: MetricKind, metrics: Prisma.JsonValue | null): number | null {
+  const m = asTagged(metrics);
+  if (!m?.data || typeof m.tool !== "string") return null;
+  try {
+    return byTool(m.tool as ToolName).readMetric(kind, m.data);
+  } catch {
+    // byTool throws on unknown tool names; tolerate stale rows whose tool
+    // is no longer registered (e.g. a Run from a deleted-tool migration).
+    return null;
+  }
 }
 
 export function readP95LatencyMs(metrics: Prisma.JsonValue | null): number | null {
-  const m = asTagged(metrics);
-  if (!m?.data) return null;
-  switch (m.tool) {
-    case "guidellm":
-      return fromDist(m.data, "e2eLatency", "p95");
-    case "vegeta":
-      return fromDist(m.data, "latencies", "p95");
-    case "evalscope":
-    case "aiperf":
-      return fromDist(m.data, "e2eLatency", "p95");
-    default:
-      return null;
-  }
+  return readByKind("e2e.p95", metrics);
 }

--- a/apps/api/src/modules/insights/metrics.ts
+++ b/apps/api/src/modules/insights/metrics.ts
@@ -1,90 +1,40 @@
+import { type MetricKind, type ToolName, byTool } from "@modeldoctor/tool-adapters";
+
 type MetricsBlob = { tool?: string; data?: Record<string, any> } | null | undefined;
 
-function fromDist(m: MetricsBlob, key: string, field: string): number | null {
-  const v = m?.data?.[key]?.[field];
-  return typeof v === "number" && Number.isFinite(v) ? v : null;
-}
+/**
+ * Check-id (used by ComparisonService.ALL_CHECK_IDS) → adapter MetricKind.
+ * Multiple scenario-prefixed check ids can collapse to the same MetricKind —
+ * e.g. inference / capacity / gateway error_rate all read the same field.
+ * Anything not in this map (yet) returns null.
+ */
+const CHECK_ID_TO_METRIC_KIND: Record<string, MetricKind> = {
+  "inference.ttft.p95.ms": "ttft.p95",
+  "inference.ttft.p99.ms": "ttft.p99",
+  "inference.itl.p95.ms": "itl.p95",
+  "inference.e2e.p95.ms": "e2e.p95",
+  "inference.e2e.p99.ms": "e2e.p99",
+  "inference.error_rate": "errorRate",
+  "capacity.error_rate": "errorRate",
+  "gateway.error_rate": "errorRate",
+  "inference.throughput.req_per_s": "requestsPerSec",
+  "capacity.max_qps": "requestsPerSec",
+  "gateway.throughput.req_per_s": "requestsPerSec",
+  "capacity.tail_ratio": "tailRatio",
+  "gateway.tail_ratio": "tailRatio",
+};
 
 export function extractMetric(m: MetricsBlob, checkId: string): number | null {
   if (!m?.tool || !m?.data) return null;
-  switch (checkId) {
-    case "inference.ttft.p95.ms":
-      if (m.tool === "guidellm") return fromDist(m, "ttft", "p95");
-      if (m.tool === "evalscope" || m.tool === "aiperf") return fromDist(m, "ttft", "p95");
-      return null;
-    case "inference.ttft.p99.ms":
-      if (m.tool === "guidellm") return fromDist(m, "ttft", "p99");
-      if (m.tool === "evalscope" || m.tool === "aiperf") return fromDist(m, "ttft", "p99");
-      return null;
-    case "inference.itl.p95.ms":
-      if (m.tool === "guidellm") return fromDist(m, "itl", "p95");
-      if (m.tool === "evalscope" || m.tool === "aiperf") return fromDist(m, "itl", "p95");
-      return null;
-    case "inference.e2e.p95.ms":
-      if (m.tool === "guidellm") return fromDist(m, "e2eLatency", "p95");
-      if (m.tool === "vegeta") return fromDist(m, "latencies", "p95");
-      if (m.tool === "evalscope" || m.tool === "aiperf") return fromDist(m, "e2eLatency", "p95");
-      return null;
-    case "inference.e2e.p99.ms":
-      if (m.tool === "guidellm") return fromDist(m, "e2eLatency", "p99");
-      if (m.tool === "vegeta") return fromDist(m, "latencies", "p99");
-      if (m.tool === "evalscope" || m.tool === "aiperf") return fromDist(m, "e2eLatency", "p99");
-      return null;
-    case "inference.error_rate":
-    case "capacity.error_rate":
-    case "gateway.error_rate":
-      if (m.tool === "guidellm") {
-        const r = m.data.requests as { total?: number; error?: number } | undefined;
-        const t = r?.total;
-        const e = r?.error;
-        if (typeof t !== "number" || typeof e !== "number" || t === 0) return null;
-        return e / t;
-      }
-      if (m.tool === "vegeta") {
-        const s = m.data.success;
-        return typeof s === "number" ? 1 - s / 100 : null;
-      }
-      if (m.tool === "evalscope" || m.tool === "aiperf") {
-        // evalscope/aiperf carry requests.errorRate as a 0-1 fraction directly,
-        // so no division by total is required.
-        const r = m.data.requests as { errorRate?: number } | undefined;
-        const er = r?.errorRate;
-        return typeof er === "number" && Number.isFinite(er) ? er : null;
-      }
-      return null;
-    case "inference.throughput.req_per_s":
-    case "capacity.max_qps":
-    case "gateway.throughput.req_per_s": {
-      if (m.tool === "guidellm") return m.data.requestsPerSecond?.mean ?? null;
-      if (m.tool === "vegeta") return m.data.requests?.throughput ?? null;
-      if (m.tool === "evalscope" || m.tool === "aiperf") {
-        const t = m.data.throughput as { requestsPerSec?: number } | undefined;
-        const v = t?.requestsPerSec;
-        return typeof v === "number" && Number.isFinite(v) ? v : null;
-      }
-      return null;
-    }
-    case "capacity.tail_ratio":
-    case "gateway.tail_ratio": {
-      let p50: number | null = null;
-      let p99: number | null = null;
-      if (m.tool === "guidellm") {
-        p50 = m.data.e2eLatency?.p50 ?? null;
-        p99 = m.data.e2eLatency?.p99 ?? null;
-      }
-      if (m.tool === "vegeta") {
-        p50 = m.data.latencies?.p50 ?? null;
-        p99 = m.data.latencies?.p99 ?? null;
-      }
-      if (m.tool === "evalscope" || m.tool === "aiperf") {
-        p50 = m.data.e2eLatency?.p50 ?? null;
-        p99 = m.data.e2eLatency?.p99 ?? null;
-      }
-      if (typeof p50 !== "number" || typeof p99 !== "number" || p50 <= 0) return null;
-      return p99 / p50;
-    }
+  const kind = CHECK_ID_TO_METRIC_KIND[checkId];
+  if (!kind) return null;
+  try {
+    return byTool(m.tool as ToolName).readMetric(kind, m.data);
+  } catch {
+    // byTool throws on unknown tool names; tolerate stale rows whose tool
+    // is no longer registered (e.g. a Run from a deleted-tool migration).
+    return null;
   }
-  return null;
 }
 
 export function median(values: number[]): number {

--- a/apps/api/src/modules/insights/metrics.ts
+++ b/apps/api/src/modules/insights/metrics.ts
@@ -1,4 +1,4 @@
-import { type MetricKind, type ToolName, byTool } from "@modeldoctor/tool-adapters";
+import { type MetricKind, readMetricSafe } from "@modeldoctor/tool-adapters";
 
 type MetricsBlob = { tool?: string; data?: Record<string, any> } | null | undefined;
 
@@ -25,16 +25,9 @@ const CHECK_ID_TO_METRIC_KIND: Record<string, MetricKind> = {
 };
 
 export function extractMetric(m: MetricsBlob, checkId: string): number | null {
-  if (!m?.tool || !m?.data) return null;
   const kind = CHECK_ID_TO_METRIC_KIND[checkId];
   if (!kind) return null;
-  try {
-    return byTool(m.tool as ToolName).readMetric(kind, m.data);
-  } catch {
-    // byTool throws on unknown tool names; tolerate stale rows whose tool
-    // is no longer registered (e.g. a Run from a deleted-tool migration).
-    return null;
-  }
+  return readMetricSafe(kind, m);
 }
 
 export function median(values: number[]): number {

--- a/apps/api/src/modules/saved-compares/metrics.ts
+++ b/apps/api/src/modules/saved-compares/metrics.ts
@@ -1,44 +1,15 @@
-import { type MetricKind, type ToolName, byTool } from "@modeldoctor/tool-adapters";
-
-type Tagged = { tool?: string; data?: Record<string, unknown> };
-
-export function asTagged(m: unknown): Tagged | null {
-  if (!m || typeof m !== "object") return null;
-  const t = m as Tagged;
-  return t.data ? t : null;
-}
-
-function asFiniteNumber(v: unknown): number | null {
-  return typeof v === "number" && Number.isFinite(v) ? v : null;
-}
-
-function fromDist(data: Record<string, unknown>, key: string, field: string): number | null {
-  const dist = data[key] as Record<string, unknown> | undefined;
-  return asFiniteNumber(dist?.[field]);
-}
-
-function readByKind(kind: MetricKind, m: unknown): number | null {
-  const t = asTagged(m);
-  if (!t?.data || typeof t.tool !== "string") return null;
-  try {
-    return byTool(t.tool as ToolName).readMetric(kind, t.data);
-  } catch {
-    // byTool throws on unknown tool names; tolerate stale rows whose tool
-    // is no longer registered (e.g. a Run from a deleted-tool migration).
-    return null;
-  }
-}
+import { readMetricSafe } from "@modeldoctor/tool-adapters";
 
 export function readP95Latency(m: unknown): number | null {
-  return readByKind("e2e.p95", m);
+  return readMetricSafe("e2e.p95", m as { tool?: unknown; data?: unknown } | null);
 }
 
 export function readErrorRate(m: unknown): number | null {
-  return readByKind("errorRate", m);
+  return readMetricSafe("errorRate", m as { tool?: unknown; data?: unknown } | null);
 }
 
 export function readThroughput(m: unknown): number | null {
-  return readByKind("requestsPerSec", m);
+  return readMetricSafe("requestsPerSec", m as { tool?: unknown; data?: unknown } | null);
 }
 
 export interface PromptMetricsSummary {
@@ -51,49 +22,31 @@ export interface PromptMetricsSummary {
 /**
  * Build a compact metrics snapshot for AI compare narratives.
  *
- * The scalar readers (throughput, errorRate) delegate to `adapter.readMetric`.
- * The p50/p90/p99 dist buckets need a per-tool field-path lookup because the
- * shared `MetricKind` enum exposes only p95/p99 percentiles — adding p50/p90
- * is a future Task 5 extension. Until then, the tool→dist-key resolution lives
- * inline; the table is intentionally tiny so future tool additions are obvious.
+ * All field reads delegate to `readMetricSafe`. The `ttft` and `e2e`
+ * sub-objects are null when the tool doesn't carry that distribution at
+ * all (vegeta has no TTFT) — detected by checking whether any of p50/p90/p99
+ * resolves to a number. Now that `MetricKind` includes the p50/p90 buckets,
+ * no per-tool field-path table is needed.
  */
-const TTFT_DIST_KEY: Partial<Record<ToolName, string>> = {
-  guidellm: "ttft",
-  evalscope: "ttft",
-  aiperf: "ttft",
-  // vegeta is single-shot HTTP; no TTFT.
-};
-const E2E_DIST_KEY: Partial<Record<ToolName, string>> = {
-  guidellm: "e2eLatency",
-  evalscope: "e2eLatency",
-  aiperf: "e2eLatency",
-  vegeta: "latencies",
-};
-
 export function summarizeForPrompt(m: unknown): PromptMetricsSummary {
-  const t = asTagged(m);
-  const tool = t?.tool as ToolName | undefined;
-  const ttftKey = tool ? TTFT_DIST_KEY[tool] : undefined;
-  const e2eKey = tool ? E2E_DIST_KEY[tool] : undefined;
+  const summary = m as { tool?: unknown; data?: unknown } | null;
+  const ttftP50 = readMetricSafe("ttft.p50", summary);
+  const ttftP90 = readMetricSafe("ttft.p90", summary);
+  const ttftP99 = readMetricSafe("ttft.p99", summary);
+  const e2eP50 = readMetricSafe("e2e.p50", summary);
+  const e2eP90 = readMetricSafe("e2e.p90", summary);
+  const e2eP99 = readMetricSafe("e2e.p99", summary);
 
   return {
-    throughput: readThroughput(m),
-    errorRate: readErrorRate(m),
+    throughput: readMetricSafe("requestsPerSec", summary),
+    errorRate: readMetricSafe("errorRate", summary),
     ttft:
-      t?.data && ttftKey
-        ? {
-            p50: fromDist(t.data, ttftKey, "p50"),
-            p90: fromDist(t.data, ttftKey, "p90"),
-            p99: fromDist(t.data, ttftKey, "p99"),
-          }
-        : null,
+      ttftP50 === null && ttftP90 === null && ttftP99 === null
+        ? null
+        : { p50: ttftP50, p90: ttftP90, p99: ttftP99 },
     e2e:
-      t?.data && e2eKey
-        ? {
-            p50: fromDist(t.data, e2eKey, "p50"),
-            p90: fromDist(t.data, e2eKey, "p90"),
-            p99: fromDist(t.data, e2eKey, "p99"),
-          }
-        : null,
+      e2eP50 === null && e2eP90 === null && e2eP99 === null
+        ? null
+        : { p50: e2eP50, p90: e2eP90, p99: e2eP99 },
   };
 }

--- a/apps/api/src/modules/saved-compares/metrics.ts
+++ b/apps/api/src/modules/saved-compares/metrics.ts
@@ -1,3 +1,5 @@
+import { type MetricKind, type ToolName, byTool } from "@modeldoctor/tool-adapters";
+
 type Tagged = { tool?: string; data?: Record<string, unknown> };
 
 export function asTagged(m: unknown): Tagged | null {
@@ -15,65 +17,28 @@ function fromDist(data: Record<string, unknown>, key: string, field: string): nu
   return asFiniteNumber(dist?.[field]);
 }
 
-export function readP95Latency(m: unknown): number | null {
+function readByKind(kind: MetricKind, m: unknown): number | null {
   const t = asTagged(m);
-  if (!t?.data) return null;
-  switch (t.tool) {
-    case "guidellm":
-      return fromDist(t.data, "e2eLatency", "p95");
-    case "vegeta":
-      return fromDist(t.data, "latencies", "p95");
-    case "evalscope":
-    case "aiperf":
-      return fromDist(t.data, "e2eLatency", "p95");
-    default:
-      return null;
+  if (!t?.data || typeof t.tool !== "string") return null;
+  try {
+    return byTool(t.tool as ToolName).readMetric(kind, t.data);
+  } catch {
+    // byTool throws on unknown tool names; tolerate stale rows whose tool
+    // is no longer registered (e.g. a Run from a deleted-tool migration).
+    return null;
   }
+}
+
+export function readP95Latency(m: unknown): number | null {
+  return readByKind("e2e.p95", m);
 }
 
 export function readErrorRate(m: unknown): number | null {
-  const t = asTagged(m);
-  if (!t?.data) return null;
-  switch (t.tool) {
-    case "guidellm": {
-      const r = t.data.requests as { total?: number; error?: number } | undefined;
-      const total = asFiniteNumber(r?.total);
-      const error = asFiniteNumber(r?.error);
-      if (total === null || error === null || total === 0) return null;
-      return error / total;
-    }
-    case "vegeta": {
-      const s = asFiniteNumber(t.data.success);
-      return s === null ? null : 1 - s / 100;
-    }
-    case "evalscope":
-    case "aiperf": {
-      // evalscope/aiperf schemas carry errorRate as a 0-1 fraction directly,
-      // so no division by total is required.
-      const r = t.data.requests as { errorRate?: number } | undefined;
-      return asFiniteNumber(r?.errorRate);
-    }
-    default:
-      return null;
-  }
+  return readByKind("errorRate", m);
 }
 
 export function readThroughput(m: unknown): number | null {
-  const t = asTagged(m);
-  if (!t?.data) return null;
-  switch (t.tool) {
-    case "guidellm":
-      return asFiniteNumber((t.data.requestsPerSecond as { mean?: number } | undefined)?.mean);
-    case "vegeta":
-      return asFiniteNumber((t.data.requests as { throughput?: number } | undefined)?.throughput);
-    case "evalscope":
-    case "aiperf":
-      return asFiniteNumber(
-        (t.data.throughput as { requestsPerSec?: number } | undefined)?.requestsPerSec,
-      );
-    default:
-      return null;
-  }
+  return readByKind("requestsPerSec", m);
 }
 
 export interface PromptMetricsSummary {
@@ -83,18 +48,33 @@ export interface PromptMetricsSummary {
   e2e: { p50: number | null; p90: number | null; p99: number | null } | null;
 }
 
+/**
+ * Build a compact metrics snapshot for AI compare narratives.
+ *
+ * The scalar readers (throughput, errorRate) delegate to `adapter.readMetric`.
+ * The p50/p90/p99 dist buckets need a per-tool field-path lookup because the
+ * shared `MetricKind` enum exposes only p95/p99 percentiles — adding p50/p90
+ * is a future Task 5 extension. Until then, the tool→dist-key resolution lives
+ * inline; the table is intentionally tiny so future tool additions are obvious.
+ */
+const TTFT_DIST_KEY: Partial<Record<ToolName, string>> = {
+  guidellm: "ttft",
+  evalscope: "ttft",
+  aiperf: "ttft",
+  // vegeta is single-shot HTTP; no TTFT.
+};
+const E2E_DIST_KEY: Partial<Record<ToolName, string>> = {
+  guidellm: "e2eLatency",
+  evalscope: "e2eLatency",
+  aiperf: "e2eLatency",
+  vegeta: "latencies",
+};
+
 export function summarizeForPrompt(m: unknown): PromptMetricsSummary {
   const t = asTagged(m);
-  const tool = t?.tool;
-  // evalscope + aiperf share the same nested ttft / e2eLatency dist shape as
-  // guidellm. vegeta has no TTFT (single-shot HTTP), so ttftKey stays null.
-  const ttftKey = tool === "guidellm" || tool === "evalscope" || tool === "aiperf" ? "ttft" : null;
-  const e2eKey =
-    tool === "guidellm" || tool === "evalscope" || tool === "aiperf"
-      ? "e2eLatency"
-      : tool === "vegeta"
-        ? "latencies"
-        : null;
+  const tool = t?.tool as ToolName | undefined;
+  const ttftKey = tool ? TTFT_DIST_KEY[tool] : undefined;
+  const e2eKey = tool ? E2E_DIST_KEY[tool] : undefined;
 
   return {
     throughput: readThroughput(m),

--- a/apps/benchmark-runner/README.md
+++ b/apps/benchmark-runner/README.md
@@ -154,3 +154,28 @@ docker run --rm \
   -e MD_OUTPUT_FILES='{"report":"report.json"}' \
   md-runner-guidellm:dev3
 ```
+
+## Air-gapped clusters
+
+The evalscope + aiperf images bake their datasets at build time so runs work without internet egress from the cluster:
+
+| Image | Dataset enum value | Baked path | Source |
+|---|---|---|---|
+| evalscope | `longalpaca` | `/opt/evalscope-datasets/longalpaca/` | `AI-ModelScope/LongAlpaca-12k` (modelscope) |
+| evalscope | `openqa` | `/opt/evalscope-datasets/openqa/open_qa.jsonl` | `AI-ModelScope/HC3-Chinese:open_qa.jsonl` |
+| evalscope | `random` | n/a (synthetic) | — |
+| aiperf | `sharegpt` | `/app/.cache/aiperf/datasets/ShareGPT_V3_unfiltered_cleaned_split.json` | `anon8231489123/ShareGPT_Vicuna_unfiltered` (HuggingFace) |
+| aiperf | `synthetic` | n/a (built-in generator) | — |
+
+After build + before deploy, run `apps/benchmark-runner/scripts/verify-airgap.sh` to confirm every baked path is reachable with `--network none`.
+
+Image-size impact (rough):
+
+- `md-runner-evalscope`: ~1.75 GB (`python:3.11-slim` base + evalscope ~1.4 GB + LongAlpaca ~200 MB + open_qa ~50 MB)
+- `md-runner-aiperf`: ~1.7 GB (base + aiperf deps ~300 MB + ShareGPT ~672 MB)
+
+If a future dataset needs to be added:
+1. Add the bake step in the relevant Dockerfile.
+2. Add the path to `packages/tool-adapters/src/<tool>/runtime.ts` `BAKED_DATASET_PATHS` (evalscope) or document where the loader picks it up (aiperf).
+3. Add a check to `verify-airgap.sh`.
+4. Update this table.

--- a/apps/benchmark-runner/images/aiperf.Dockerfile
+++ b/apps/benchmark-runner/images/aiperf.Dockerfile
@@ -1,9 +1,8 @@
 # syntax=docker/dockerfile:1.6
 
-# Replacement for the deprecated genai-perf image. AIPerf is the
-# NVIDIA-recommended successor (ai-dynamo/aiperf). Same posture as
-# genai-perf: python-slim base, the perf tool is a pure-Python load
-# generator (no GPU / CUDA needed).
+# NVIDIA aiperf (ai-dynamo) perf load generator. Bakes ShareGPT V3
+# corpus (~672 MB) at build time so --public-dataset sharegpt works
+# on air-gapped clusters. Image ~1.7 GB.
 FROM python:3.11-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -17,6 +16,18 @@ RUN pip install --no-cache-dir \
 
 WORKDIR /app
 COPY runner runner
+
+# Bake ShareGPT V3 corpus (~672 MB) so --public-dataset sharegpt
+# works on air-gapped clusters. aiperf's ShareGPTLoader resolves
+# `.cache/aiperf/datasets/<filename>` relative to WORKDIR (/app);
+# pre-populate that exact path. Image goes from ~1 GB to ~1.7 GB.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && mkdir -p /app/.cache/aiperf/datasets \
+    && curl -fL --output /app/.cache/aiperf/datasets/ShareGPT_V3_unfiltered_cleaned_split.json \
+        https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json \
+    && apt-get purge -y --auto-remove curl \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --create-home --shell /sbin/nologin runner \
     && chown -R runner:runner /app

--- a/apps/benchmark-runner/images/evalscope.Dockerfile
+++ b/apps/benchmark-runner/images/evalscope.Dockerfile
@@ -1,10 +1,8 @@
 # syntax=docker/dockerfile:1.6
 
-# Phase 1 of evalscope rollout. evalscope is the load generator, not the
-# model server. Bake LongAlpaca-12k at build time so air-gapped clusters
-# can run the official 6-task methodology without runtime network egress.
-# Image ~1.7 GB (python:3.11-slim ~130 MB + evalscope+deps ~1.4 GB +
-# LongAlpaca dataset ~200 MB).
+# Modelscope evalscope perf load generator. Bakes LongAlpaca-12k +
+# HC3-Chinese open_qa.jsonl at build time so the image runs on
+# air-gapped clusters. Image ~1.75 GB.
 FROM python:3.11-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/apps/benchmark-runner/images/evalscope.Dockerfile
+++ b/apps/benchmark-runner/images/evalscope.Dockerfile
@@ -24,6 +24,14 @@ RUN modelscope download \
         --dataset AI-ModelScope/LongAlpaca-12k \
         --local_dir /opt/evalscope-datasets/longalpaca
 
+# Bake openqa (HC3-Chinese) for the inf-evalscope-short template + any
+# openqa-driven manual runs. Only open_qa.jsonl is needed.
+RUN python -c "from modelscope import dataset_snapshot_download; \
+    import shutil, os; \
+    p = dataset_snapshot_download('AI-ModelScope/HC3-Chinese', allow_patterns=['open_qa.jsonl']); \
+    os.makedirs('/opt/evalscope-datasets/openqa', exist_ok=True); \
+    shutil.copy(os.path.join(p, 'open_qa.jsonl'), '/opt/evalscope-datasets/openqa/open_qa.jsonl')"
+
 WORKDIR /app
 COPY runner runner
 

--- a/apps/benchmark-runner/scripts/verify-airgap.sh
+++ b/apps/benchmark-runner/scripts/verify-airgap.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Verify the evalscope + aiperf runner images can boot and access
+# every baked dataset enum value WITHOUT network egress. Run after
+# building the images locally (or against pulled :latest images).
+#
+# Usage:
+#   ./apps/benchmark-runner/scripts/verify-airgap.sh
+#   IMAGE_EVALSCOPE=md-runner-evalscope:dev ./apps/benchmark-runner/scripts/verify-airgap.sh
+#   IMAGE_AIPERF=md-runner-aiperf:dev ./apps/benchmark-runner/scripts/verify-airgap.sh
+#
+# Adds nothing to CI today — manual gate for the deploying operator.
+
+set -euo pipefail
+
+EVALSCOPE_IMAGE="${IMAGE_EVALSCOPE:-md-runner-evalscope:dev}"
+AIPERF_IMAGE="${IMAGE_AIPERF:-md-runner-aiperf:dev}"
+
+pass() { printf "  \033[32m✓\033[0m %s\n" "$1"; }
+fail() { printf "  \033[31m✗\033[0m %s\n" "$1"; exit 1; }
+
+echo "==> evalscope (${EVALSCOPE_IMAGE})"
+docker run --rm --network none --entrypoint /bin/sh "$EVALSCOPE_IMAGE" \
+  -c 'test -d /opt/evalscope-datasets/longalpaca && ls /opt/evalscope-datasets/longalpaca | head -1' \
+  >/dev/null && pass "longalpaca baked" || fail "longalpaca missing"
+
+docker run --rm --network none --entrypoint /bin/sh "$EVALSCOPE_IMAGE" \
+  -c 'test -s /opt/evalscope-datasets/openqa/open_qa.jsonl' \
+  >/dev/null && pass "openqa baked (open_qa.jsonl)" || fail "openqa missing"
+
+echo "==> aiperf (${AIPERF_IMAGE})"
+docker run --rm --network none --entrypoint /bin/sh "$AIPERF_IMAGE" \
+  -c 'test -s /app/.cache/aiperf/datasets/ShareGPT_V3_unfiltered_cleaned_split.json' \
+  >/dev/null && pass "ShareGPT baked" || fail "ShareGPT missing"
+
+echo
+echo "==> all baked datasets present; air-gapped runs supported."

--- a/apps/web/src/features/benchmarks/__tests__/reports/CapacityReport.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/reports/CapacityReport.test.tsx
@@ -1,6 +1,7 @@
 import type { Benchmark } from "@modeldoctor/contracts";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import "@/lib/i18n";
 import { CapacityReport } from "../../reports/CapacityReport";
 
 const guidellmReport = {

--- a/apps/web/src/features/benchmarks/__tests__/reports/InferenceReport.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/reports/InferenceReport.test.tsx
@@ -1,6 +1,7 @@
 import type { Benchmark } from "@modeldoctor/contracts";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import "@/lib/i18n";
 import { InferenceReport } from "../../reports/InferenceReport";
 
 const guidellmReport = {

--- a/apps/web/src/features/benchmarks/compare/client-metrics.ts
+++ b/apps/web/src/features/benchmarks/compare/client-metrics.ts
@@ -1,19 +1,4 @@
-type Tagged = { tool?: string; data?: Record<string, unknown> };
-
-function asTagged(m: unknown): Tagged | null {
-  if (!m || typeof m !== "object") return null;
-  const t = m as Tagged;
-  return t.data ? t : null;
-}
-
-function asFiniteNumber(v: unknown): number | null {
-  return typeof v === "number" && Number.isFinite(v) ? v : null;
-}
-
-function fromDist(data: Record<string, unknown>, key: string, field: string): number | null {
-  const dist = data[key] as Record<string, unknown> | undefined;
-  return asFiniteNumber(dist?.[field]);
-}
+import { readMetricSafe } from "@modeldoctor/tool-adapters/schemas";
 
 export interface PromptMetricsSummary {
   throughput: number | null;
@@ -25,70 +10,32 @@ export interface PromptMetricsSummary {
 /**
  * Client-side mirror of `apps/api/src/modules/saved-compares/metrics.ts#summarizeForPrompt`.
  * Used by `StageBarChartsSection` to derive chart datasets from raw `summaryMetrics`
- * blobs without round-tripping through the server. Keep in sync with the server reader
- * — both sides must agree on tool-specific dist key mapping.
+ * blobs without round-tripping through the server.
+ *
+ * All per-tool field-path logic lives in each adapter's `readMetric`; this
+ * function just picks the right `MetricKind`s and delegates via the FE-safe
+ * `readMetricSafe`. The `ttft` / `e2e` sub-objects collapse to null only when
+ * every dist bucket is null (e.g. vegeta has no TTFT at all).
  */
 export function summarizeForPrompt(m: unknown): PromptMetricsSummary {
-  const t = asTagged(m);
-  const tool = t?.tool;
-  // evalscope + aiperf share the same nested ttft / e2eLatency dist shape as
-  // guidellm. vegeta has no TTFT (single-shot HTTP), so ttftKey stays null.
-  const ttftKey = tool === "guidellm" || tool === "evalscope" || tool === "aiperf" ? "ttft" : null;
-  const e2eKey =
-    tool === "guidellm" || tool === "evalscope" || tool === "aiperf"
-      ? "e2eLatency"
-      : tool === "vegeta"
-        ? "latencies"
-        : null;
-
-  const throughput = !t?.data
-    ? null
-    : tool === "guidellm"
-      ? asFiniteNumber((t.data.requestsPerSecond as { mean?: number } | undefined)?.mean)
-      : tool === "vegeta"
-        ? asFiniteNumber((t.data.requests as { throughput?: number } | undefined)?.throughput)
-        : tool === "evalscope" || tool === "aiperf"
-          ? asFiniteNumber(
-              (t.data.throughput as { requestsPerSec?: number } | undefined)?.requestsPerSec,
-            )
-          : null;
-
-  let errorRate: number | null = null;
-  if (t?.data) {
-    if (tool === "guidellm") {
-      const r = t.data.requests as { total?: number; error?: number } | undefined;
-      const total = asFiniteNumber(r?.total);
-      const err = asFiniteNumber(r?.error);
-      errorRate = total !== null && total > 0 && err !== null ? err / total : null;
-    } else if (tool === "vegeta") {
-      const s = asFiniteNumber(t.data.success);
-      errorRate = s === null ? null : 1 - s / 100;
-    } else if (tool === "evalscope" || tool === "aiperf") {
-      // evalscope/aiperf carry requests.errorRate as a 0-1 fraction directly,
-      // so no division by total is required.
-      const r = t.data.requests as { errorRate?: number } | undefined;
-      errorRate = asFiniteNumber(r?.errorRate);
-    }
-  }
+  const summary = m as { tool?: unknown; data?: unknown } | null;
+  const ttftP50 = readMetricSafe("ttft.p50", summary);
+  const ttftP90 = readMetricSafe("ttft.p90", summary);
+  const ttftP99 = readMetricSafe("ttft.p99", summary);
+  const e2eP50 = readMetricSafe("e2e.p50", summary);
+  const e2eP90 = readMetricSafe("e2e.p90", summary);
+  const e2eP99 = readMetricSafe("e2e.p99", summary);
 
   return {
-    throughput,
-    errorRate,
+    throughput: readMetricSafe("requestsPerSec", summary),
+    errorRate: readMetricSafe("errorRate", summary),
     ttft:
-      t?.data && ttftKey
-        ? {
-            p50: fromDist(t.data, ttftKey, "p50"),
-            p90: fromDist(t.data, ttftKey, "p90"),
-            p99: fromDist(t.data, ttftKey, "p99"),
-          }
-        : null,
+      ttftP50 === null && ttftP90 === null && ttftP99 === null
+        ? null
+        : { p50: ttftP50, p90: ttftP90, p99: ttftP99 },
     e2e:
-      t?.data && e2eKey
-        ? {
-            p50: fromDist(t.data, e2eKey, "p50"),
-            p90: fromDist(t.data, e2eKey, "p90"),
-            p99: fromDist(t.data, e2eKey, "p99"),
-          }
-        : null,
+      e2eP50 === null && e2eP90 === null && e2eP99 === null
+        ? null
+        : { p50: e2eP50, p90: e2eP90, p99: e2eP99 },
   };
 }

--- a/apps/web/src/features/benchmarks/compare/metrics.ts
+++ b/apps/web/src/features/benchmarks/compare/metrics.ts
@@ -1,97 +1,30 @@
 import type { Benchmark, BenchmarkTool } from "@modeldoctor/contracts";
+import { type MetricKind, readMetricSafe } from "@modeldoctor/tool-adapters/schemas";
 
 // summaryMetrics is the discriminated union written by tool-adapter
 // parseFinalReport: { tool, data } (see
 // packages/tool-adapters/src/{guidellm,vegeta,aiperf,evalscope}/runtime.ts).
 // vegeta latencies are normalized to ms by the adapter (NOT ns).
+//
+// All per-tool field-path logic now lives in each adapter's `readMetric`
+// (see packages/tool-adapters/src/<tool>/read-metric.ts). This module
+// just picks `MetricKind`s and delegates via the shared `readMetricSafe`
+// helper — adding a new tool / metric updates exactly one adapter file.
 
 type SummaryMetrics = Benchmark["summaryMetrics"];
-type Tagged = { tool?: string; data?: Record<string, unknown> };
-
-function asTagged(metrics: SummaryMetrics): Tagged | null {
-  if (!metrics) return null;
-  const m = metrics as Tagged;
-  return m.data ? m : null;
-}
-
-// Number.isFinite filters NaN and ±Infinity. The verdict.ts contract requires
-// finite numbers; routing every reader through this guard means upstream
-// adapter regressions (e.g. a future tool emitting `0/0 = NaN`) degrade to
-// `null` here instead of poisoning delta math downstream.
-function asFiniteNumber(v: unknown): number | null {
-  return typeof v === "number" && Number.isFinite(v) ? v : null;
-}
-
-function fromDist(data: Record<string, unknown>, key: string, field: string): number | null {
-  const dist = data[key] as Record<string, unknown> | undefined;
-  return asFiniteNumber(dist?.[field]);
-}
 
 // ─── Verdict-eligible readers ────────────────────────────────────────────────
 
 export function readP95Latency(metrics: SummaryMetrics): number | null {
-  const m = asTagged(metrics);
-  if (!m?.data) return null;
-  switch (m.tool) {
-    case "guidellm":
-      return fromDist(m.data, "e2eLatency", "p95");
-    case "vegeta":
-      return fromDist(m.data, "latencies", "p95");
-    case "evalscope":
-    case "aiperf":
-      return fromDist(m.data, "e2eLatency", "p95");
-    default:
-      return null;
-  }
+  return readMetricSafe("e2e.p95", metrics as { tool?: unknown; data?: unknown } | null);
 }
 
 export function readErrorRate(metrics: SummaryMetrics): number | null {
-  const m = asTagged(metrics);
-  if (!m?.data) return null;
-  switch (m.tool) {
-    case "guidellm": {
-      const r = m.data.requests as { total?: number; error?: number } | undefined;
-      const total = asFiniteNumber(r?.total);
-      const error = asFiniteNumber(r?.error);
-      if (total === null || error === null || total === 0) return null;
-      return error / total;
-    }
-    case "vegeta": {
-      const s = asFiniteNumber(m.data.success);
-      return s === null ? null : 1 - s / 100;
-    }
-    case "evalscope":
-    case "aiperf": {
-      // evalscope/aiperf schemas carry errorRate as a 0-1 fraction directly,
-      // so no division by total is required.
-      const r = m.data.requests as { errorRate?: number } | undefined;
-      return asFiniteNumber(r?.errorRate);
-    }
-    default:
-      return null;
-  }
+  return readMetricSafe("errorRate", metrics as { tool?: unknown; data?: unknown } | null);
 }
 
 export function readThroughput(metrics: SummaryMetrics): number | null {
-  const m = asTagged(metrics);
-  if (!m?.data) return null;
-  switch (m.tool) {
-    case "guidellm": {
-      const r = m.data.requestsPerSecond as { mean?: number } | undefined;
-      return asFiniteNumber(r?.mean);
-    }
-    case "vegeta": {
-      const r = m.data.requests as { throughput?: number } | undefined;
-      return asFiniteNumber(r?.throughput);
-    }
-    case "evalscope":
-    case "aiperf": {
-      const r = m.data.throughput as { requestsPerSec?: number } | undefined;
-      return asFiniteNumber(r?.requestsPerSec);
-    }
-    default:
-      return null;
-  }
+  return readMetricSafe("requestsPerSec", metrics as { tool?: unknown; data?: unknown } | null);
 }
 
 // ─── Grid row descriptors ────────────────────────────────────────────────────
@@ -114,50 +47,68 @@ export interface MetricRowDescriptor {
   unitSuffix?: string; // for the cell display (e.g. "ms", "%")
 }
 
-function distRow(
+function metricRow(
   labelKey: string,
-  toolKey: string,
-  field: string,
+  kind: MetricKind,
   opts: { digits?: number; unitSuffix?: string; verdictKind?: VerdictKind } = {},
 ): MetricRowDescriptor {
   return {
     labelKey,
-    read: (m) => {
-      const t = asTagged(m);
-      return t?.data ? fromDist(t.data, toolKey, field) : null;
-    },
+    read: (m) => readMetricSafe(kind, m as { tool?: unknown; data?: unknown } | null),
     digits: opts.digits,
     unitSuffix: opts.unitSuffix,
     verdictKind: opts.verdictKind,
   };
 }
 
+// `ttftMean` / `itlMean` / latency min/mean/max have no MetricKind counterparts
+// (only the dist buckets are first-class). Fall back to direct field reads
+// where MetricKind doesn't cover the case.
+function rawDistRow(
+  labelKey: string,
+  toolKey: string,
+  field: string,
+  opts: { unitSuffix?: string } = {},
+): MetricRowDescriptor {
+  return {
+    labelKey,
+    read: (m) => {
+      const t = m as { tool?: unknown; data?: Record<string, unknown> } | null;
+      if (!t?.data) return null;
+      const dist = t.data[toolKey] as Record<string, unknown> | undefined;
+      const v = dist?.[field];
+      return typeof v === "number" && Number.isFinite(v) ? v : null;
+    },
+    unitSuffix: opts.unitSuffix,
+  };
+}
+
 const guidellmRows: MetricRowDescriptor[] = [
-  distRow("ttftMean", "ttft", "mean", { unitSuffix: "ms" }),
-  distRow("ttftP50", "ttft", "p50", { unitSuffix: "ms" }),
-  distRow("ttftP95", "ttft", "p95", { unitSuffix: "ms" }),
-  distRow("ttftP99", "ttft", "p99", { unitSuffix: "ms" }),
-  distRow("itlMean", "itl", "mean", { unitSuffix: "ms" }),
-  distRow("itlP95", "itl", "p95", { unitSuffix: "ms" }),
-  distRow("e2eLatencyP50", "e2eLatency", "p50", { unitSuffix: "ms" }),
+  rawDistRow("ttftMean", "ttft", "mean", { unitSuffix: "ms" }),
+  metricRow("ttftP50", "ttft.p50", { unitSuffix: "ms" }),
+  metricRow("ttftP95", "ttft.p95", { unitSuffix: "ms" }),
+  metricRow("ttftP99", "ttft.p99", { unitSuffix: "ms" }),
+  rawDistRow("itlMean", "itl", "mean", { unitSuffix: "ms" }),
+  metricRow("itlP95", "itl.p95", { unitSuffix: "ms" }),
+  metricRow("e2eLatencyP50", "e2e.p50", { unitSuffix: "ms" }),
   // Verdict-eligible: shared latency P95 row uses the same reader as the
   // standalone readP95Latency exported above.
-  { labelKey: "latencyP95", read: readP95Latency, verdictKind: "latency", unitSuffix: "ms" },
-  distRow("e2eLatencyP99", "e2eLatency", "p99", { unitSuffix: "ms" }),
-  { labelKey: "errorRate", read: readErrorRate, verdictKind: "errorRate", digits: 4 },
-  { labelKey: "throughput", read: readThroughput, verdictKind: "throughput", unitSuffix: "req/s" },
+  metricRow("latencyP95", "e2e.p95", { unitSuffix: "ms", verdictKind: "latency" }),
+  metricRow("e2eLatencyP99", "e2e.p99", { unitSuffix: "ms" }),
+  metricRow("errorRate", "errorRate", { digits: 4, verdictKind: "errorRate" }),
+  metricRow("throughput", "requestsPerSec", { unitSuffix: "req/s", verdictKind: "throughput" }),
 ];
 
 const vegetaRows: MetricRowDescriptor[] = [
-  distRow("latencyMin", "latencies", "min", { unitSuffix: "ms" }),
-  distRow("latencyMean", "latencies", "mean", { unitSuffix: "ms" }),
-  distRow("latencyP50", "latencies", "p50", { unitSuffix: "ms" }),
-  distRow("latencyP90", "latencies", "p90", { unitSuffix: "ms" }),
-  { labelKey: "latencyP95", read: readP95Latency, verdictKind: "latency", unitSuffix: "ms" },
-  distRow("latencyP99", "latencies", "p99", { unitSuffix: "ms" }),
-  distRow("latencyMax", "latencies", "max", { unitSuffix: "ms" }),
-  { labelKey: "errorRate", read: readErrorRate, verdictKind: "errorRate", digits: 4 },
-  { labelKey: "throughput", read: readThroughput, verdictKind: "throughput", unitSuffix: "req/s" },
+  rawDistRow("latencyMin", "latencies", "min", { unitSuffix: "ms" }),
+  rawDistRow("latencyMean", "latencies", "mean", { unitSuffix: "ms" }),
+  metricRow("latencyP50", "e2e.p50", { unitSuffix: "ms" }),
+  metricRow("latencyP90", "e2e.p90", { unitSuffix: "ms" }),
+  metricRow("latencyP95", "e2e.p95", { unitSuffix: "ms", verdictKind: "latency" }),
+  metricRow("latencyP99", "e2e.p99", { unitSuffix: "ms" }),
+  rawDistRow("latencyMax", "latencies", "max", { unitSuffix: "ms" }),
+  metricRow("errorRate", "errorRate", { digits: 4, verdictKind: "errorRate" }),
+  metricRow("throughput", "requestsPerSec", { unitSuffix: "req/s", verdictKind: "throughput" }),
 ];
 
 // evalscope and aiperf surface the same inference fields (ttft / e2eLatency /
@@ -166,17 +117,17 @@ const vegetaRows: MetricRowDescriptor[] = [
 // fields (prefixCacheStats.hitRate) are rendered in the report component, not
 // the compare grid.
 const inferenceRowsForNewTools: MetricRowDescriptor[] = [
-  distRow("ttftMean", "ttft", "mean", { unitSuffix: "ms" }),
-  distRow("ttftP50", "ttft", "p50", { unitSuffix: "ms" }),
-  distRow("ttftP95", "ttft", "p95", { unitSuffix: "ms" }),
-  distRow("ttftP99", "ttft", "p99", { unitSuffix: "ms" }),
-  distRow("itlMean", "itl", "mean", { unitSuffix: "ms" }),
-  distRow("itlP95", "itl", "p95", { unitSuffix: "ms" }),
-  distRow("e2eLatencyP50", "e2eLatency", "p50", { unitSuffix: "ms" }),
-  { labelKey: "latencyP95", read: readP95Latency, verdictKind: "latency", unitSuffix: "ms" },
-  distRow("e2eLatencyP99", "e2eLatency", "p99", { unitSuffix: "ms" }),
-  { labelKey: "errorRate", read: readErrorRate, verdictKind: "errorRate", digits: 4 },
-  { labelKey: "throughput", read: readThroughput, verdictKind: "throughput", unitSuffix: "req/s" },
+  rawDistRow("ttftMean", "ttft", "mean", { unitSuffix: "ms" }),
+  metricRow("ttftP50", "ttft.p50", { unitSuffix: "ms" }),
+  metricRow("ttftP95", "ttft.p95", { unitSuffix: "ms" }),
+  metricRow("ttftP99", "ttft.p99", { unitSuffix: "ms" }),
+  rawDistRow("itlMean", "itl", "mean", { unitSuffix: "ms" }),
+  metricRow("itlP95", "itl.p95", { unitSuffix: "ms" }),
+  metricRow("e2eLatencyP50", "e2e.p50", { unitSuffix: "ms" }),
+  metricRow("latencyP95", "e2e.p95", { unitSuffix: "ms", verdictKind: "latency" }),
+  metricRow("e2eLatencyP99", "e2e.p99", { unitSuffix: "ms" }),
+  metricRow("errorRate", "errorRate", { digits: 4, verdictKind: "errorRate" }),
+  metricRow("throughput", "requestsPerSec", { unitSuffix: "req/s", verdictKind: "throughput" }),
 ];
 
 // Formats a baseline-to-current delta as a signed string for display in

--- a/apps/web/src/features/benchmarks/forms/AiperfParamsForm.tsx
+++ b/apps/web/src/features/benchmarks/forms/AiperfParamsForm.tsx
@@ -18,6 +18,7 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { numberField } from "./_shared/numberField";
 
 const DATASETS = ["synthetic", "sharegpt"] as const;
 // NOTE: AIPerf's CLI takes `--endpoint-type chat|completions` (not a full path);
@@ -48,14 +49,7 @@ export function AiperfParamsForm({ fieldPrefix = "params" }: AiperfParamsFormPro
               <FormItem>
                 <FormLabel>{t("forms.aiperf.concurrency")}</FormLabel>
                 <FormControl>
-                  <Input
-                    type="number"
-                    {...field}
-                    value={field.value ?? ""}
-                    onChange={(e) =>
-                      field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                    }
-                  />
+                  <Input type="number" {...numberField(field)} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -68,14 +62,7 @@ export function AiperfParamsForm({ fieldPrefix = "params" }: AiperfParamsFormPro
               <FormItem>
                 <FormLabel>{t("forms.aiperf.requestCount")}</FormLabel>
                 <FormControl>
-                  <Input
-                    type="number"
-                    {...field}
-                    value={field.value ?? ""}
-                    onChange={(e) =>
-                      field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                    }
-                  />
+                  <Input type="number" {...numberField(field)} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -116,14 +103,7 @@ export function AiperfParamsForm({ fieldPrefix = "params" }: AiperfParamsFormPro
               <FormItem>
                 <FormLabel>{t("forms.aiperf.inputTokensMean")}</FormLabel>
                 <FormControl>
-                  <Input
-                    type="number"
-                    {...field}
-                    value={field.value ?? ""}
-                    onChange={(e) =>
-                      field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                    }
-                  />
+                  <Input type="number" {...numberField(field)} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -136,14 +116,7 @@ export function AiperfParamsForm({ fieldPrefix = "params" }: AiperfParamsFormPro
               <FormItem>
                 <FormLabel>{t("forms.aiperf.inputTokensStddev")}</FormLabel>
                 <FormControl>
-                  <Input
-                    type="number"
-                    {...field}
-                    value={field.value ?? ""}
-                    onChange={(e) =>
-                      field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                    }
-                  />
+                  <Input type="number" {...numberField(field)} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -160,14 +133,7 @@ export function AiperfParamsForm({ fieldPrefix = "params" }: AiperfParamsFormPro
               <FormItem>
                 <FormLabel>{t("forms.aiperf.outputTokensMean")}</FormLabel>
                 <FormControl>
-                  <Input
-                    type="number"
-                    {...field}
-                    value={field.value ?? ""}
-                    onChange={(e) =>
-                      field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                    }
-                  />
+                  <Input type="number" {...numberField(field)} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -180,14 +146,7 @@ export function AiperfParamsForm({ fieldPrefix = "params" }: AiperfParamsFormPro
               <FormItem>
                 <FormLabel>{t("forms.aiperf.outputTokensStddev")}</FormLabel>
                 <FormControl>
-                  <Input
-                    type="number"
-                    {...field}
-                    value={field.value ?? ""}
-                    onChange={(e) =>
-                      field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                    }
-                  />
+                  <Input type="number" {...numberField(field)} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -240,14 +199,7 @@ export function AiperfParamsForm({ fieldPrefix = "params" }: AiperfParamsFormPro
               <FormItem>
                 <FormLabel>{t("forms.aiperf.seed")}</FormLabel>
                 <FormControl>
-                  <Input
-                    type="number"
-                    {...field}
-                    value={field.value ?? ""}
-                    onChange={(e) =>
-                      field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                    }
-                  />
+                  <Input type="number" {...numberField(field)} />
                 </FormControl>
                 <FormDescription>{t("forms.aiperf.seedHint")}</FormDescription>
                 <FormMessage />

--- a/apps/web/src/features/benchmarks/forms/EvalscopeParamsForm.tsx
+++ b/apps/web/src/features/benchmarks/forms/EvalscopeParamsForm.tsx
@@ -18,6 +18,7 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { numberField } from "./_shared/numberField";
 
 const DATASETS = ["longalpaca", "openqa", "random"] as const;
 const API_PATHS = ["/v1/chat/completions", "/v1/completions"] as const;
@@ -66,14 +67,7 @@ export function EvalscopeParamsForm({ fieldPrefix = "params" }: EvalscopeParamsF
               <FormItem>
                 <FormLabel>{t("forms.evalscope.parallel")}</FormLabel>
                 <FormControl>
-                  <Input
-                    type="number"
-                    {...field}
-                    value={field.value ?? ""}
-                    onChange={(e) =>
-                      field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                    }
-                  />
+                  <Input type="number" {...numberField(field)} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -86,14 +80,7 @@ export function EvalscopeParamsForm({ fieldPrefix = "params" }: EvalscopeParamsF
               <FormItem>
                 <FormLabel>{t("forms.evalscope.number")}</FormLabel>
                 <FormControl>
-                  <Input
-                    type="number"
-                    {...field}
-                    value={field.value ?? ""}
-                    onChange={(e) =>
-                      field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                    }
-                  />
+                  <Input type="number" {...numberField(field)} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -110,14 +97,7 @@ export function EvalscopeParamsForm({ fieldPrefix = "params" }: EvalscopeParamsF
               <FormItem>
                 <FormLabel>{t("forms.evalscope.minPromptLength")}</FormLabel>
                 <FormControl>
-                  <Input
-                    type="number"
-                    {...field}
-                    value={field.value ?? ""}
-                    onChange={(e) =>
-                      field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                    }
-                  />
+                  <Input type="number" {...numberField(field)} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -130,14 +110,7 @@ export function EvalscopeParamsForm({ fieldPrefix = "params" }: EvalscopeParamsF
               <FormItem>
                 <FormLabel>{t("forms.evalscope.maxPromptLength")}</FormLabel>
                 <FormControl>
-                  <Input
-                    type="number"
-                    {...field}
-                    value={field.value ?? ""}
-                    onChange={(e) =>
-                      field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                    }
-                  />
+                  <Input type="number" {...numberField(field)} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -154,14 +127,7 @@ export function EvalscopeParamsForm({ fieldPrefix = "params" }: EvalscopeParamsF
               <FormItem>
                 <FormLabel>{t("forms.evalscope.minTokens")}</FormLabel>
                 <FormControl>
-                  <Input
-                    type="number"
-                    {...field}
-                    value={field.value ?? ""}
-                    onChange={(e) =>
-                      field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                    }
-                  />
+                  <Input type="number" {...numberField(field)} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -174,14 +140,7 @@ export function EvalscopeParamsForm({ fieldPrefix = "params" }: EvalscopeParamsF
               <FormItem>
                 <FormLabel>{t("forms.evalscope.maxTokens")}</FormLabel>
                 <FormControl>
-                  <Input
-                    type="number"
-                    {...field}
-                    value={field.value ?? ""}
-                    onChange={(e) =>
-                      field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                    }
-                  />
+                  <Input type="number" {...numberField(field)} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -234,14 +193,7 @@ export function EvalscopeParamsForm({ fieldPrefix = "params" }: EvalscopeParamsF
               <FormItem>
                 <FormLabel>{t("forms.evalscope.seed")}</FormLabel>
                 <FormControl>
-                  <Input
-                    type="number"
-                    {...field}
-                    value={field.value ?? ""}
-                    onChange={(e) =>
-                      field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                    }
-                  />
+                  <Input type="number" {...numberField(field)} />
                 </FormControl>
                 <FormDescription>{t("forms.evalscope.seedHint")}</FormDescription>
                 <FormMessage />

--- a/apps/web/src/features/benchmarks/forms/_shared/numberField.ts
+++ b/apps/web/src/features/benchmarks/forms/_shared/numberField.ts
@@ -1,0 +1,34 @@
+import type { ChangeEvent } from "react";
+import type { ControllerRenderProps, FieldPath, FieldValues } from "react-hook-form";
+
+/**
+ * Spread-friendly props for binding a react-hook-form numeric field to an
+ * <Input type="number" />. Implements the blank-string → undefined
+ * convention so optional numeric fields don't emit NaN. Required fields
+ * still parse via Number(), Zod will surface the "Expected number" error
+ * if the field stays empty.
+ *
+ * Usage:
+ *   <FormField name="params.parallel" control={form.control} render={({ field }) => (
+ *     <FormItem>
+ *       <FormLabel required>Parallel</FormLabel>
+ *       <FormControl><Input type="number" {...numberField(field)} /></FormControl>
+ *       <FormMessage />
+ *     </FormItem>
+ *   )} />
+ */
+export function numberField<
+  TFieldValues extends FieldValues,
+  TName extends FieldPath<TFieldValues>,
+>(field: ControllerRenderProps<TFieldValues, TName>) {
+  return {
+    name: field.name,
+    onBlur: field.onBlur,
+    ref: field.ref,
+    value: (field.value as number | undefined) ?? "",
+    onChange: (e: ChangeEvent<HTMLInputElement>) => {
+      const raw = e.target.value;
+      field.onChange(raw === "" ? undefined : Number(raw));
+    },
+  };
+}

--- a/apps/web/src/features/benchmarks/reports/KvCacheStressReport.tsx
+++ b/apps/web/src/features/benchmarks/reports/KvCacheStressReport.tsx
@@ -10,6 +10,7 @@ import {
 import type { Benchmark } from "@modeldoctor/contracts";
 import { type EvalscopeReport, evalscopeReportSchema } from "@modeldoctor/tool-adapters/schemas";
 import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { MetricCard } from "../components/MetricCard";
 import { useBenchmarkList } from "../queries";
 import { UnknownReport } from "./UnknownReport";
@@ -51,64 +52,71 @@ export function KvCacheStressReport({ benchmark }: KvCacheStressReportProps) {
 }
 
 function KvCacheStressMetrics({ data }: { data: EvalscopeReport }) {
+  const { t } = useTranslation("benchmarks");
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
       <MetricCard
-        title="TTFT (ms)"
+        title={t("reports.shared.ttftMs")}
         rows={[
-          { label: "mean", value: fmt(data.ttft.mean) },
-          { label: "p50", value: fmt(data.ttft.p50) },
-          { label: "p90", value: fmt(data.ttft.p90) },
-          { label: "p95", value: fmt(data.ttft.p95) },
-          { label: "p99", value: fmt(data.ttft.p99) },
+          { label: t("reports.shared.meanLabel"), value: fmt(data.ttft.mean) },
+          { label: t("reports.shared.p50Label"), value: fmt(data.ttft.p50) },
+          { label: t("reports.shared.p90Label"), value: fmt(data.ttft.p90) },
+          { label: t("reports.shared.p95Label"), value: fmt(data.ttft.p95) },
+          { label: t("reports.shared.p99Label"), value: fmt(data.ttft.p99) },
         ]}
       />
       <MetricCard
-        title="ITL (ms)"
+        title={t("reports.shared.itlMs")}
         rows={[
-          { label: "mean", value: fmt(data.itl.mean) },
-          { label: "p50", value: fmt(data.itl.p50) },
-          { label: "p90", value: fmt(data.itl.p90) },
-          { label: "p95", value: fmt(data.itl.p95) },
-          { label: "p99", value: fmt(data.itl.p99) },
+          { label: t("reports.shared.meanLabel"), value: fmt(data.itl.mean) },
+          { label: t("reports.shared.p50Label"), value: fmt(data.itl.p50) },
+          { label: t("reports.shared.p90Label"), value: fmt(data.itl.p90) },
+          { label: t("reports.shared.p95Label"), value: fmt(data.itl.p95) },
+          { label: t("reports.shared.p99Label"), value: fmt(data.itl.p99) },
         ]}
       />
       <MetricCard
-        title="E2E latency (ms)"
+        title={t("reports.shared.e2eLatencyMs")}
         rows={[
-          { label: "mean", value: fmt(data.e2eLatency.mean) },
-          { label: "p50", value: fmt(data.e2eLatency.p50) },
-          { label: "p90", value: fmt(data.e2eLatency.p90) },
-          { label: "p95", value: fmt(data.e2eLatency.p95) },
-          { label: "p99", value: fmt(data.e2eLatency.p99) },
+          { label: t("reports.shared.meanLabel"), value: fmt(data.e2eLatency.mean) },
+          { label: t("reports.shared.p50Label"), value: fmt(data.e2eLatency.p50) },
+          { label: t("reports.shared.p90Label"), value: fmt(data.e2eLatency.p90) },
+          { label: t("reports.shared.p95Label"), value: fmt(data.e2eLatency.p95) },
+          { label: t("reports.shared.p99Label"), value: fmt(data.e2eLatency.p99) },
         ]}
       />
       <MetricCard
-        title="Throughput"
+        title={t("reports.shared.throughput")}
         rows={[
-          { label: "RPS", value: fmt(data.throughput.requestsPerSec) },
-          { label: "Output TPS", value: fmt(data.throughput.outputTokensPerSec) },
-          { label: "Total TPS", value: fmt(data.throughput.totalTokensPerSec) },
-        ]}
-      />
-      <MetricCard
-        title="Requests"
-        rows={[
-          { label: "total", value: data.requests.total },
-          { label: "success", value: data.requests.success },
-          { label: "error", value: data.requests.error },
+          { label: t("reports.shared.rps"), value: fmt(data.throughput.requestsPerSec) },
           {
-            label: "errorRate",
+            label: t("reports.shared.outputTps"),
+            value: fmt(data.throughput.outputTokensPerSec),
+          },
+          {
+            label: t("reports.shared.totalTps"),
+            value: fmt(data.throughput.totalTokensPerSec),
+          },
+        ]}
+      />
+      <MetricCard
+        title={t("reports.shared.requests")}
+        rows={[
+          { label: t("reports.shared.totalLabel"), value: data.requests.total },
+          { label: t("reports.shared.successLabel"), value: data.requests.success },
+          { label: t("reports.shared.errorLabel"), value: data.requests.error },
+          {
+            label: t("reports.shared.errorRateLabel"),
             value: `${(data.requests.errorRate * 100).toFixed(2)}%`,
           },
         ]}
       />
       {data.prefixCacheStats ? (
         <MetricCard
-          title="Prefix cache"
+          title={t("reports.shared.prefixCache")}
           rows={[
             {
-              label: "Hit rate",
+              label: t("reports.shared.hitRate"),
               value: `${(data.prefixCacheStats.hitRate * 100).toFixed(1)}%`,
             },
           ]}
@@ -135,6 +143,7 @@ interface ColdWarmPairPanelProps {
  * Renders nothing when no sibling is found (preserves the spec contract).
  */
 function ColdWarmPairPanel({ benchmark, cold }: ColdWarmPairPanelProps) {
+  const { t } = useTranslation("benchmarks");
   const isWarm = benchmark.name.endsWith(RERUN_SUFFIX);
   const sourceName = isWarm ? benchmark.name.slice(0, -RERUN_SUFFIX.length) : benchmark.name;
   const siblingName = isWarm ? sourceName : `${sourceName}${RERUN_SUFFIX}`;
@@ -174,33 +183,35 @@ function ColdWarmPairPanel({ benchmark, cold }: ColdWarmPairPanelProps) {
   const r2 = isWarm ? cold : siblingData;
 
   const rows: Array<{ label: string; r1: number; r2: number }> = [
-    { label: "TTFT p95 (ms)", r1: r1.ttft.p95, r2: r2.ttft.p95 },
+    { label: t("reports.kvCacheStress.ttftP95Ms"), r1: r1.ttft.p95, r2: r2.ttft.p95 },
     {
-      label: "Throughput · RPS",
+      label: `${t("reports.shared.throughput")} · ${t("reports.kvCacheStress.rps")}`,
       r1: r1.throughput.requestsPerSec,
       r2: r2.throughput.requestsPerSec,
     },
     {
-      label: "Throughput · Output TPS",
+      label: `${t("reports.shared.throughput")} · ${t("reports.kvCacheStress.outputTokensPerSec")}`,
       r1: r1.throughput.outputTokensPerSec,
       r2: r2.throughput.outputTokensPerSec,
     },
-    { label: "ITL p50 (ms)", r1: r1.itl.p50, r2: r2.itl.p50 },
+    { label: t("reports.kvCacheStress.itlP50Ms"), r1: r1.itl.p50, r2: r2.itl.p50 },
   ];
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-sm font-semibold">Cold vs. warm (R1 → R2)</CardTitle>
+        <CardTitle className="text-sm font-semibold">
+          {t("reports.kvCacheStress.coldVsWarm")}
+        </CardTitle>
       </CardHeader>
       <CardContent>
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>Metric</TableHead>
-              <TableHead className="text-right">R1 · cold</TableHead>
-              <TableHead className="text-right">R2 · warm</TableHead>
-              <TableHead className="text-right">Δ</TableHead>
+              <TableHead>{t("compare.metricColumnLabel")}</TableHead>
+              <TableHead className="text-right">{t("reports.kvCacheStress.cold")}</TableHead>
+              <TableHead className="text-right">{t("reports.kvCacheStress.warm")}</TableHead>
+              <TableHead className="text-right">{t("reports.kvCacheStress.delta")}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>

--- a/apps/web/src/features/benchmarks/reports/KvCacheStressReport.tsx
+++ b/apps/web/src/features/benchmarks/reports/KvCacheStressReport.tsx
@@ -11,9 +11,9 @@ import type { Benchmark } from "@modeldoctor/contracts";
 import { type EvalscopeReport, evalscopeReportSchema } from "@modeldoctor/tool-adapters/schemas";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { MetricCard } from "../components/MetricCard";
 import { useBenchmarkList } from "../queries";
 import { UnknownReport } from "./UnknownReport";
+import { InferenceMetricsGrid } from "./_shared/InferenceMetricsGrid";
 
 export interface KvCacheStressReportProps {
   benchmark: Benchmark;
@@ -52,77 +52,17 @@ export function KvCacheStressReport({ benchmark }: KvCacheStressReportProps) {
 }
 
 function KvCacheStressMetrics({ data }: { data: EvalscopeReport }) {
-  const { t } = useTranslation("benchmarks");
   return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-      <MetricCard
-        title={t("reports.shared.ttftMs")}
-        rows={[
-          { label: t("reports.shared.meanLabel"), value: fmt(data.ttft.mean) },
-          { label: t("reports.shared.p50Label"), value: fmt(data.ttft.p50) },
-          { label: t("reports.shared.p90Label"), value: fmt(data.ttft.p90) },
-          { label: t("reports.shared.p95Label"), value: fmt(data.ttft.p95) },
-          { label: t("reports.shared.p99Label"), value: fmt(data.ttft.p99) },
-        ]}
-      />
-      <MetricCard
-        title={t("reports.shared.itlMs")}
-        rows={[
-          { label: t("reports.shared.meanLabel"), value: fmt(data.itl.mean) },
-          { label: t("reports.shared.p50Label"), value: fmt(data.itl.p50) },
-          { label: t("reports.shared.p90Label"), value: fmt(data.itl.p90) },
-          { label: t("reports.shared.p95Label"), value: fmt(data.itl.p95) },
-          { label: t("reports.shared.p99Label"), value: fmt(data.itl.p99) },
-        ]}
-      />
-      <MetricCard
-        title={t("reports.shared.e2eLatencyMs")}
-        rows={[
-          { label: t("reports.shared.meanLabel"), value: fmt(data.e2eLatency.mean) },
-          { label: t("reports.shared.p50Label"), value: fmt(data.e2eLatency.p50) },
-          { label: t("reports.shared.p90Label"), value: fmt(data.e2eLatency.p90) },
-          { label: t("reports.shared.p95Label"), value: fmt(data.e2eLatency.p95) },
-          { label: t("reports.shared.p99Label"), value: fmt(data.e2eLatency.p99) },
-        ]}
-      />
-      <MetricCard
-        title={t("reports.shared.throughput")}
-        rows={[
-          { label: t("reports.shared.rps"), value: fmt(data.throughput.requestsPerSec) },
-          {
-            label: t("reports.shared.outputTps"),
-            value: fmt(data.throughput.outputTokensPerSec),
-          },
-          {
-            label: t("reports.shared.totalTps"),
-            value: fmt(data.throughput.totalTokensPerSec),
-          },
-        ]}
-      />
-      <MetricCard
-        title={t("reports.shared.requests")}
-        rows={[
-          { label: t("reports.shared.totalLabel"), value: data.requests.total },
-          { label: t("reports.shared.successLabel"), value: data.requests.success },
-          { label: t("reports.shared.errorLabel"), value: data.requests.error },
-          {
-            label: t("reports.shared.errorRateLabel"),
-            value: `${(data.requests.errorRate * 100).toFixed(2)}%`,
-          },
-        ]}
-      />
-      {data.prefixCacheStats ? (
-        <MetricCard
-          title={t("reports.shared.prefixCache")}
-          rows={[
-            {
-              label: t("reports.shared.hitRate"),
-              value: `${(data.prefixCacheStats.hitRate * 100).toFixed(1)}%`,
-            },
-          ]}
-        />
-      ) : null}
-    </div>
+    <InferenceMetricsGrid
+      data={{
+        ttft: data.ttft,
+        itl: data.itl,
+        e2e: data.e2eLatency,
+        throughput: data.throughput,
+        requests: data.requests,
+        prefixCache: data.prefixCacheStats,
+      }}
+    />
   );
 }
 

--- a/apps/web/src/features/benchmarks/reports/_shared/InferenceMetricsGrid.tsx
+++ b/apps/web/src/features/benchmarks/reports/_shared/InferenceMetricsGrid.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { MetricCard, type MetricRow } from "../../components/MetricCard";
 
 interface Dist {
@@ -51,77 +52,88 @@ function fmt(n: number, digits = 1): string {
 }
 
 export function InferenceMetricsGrid({ data }: { data: NormalizedInferenceData }) {
+  const { t } = useTranslation("benchmarks");
+
   const throughputRows: MetricRow[] = [
-    { label: "RPS", value: fmt(data.throughput.requestsPerSec) },
-    { label: "Output TPS", value: fmt(data.throughput.outputTokensPerSec) },
+    { label: t("reports.shared.rps"), value: fmt(data.throughput.requestsPerSec) },
+    { label: t("reports.shared.outputTps"), value: fmt(data.throughput.outputTokensPerSec) },
   ];
   if (typeof data.throughput.inputTokensPerSec === "number") {
-    throughputRows.push({ label: "Input TPS", value: fmt(data.throughput.inputTokensPerSec) });
+    throughputRows.push({
+      label: t("reports.shared.inputTps"),
+      value: fmt(data.throughput.inputTokensPerSec),
+    });
   }
-  throughputRows.push({ label: "Total TPS", value: fmt(data.throughput.totalTokensPerSec) });
+  throughputRows.push({
+    label: t("reports.shared.totalTps"),
+    value: fmt(data.throughput.totalTokensPerSec),
+  });
 
   const requestsRows: MetricRow[] = [
-    { label: "total", value: data.requests.total },
-    { label: "success", value: data.requests.success },
-    { label: "error", value: data.requests.error },
+    { label: t("reports.shared.totalLabel"), value: data.requests.total },
+    { label: t("reports.shared.successLabel"), value: data.requests.success },
+    { label: t("reports.shared.errorLabel"), value: data.requests.error },
   ];
   if (typeof data.requests.incomplete === "number") {
-    requestsRows.push({ label: "incomplete", value: data.requests.incomplete });
+    requestsRows.push({
+      label: t("reports.shared.incompleteLabel"),
+      value: data.requests.incomplete,
+    });
   }
   requestsRows.push({
-    label: "errorRate",
+    label: t("reports.shared.errorRateLabel"),
     value: `${(data.requests.errorRate * 100).toFixed(2)}%`,
   });
 
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
       <MetricCard
-        title="TTFT (ms)"
+        title={t("reports.shared.ttftMs")}
         rows={[
-          { label: "mean", value: fmt(data.ttft.mean) },
-          { label: "p50", value: fmt(data.ttft.p50) },
-          { label: "p90", value: fmt(data.ttft.p90) },
-          { label: "p95", value: fmt(data.ttft.p95) },
-          { label: "p99", value: fmt(data.ttft.p99) },
+          { label: t("reports.shared.meanLabel"), value: fmt(data.ttft.mean) },
+          { label: t("reports.shared.p50Label"), value: fmt(data.ttft.p50) },
+          { label: t("reports.shared.p90Label"), value: fmt(data.ttft.p90) },
+          { label: t("reports.shared.p95Label"), value: fmt(data.ttft.p95) },
+          { label: t("reports.shared.p99Label"), value: fmt(data.ttft.p99) },
         ]}
       />
       <MetricCard
-        title="ITL (ms)"
+        title={t("reports.shared.itlMs")}
         rows={[
-          { label: "mean", value: fmt(data.itl.mean) },
-          { label: "p50", value: fmt(data.itl.p50) },
-          { label: "p90", value: fmt(data.itl.p90) },
-          { label: "p95", value: fmt(data.itl.p95) },
-          { label: "p99", value: fmt(data.itl.p99) },
+          { label: t("reports.shared.meanLabel"), value: fmt(data.itl.mean) },
+          { label: t("reports.shared.p50Label"), value: fmt(data.itl.p50) },
+          { label: t("reports.shared.p90Label"), value: fmt(data.itl.p90) },
+          { label: t("reports.shared.p95Label"), value: fmt(data.itl.p95) },
+          { label: t("reports.shared.p99Label"), value: fmt(data.itl.p99) },
         ]}
       />
       <MetricCard
-        title="E2E latency (ms)"
+        title={t("reports.shared.e2eLatencyMs")}
         rows={[
-          { label: "mean", value: fmt(data.e2e.mean) },
-          { label: "p50", value: fmt(data.e2e.p50) },
-          { label: "p90", value: fmt(data.e2e.p90) },
-          { label: "p95", value: fmt(data.e2e.p95) },
-          { label: "p99", value: fmt(data.e2e.p99) },
+          { label: t("reports.shared.meanLabel"), value: fmt(data.e2e.mean) },
+          { label: t("reports.shared.p50Label"), value: fmt(data.e2e.p50) },
+          { label: t("reports.shared.p90Label"), value: fmt(data.e2e.p90) },
+          { label: t("reports.shared.p95Label"), value: fmt(data.e2e.p95) },
+          { label: t("reports.shared.p99Label"), value: fmt(data.e2e.p99) },
         ]}
       />
-      <MetricCard title="Throughput" rows={throughputRows} />
+      <MetricCard title={t("reports.shared.throughput")} rows={throughputRows} />
       {data.concurrency ? (
         <MetricCard
-          title="Concurrency"
+          title={t("reports.shared.concurrency")}
           rows={[
-            { label: "mean", value: fmt(data.concurrency.mean) },
-            { label: "max", value: data.concurrency.max },
+            { label: t("reports.shared.meanLabel"), value: fmt(data.concurrency.mean) },
+            { label: t("reports.shared.maxLabel"), value: data.concurrency.max },
           ]}
         />
       ) : null}
-      <MetricCard title="Requests" rows={requestsRows} />
+      <MetricCard title={t("reports.shared.requests")} rows={requestsRows} />
       {data.prefixCache ? (
         <MetricCard
-          title="Prefix cache"
+          title={t("reports.shared.prefixCache")}
           rows={[
             {
-              label: "hitRate",
+              label: t("reports.shared.hitRate"),
               value: `${(data.prefixCache.hitRate * 100).toFixed(2)}%`,
             },
           ]}

--- a/apps/web/src/features/benchmarks/reports/_shared/InferenceMetricsGrid.tsx
+++ b/apps/web/src/features/benchmarks/reports/_shared/InferenceMetricsGrid.tsx
@@ -1,0 +1,132 @@
+import { MetricCard, type MetricRow } from "../../components/MetricCard";
+
+interface Dist {
+  mean: number;
+  p50: number;
+  p90: number;
+  p95: number;
+  p99: number;
+}
+
+interface Requests {
+  total: number;
+  success: number;
+  error: number;
+  errorRate: number;
+  /** guidellm exposes this; evalscope/aiperf do not. */
+  incomplete?: number;
+}
+
+interface Throughput {
+  requestsPerSec: number;
+  outputTokensPerSec: number;
+  totalTokensPerSec: number;
+  /** guidellm exposes this; evalscope/aiperf do not. */
+  inputTokensPerSec?: number;
+}
+
+interface Concurrency {
+  mean: number;
+  max: number;
+}
+
+interface PrefixCache {
+  hitRate: number;
+}
+
+export interface NormalizedInferenceData {
+  ttft: Dist;
+  itl: Dist;
+  e2e: Dist;
+  throughput: Throughput;
+  requests: Requests;
+  /** guidellm-only panel. */
+  concurrency?: Concurrency;
+  /** evalscope-only panel. */
+  prefixCache?: PrefixCache;
+}
+
+function fmt(n: number, digits = 1): string {
+  return n.toFixed(digits);
+}
+
+export function InferenceMetricsGrid({ data }: { data: NormalizedInferenceData }) {
+  const throughputRows: MetricRow[] = [
+    { label: "RPS", value: fmt(data.throughput.requestsPerSec) },
+    { label: "Output TPS", value: fmt(data.throughput.outputTokensPerSec) },
+  ];
+  if (typeof data.throughput.inputTokensPerSec === "number") {
+    throughputRows.push({ label: "Input TPS", value: fmt(data.throughput.inputTokensPerSec) });
+  }
+  throughputRows.push({ label: "Total TPS", value: fmt(data.throughput.totalTokensPerSec) });
+
+  const requestsRows: MetricRow[] = [
+    { label: "total", value: data.requests.total },
+    { label: "success", value: data.requests.success },
+    { label: "error", value: data.requests.error },
+  ];
+  if (typeof data.requests.incomplete === "number") {
+    requestsRows.push({ label: "incomplete", value: data.requests.incomplete });
+  }
+  requestsRows.push({
+    label: "errorRate",
+    value: `${(data.requests.errorRate * 100).toFixed(2)}%`,
+  });
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+      <MetricCard
+        title="TTFT (ms)"
+        rows={[
+          { label: "mean", value: fmt(data.ttft.mean) },
+          { label: "p50", value: fmt(data.ttft.p50) },
+          { label: "p90", value: fmt(data.ttft.p90) },
+          { label: "p95", value: fmt(data.ttft.p95) },
+          { label: "p99", value: fmt(data.ttft.p99) },
+        ]}
+      />
+      <MetricCard
+        title="ITL (ms)"
+        rows={[
+          { label: "mean", value: fmt(data.itl.mean) },
+          { label: "p50", value: fmt(data.itl.p50) },
+          { label: "p90", value: fmt(data.itl.p90) },
+          { label: "p95", value: fmt(data.itl.p95) },
+          { label: "p99", value: fmt(data.itl.p99) },
+        ]}
+      />
+      <MetricCard
+        title="E2E latency (ms)"
+        rows={[
+          { label: "mean", value: fmt(data.e2e.mean) },
+          { label: "p50", value: fmt(data.e2e.p50) },
+          { label: "p90", value: fmt(data.e2e.p90) },
+          { label: "p95", value: fmt(data.e2e.p95) },
+          { label: "p99", value: fmt(data.e2e.p99) },
+        ]}
+      />
+      <MetricCard title="Throughput" rows={throughputRows} />
+      {data.concurrency ? (
+        <MetricCard
+          title="Concurrency"
+          rows={[
+            { label: "mean", value: fmt(data.concurrency.mean) },
+            { label: "max", value: data.concurrency.max },
+          ]}
+        />
+      ) : null}
+      <MetricCard title="Requests" rows={requestsRows} />
+      {data.prefixCache ? (
+        <MetricCard
+          title="Prefix cache"
+          rows={[
+            {
+              label: "hitRate",
+              value: `${(data.prefixCache.hitRate * 100).toFixed(2)}%`,
+            },
+          ]}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/benchmarks/reports/_shared/InferenceMetricsGrid.tsx
+++ b/apps/web/src/features/benchmarks/reports/_shared/InferenceMetricsGrid.tsx
@@ -134,7 +134,7 @@ export function InferenceMetricsGrid({ data }: { data: NormalizedInferenceData }
           rows={[
             {
               label: t("reports.shared.hitRate"),
-              value: `${(data.prefixCache.hitRate * 100).toFixed(2)}%`,
+              value: `${(data.prefixCache.hitRate * 100).toFixed(1)}%`,
             },
           ]}
         />

--- a/apps/web/src/features/benchmarks/reports/aiperf/InferenceMetrics.tsx
+++ b/apps/web/src/features/benchmarks/reports/aiperf/InferenceMetrics.tsx
@@ -1,79 +1,28 @@
 import type { Benchmark } from "@modeldoctor/contracts";
-import { type AiperfReport, aiperfReportSchema } from "@modeldoctor/tool-adapters/schemas";
-import { MetricCard } from "../../components/MetricCard";
+import { aiperfReportSchema } from "@modeldoctor/tool-adapters/schemas";
 import { UnknownReport } from "../UnknownReport";
+import { InferenceMetricsGrid } from "../_shared/InferenceMetricsGrid";
 
 export interface AiperfInferenceMetricsProps {
   benchmark: Benchmark;
 }
 
-function fmt(n: number, digits = 1): string {
-  return n.toFixed(digits);
-}
-
 export function AiperfInferenceMetrics({ benchmark }: AiperfInferenceMetricsProps) {
-  const tagged = benchmark.summaryMetrics as {
-    tool?: string;
-    data?: unknown;
-  } | null;
+  const tagged = benchmark.summaryMetrics as { tool?: string; data?: unknown } | null;
   const parsed = aiperfReportSchema.safeParse(tagged?.data);
   if (!parsed.success) {
     return <UnknownReport benchmark={benchmark} reason={parsed.error.message} />;
   }
-  const data: AiperfReport = parsed.data;
-
+  const r = parsed.data;
   return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-      <MetricCard
-        title="TTFT (ms)"
-        rows={[
-          { label: "mean", value: fmt(data.ttft.mean) },
-          { label: "p50", value: fmt(data.ttft.p50) },
-          { label: "p90", value: fmt(data.ttft.p90) },
-          { label: "p95", value: fmt(data.ttft.p95) },
-          { label: "p99", value: fmt(data.ttft.p99) },
-        ]}
-      />
-      <MetricCard
-        title="ITL (ms)"
-        rows={[
-          { label: "mean", value: fmt(data.itl.mean) },
-          { label: "p50", value: fmt(data.itl.p50) },
-          { label: "p90", value: fmt(data.itl.p90) },
-          { label: "p95", value: fmt(data.itl.p95) },
-          { label: "p99", value: fmt(data.itl.p99) },
-        ]}
-      />
-      <MetricCard
-        title="E2E latency (ms)"
-        rows={[
-          { label: "mean", value: fmt(data.e2eLatency.mean) },
-          { label: "p50", value: fmt(data.e2eLatency.p50) },
-          { label: "p90", value: fmt(data.e2eLatency.p90) },
-          { label: "p95", value: fmt(data.e2eLatency.p95) },
-          { label: "p99", value: fmt(data.e2eLatency.p99) },
-        ]}
-      />
-      <MetricCard
-        title="Throughput"
-        rows={[
-          { label: "RPS", value: fmt(data.throughput.requestsPerSec) },
-          { label: "Output TPS", value: fmt(data.throughput.outputTokensPerSec) },
-          { label: "Total TPS", value: fmt(data.throughput.totalTokensPerSec) },
-        ]}
-      />
-      <MetricCard
-        title="Requests"
-        rows={[
-          { label: "total", value: data.requests.total },
-          { label: "success", value: data.requests.success },
-          { label: "error", value: data.requests.error },
-          {
-            label: "errorRate",
-            value: `${(data.requests.errorRate * 100).toFixed(2)}%`,
-          },
-        ]}
-      />
-    </div>
+    <InferenceMetricsGrid
+      data={{
+        ttft: r.ttft,
+        itl: r.itl,
+        e2e: r.e2eLatency,
+        throughput: r.throughput,
+        requests: r.requests,
+      }}
+    />
   );
 }

--- a/apps/web/src/features/benchmarks/reports/evalscope/InferenceMetrics.tsx
+++ b/apps/web/src/features/benchmarks/reports/evalscope/InferenceMetrics.tsx
@@ -1,90 +1,29 @@
 import type { Benchmark } from "@modeldoctor/contracts";
-import { type EvalscopeReport, evalscopeReportSchema } from "@modeldoctor/tool-adapters/schemas";
-import { MetricCard } from "../../components/MetricCard";
+import { evalscopeReportSchema } from "@modeldoctor/tool-adapters/schemas";
 import { UnknownReport } from "../UnknownReport";
+import { InferenceMetricsGrid } from "../_shared/InferenceMetricsGrid";
 
 export interface EvalscopeInferenceMetricsProps {
   benchmark: Benchmark;
 }
 
-function fmt(n: number, digits = 1): string {
-  return n.toFixed(digits);
-}
-
 export function EvalscopeInferenceMetrics({ benchmark }: EvalscopeInferenceMetricsProps) {
-  const tagged = benchmark.summaryMetrics as {
-    tool?: string;
-    data?: unknown;
-  } | null;
+  const tagged = benchmark.summaryMetrics as { tool?: string; data?: unknown } | null;
   const parsed = evalscopeReportSchema.safeParse(tagged?.data);
   if (!parsed.success) {
     return <UnknownReport benchmark={benchmark} reason={parsed.error.message} />;
   }
-  const data: EvalscopeReport = parsed.data;
-
+  const r = parsed.data;
   return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-      <MetricCard
-        title="TTFT (ms)"
-        rows={[
-          { label: "mean", value: fmt(data.ttft.mean) },
-          { label: "p50", value: fmt(data.ttft.p50) },
-          { label: "p90", value: fmt(data.ttft.p90) },
-          { label: "p95", value: fmt(data.ttft.p95) },
-          { label: "p99", value: fmt(data.ttft.p99) },
-        ]}
-      />
-      <MetricCard
-        title="ITL (ms)"
-        rows={[
-          { label: "mean", value: fmt(data.itl.mean) },
-          { label: "p50", value: fmt(data.itl.p50) },
-          { label: "p90", value: fmt(data.itl.p90) },
-          { label: "p95", value: fmt(data.itl.p95) },
-          { label: "p99", value: fmt(data.itl.p99) },
-        ]}
-      />
-      <MetricCard
-        title="E2E latency (ms)"
-        rows={[
-          { label: "mean", value: fmt(data.e2eLatency.mean) },
-          { label: "p50", value: fmt(data.e2eLatency.p50) },
-          { label: "p90", value: fmt(data.e2eLatency.p90) },
-          { label: "p95", value: fmt(data.e2eLatency.p95) },
-          { label: "p99", value: fmt(data.e2eLatency.p99) },
-        ]}
-      />
-      <MetricCard
-        title="Throughput"
-        rows={[
-          { label: "RPS", value: fmt(data.throughput.requestsPerSec) },
-          { label: "Output TPS", value: fmt(data.throughput.outputTokensPerSec) },
-          { label: "Total TPS", value: fmt(data.throughput.totalTokensPerSec) },
-        ]}
-      />
-      <MetricCard
-        title="Requests"
-        rows={[
-          { label: "total", value: data.requests.total },
-          { label: "success", value: data.requests.success },
-          { label: "error", value: data.requests.error },
-          {
-            label: "errorRate",
-            value: `${(data.requests.errorRate * 100).toFixed(2)}%`,
-          },
-        ]}
-      />
-      {data.prefixCacheStats ? (
-        <MetricCard
-          title="Prefix cache"
-          rows={[
-            {
-              label: "hitRate",
-              value: `${(data.prefixCacheStats.hitRate * 100).toFixed(2)}%`,
-            },
-          ]}
-        />
-      ) : null}
-    </div>
+    <InferenceMetricsGrid
+      data={{
+        ttft: r.ttft,
+        itl: r.itl,
+        e2e: r.e2eLatency,
+        throughput: r.throughput,
+        requests: r.requests,
+        prefixCache: r.prefixCacheStats,
+      }}
+    />
   );
 }

--- a/apps/web/src/features/benchmarks/reports/guidellm/InferenceMetrics.tsx
+++ b/apps/web/src/features/benchmarks/reports/guidellm/InferenceMetrics.tsx
@@ -1,14 +1,10 @@
 import type { Benchmark } from "@modeldoctor/contracts";
-import { type GuidellmReport, guidellmReportSchema } from "@modeldoctor/tool-adapters/schemas";
-import { MetricCard } from "../../components/MetricCard";
+import { guidellmReportSchema } from "@modeldoctor/tool-adapters/schemas";
 import { UnknownReport } from "../UnknownReport";
+import { InferenceMetricsGrid } from "../_shared/InferenceMetricsGrid";
 
 export interface GuidellmInferenceMetricsProps {
   benchmark: Benchmark;
-}
-
-function fmt(n: number, digits = 1): string {
-  return n.toFixed(digits);
 }
 
 export function GuidellmInferenceMetrics({ benchmark }: GuidellmInferenceMetricsProps) {
@@ -17,65 +13,29 @@ export function GuidellmInferenceMetrics({ benchmark }: GuidellmInferenceMetrics
   if (!parsed.success) {
     return <UnknownReport benchmark={benchmark} reason={parsed.error.message} />;
   }
-  const data: GuidellmReport = parsed.data;
-
+  const r = parsed.data;
   return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-      <MetricCard
-        title="TTFT (ms)"
-        rows={[
-          { label: "mean", value: fmt(data.ttft.mean) },
-          { label: "p50", value: fmt(data.ttft.p50) },
-          { label: "p90", value: fmt(data.ttft.p90) },
-          { label: "p95", value: fmt(data.ttft.p95) },
-          { label: "p99", value: fmt(data.ttft.p99) },
-        ]}
-      />
-      <MetricCard
-        title="ITL (ms)"
-        rows={[
-          { label: "mean", value: fmt(data.itl.mean) },
-          { label: "p50", value: fmt(data.itl.p50) },
-          { label: "p90", value: fmt(data.itl.p90) },
-          { label: "p95", value: fmt(data.itl.p95) },
-          { label: "p99", value: fmt(data.itl.p99) },
-        ]}
-      />
-      <MetricCard
-        title="E2E latency (ms)"
-        rows={[
-          { label: "mean", value: fmt(data.e2eLatency.mean) },
-          { label: "p50", value: fmt(data.e2eLatency.p50) },
-          { label: "p90", value: fmt(data.e2eLatency.p90) },
-          { label: "p95", value: fmt(data.e2eLatency.p95) },
-          { label: "p99", value: fmt(data.e2eLatency.p99) },
-        ]}
-      />
-      <MetricCard
-        title="Throughput"
-        rows={[
-          { label: "RPS", value: fmt(data.requestsPerSecond.mean) },
-          { label: "Output TPS", value: fmt(data.outputTokensPerSecond.mean) },
-          { label: "Input TPS", value: fmt(data.inputTokensPerSecond.mean) },
-          { label: "Total TPS", value: fmt(data.totalTokensPerSecond.mean) },
-        ]}
-      />
-      <MetricCard
-        title="Concurrency"
-        rows={[
-          { label: "mean", value: fmt(data.concurrency.mean) },
-          { label: "max", value: data.concurrency.max },
-        ]}
-      />
-      <MetricCard
-        title="Requests"
-        rows={[
-          { label: "total", value: data.requests.total },
-          { label: "success", value: data.requests.success },
-          { label: "error", value: data.requests.error },
-          { label: "incomplete", value: data.requests.incomplete },
-        ]}
-      />
-    </div>
+    <InferenceMetricsGrid
+      data={{
+        ttft: r.ttft,
+        itl: r.itl,
+        e2e: r.e2eLatency,
+        throughput: {
+          requestsPerSec: r.requestsPerSecond.mean,
+          outputTokensPerSec: r.outputTokensPerSecond.mean,
+          inputTokensPerSec: r.inputTokensPerSecond.mean,
+          totalTokensPerSec: r.totalTokensPerSecond.mean,
+        },
+        requests: {
+          total: r.requests.total,
+          success: r.requests.success,
+          error: r.requests.error,
+          incomplete: r.requests.incomplete,
+          // guidellm doesn't expose errorRate as a field — compute it
+          errorRate: r.requests.total > 0 ? r.requests.error / r.requests.total : 0,
+        },
+        concurrency: r.concurrency,
+      }}
+    />
   );
 }

--- a/apps/web/src/features/insights/checks/capacity.ts
+++ b/apps/web/src/features/insights/checks/capacity.ts
@@ -1,23 +1,8 @@
-import { readErrorRate, readThroughput } from "@/features/benchmarks/compare/metrics";
+import { readMetricSafe } from "@modeldoctor/tool-adapters/schemas";
 import type { CheckDescriptor } from "./descriptors";
 
-function tailRatio(m: any): number | null {
-  const t = (m as any)?.tool;
-  if (!t) return null;
-  let p50: number | null = null;
-  let p99: number | null = null;
-  if (t === "guidellm") {
-    p50 = m?.data?.e2eLatency?.p50 ?? null;
-    p99 = m?.data?.e2eLatency?.p99 ?? null;
-  } else if (t === "vegeta") {
-    p50 = m?.data?.latencies?.p50 ?? null;
-    p99 = m?.data?.latencies?.p99 ?? null;
-  } else if (t === "evalscope" || t === "aiperf") {
-    p50 = m?.data?.e2eLatency?.p50 ?? null;
-    p99 = m?.data?.e2eLatency?.p99 ?? null;
-  }
-  if (typeof p50 !== "number" || typeof p99 !== "number" || p50 <= 0) return null;
-  return p99 / p50;
+function read(kind: Parameters<typeof readMetricSafe>[0]) {
+  return (m: unknown) => readMetricSafe(kind, m as { tool?: unknown; data?: unknown } | null);
 }
 
 export const capacityChecks: CheckDescriptor[] = [
@@ -28,8 +13,8 @@ export const capacityChecks: CheckDescriptor[] = [
     defaultWeight: 1.0,
     direction: "higher_is_better",
     recommendationKey: "checks.capacity.max_qps.recommendation",
-    // For capacity scenario the throughput is the headline number — same reader.
-    read: (m) => readThroughput(m as any),
+    // For capacity scenario the throughput is the headline number.
+    read: read("requestsPerSec"),
   },
   {
     id: "capacity.error_rate",
@@ -38,7 +23,7 @@ export const capacityChecks: CheckDescriptor[] = [
     defaultWeight: 1.0,
     direction: "lower_is_better",
     recommendationKey: "checks.capacity.error_rate.recommendation",
-    read: (m) => readErrorRate(m as any),
+    read: read("errorRate"),
   },
   {
     id: "capacity.tail_ratio",
@@ -47,6 +32,6 @@ export const capacityChecks: CheckDescriptor[] = [
     defaultWeight: 0.7,
     direction: "lower_is_better",
     recommendationKey: "checks.capacity.tail_ratio.recommendation",
-    read: tailRatio,
+    read: read("tailRatio"),
   },
 ];

--- a/apps/web/src/features/insights/checks/inference.ts
+++ b/apps/web/src/features/insights/checks/inference.ts
@@ -1,16 +1,10 @@
-import {
-  readErrorRate,
-  readP95Latency,
-  readThroughput,
-} from "@/features/benchmarks/compare/metrics";
+import { readMetricSafe } from "@modeldoctor/tool-adapters/schemas";
 import type { CheckDescriptor } from "./descriptors";
 
-function fromDist(metrics: unknown, key: string, field: string): number | null {
-  const m = metrics as { tool?: string; data?: Record<string, unknown> } | null;
-  if (!m?.data) return null;
-  const dist = m.data[key] as Record<string, unknown> | undefined;
-  const v = dist?.[field];
-  return typeof v === "number" && Number.isFinite(v) ? v : null;
+// `run.summaryMetrics` is the contracts-side discriminated union; the helper
+// just needs `{ tool?, data? }`. Cast at the boundary like compare/metrics.ts.
+function read(kind: Parameters<typeof readMetricSafe>[0]) {
+  return (m: unknown) => readMetricSafe(kind, m as { tool?: unknown; data?: unknown } | null);
 }
 
 export const inferenceChecks: CheckDescriptor[] = [
@@ -22,12 +16,7 @@ export const inferenceChecks: CheckDescriptor[] = [
     defaultWeight: 1.0,
     direction: "lower_is_better",
     recommendationKey: "checks.inference.ttft.p95.ms.recommendation",
-    read: (m) => {
-      const t = (m as { tool?: string } | null)?.tool;
-      if (t === "guidellm" || t === "evalscope" || t === "aiperf")
-        return fromDist(m, "ttft", "p95");
-      return null;
-    },
+    read: read("ttft.p95"),
   },
   {
     id: "inference.ttft.p99.ms",
@@ -37,12 +26,7 @@ export const inferenceChecks: CheckDescriptor[] = [
     defaultWeight: 0.5,
     direction: "lower_is_better",
     recommendationKey: "checks.inference.ttft.p99.ms.recommendation",
-    read: (m) => {
-      const t = (m as { tool?: string } | null)?.tool;
-      if (t === "guidellm" || t === "evalscope" || t === "aiperf")
-        return fromDist(m, "ttft", "p99");
-      return null;
-    },
+    read: read("ttft.p99"),
   },
   {
     id: "inference.itl.p95.ms",
@@ -52,7 +36,7 @@ export const inferenceChecks: CheckDescriptor[] = [
     defaultWeight: 0.7,
     direction: "lower_is_better",
     recommendationKey: "checks.inference.itl.p95.ms.recommendation",
-    read: (m) => fromDist(m, "itl", "p95"),
+    read: read("itl.p95"),
   },
   {
     id: "inference.e2e.p95.ms",
@@ -61,8 +45,7 @@ export const inferenceChecks: CheckDescriptor[] = [
     defaultWeight: 0.7,
     direction: "lower_is_better",
     recommendationKey: "checks.inference.e2e.p95.ms.recommendation",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    read: (m) => readP95Latency(m as any),
+    read: read("e2e.p95"),
   },
   {
     id: "inference.e2e.p99.ms",
@@ -71,13 +54,7 @@ export const inferenceChecks: CheckDescriptor[] = [
     defaultWeight: 0.5,
     direction: "lower_is_better",
     recommendationKey: "checks.inference.e2e.p99.ms.recommendation",
-    read: (m) => {
-      const t = (m as { tool?: string } | null)?.tool;
-      if (t === "guidellm") return fromDist(m, "e2eLatency", "p99");
-      if (t === "vegeta") return fromDist(m, "latencies", "p99");
-      if (t === "evalscope" || t === "aiperf") return fromDist(m, "e2eLatency", "p99");
-      return null;
-    },
+    read: read("e2e.p99"),
   },
   {
     id: "inference.error_rate",
@@ -86,8 +63,7 @@ export const inferenceChecks: CheckDescriptor[] = [
     defaultWeight: 1.0,
     direction: "lower_is_better",
     recommendationKey: "checks.inference.error_rate.recommendation",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    read: (m) => readErrorRate(m as any),
+    read: read("errorRate"),
   },
   {
     id: "inference.throughput.req_per_s",
@@ -96,7 +72,6 @@ export const inferenceChecks: CheckDescriptor[] = [
     defaultWeight: 0.5,
     direction: "higher_is_better",
     recommendationKey: "checks.inference.throughput.req_per_s.recommendation",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    read: (m) => readThroughput(m as any),
+    read: read("requestsPerSec"),
   },
 ];

--- a/apps/web/src/locales/en-US/benchmarks.json
+++ b/apps/web/src/locales/en-US/benchmarks.json
@@ -426,6 +426,41 @@
     }
   },
   "reports": {
+    "shared": {
+      "ttftMs": "TTFT (ms)",
+      "itlMs": "ITL (ms)",
+      "e2eLatencyMs": "E2E latency (ms)",
+      "throughput": "Throughput",
+      "requests": "Requests",
+      "prefixCache": "Prefix cache",
+      "concurrency": "Concurrency",
+      "rps": "RPS",
+      "outputTps": "Output TPS",
+      "inputTps": "Input TPS",
+      "totalTps": "Total TPS",
+      "totalLabel": "total",
+      "successLabel": "success",
+      "errorLabel": "error",
+      "incompleteLabel": "incomplete",
+      "errorRateLabel": "error rate",
+      "hitRate": "Hit rate",
+      "meanLabel": "mean",
+      "maxLabel": "max",
+      "p50Label": "p50",
+      "p90Label": "p90",
+      "p95Label": "p95",
+      "p99Label": "p99"
+    },
+    "kvCacheStress": {
+      "coldVsWarm": "Cold vs Warm",
+      "cold": "Cold (R1)",
+      "warm": "Warm (R2)",
+      "delta": "Δ",
+      "ttftP95Ms": "TTFT p95 (ms)",
+      "rps": "RPS",
+      "outputTokensPerSec": "Output tokens/s",
+      "itlP50Ms": "ITL p50 (ms)"
+    },
     "prefixCacheProbe": {
       "stickiness": "Stickiness",
       "deterministic": "Deterministic",

--- a/apps/web/src/locales/zh-CN/benchmarks.json
+++ b/apps/web/src/locales/zh-CN/benchmarks.json
@@ -426,6 +426,41 @@
     }
   },
   "reports": {
+    "shared": {
+      "ttftMs": "TTFT (ms)",
+      "itlMs": "逐 token 延迟 (ms)",
+      "e2eLatencyMs": "端到端延迟 (ms)",
+      "throughput": "吞吐",
+      "requests": "请求",
+      "prefixCache": "前缀缓存",
+      "concurrency": "并发",
+      "rps": "RPS",
+      "outputTps": "输出 TPS",
+      "inputTps": "输入 TPS",
+      "totalTps": "总 TPS",
+      "totalLabel": "总数",
+      "successLabel": "成功",
+      "errorLabel": "失败",
+      "incompleteLabel": "未完成",
+      "errorRateLabel": "错误率",
+      "hitRate": "命中率",
+      "meanLabel": "均值",
+      "maxLabel": "最大",
+      "p50Label": "p50",
+      "p90Label": "p90",
+      "p95Label": "p95",
+      "p99Label": "p99"
+    },
+    "kvCacheStress": {
+      "coldVsWarm": "冷态 vs 热态",
+      "cold": "冷态 (R1)",
+      "warm": "热态 (R2)",
+      "delta": "Δ",
+      "ttftP95Ms": "TTFT p95 (ms)",
+      "rps": "RPS",
+      "outputTokensPerSec": "输出 token/s",
+      "itlP50Ms": "ITL p50 (ms)"
+    },
     "prefixCacheProbe": {
       "stickiness": "粘附率",
       "deterministic": "确定性",

--- a/docs/superpowers/plans/2026-05-14-evalscope-aiperf-followup.md
+++ b/docs/superpowers/plans/2026-05-14-evalscope-aiperf-followup.md
@@ -1,0 +1,1142 @@
+# Evalscope + AIPerf Follow-up Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close every deferred / non-blocking item from PR #183. Bake all external datasets into runner images for air-gapped production; refactor metric readers so future tool additions can't silently miss a runtime switch; finish the user-facing surface (1 aiperf template + full report i18n); polish small leftovers.
+
+**Architecture:** 4 phases, 15 bite-sized tasks. Phase 1 (image baking) is the user's highest priority — production has no internet egress. Phase 2 (exhaustiveness refactor) is the architectural fix for the class drift that caused 6 metric readers to silently miss new tools in PR #183. Phase 3 fills user-facing gaps. Phase 4 is polish.
+
+**Tech stack:** unchanged from PR #183 — pnpm workspaces, Vitest 2, NestJS, Prisma, shadcn/ui, react-i18next, modelscope (evalscope), HuggingFace (aiperf).
+
+---
+
+## Phase 1 · Air-gapped image readiness
+
+### Task 1 · Bake evalscope `openqa` dataset
+
+**Files:**
+- Modify: `apps/benchmark-runner/images/evalscope.Dockerfile`
+- Modify: `packages/tool-adapters/src/evalscope/runtime.ts`
+- Modify: `packages/tool-adapters/src/evalscope/runtime.spec.ts`
+
+**Context:** evalscope's `openqa` plugin (see `evalscope/perf/plugin/datasets/openqa.py`) calls `dataset_snapshot_download('AI-ModelScope/HC3-Chinese', allow_patterns=['open_qa.jsonl'])` at runtime. Air-gapped clusters fail because modelscope hub is unreachable. The plugin honors `--dataset-path` when set — it skips the download entirely. So the fix is two-pronged: (a) bake the JSONL into the image, (b) make the adapter pass `--dataset-path` for `openqa` like it does for `longalpaca`.
+
+- [ ] **Step 1 · Add openqa bake step to evalscope.Dockerfile**
+
+After the existing LongAlpaca RUN, add:
+
+```dockerfile
+# Bake openqa (HC3-Chinese) for the inf-evalscope-short template + any
+# openqa-driven manual runs. Only the open_qa.jsonl file is needed
+# (a few MB), not the rest of HC3-Chinese.
+RUN python -c "from modelscope import dataset_snapshot_download; \
+    p = dataset_snapshot_download('AI-ModelScope/HC3-Chinese', allow_patterns=['open_qa.jsonl']); \
+    import shutil; shutil.move(p, '/opt/evalscope-datasets/openqa-src'); \
+    import os; \
+    os.makedirs('/opt/evalscope-datasets/openqa', exist_ok=True); \
+    shutil.copy('/opt/evalscope-datasets/openqa-src/open_qa.jsonl', '/opt/evalscope-datasets/openqa/open_qa.jsonl'); \
+    shutil.rmtree('/opt/evalscope-datasets/openqa-src')"
+```
+
+This produces `/opt/evalscope-datasets/openqa/open_qa.jsonl` regardless of modelscope's internal sharded cache layout.
+
+- [ ] **Step 2 · Update BAKED_DATASET_PATHS in adapter runtime**
+
+In `packages/tool-adapters/src/evalscope/runtime.ts`, change `BAKED_DATASET_PATHS` from:
+
+```ts
+const BAKED_DATASET_PATHS: Record<string, string> = {
+  longalpaca: "/opt/evalscope-datasets/longalpaca",
+};
+```
+
+to:
+
+```ts
+const BAKED_DATASET_PATHS: Record<string, string> = {
+  longalpaca: "/opt/evalscope-datasets/longalpaca",
+  openqa: "/opt/evalscope-datasets/openqa/open_qa.jsonl",
+};
+```
+
+(longalpaca's plugin auto-discovers JSONL files in the directory; openqa's plugin reads a single file, so pass the file path directly. Verify by reading the openqa plugin's `dataset_line_by_line` invocation; it accepts either path.)
+
+- [ ] **Step 3 · Add a runtime.spec.ts test**
+
+Open `packages/tool-adapters/src/evalscope/runtime.spec.ts`. Find the existing longalpaca test. Add a parallel one:
+
+```ts
+it("passes --dataset-path for openqa", () => {
+  const result = adapter.buildCommand({
+    runId: "r1",
+    params: { ...defaults, dataset: "openqa" },
+    connection: testConn,
+    callback: testCb,
+  });
+  expect(result.argv).toContain("--dataset-path");
+  expect(result.argv).toContain("/opt/evalscope-datasets/openqa/open_qa.jsonl");
+});
+
+it("does not pass --dataset-path for random (synthetic dataset)", () => {
+  const result = adapter.buildCommand({
+    runId: "r1",
+    params: { ...defaults, dataset: "random" },
+    connection: testConn,
+    callback: testCb,
+  });
+  expect(result.argv).not.toContain("--dataset-path");
+});
+```
+
+- [ ] **Step 4 · Run + verify**
+
+```bash
+pnpm -F @modeldoctor/tool-adapters test --run src/evalscope/runtime.spec.ts
+```
+
+Expected: existing 14 + 2 new tests all PASS.
+
+- [ ] **Step 5 · Commit**
+
+```bash
+git add packages/tool-adapters/src/evalscope/runtime.ts \
+        packages/tool-adapters/src/evalscope/runtime.spec.ts \
+        apps/benchmark-runner/images/evalscope.Dockerfile
+git commit -m "$(cat <<'EOF'
+feat(runner): bake openqa dataset into evalscope image for air-gap
+
+evalscope's openqa plugin calls dataset_snapshot_download at runtime,
+unreachable on air-gapped clusters. Bake AI-ModelScope/HC3-Chinese's
+open_qa.jsonl into /opt/evalscope-datasets/openqa/ and pass that path
+via --dataset-path so the plugin skips its download attempt.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2 · Bake aiperf `ShareGPT` dataset
+
+**Files:**
+- Modify: `apps/benchmark-runner/images/aiperf.Dockerfile`
+
+**Context:** aiperf's `ShareGPTLoader` (see `aiperf/dataset/loader/sharegpt.py`) downloads `https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json` (~672 MB) to `.cache/aiperf/datasets/ShareGPT_V3_unfiltered_cleaned_split.json`. The path is relative (pathlib `Path(".cache/aiperf/datasets")`) — resolved from the container's CWD. The image's WORKDIR is `/app`, so the cache resolves to `/app/.cache/aiperf/datasets/`. Pre-populate that exact location.
+
+- [ ] **Step 1 · Add ShareGPT bake step**
+
+Insert before the `USER runner` line:
+
+```dockerfile
+# Bake ShareGPT V3 (~672 MB). aiperf's ShareGPTLoader resolves
+# `.cache/aiperf/datasets/<filename>` relative to WORKDIR (/app), so
+# pre-populate that exact path. Image size: ~1 GB → ~1.7 GB.
+RUN mkdir -p /app/.cache/aiperf/datasets \
+    && curl -fL --output /app/.cache/aiperf/datasets/ShareGPT_V3_unfiltered_cleaned_split.json \
+        https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json
+```
+
+Then update the chown to include the cache:
+
+```dockerfile
+RUN useradd --create-home --shell /sbin/nologin runner \
+    && chown -R runner:runner /app
+```
+
+The existing `chown -R runner:runner /app` already covers `/app/.cache/`, so no edit needed there — but verify after the move.
+
+- [ ] **Step 2 · Verify integrity hint**
+
+Add a comment noting the file size as a build-time sanity check (curl doesn't fail loudly if the response is shorter than expected unless `-f` is set, which it is):
+
+```dockerfile
+# Sanity: file should be ~640 MiB; build will surface curl errors with -f.
+```
+
+Optional: add a `RUN test "$(stat -c%s /app/.cache/aiperf/datasets/ShareGPT_V3_unfiltered_cleaned_split.json)" -gt 600000000` step. Skip if it complicates layer caching.
+
+- [ ] **Step 3 · Document the bake choice**
+
+Add a header comment to the Dockerfile noting the trade-off:
+
+```dockerfile
+# Bakes ShareGPT V3 corpus (~672 MB) to make sharegpt-driven runs
+# work on air-gapped clusters. Image goes from ~1 GB to ~1.7 GB.
+# Synthetic-only deployments can use a slimmer variant by skipping
+# the bake step (not currently published).
+```
+
+- [ ] **Step 4 · No runtime adapter change needed**
+
+aiperf reads from `.cache/aiperf/datasets/` automatically when `--public-dataset sharegpt` is set; the cache check precedes the HTTP fetch. Verify by reading the `_load_dataset` method in `base_public_dataset.py` if you doubt this.
+
+- [ ] **Step 5 · Commit**
+
+```bash
+git add apps/benchmark-runner/images/aiperf.Dockerfile
+git commit -m "$(cat <<'EOF'
+feat(runner): bake ShareGPT corpus into aiperf image for air-gap
+
+aiperf's ShareGPTLoader downloads ~672 MB from HuggingFace on first
+use; unreachable on air-gapped clusters. Pre-populate
+/app/.cache/aiperf/datasets/ (aiperf's resolved relative cache path)
+with the file so --public-dataset sharegpt works offline. Image goes
+from ~1 GB to ~1.7 GB.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3 · Air-gap verification script
+
+**Files:**
+- Create: `apps/benchmark-runner/scripts/verify-airgap.sh`
+
+**Context:** Without an automated check, future regressions can sneak in (e.g. someone adds a new dataset enum value, forgets to bake it). Provide a script that runs each Dockerfile with `--network none` and exercises the dataset path.
+
+- [ ] **Step 1 · Write the script**
+
+```bash
+#!/usr/bin/env bash
+# Verify the evalscope + aiperf runner images can boot and access
+# every supported dataset enum value WITHOUT network egress. Run after
+# building the images locally (or against pulled :latest images).
+#
+# Usage:
+#   ./apps/benchmark-runner/scripts/verify-airgap.sh
+#   IMAGE_EVALSCOPE=md-runner-evalscope:dev ./apps/benchmark-runner/scripts/verify-airgap.sh
+
+set -euo pipefail
+
+EVALSCOPE_IMAGE="${IMAGE_EVALSCOPE:-md-runner-evalscope:dev}"
+AIPERF_IMAGE="${IMAGE_AIPERF:-md-runner-aiperf:dev}"
+
+echo "==> evalscope longalpaca bake check"
+docker run --rm --network none "$EVALSCOPE_IMAGE" \
+  test -f /opt/evalscope-datasets/longalpaca/LongAlpaca-12k.json \
+  || (echo "FAIL: longalpaca not baked" && exit 1)
+
+echo "==> evalscope openqa bake check"
+docker run --rm --network none "$EVALSCOPE_IMAGE" \
+  test -f /opt/evalscope-datasets/openqa/open_qa.jsonl \
+  || (echo "FAIL: openqa not baked" && exit 1)
+
+echo "==> aiperf ShareGPT bake check"
+docker run --rm --network none "$AIPERF_IMAGE" \
+  test -f /app/.cache/aiperf/datasets/ShareGPT_V3_unfiltered_cleaned_split.json \
+  || (echo "FAIL: ShareGPT not baked" && exit 1)
+
+echo "==> all baked datasets present; air-gapped runs supported"
+```
+
+(The exact LongAlpaca filename inside `/opt/evalscope-datasets/longalpaca/` may differ — adjust the `test -f` path after a local build. If modelscope's download produces a directory structure rather than a single JSON, switch to `test -d` and a non-empty directory check.)
+
+- [ ] **Step 2 · Make executable + smoke test locally**
+
+```bash
+chmod +x apps/benchmark-runner/scripts/verify-airgap.sh
+./tools/build-runner-images.sh --no-import
+IMAGE_EVALSCOPE=md-runner-evalscope:<tag> IMAGE_AIPERF=md-runner-aiperf:<tag> \
+  ./apps/benchmark-runner/scripts/verify-airgap.sh
+```
+
+If verification fails, fix the bake step in Task 1 or 2 before continuing.
+
+- [ ] **Step 3 · Commit**
+
+```bash
+git add apps/benchmark-runner/scripts/verify-airgap.sh
+git commit -m "$(cat <<'EOF'
+build(runner): add air-gapped dataset verification script
+
+Confirms every dataset enum value supported by evalscope + aiperf has
+its source file present in the runner image, run with --network none.
+Catches future regressions where someone adds a new dataset enum
+value but forgets to bake it.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4 · Document air-gapped operator workflow
+
+**Files:**
+- Modify: `apps/benchmark-runner/README.md`
+
+**Context:** The operator deploying to production needs to know which datasets are baked, what's missing, and how to verify before rollout. A small README section is the cheapest place to put this.
+
+- [ ] **Step 1 · Add an "Air-gapped clusters" section**
+
+Find the existing README (it covers `tools/build-runner-images.sh` usage already). Add:
+
+```markdown
+## Air-gapped clusters
+
+The evalscope + aiperf images bake their datasets at build time so runs
+work without internet egress from the cluster:
+
+| Image | Dataset enum value | Baked path | Source |
+|---|---|---|---|
+| evalscope | `longalpaca` | `/opt/evalscope-datasets/longalpaca/` | `AI-ModelScope/LongAlpaca-12k` (modelscope) |
+| evalscope | `openqa` | `/opt/evalscope-datasets/openqa/open_qa.jsonl` | `AI-ModelScope/HC3-Chinese:open_qa.jsonl` |
+| evalscope | `random` | n/a (synthetic) | — |
+| aiperf | `sharegpt` | `/app/.cache/aiperf/datasets/ShareGPT_V3_unfiltered_cleaned_split.json` | `anon8231489123/ShareGPT_Vicuna_unfiltered` (HuggingFace) |
+| aiperf | `synthetic` | n/a (built-in generator) | — |
+
+After build + before deploy, run `apps/benchmark-runner/scripts/verify-airgap.sh`
+to confirm every baked path is reachable with `--network none`.
+```
+
+- [ ] **Step 2 · Commit**
+
+```bash
+git add apps/benchmark-runner/README.md
+git commit -m "$(cat <<'EOF'
+docs(runner): document air-gapped dataset baking matrix
+
+Lists every dataset enum value supported by evalscope and aiperf, its
+baked path inside the image, and the upstream source — so the deploying
+operator can verify before rollout.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 2 · ToolName exhaustiveness refactor
+
+### Task 5 · Adapter-level metric extractor interface
+
+**Files:**
+- Modify: `packages/tool-adapters/src/core/interface.ts`
+- Create: `packages/tool-adapters/src/core/metric-extractor.ts`
+- Modify: each adapter's `index.ts` to wire the new method
+
+**Context:** Today, `apps/api/src/modules/insights/metrics.ts`, `apps/api/src/modules/saved-compares/metrics.ts`, `apps/api/src/modules/benchmark/metrics.ts`, `apps/web/src/features/benchmarks/compare/metrics.ts`, `apps/web/src/features/benchmarks/compare/client-metrics.ts`, and `apps/web/src/features/insights/checks/*.ts` all `switch (tool)` on the tool name to read the right field path. Adding a new tool means hunting every one of those six files. PR #183 review caught this — multiple files silently dropped genai-perf without adding evalscope/aiperf. Fix the class drift by moving the extraction into adapter responsibility.
+
+- [ ] **Step 1 · Define MetricKind + ToolMetricExtractor**
+
+Create `packages/tool-adapters/src/core/metric-extractor.ts`:
+
+```ts
+import type { z } from "zod";
+
+// Standard inference-shape metrics every load-generator tool can expose.
+// `null` = the tool doesn't carry this metric (e.g. vegeta has no TTFT).
+export type MetricKind =
+  | "ttft.p95"
+  | "ttft.p99"
+  | "itl.p95"
+  | "e2e.p95"
+  | "e2e.p99"
+  | "errorRate"        // 0-1 fraction
+  | "requestsPerSec"
+  | "outputTokensPerSec"
+  | "tailRatio";       // e2e.p99 / e2e.p50
+
+export interface ToolMetricExtractor {
+  /**
+   * Pull one well-known metric out of the tool's persisted summary.
+   * The `data` argument is the `.data` payload from `summaryMetrics`
+   * (already discriminated by tool). Implementations return `null`
+   * when the tool doesn't carry that metric, when the data is missing,
+   * or when the value is non-finite.
+   */
+  readMetric(kind: MetricKind, data: Record<string, unknown>): number | null;
+}
+```
+
+- [ ] **Step 2 · Extend ToolAdapter interface**
+
+In `packages/tool-adapters/src/core/interface.ts`, add:
+
+```ts
+import type { ToolMetricExtractor } from "./metric-extractor.js";
+
+export interface ToolAdapter extends ToolMetricExtractor {
+  // ... existing fields ...
+}
+```
+
+So every adapter must implement `readMetric`. The compile-time check is now "every Tool in the registry has every MetricKind covered."
+
+- [ ] **Step 3 · Implement readMetric per adapter (5 adapters)**
+
+In each adapter's `index.ts` (`guidellm/index.ts`, `vegeta/index.ts`, `prefix-cache-probe/index.ts`, `evalscope/index.ts`, `aiperf/index.ts`), add a `readMetric` function that returns the right field for each MetricKind based on the tool's report shape.
+
+Example for guidellm:
+
+```ts
+function readMetric(kind: MetricKind, data: Record<string, unknown>): number | null {
+  const fin = (v: unknown): number | null =>
+    typeof v === "number" && Number.isFinite(v) ? v : null;
+  const dist = (key: string, field: string): number | null => {
+    const d = data[key] as Record<string, unknown> | undefined;
+    return fin(d?.[field]);
+  };
+  switch (kind) {
+    case "ttft.p95": return dist("ttft", "p95");
+    case "ttft.p99": return dist("ttft", "p99");
+    case "itl.p95":  return dist("itl", "p95");
+    case "e2e.p95":  return dist("e2eLatency", "p95");
+    case "e2e.p99":  return dist("e2eLatency", "p99");
+    case "errorRate": {
+      const r = data.requests as { total?: number; error?: number } | undefined;
+      const t = fin(r?.total), e = fin(r?.error);
+      return t === null || e === null || t === 0 ? null : e / t;
+    }
+    case "requestsPerSec": {
+      const r = data.requestsPerSecond as { mean?: number } | undefined;
+      return fin(r?.mean);
+    }
+    case "outputTokensPerSec": {
+      const r = data.outputTokensPerSecond as { mean?: number } | undefined;
+      return fin(r?.mean);
+    }
+    case "tailRatio": {
+      const p50 = dist("e2eLatency", "p50"), p99 = dist("e2eLatency", "p99");
+      return p50 === null || p99 === null || p50 === 0 ? null : p99 / p50;
+    }
+    default: {
+      const _exhaustive: never = kind;
+      return null;
+    }
+  }
+}
+
+export const guidellmAdapter: ToolAdapter = { ..., readMetric };
+```
+
+For vegeta, most kinds return null except `e2e.p95` (latencies.p95), `errorRate` (1 - success/100), `requestsPerSec` (requests.throughput).
+
+For prefix-cache-probe, all kinds return null.
+
+For evalscope + aiperf: same as the FE compare/metrics.ts shape — `data.ttft|itl|e2eLatency.{p95,p99}`, `data.throughput.requestsPerSec`, etc.
+
+- [ ] **Step 4 · Tests per adapter**
+
+In each adapter's `index.ts.spec.ts` or its companion test, add a `describe("readMetric", () => { ... })` block exercising every MetricKind with the adapter's known fixture data. Total: 5 adapters × 9 MetricKinds = 45 small assertions. Catch field-path bugs at adapter level instead of consumer level.
+
+- [ ] **Step 5 · Run + verify**
+
+```bash
+pnpm -F @modeldoctor/tool-adapters test --run
+```
+
+Expected: all existing tests + ~45 new assertions all PASS.
+
+- [ ] **Step 6 · Commit**
+
+```bash
+git add packages/tool-adapters/src/core/metric-extractor.ts \
+        packages/tool-adapters/src/core/interface.ts \
+        packages/tool-adapters/src/{guidellm,vegeta,prefix-cache-probe,evalscope,aiperf}/index.ts \
+        packages/tool-adapters/src/**/*.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(tool-adapters): adapter-level readMetric(kind, data) interface
+
+Replaces six runtime switch (tool) blocks scattered across api + web
+with a single `adapter.readMetric(kind, data)` lookup. New MetricKind
+enum lists every well-known inference metric (ttft.p95, e2e.p99,
+errorRate, requestsPerSec, tailRatio, ...). Each of the 5 adapters
+implements readMetric with its own field paths.
+
+Compile-time check: adding a new MetricKind without updating an
+adapter is a type error (exhaustive switch + `as never`). Consumers
+that didn't already cover a new tool when added (the class-drift bug
+caught in PR #183 review) is now impossible — there's only one site
+to add a tool, not six.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6 · Refactor API metric reader modules
+
+**Files:**
+- Modify: `apps/api/src/modules/benchmark/metrics.ts`
+- Modify: `apps/api/src/modules/insights/metrics.ts`
+- Modify: `apps/api/src/modules/saved-compares/metrics.ts`
+
+**Context:** With Task 5's `adapter.readMetric` in place, the three API modules can replace their `switch (tool)` with a one-liner.
+
+- [ ] **Step 1 · Refactor `benchmark/metrics.ts`**
+
+Replace the body of `readP95LatencyMs`:
+
+```ts
+import { byTool, type MetricKind, type ToolName } from "@modeldoctor/tool-adapters";
+
+function readByKind(kind: MetricKind, metrics: Prisma.JsonValue | null): number | null {
+  const m = asTagged(metrics);
+  if (!m?.data || !m.tool) return null;
+  try {
+    return byTool(m.tool as ToolName).readMetric(kind, m.data);
+  } catch {
+    return null;  // unknown tool / parse error → null, not throw
+  }
+}
+
+export function readP95LatencyMs(metrics: Prisma.JsonValue | null): number | null {
+  return readByKind("e2e.p95", metrics);
+}
+```
+
+(The `try/catch` is defensive: `byTool` throws on unknown tool names. Data could legitimately carry a tool name no longer registered.)
+
+- [ ] **Step 2 · Refactor `insights/metrics.ts`**
+
+Replace each per-metric switch with `readByKind` calls. The existing `extractMetric` function takes a metric id string ("ttft.p95", "e2e.p95", etc.) — map those directly to MetricKind. Drop the per-tool switches entirely.
+
+- [ ] **Step 3 · Refactor `saved-compares/metrics.ts`**
+
+`readP95Latency`, `readErrorRate`, `readThroughput` all become one-liners:
+
+```ts
+export const readP95Latency = (m: unknown) => readByKind("e2e.p95", m);
+export const readErrorRate = (m: unknown) => readByKind("errorRate", m);
+export const readThroughput = (m: unknown) => readByKind("requestsPerSec", m);
+```
+
+`summarizeForPrompt` similarly delegates each field to `readByKind`.
+
+- [ ] **Step 4 · Run + verify**
+
+```bash
+pnpm -F @modeldoctor/api test --run
+pnpm -F @modeldoctor/api type-check
+```
+
+Expected: all 647+ tests pass; no regressions.
+
+- [ ] **Step 5 · Commit**
+
+```bash
+git add apps/api/src/modules/benchmark/metrics.ts \
+        apps/api/src/modules/insights/metrics.ts \
+        apps/api/src/modules/saved-compares/metrics.ts
+git commit -m "$(cat <<'EOF'
+refactor(api): metric readers delegate to adapter.readMetric
+
+Three api modules (benchmark/metrics, insights/metrics, saved-compares/
+metrics) had near-identical switch (tool) blocks. Replace each with
+`byTool(tool).readMetric(kind, data)` — one source of truth, in the
+tool-adapters package.
+
+PR #183's class-drift bug — six switches updated for genai-perf
+deletion but only two updated for evalscope+aiperf addition — is now
+structurally impossible: adapters own their field paths, consumers
+just pick a MetricKind.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7 · Refactor FE compare metric modules
+
+**Files:**
+- Modify: `apps/web/src/features/benchmarks/compare/metrics.ts`
+- Modify: `apps/web/src/features/benchmarks/compare/client-metrics.ts`
+
+**Context:** Same pattern as Task 6 but on the FE side. These two files also `switch (tool)`.
+
+- [ ] **Step 1 · Refactor `compare/metrics.ts`**
+
+Replace each top-level reader (`readP95Latency`, `readErrorRate`, `readThroughput`) with a one-liner that delegates to `byTool(tool).readMetric(kind, data)`. Mirror the API side from Task 6.
+
+The `rowDescriptorsForTool` function should also be refactored: the row descriptors are essentially tuples of `(labelKey, MetricKind, formatHint)`. Build them per-tool by querying the adapter (i.e. each adapter could optionally expose `inferenceRowDescriptors(): MetricRowDescriptor[]`). Defer the deeper refactor to a follow-up if it grows the diff too much — the simpler fix is to keep `rowDescriptorsForTool` as-is but rewrite each row's `read` to use `readByKind`.
+
+- [ ] **Step 2 · Refactor `client-metrics.ts`**
+
+`summarizeForPrompt` is the main affected function. Replace each `tool === "..." ? ... : ...` chain with `readByKind` calls.
+
+- [ ] **Step 3 · Run + verify**
+
+```bash
+pnpm -F web test --run apps/web/src/features/benchmarks/compare/
+pnpm -F web type-check
+```
+
+- [ ] **Step 4 · Commit**
+
+```bash
+git add apps/web/src/features/benchmarks/compare/metrics.ts \
+        apps/web/src/features/benchmarks/compare/client-metrics.ts \
+        apps/web/src/features/benchmarks/compare/__tests__/metrics.test.ts
+git commit -m "$(cat <<'EOF'
+refactor(web): compare metric readers delegate to adapter.readMetric
+
+Mirrors the api-side refactor from the previous commit. FE compare/
+metrics.ts and client-metrics.ts now call byTool(tool).readMetric
+instead of carrying their own per-tool switches.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8 · Refactor FE insights checks
+
+**Files:**
+- Modify: `apps/web/src/features/insights/checks/inference.ts`
+- Modify: `apps/web/src/features/insights/checks/capacity.ts`
+
+**Context:** Same pattern. Inference checks (`ttftP95`, `e2eP95`, etc.) each carry their own `toolFilter` + `read` function. Replace `read` with `readByKind`; collapse `toolFilter` to "tools where `readMetric(kind, fixture) !== null` for a sample fixture" (i.e. auto-derive from adapters), OR just keep toolFilter as a hardcoded list of supported-tool names.
+
+The cleaner architecture is to derive `toolFilter` automatically — but that requires a sample fixture per adapter, which complicates this task. Simpler: keep toolFilter manual but replace the read function with a delegate.
+
+- [ ] **Step 1 · Refactor each Check's `read` function**
+
+```ts
+{
+  id: "ttft.p95",
+  toolFilter: ["guidellm", "evalscope", "aiperf"] as ToolName[],
+  read: (run) => readByKind("ttft.p95", run.summaryMetrics),
+  threshold: 1500,
+}
+```
+
+`readByKind` is the same helper from Task 6/7 (imported from a shared location, e.g. `apps/web/src/features/benchmarks/compare/metrics.ts` or extracted to a fresh `apps/web/src/features/benchmarks/_shared/metric-reader.ts`).
+
+- [ ] **Step 2 · Run + verify**
+
+```bash
+pnpm -F web test --run apps/web/src/features/insights/
+pnpm -F web type-check
+```
+
+- [ ] **Step 3 · Commit**
+
+```bash
+git add apps/web/src/features/insights/checks/inference.ts \
+        apps/web/src/features/insights/checks/capacity.ts
+git commit -m "$(cat <<'EOF'
+refactor(web): insights checks read via adapter.readMetric
+
+Each Check's `read` callback now delegates to readByKind instead of
+its own switch (tool). toolFilter stays manual for now (auto-deriving
+it requires a sample fixture per adapter — out of scope here).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 9 · Extract `<InferenceMetricsGrid>` shared component
+
+**Files:**
+- Create: `apps/web/src/features/benchmarks/reports/_shared/InferenceMetricsGrid.tsx`
+- Modify: `apps/web/src/features/benchmarks/reports/guidellm/InferenceMetrics.tsx`
+- Modify: `apps/web/src/features/benchmarks/reports/evalscope/InferenceMetrics.tsx`
+- Modify: `apps/web/src/features/benchmarks/reports/aiperf/InferenceMetrics.tsx`
+
+**Context:** PR #183 created two near-duplicate `InferenceMetrics` files (evalscope, aiperf) that match the existing guidellm style. Each renders the same 5-6 MetricCards (TTFT, ITL, E2E, Throughput, Requests). Now that there are three files with ~80% overlap, the abstraction pays off.
+
+- [ ] **Step 1 · Define a shared report shape**
+
+The three tools agree on the inference metric shape: `ttft / itl / e2eLatency: {mean,p50,p90,p95,p99}`, `throughput: {requestsPerSec, outputTokensPerSec, totalTokensPerSec}` (guidellm uses `requestsPerSecond.mean` instead — adapt), `requests: {total, success, error, errorRate}`. Build a normalizer in the shared component.
+
+```tsx
+// apps/web/src/features/benchmarks/reports/_shared/InferenceMetricsGrid.tsx
+import { MetricCard } from "../../components/MetricCard";
+
+interface Dist { mean: number; p50: number; p90: number; p95: number; p99: number }
+interface Requests { total: number; success: number; error: number; errorRate: number }
+interface Throughput { requestsPerSec: number; outputTokensPerSec: number; totalTokensPerSec: number }
+interface PrefixCache { hitRate: number }
+
+interface NormalizedInferenceData {
+  ttft: Dist;
+  itl: Dist;
+  e2e: Dist;
+  throughput: Throughput;
+  requests: Requests;
+  prefixCache?: PrefixCache;
+}
+
+export function InferenceMetricsGrid({ data }: { data: NormalizedInferenceData }) {
+  const fmt = (n: number, d = 1) => n.toFixed(d);
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {/* TTFT MetricCard, ITL MetricCard, E2E MetricCard, Throughput MetricCard,
+          Requests MetricCard, conditionally Prefix Cache MetricCard */}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2 · Rewrite the three per-tool files as thin normalizers**
+
+Each becomes ~15 lines:
+
+```tsx
+// evalscope/InferenceMetrics.tsx
+import type { Benchmark } from "@modeldoctor/contracts";
+import { evalscopeReportSchema } from "@modeldoctor/tool-adapters/schemas";
+import { InferenceMetricsGrid } from "../_shared/InferenceMetricsGrid";
+import { UnknownReport } from "../UnknownReport";
+
+export function EvalscopeInferenceMetrics({ benchmark }: { benchmark: Benchmark }) {
+  const tagged = benchmark.summaryMetrics as { data?: unknown } | null;
+  const parsed = evalscopeReportSchema.safeParse(tagged?.data);
+  if (!parsed.success) return <UnknownReport benchmark={benchmark} reason={parsed.error.message} />;
+  const r = parsed.data;
+  return (
+    <InferenceMetricsGrid
+      data={{
+        ttft: r.ttft, itl: r.itl, e2e: r.e2eLatency,
+        throughput: r.throughput,
+        requests: r.requests,
+        prefixCache: r.prefixCacheStats,
+      }}
+    />
+  );
+}
+```
+
+guidellm's normalizer maps `requestsPerSecond.mean → throughput.requestsPerSec` (with `outputTokensPerSec` from `outputTokensPerSecond.mean`, etc.). aiperf has no prefix cache — omit that field.
+
+- [ ] **Step 3 · Run + verify**
+
+```bash
+pnpm -F web test --run
+pnpm -F web type-check
+```
+
+- [ ] **Step 4 · Commit**
+
+```bash
+git add apps/web/src/features/benchmarks/reports/_shared/InferenceMetricsGrid.tsx \
+        apps/web/src/features/benchmarks/reports/{guidellm,evalscope,aiperf}/InferenceMetrics.tsx
+git commit -m "$(cat <<'EOF'
+refactor(web): share InferenceMetricsGrid across guidellm/evalscope/aiperf
+
+The three per-tool InferenceMetrics files had ~80% overlap (5
+MetricCards each, identical layout). Extract the grid into
+_shared/InferenceMetricsGrid.tsx; each per-tool file now just
+normalizes its tool's data shape into the grid's NormalizedInferenceData
+contract. Evalscope keeps its optional prefix-cache card; aiperf
+omits it; guidellm maps requestsPerSecond.mean → throughput.requestsPerSec.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 3 · User-facing completeness
+
+### Task 10 · Add 1 official aiperf template
+
+**Files:**
+- Modify: `apps/api/prisma/seed.ts`
+
+**Context:** Tool union has `aiperf` but 0 aiperf official templates. Users can pick aiperf manually but lose the "prefill from template" experience.
+
+- [ ] **Step 1 · Append the template**
+
+After the 2 inference evalscope templates, add:
+
+```ts
+{
+  id: "tpl_inf_aiperf_baseline",
+  name: "AIPerf · 综合基线",
+  description:
+    "AIPerf 通用基线:concurrency=8, 200 requests, synthetic 输入均值 1024 tokens / 输出均值 256 tokens。一发就有,适合横评。",
+  scenario: "inference",
+  tool: "aiperf",
+  config: {
+    concurrency: 8,
+    requestCount: 200,
+    inputTokensMean: 1024,
+    inputTokensStddev: 128,
+    outputTokensMean: 256,
+    outputTokensStddev: 64,
+    endpointType: "chat",
+    streaming: true,
+    dataset: "synthetic",
+    seed: 42,
+  },
+  tags: ["inference", "aiperf", "baseline", "synthetic"],
+},
+```
+
+- [ ] **Step 2 · Re-seed dev DB**
+
+```bash
+pnpm -F @modeldoctor/api db:seed
+psql postgresql://modeldoctor:modeldoctor@localhost:5432/modeldoctor \
+  -c "SELECT tool, COUNT(*) FROM benchmark_templates GROUP BY tool ORDER BY tool;"
+```
+
+Expected: 9 guidellm + 8 evalscope + 1 aiperf = 18 total.
+
+- [ ] **Step 3 · Run tests**
+
+```bash
+pnpm -F @modeldoctor/api test --run
+```
+
+- [ ] **Step 4 · Commit**
+
+```bash
+git add apps/api/prisma/seed.ts
+git commit -m "$(cat <<'EOF'
+feat(api): 1 official aiperf inference template
+
+tpl_inf_aiperf_baseline: concurrency=8, 200 requests, synthetic input
+mean 1024 / output mean 256 — the obvious AIPerf landing baseline so
+users coming from the genai-perf flow have a 1-click template equivalent.
+
+Seed-time validator (touched in #183) now exercises all three tool
+schemas (guidellm + evalscope + aiperf) since this is the first aiperf
+template to flow through it.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 11 · Report i18n keys + wire useTranslation
+
+**Files:**
+- Modify: `apps/web/src/locales/zh-CN/benchmarks.json`
+- Modify: `apps/web/src/locales/en-US/benchmarks.json`
+- Modify: `apps/web/src/features/benchmarks/reports/_shared/InferenceMetricsGrid.tsx`
+- Modify: `apps/web/src/features/benchmarks/reports/KvCacheStressReport.tsx`
+
+**Context:** PR #183 left report-panel labels inline-English (e.g. `"TTFT (ms)"`, `"Throughput"`, `"Prefix cache"`). Chinese users see English. Form labels (Task 18 of #183) were i18n'd; report labels weren't.
+
+- [ ] **Step 1 · Add i18n keys to both locales**
+
+Add a `reports.shared.*` block (shared across the three inference report renders, since they all use InferenceMetricsGrid now):
+
+```json
+"reports": {
+  "shared": {
+    "ttftMs": "TTFT (ms)",
+    "itlMs": "ITL (ms)",
+    "e2eLatencyMs": "E2E latency (ms)",
+    "throughput": "Throughput",
+    "requests": "Requests",
+    "prefixCache": "Prefix cache",
+    "rps": "RPS",
+    "outputTps": "Output TPS",
+    "totalTps": "Total TPS",
+    "totalLabel": "total",
+    "successLabel": "success",
+    "errorLabel": "error",
+    "errorRateLabel": "error rate",
+    "hitRate": "Hit rate"
+  },
+  "kvCacheStress": {
+    "coldVsWarm": "Cold vs Warm",
+    "cold": "Cold (R1)",
+    "warm": "Warm (R2)",
+    "delta": "Δ"
+  }
+}
+```
+
+zh-CN equivalents: `"TTFT (ms)"`, `"逐 token 延迟 (ms)"`, `"端到端延迟 (ms)"`, `"吞吐"`, `"请求"`, `"前缀缓存"`, `"RPS"`, `"输出 TPS"`, `"总 TPS"`, `"总数"`, `"成功"`, `"失败"`, `"错误率"`, `"命中率"`, `"冷态 vs 热态"`, `"冷态 (R1)"`, `"热态 (R2)"`, `"Δ"`.
+
+- [ ] **Step 2 · Wire useTranslation in InferenceMetricsGrid**
+
+```tsx
+import { useTranslation } from "react-i18next";
+
+export function InferenceMetricsGrid({ data }: { data: NormalizedInferenceData }) {
+  const { t } = useTranslation("benchmarks");
+  // ... use t("reports.shared.ttftMs") etc.
+}
+```
+
+- [ ] **Step 3 · Same for KvCacheStressReport**
+
+The component currently uses inline English. Add `useTranslation("benchmarks")` and replace `"TTFT P95 (ms)"` etc. with `t("reports.shared.ttftMs")`, `"Cold vs Warm"` with `t("reports.kvCacheStress.coldVsWarm")`, etc.
+
+- [ ] **Step 4 · Run i18n parity check + tests**
+
+```bash
+cd apps/web && node scripts/check-i18n-parity.mjs
+pnpm -F web test --run
+pnpm -F web type-check
+```
+
+- [ ] **Step 5 · Commit**
+
+```bash
+git add apps/web/src/locales/{zh-CN,en-US}/benchmarks.json \
+        apps/web/src/features/benchmarks/reports/_shared/InferenceMetricsGrid.tsx \
+        apps/web/src/features/benchmarks/reports/KvCacheStressReport.tsx
+git commit -m "$(cat <<'EOF'
+feat(web): i18n keys for inference + KV-cache report panels
+
+PR #183 left report-panel labels inline-English (TTFT (ms),
+Throughput, Prefix cache, Cold vs Warm, etc.). Add reports.shared.*
+and reports.kvCacheStress.* keys to zh-CN + en-US; wire useTranslation
+in InferenceMetricsGrid + KvCacheStressReport.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 4 · Polish
+
+### Task 12 · `numberField` form helper
+
+**Files:**
+- Create: `apps/web/src/features/benchmarks/forms/_shared/numberField.ts`
+- Modify: `apps/web/src/features/benchmarks/forms/EvalscopeParamsForm.tsx`
+- Modify: `apps/web/src/features/benchmarks/forms/AiperfParamsForm.tsx`
+
+**Context:** The `value={field.value ?? ""}` + `onChange={(e) => field.onChange(e.target.value === "" ? undefined : Number(e.target.value))}` pattern repeats ~7 times per form. Extract a helper.
+
+- [ ] **Step 1 · Write the helper**
+
+```ts
+// apps/web/src/features/benchmarks/forms/_shared/numberField.ts
+import type { ControllerRenderProps } from "react-hook-form";
+
+/** Bind a react-hook-form numeric field with blank→undefined semantics.
+ *  Avoids ~14 lines of inline boilerplate across each per-tool form. */
+export function numberField<T extends Record<string, unknown>, K extends keyof T>(
+  field: ControllerRenderProps<T, K>,
+) {
+  return {
+    value: (field.value as number | undefined) ?? "",
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+      const raw = e.target.value;
+      field.onChange(raw === "" ? undefined : Number(raw));
+    },
+    onBlur: field.onBlur,
+    name: field.name,
+    ref: field.ref,
+  };
+}
+```
+
+- [ ] **Step 2 · Apply to EvalscopeParamsForm + AiperfParamsForm**
+
+Replace each numeric `FormField`'s inline `value=...`/`onChange=...` with `<Input type="number" {...numberField(field)} />`.
+
+- [ ] **Step 3 · Verify**
+
+```bash
+pnpm -F web test --run apps/web/src/features/benchmarks/forms/
+pnpm -F web type-check
+```
+
+- [ ] **Step 4 · Commit**
+
+```bash
+git add apps/web/src/features/benchmarks/forms/_shared/numberField.ts \
+        apps/web/src/features/benchmarks/forms/{Evalscope,Aiperf}ParamsForm.tsx
+git commit -m "$(cat <<'EOF'
+chore(web): extract numberField() helper for shadcn form integration
+
+Removes ~14 lines of value+onChange boilerplate per numeric field (×7
+fields × 2 forms = ~28 collapsed lines). Helper enforces the
+blank→undefined contract uniformly so optional fields don't emit NaN.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 13 · Clean stale Phase-N comments
+
+**Files:**
+- Modify: `apps/benchmark-runner/images/evalscope.Dockerfile`
+- Modify: `apps/benchmark-runner/images/aiperf.Dockerfile`
+
+**Context:** Header comments reference "Phase 1 of evalscope rollout" / "Replacement for the deprecated genai-perf image" (which is true historical context but reads oddly now that the migration is complete). Tighten to one sentence focused on what the image IS, not how it came to exist.
+
+- [ ] **Step 1 · Rewrite evalscope.Dockerfile header**
+
+Replace the multi-line "Phase 1 of evalscope rollout. … Image ~1.7 GB" comment with:
+
+```dockerfile
+# Modelscope evalscope perf load generator. Bakes LongAlpaca-12k +
+# HC3-Chinese open_qa.jsonl at build time so the image runs on
+# air-gapped clusters. Image ~1.75 GB.
+```
+
+- [ ] **Step 2 · Rewrite aiperf.Dockerfile header**
+
+```dockerfile
+# NVIDIA aiperf (ai-dynamo) perf load generator. Bakes ShareGPT V3
+# corpus (~672 MB) at build time so --public-dataset sharegpt works
+# on air-gapped clusters. Image ~1.7 GB.
+```
+
+- [ ] **Step 3 · Commit**
+
+```bash
+git add apps/benchmark-runner/images/{evalscope,aiperf}.Dockerfile
+git commit -m "$(cat <<'EOF'
+chore(runner): trim Dockerfile header comments to current state
+
+Drop "Phase 1 of evalscope rollout" / "Replacement for genai-perf"
+prose. Replace with one-sentence statement of what each image IS now
+that the migration is merged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 14 · `pnpm -r build` cleans dist/
+
+**Files:**
+- Modify: `packages/tool-adapters/package.json`
+- Modify: `packages/contracts/package.json`
+
+**Context:** `tsc` doesn't delete emit for files that were deleted from the source tree. Result: after Task 19/20 of #183, `packages/tool-adapters/dist/genai-perf/` and `dist/kv-cache-stress/` persisted as stale artifacts that grep would still match. Manual `rm -rf` cleared them, but the next deletion will reintroduce the same drift. Fix it by always cleaning dist before building.
+
+- [ ] **Step 1 · Add rimraf to build scripts**
+
+In `packages/tool-adapters/package.json`'s `scripts.build`:
+
+```json
+"build": "rimraf dist && tsc -p tsconfig.build.json",
+```
+
+Same in `packages/contracts/package.json` if it has its own dist (check).
+
+- [ ] **Step 2 · Verify `rimraf` is already a dev dep**
+
+```bash
+pnpm -F @modeldoctor/tool-adapters list rimraf
+```
+
+If absent, add it: `pnpm -F @modeldoctor/tool-adapters add -D rimraf`. (It's probably already in the workspace from another package.)
+
+- [ ] **Step 3 · Verify build still works**
+
+```bash
+pnpm -r build
+ls packages/tool-adapters/dist/
+```
+
+Expected: dist has the current 5 adapter subdirs, no stale ones.
+
+- [ ] **Step 4 · Commit**
+
+```bash
+git add packages/tool-adapters/package.json packages/contracts/package.json
+git commit -m "$(cat <<'EOF'
+chore(packages): clean dist/ before tsc to prevent stale-emit drift
+
+After a file deletion (e.g. removing an adapter), tsc leaves the
+previous .d.ts / .js in dist/ until something runs `rimraf`. PR #183
+hit this twice (genai-perf and kv-cache-stress dist remnants).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 15 · Final verification + PR
+
+**Files:** none (process)
+
+- [ ] **Step 1 · Run the full workspace gate**
+
+```bash
+pnpm -r build
+pnpm -F @modeldoctor/tool-adapters test --run
+pnpm -F @modeldoctor/api test --run
+pnpm -F web test --run
+pnpm -F @modeldoctor/api type-check
+pnpm -F web type-check
+pnpm -F @modeldoctor/tool-adapters lint
+pnpm -F @modeldoctor/api lint
+pnpm -F web lint
+cd apps/web && node scripts/check-i18n-parity.mjs
+```
+
+All must be green.
+
+- [ ] **Step 2 · Run the air-gap verification (if Docker available)**
+
+```bash
+./tools/build-runner-images.sh --no-import
+./apps/benchmark-runner/scripts/verify-airgap.sh
+```
+
+Expected: all bake checks pass.
+
+- [ ] **Step 3 · Push + open PR**
+
+```bash
+git push -u origin feat/evalscope-aiperf-followup
+gh pr create --title "feat: evalscope+aiperf followup — air-gap, exhaustiveness refactor, polish" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Follow-up to PR #183 covering every deferred / non-blocking item from that branch's code review:
+
+- **Air-gap readiness (Tasks 1-4)**: bake every external dataset (LongAlpaca-12k already done in #183; add HC3-Chinese open_qa.jsonl and ShareGPT V3) into the evalscope + aiperf runner images. Add a `verify-airgap.sh` script + README matrix so the deploying operator can validate before rollout.
+- **ToolName exhaustiveness refactor (Tasks 5-9)**: replace six runtime `switch (tool)` blocks with a single `adapter.readMetric(kind, data)` interface. Adding a new tool now requires updating exactly one site (the adapter's `index.ts`) — the class drift that caused PR #183's review to find 6 missing branches is structurally impossible.
+- **User-facing completeness (Tasks 10-11)**: 1 official aiperf inference template + full i18n for the inference + KV-cache report panels.
+- **Polish (Tasks 12-14)**: `numberField()` form helper, stale Dockerfile header comments, `rimraf dist` to prevent stale-emit drift.
+
+## Test plan
+
+- [x] `pnpm -r build` clean
+- [x] tool-adapters / api / web test suites all green
+- [x] api / web type-check + lint clean
+- [x] i18n parity OK
+- [x] air-gap verification script passes against locally-built images
+- [ ] Manual smoke against dev k3d cluster (operator follow-up — same as #183)
+
+refs #179
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4 · Watch CI**
+
+Use Monitor (or `gh pr checks <N>` polling) until every check is in a terminal state. Fix any CI-only failures (biome stale cache, missing fixture deps, etc.) before declaring done.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** every loose end from PR #183 (A/B/C categories listed in the conversation) maps to a task above. The "operator follow-up" items (push images / set env vars / smoke against cluster) are not engineer tasks — left for ops.
+- **Migration policy:** the data-only Prisma migration from #183 stays (already applied + merged). CLAUDE.md's carve-out is the lasting fix. No follow-up needed here.
+- **Three near-duplicate InferenceMetrics files:** addressed in Task 9 by extracting `InferenceMetricsGrid` — refactor justified now that three tools share the shape.
+- **Tests:** Tasks 5 (adapter.readMetric tests, ~45 assertions) and 11 (i18n parity) carry most new test surface. Other tasks rely on existing test coverage to catch regressions.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "dev": "tsc -w -p tsconfig.build.json --preserveWatchOutput",
     "type-check": "tsc -p tsconfig.json --noEmit",
     "lint": "biome check src",

--- a/packages/tool-adapters/package.json
+++ b/packages/tool-adapters/package.json
@@ -20,7 +20,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "dev": "tsc -w -p tsconfig.build.json --preserveWatchOutput",
     "type-check": "tsc -p tsconfig.json --noEmit",
     "lint": "biome check src",

--- a/packages/tool-adapters/src/aiperf/index.spec.ts
+++ b/packages/tool-adapters/src/aiperf/index.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { aiperfAdapter } from "./index.js";
+
+// Sample mirrors aiperfReportSchema (see ./schema.ts).
+// Same shape as evalscope minus prefixCacheStats — they share the
+// "inference-three-piece" report shape so FE can render with one grid.
+const sample: Record<string, unknown> = {
+  throughput: { requestsPerSec: 6.5, outputTokensPerSec: 950, totalTokensPerSec: 1300 },
+  ttft: { mean: 120, p50: 100, p90: 180, p95: 220, p99: 320 },
+  itl: { mean: 32, p50: 30, p90: 42, p95: 48, p99: 62 },
+  e2eLatency: { mean: 1100, p50: 1000, p90: 1500, p95: 1700, p99: 2200 },
+  requests: { total: 100, success: 97, error: 3, errorRate: 0.03 },
+};
+
+describe("aiperfAdapter.readMetric", () => {
+  it("ttft.p95", () => {
+    expect(aiperfAdapter.readMetric("ttft.p95", sample)).toBe(220);
+  });
+  it("ttft.p99", () => {
+    expect(aiperfAdapter.readMetric("ttft.p99", sample)).toBe(320);
+  });
+  it("itl.p95", () => {
+    expect(aiperfAdapter.readMetric("itl.p95", sample)).toBe(48);
+  });
+  it("e2e.p95", () => {
+    expect(aiperfAdapter.readMetric("e2e.p95", sample)).toBe(1700);
+  });
+  it("e2e.p99", () => {
+    expect(aiperfAdapter.readMetric("e2e.p99", sample)).toBe(2200);
+  });
+  it("errorRate (already 0-1)", () => {
+    expect(aiperfAdapter.readMetric("errorRate", sample)).toBe(0.03);
+  });
+  it("requestsPerSec", () => {
+    expect(aiperfAdapter.readMetric("requestsPerSec", sample)).toBe(6.5);
+  });
+  it("outputTokensPerSec", () => {
+    expect(aiperfAdapter.readMetric("outputTokensPerSec", sample)).toBe(950);
+  });
+  it("tailRatio (e2e p99/p50)", () => {
+    expect(aiperfAdapter.readMetric("tailRatio", sample)).toBeCloseTo(2200 / 1000, 4);
+  });
+  it("null on missing data", () => {
+    expect(aiperfAdapter.readMetric("ttft.p95", {})).toBeNull();
+    expect(aiperfAdapter.readMetric("errorRate", {})).toBeNull();
+    expect(aiperfAdapter.readMetric("tailRatio", {})).toBeNull();
+  });
+});

--- a/packages/tool-adapters/src/aiperf/index.spec.ts
+++ b/packages/tool-adapters/src/aiperf/index.spec.ts
@@ -13,14 +13,29 @@ const sample: Record<string, unknown> = {
 };
 
 describe("aiperfAdapter.readMetric", () => {
+  it("ttft.p50", () => {
+    expect(aiperfAdapter.readMetric("ttft.p50", sample)).toBe(100);
+  });
+  it("ttft.p90", () => {
+    expect(aiperfAdapter.readMetric("ttft.p90", sample)).toBe(180);
+  });
   it("ttft.p95", () => {
     expect(aiperfAdapter.readMetric("ttft.p95", sample)).toBe(220);
   });
   it("ttft.p99", () => {
     expect(aiperfAdapter.readMetric("ttft.p99", sample)).toBe(320);
   });
+  it("itl.p50", () => {
+    expect(aiperfAdapter.readMetric("itl.p50", sample)).toBe(30);
+  });
   it("itl.p95", () => {
     expect(aiperfAdapter.readMetric("itl.p95", sample)).toBe(48);
+  });
+  it("e2e.p50", () => {
+    expect(aiperfAdapter.readMetric("e2e.p50", sample)).toBe(1000);
+  });
+  it("e2e.p90", () => {
+    expect(aiperfAdapter.readMetric("e2e.p90", sample)).toBe(1500);
   });
   it("e2e.p95", () => {
     expect(aiperfAdapter.readMetric("e2e.p95", sample)).toBe(1700);

--- a/packages/tool-adapters/src/aiperf/index.ts
+++ b/packages/tool-adapters/src/aiperf/index.ts
@@ -1,56 +1,9 @@
-import type { MetricKind, ToolAdapter } from "../core/interface.js";
+import type { ToolAdapter } from "../core/interface.js";
+import { aiperfReadMetric } from "./read-metric.js";
 import { buildCommand, getMaxDurationSeconds, parseFinalReport, parseProgress } from "./runtime.js";
 import { aiperfParamDefaults, aiperfParamsSchema, aiperfReportSchema } from "./schema.js";
 
-const fin = (v: unknown): number | null =>
-  typeof v === "number" && Number.isFinite(v) ? v : null;
-
-const dist = (
-  data: Record<string, unknown>,
-  key: string,
-  field: string,
-): number | null => {
-  const d = data[key] as Record<string, unknown> | undefined;
-  return fin(d?.[field]);
-};
-
-function readMetric(kind: MetricKind, data: Record<string, unknown>): number | null {
-  switch (kind) {
-    case "ttft.p95":
-      return dist(data, "ttft", "p95");
-    case "ttft.p99":
-      return dist(data, "ttft", "p99");
-    case "itl.p95":
-      return dist(data, "itl", "p95");
-    case "e2e.p95":
-      return dist(data, "e2eLatency", "p95");
-    case "e2e.p99":
-      return dist(data, "e2eLatency", "p99");
-    case "errorRate": {
-      // aiperf's normalized schema already exposes errorRate as 0-1.
-      const r = data.requests as { errorRate?: number } | undefined;
-      return fin(r?.errorRate);
-    }
-    case "requestsPerSec": {
-      const t = data.throughput as { requestsPerSec?: number } | undefined;
-      return fin(t?.requestsPerSec);
-    }
-    case "outputTokensPerSec": {
-      const t = data.throughput as { outputTokensPerSec?: number } | undefined;
-      return fin(t?.outputTokensPerSec);
-    }
-    case "tailRatio": {
-      const p50 = dist(data, "e2eLatency", "p50");
-      const p99 = dist(data, "e2eLatency", "p99");
-      return p50 === null || p99 === null || p50 === 0 ? null : p99 / p50;
-    }
-    default: {
-      const _exhaustive: never = kind;
-      void _exhaustive;
-      return null;
-    }
-  }
-}
+export { aiperfReadMetric } from "./read-metric.js";
 
 export const aiperfAdapter: ToolAdapter = {
   name: "aiperf",
@@ -62,7 +15,7 @@ export const aiperfAdapter: ToolAdapter = {
   parseProgress,
   parseFinalReport,
   getMaxDurationSeconds,
-  readMetric,
+  readMetric: aiperfReadMetric,
 };
 
 export type { AiperfParams, AiperfReport } from "./schema.js";

--- a/packages/tool-adapters/src/aiperf/index.ts
+++ b/packages/tool-adapters/src/aiperf/index.ts
@@ -1,6 +1,56 @@
-import type { ToolAdapter } from "../core/interface.js";
+import type { MetricKind, ToolAdapter } from "../core/interface.js";
 import { buildCommand, getMaxDurationSeconds, parseFinalReport, parseProgress } from "./runtime.js";
 import { aiperfParamDefaults, aiperfParamsSchema, aiperfReportSchema } from "./schema.js";
+
+const fin = (v: unknown): number | null =>
+  typeof v === "number" && Number.isFinite(v) ? v : null;
+
+const dist = (
+  data: Record<string, unknown>,
+  key: string,
+  field: string,
+): number | null => {
+  const d = data[key] as Record<string, unknown> | undefined;
+  return fin(d?.[field]);
+};
+
+function readMetric(kind: MetricKind, data: Record<string, unknown>): number | null {
+  switch (kind) {
+    case "ttft.p95":
+      return dist(data, "ttft", "p95");
+    case "ttft.p99":
+      return dist(data, "ttft", "p99");
+    case "itl.p95":
+      return dist(data, "itl", "p95");
+    case "e2e.p95":
+      return dist(data, "e2eLatency", "p95");
+    case "e2e.p99":
+      return dist(data, "e2eLatency", "p99");
+    case "errorRate": {
+      // aiperf's normalized schema already exposes errorRate as 0-1.
+      const r = data.requests as { errorRate?: number } | undefined;
+      return fin(r?.errorRate);
+    }
+    case "requestsPerSec": {
+      const t = data.throughput as { requestsPerSec?: number } | undefined;
+      return fin(t?.requestsPerSec);
+    }
+    case "outputTokensPerSec": {
+      const t = data.throughput as { outputTokensPerSec?: number } | undefined;
+      return fin(t?.outputTokensPerSec);
+    }
+    case "tailRatio": {
+      const p50 = dist(data, "e2eLatency", "p50");
+      const p99 = dist(data, "e2eLatency", "p99");
+      return p50 === null || p99 === null || p50 === 0 ? null : p99 / p50;
+    }
+    default: {
+      const _exhaustive: never = kind;
+      void _exhaustive;
+      return null;
+    }
+  }
+}
 
 export const aiperfAdapter: ToolAdapter = {
   name: "aiperf",
@@ -12,6 +62,7 @@ export const aiperfAdapter: ToolAdapter = {
   parseProgress,
   parseFinalReport,
   getMaxDurationSeconds,
+  readMetric,
 };
 
 export type { AiperfParams, AiperfReport } from "./schema.js";

--- a/packages/tool-adapters/src/aiperf/read-metric.ts
+++ b/packages/tool-adapters/src/aiperf/read-metric.ts
@@ -1,0 +1,56 @@
+import type { MetricKind } from "../core/metric-extractor.js";
+
+const fin = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
+
+const dist = (data: Record<string, unknown>, key: string, field: string): number | null => {
+  const d = data[key] as Record<string, unknown> | undefined;
+  return fin(d?.[field]);
+};
+
+export function aiperfReadMetric(kind: MetricKind, data: Record<string, unknown>): number | null {
+  switch (kind) {
+    case "ttft.p50":
+      return dist(data, "ttft", "p50");
+    case "ttft.p90":
+      return dist(data, "ttft", "p90");
+    case "ttft.p95":
+      return dist(data, "ttft", "p95");
+    case "ttft.p99":
+      return dist(data, "ttft", "p99");
+    case "itl.p50":
+      return dist(data, "itl", "p50");
+    case "itl.p95":
+      return dist(data, "itl", "p95");
+    case "e2e.p50":
+      return dist(data, "e2eLatency", "p50");
+    case "e2e.p90":
+      return dist(data, "e2eLatency", "p90");
+    case "e2e.p95":
+      return dist(data, "e2eLatency", "p95");
+    case "e2e.p99":
+      return dist(data, "e2eLatency", "p99");
+    case "errorRate": {
+      // aiperf's normalized schema already exposes errorRate as 0-1.
+      const r = data.requests as { errorRate?: number } | undefined;
+      return fin(r?.errorRate);
+    }
+    case "requestsPerSec": {
+      const t = data.throughput as { requestsPerSec?: number } | undefined;
+      return fin(t?.requestsPerSec);
+    }
+    case "outputTokensPerSec": {
+      const t = data.throughput as { outputTokensPerSec?: number } | undefined;
+      return fin(t?.outputTokensPerSec);
+    }
+    case "tailRatio": {
+      const p50 = dist(data, "e2eLatency", "p50");
+      const p99 = dist(data, "e2eLatency", "p99");
+      return p50 === null || p99 === null || p50 === 0 ? null : p99 / p50;
+    }
+    default: {
+      const _exhaustive: never = kind;
+      void _exhaustive;
+      return null;
+    }
+  }
+}

--- a/packages/tool-adapters/src/core/interface.ts
+++ b/packages/tool-adapters/src/core/interface.ts
@@ -1,4 +1,9 @@
 import type { z } from "zod";
+import type { ToolMetricExtractor } from "./metric-extractor.js";
+
+// Re-export so consumers can `import { MetricKind } from "@modeldoctor/tool-adapters"`
+// instead of reaching into the core subpath.
+export type { MetricKind, ToolMetricExtractor } from "./metric-extractor.js";
 
 // ToolAdapter-registered tool names. The DB column `Run.tool` allows a
 // superset (additionally `'e2e'` and `'custom'`) — those don't go through
@@ -85,7 +90,7 @@ export interface BuildCommandResult {
 // acceptance gate). Adding a new CONNECTION-LEVEL capability that all tools
 // consume identically (e.g. `tokenizerHfId` added in #78 follow-up) is a
 // deliberate interface evolution and must be documented in the changelog.
-export interface ToolAdapter {
+export interface ToolAdapter extends ToolMetricExtractor {
   readonly name: ToolName;
   readonly scenarios: readonly import("../scenarios.js").ScenarioId[];
   readonly paramsSchema: z.ZodTypeAny;

--- a/packages/tool-adapters/src/core/metric-extractor.ts
+++ b/packages/tool-adapters/src/core/metric-extractor.ts
@@ -7,9 +7,17 @@
 // Future tool additions can only miss a metric kind on PURPOSE — there
 // is no way to silently forget all the consumer call sites.
 export type MetricKind =
+  // Time-to-first-token distribution buckets.
+  | "ttft.p50"
+  | "ttft.p90"
   | "ttft.p95"
   | "ttft.p99"
+  // Inter-token-latency distribution buckets.
+  | "itl.p50"
   | "itl.p95"
+  // End-to-end latency distribution buckets.
+  | "e2e.p50"
+  | "e2e.p90"
   | "e2e.p95"
   | "e2e.p99"
   | "errorRate" // 0-1 fraction

--- a/packages/tool-adapters/src/core/metric-extractor.ts
+++ b/packages/tool-adapters/src/core/metric-extractor.ts
@@ -1,0 +1,31 @@
+// Standard inference-shape metrics every load-generator tool can expose.
+// `null` = the tool doesn't carry this metric (e.g. vegeta has no TTFT),
+// the data is missing, or the value is non-finite.
+//
+// Centralizing these here gives the consumer side a compile-time enum
+// to switch on, and gives adapters a single contract to implement.
+// Future tool additions can only miss a metric kind on PURPOSE — there
+// is no way to silently forget all the consumer call sites.
+export type MetricKind =
+  | "ttft.p95"
+  | "ttft.p99"
+  | "itl.p95"
+  | "e2e.p95"
+  | "e2e.p99"
+  | "errorRate" // 0-1 fraction
+  | "requestsPerSec"
+  | "outputTokensPerSec"
+  | "tailRatio"; // e2e.p99 / e2e.p50
+
+export interface ToolMetricExtractor {
+  /**
+   * Pull one well-known metric out of the tool's persisted summary.
+   * `data` is the `.data` payload from `summaryMetrics` (the discriminated
+   * union, NOT the wrapped { tool, data } object). Implementations return
+   * `null` when:
+   *   - the tool doesn't carry that metric (vegeta has no TTFT etc.)
+   *   - the data is missing (undefined / wrong shape)
+   *   - the value is non-finite
+   */
+  readMetric(kind: MetricKind, data: Record<string, unknown>): number | null;
+}

--- a/packages/tool-adapters/src/core/read-metric-safe.fe.ts
+++ b/packages/tool-adapters/src/core/read-metric-safe.fe.ts
@@ -1,0 +1,27 @@
+// FE-side `readMetricSafe`. Imported by `schemas-entry.ts` so the web
+// bundle gets the helper without dragging in adapter runtimes.
+//
+// Each adapter's `<tool>ReadMetric` lives in `<tool>/read-metric.ts`
+// (no runtime.ts dependency), so this table is FE-safe.
+import { aiperfReadMetric } from "../aiperf/read-metric.js";
+import { evalscopeReadMetric } from "../evalscope/read-metric.js";
+import { guidellmReadMetric } from "../guidellm/read-metric.js";
+import { prefixCacheProbeReadMetric } from "../prefix-cache-probe/read-metric.js";
+import { vegetaReadMetric } from "../vegeta/read-metric.js";
+import type { MetricKind } from "./metric-extractor.js";
+import { type ReadMetricTable, readMetricSafeFromTable } from "./read-metric-safe.js";
+
+const FE_TABLE: ReadMetricTable = {
+  guidellm: guidellmReadMetric,
+  vegeta: vegetaReadMetric,
+  "prefix-cache-probe": prefixCacheProbeReadMetric,
+  evalscope: evalscopeReadMetric,
+  aiperf: aiperfReadMetric,
+};
+
+export function readMetricSafe(
+  kind: MetricKind,
+  summary: { tool?: unknown; data?: unknown } | null | undefined,
+): number | null {
+  return readMetricSafeFromTable(FE_TABLE, kind, summary);
+}

--- a/packages/tool-adapters/src/core/read-metric-safe.runtime.ts
+++ b/packages/tool-adapters/src/core/read-metric-safe.runtime.ts
@@ -1,0 +1,22 @@
+// Runtime-side `readMetricSafe`. Imported by `index.ts` so api consumers
+// get one helper instead of duplicating try/catch(byTool) blocks.
+import type { ToolName } from "./interface.js";
+import type { MetricKind } from "./metric-extractor.js";
+import { type ReadMetricTable, readMetricSafeFromTable } from "./read-metric-safe.js";
+import { byTool } from "./registry.js";
+
+// Defer lookup to `byTool` so a future adapter registration is picked up
+// automatically — no parallel table to keep in sync.
+const RUNTIME_TABLE: ReadMetricTable = new Proxy({} as ReadMetricTable, {
+  get(_t, prop: string) {
+    return (kind: MetricKind, data: Record<string, unknown>) =>
+      byTool(prop as ToolName).readMetric(kind, data);
+  },
+});
+
+export function readMetricSafe(
+  kind: MetricKind,
+  summary: { tool?: unknown; data?: unknown } | null | undefined,
+): number | null {
+  return readMetricSafeFromTable(RUNTIME_TABLE, kind, summary);
+}

--- a/packages/tool-adapters/src/core/read-metric-safe.ts
+++ b/packages/tool-adapters/src/core/read-metric-safe.ts
@@ -1,0 +1,45 @@
+import type { ToolName } from "./interface.js";
+import type { MetricKind } from "./metric-extractor.js";
+
+/**
+ * Per-tool metric extractor map. Filled in by `read-metric-safe.runtime.ts`
+ * (api side) or `read-metric-safe.fe.ts` (web side) so this file itself
+ * stays free of any adapter-runtime imports — both entries (`index.ts`
+ * and `schemas-entry.ts`) can share the same helper shape.
+ */
+export type ReadMetricFn = (kind: MetricKind, data: Record<string, unknown>) => number | null;
+
+export type ReadMetricTable = Readonly<Record<ToolName, ReadMetricFn>>;
+
+/**
+ * Read one metric from a `{ tool, data }` discriminated summary in a
+ * single try-catch step. Returns `null` when:
+ *   - summary is null/undefined / not an object
+ *   - tool name doesn't match any registered adapter (stale DB rows
+ *     from a deleted-tool migration that somehow survived)
+ *   - the adapter has no value for that kind / shape doesn't match
+ *
+ * Centralizing this avoids the duplicate try/catch + asTagged blocks
+ * PR #183 reviewers flagged across 5 consumer files.
+ *
+ * Callers build a thin wrapper that closes over the per-environment
+ * `table` (api runtime: `byTool(name).readMetric`; web FE: the
+ * per-adapter `<tool>ReadMetric` exports from `schemas-entry`).
+ */
+export function readMetricSafeFromTable(
+  table: ReadMetricTable,
+  kind: MetricKind,
+  summary: { tool?: unknown; data?: unknown } | null | undefined,
+): number | null {
+  if (!summary || typeof summary !== "object") return null;
+  const { tool, data } = summary;
+  if (typeof tool !== "string") return null;
+  if (!data || typeof data !== "object" || Array.isArray(data)) return null;
+  const fn = (table as Record<string, ReadMetricFn | undefined>)[tool];
+  if (!fn) return null;
+  try {
+    return fn(kind, data as Record<string, unknown>);
+  } catch {
+    return null;
+  }
+}

--- a/packages/tool-adapters/src/evalscope/index.spec.ts
+++ b/packages/tool-adapters/src/evalscope/index.spec.ts
@@ -11,14 +11,29 @@ const sample: Record<string, unknown> = {
 };
 
 describe("evalscopeAdapter.readMetric", () => {
+  it("ttft.p50", () => {
+    expect(evalscopeAdapter.readMetric("ttft.p50", sample)).toBe(80);
+  });
+  it("ttft.p90", () => {
+    expect(evalscopeAdapter.readMetric("ttft.p90", sample)).toBe(150);
+  });
   it("ttft.p95", () => {
     expect(evalscopeAdapter.readMetric("ttft.p95", sample)).toBe(200);
   });
   it("ttft.p99", () => {
     expect(evalscopeAdapter.readMetric("ttft.p99", sample)).toBe(300);
   });
+  it("itl.p50", () => {
+    expect(evalscopeAdapter.readMetric("itl.p50", sample)).toBe(28);
+  });
   it("itl.p95", () => {
     expect(evalscopeAdapter.readMetric("itl.p95", sample)).toBe(45);
+  });
+  it("e2e.p50", () => {
+    expect(evalscopeAdapter.readMetric("e2e.p50", sample)).toBe(900);
+  });
+  it("e2e.p90", () => {
+    expect(evalscopeAdapter.readMetric("e2e.p90", sample)).toBe(1400);
   });
   it("e2e.p95", () => {
     expect(evalscopeAdapter.readMetric("e2e.p95", sample)).toBe(1600);

--- a/packages/tool-adapters/src/evalscope/index.spec.ts
+++ b/packages/tool-adapters/src/evalscope/index.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { evalscopeAdapter } from "./index.js";
+
+// Sample mirrors evalscopeReportSchema (see ./schema.ts).
+const sample: Record<string, unknown> = {
+  throughput: { requestsPerSec: 8, outputTokensPerSec: 1200, totalTokensPerSec: 1500 },
+  ttft: { mean: 100, p50: 80, p90: 150, p95: 200, p99: 300 },
+  itl: { mean: 30, p50: 28, p90: 40, p95: 45, p99: 60 },
+  e2eLatency: { mean: 1000, p50: 900, p90: 1400, p95: 1600, p99: 2000 },
+  requests: { total: 100, success: 95, error: 5, errorRate: 0.05 },
+};
+
+describe("evalscopeAdapter.readMetric", () => {
+  it("ttft.p95", () => {
+    expect(evalscopeAdapter.readMetric("ttft.p95", sample)).toBe(200);
+  });
+  it("ttft.p99", () => {
+    expect(evalscopeAdapter.readMetric("ttft.p99", sample)).toBe(300);
+  });
+  it("itl.p95", () => {
+    expect(evalscopeAdapter.readMetric("itl.p95", sample)).toBe(45);
+  });
+  it("e2e.p95", () => {
+    expect(evalscopeAdapter.readMetric("e2e.p95", sample)).toBe(1600);
+  });
+  it("e2e.p99", () => {
+    expect(evalscopeAdapter.readMetric("e2e.p99", sample)).toBe(2000);
+  });
+  it("errorRate (already 0-1)", () => {
+    expect(evalscopeAdapter.readMetric("errorRate", sample)).toBe(0.05);
+  });
+  it("requestsPerSec", () => {
+    expect(evalscopeAdapter.readMetric("requestsPerSec", sample)).toBe(8);
+  });
+  it("outputTokensPerSec", () => {
+    expect(evalscopeAdapter.readMetric("outputTokensPerSec", sample)).toBe(1200);
+  });
+  it("tailRatio (e2e p99/p50)", () => {
+    expect(evalscopeAdapter.readMetric("tailRatio", sample)).toBeCloseTo(2000 / 900, 4);
+  });
+  it("null on missing data", () => {
+    expect(evalscopeAdapter.readMetric("ttft.p95", {})).toBeNull();
+    expect(evalscopeAdapter.readMetric("requestsPerSec", {})).toBeNull();
+    expect(evalscopeAdapter.readMetric("errorRate", {})).toBeNull();
+    expect(evalscopeAdapter.readMetric("tailRatio", {})).toBeNull();
+  });
+});

--- a/packages/tool-adapters/src/evalscope/index.ts
+++ b/packages/tool-adapters/src/evalscope/index.ts
@@ -1,6 +1,56 @@
-import type { ToolAdapter } from "../core/interface.js";
+import type { MetricKind, ToolAdapter } from "../core/interface.js";
 import { buildCommand, getMaxDurationSeconds, parseFinalReport, parseProgress } from "./runtime.js";
 import { evalscopeParamDefaults, evalscopeParamsSchema, evalscopeReportSchema } from "./schema.js";
+
+const fin = (v: unknown): number | null =>
+  typeof v === "number" && Number.isFinite(v) ? v : null;
+
+const dist = (
+  data: Record<string, unknown>,
+  key: string,
+  field: string,
+): number | null => {
+  const d = data[key] as Record<string, unknown> | undefined;
+  return fin(d?.[field]);
+};
+
+function readMetric(kind: MetricKind, data: Record<string, unknown>): number | null {
+  switch (kind) {
+    case "ttft.p95":
+      return dist(data, "ttft", "p95");
+    case "ttft.p99":
+      return dist(data, "ttft", "p99");
+    case "itl.p95":
+      return dist(data, "itl", "p95");
+    case "e2e.p95":
+      return dist(data, "e2eLatency", "p95");
+    case "e2e.p99":
+      return dist(data, "e2eLatency", "p99");
+    case "errorRate": {
+      // evalscope's normalized schema already exposes errorRate as 0-1.
+      const r = data.requests as { errorRate?: number } | undefined;
+      return fin(r?.errorRate);
+    }
+    case "requestsPerSec": {
+      const t = data.throughput as { requestsPerSec?: number } | undefined;
+      return fin(t?.requestsPerSec);
+    }
+    case "outputTokensPerSec": {
+      const t = data.throughput as { outputTokensPerSec?: number } | undefined;
+      return fin(t?.outputTokensPerSec);
+    }
+    case "tailRatio": {
+      const p50 = dist(data, "e2eLatency", "p50");
+      const p99 = dist(data, "e2eLatency", "p99");
+      return p50 === null || p99 === null || p50 === 0 ? null : p99 / p50;
+    }
+    default: {
+      const _exhaustive: never = kind;
+      void _exhaustive;
+      return null;
+    }
+  }
+}
 
 export const evalscopeAdapter: ToolAdapter = {
   name: "evalscope",
@@ -12,6 +62,7 @@ export const evalscopeAdapter: ToolAdapter = {
   parseProgress,
   parseFinalReport,
   getMaxDurationSeconds,
+  readMetric,
 };
 
 export type { EvalscopeParams, EvalscopeReport } from "./schema.js";

--- a/packages/tool-adapters/src/evalscope/index.ts
+++ b/packages/tool-adapters/src/evalscope/index.ts
@@ -1,56 +1,9 @@
-import type { MetricKind, ToolAdapter } from "../core/interface.js";
+import type { ToolAdapter } from "../core/interface.js";
+import { evalscopeReadMetric } from "./read-metric.js";
 import { buildCommand, getMaxDurationSeconds, parseFinalReport, parseProgress } from "./runtime.js";
 import { evalscopeParamDefaults, evalscopeParamsSchema, evalscopeReportSchema } from "./schema.js";
 
-const fin = (v: unknown): number | null =>
-  typeof v === "number" && Number.isFinite(v) ? v : null;
-
-const dist = (
-  data: Record<string, unknown>,
-  key: string,
-  field: string,
-): number | null => {
-  const d = data[key] as Record<string, unknown> | undefined;
-  return fin(d?.[field]);
-};
-
-function readMetric(kind: MetricKind, data: Record<string, unknown>): number | null {
-  switch (kind) {
-    case "ttft.p95":
-      return dist(data, "ttft", "p95");
-    case "ttft.p99":
-      return dist(data, "ttft", "p99");
-    case "itl.p95":
-      return dist(data, "itl", "p95");
-    case "e2e.p95":
-      return dist(data, "e2eLatency", "p95");
-    case "e2e.p99":
-      return dist(data, "e2eLatency", "p99");
-    case "errorRate": {
-      // evalscope's normalized schema already exposes errorRate as 0-1.
-      const r = data.requests as { errorRate?: number } | undefined;
-      return fin(r?.errorRate);
-    }
-    case "requestsPerSec": {
-      const t = data.throughput as { requestsPerSec?: number } | undefined;
-      return fin(t?.requestsPerSec);
-    }
-    case "outputTokensPerSec": {
-      const t = data.throughput as { outputTokensPerSec?: number } | undefined;
-      return fin(t?.outputTokensPerSec);
-    }
-    case "tailRatio": {
-      const p50 = dist(data, "e2eLatency", "p50");
-      const p99 = dist(data, "e2eLatency", "p99");
-      return p50 === null || p99 === null || p50 === 0 ? null : p99 / p50;
-    }
-    default: {
-      const _exhaustive: never = kind;
-      void _exhaustive;
-      return null;
-    }
-  }
-}
+export { evalscopeReadMetric } from "./read-metric.js";
 
 export const evalscopeAdapter: ToolAdapter = {
   name: "evalscope",
@@ -62,7 +15,7 @@ export const evalscopeAdapter: ToolAdapter = {
   parseProgress,
   parseFinalReport,
   getMaxDurationSeconds,
-  readMetric,
+  readMetric: evalscopeReadMetric,
 };
 
 export type { EvalscopeParams, EvalscopeReport } from "./schema.js";

--- a/packages/tool-adapters/src/evalscope/read-metric.ts
+++ b/packages/tool-adapters/src/evalscope/read-metric.ts
@@ -1,0 +1,59 @@
+import type { MetricKind } from "../core/metric-extractor.js";
+
+const fin = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
+
+const dist = (data: Record<string, unknown>, key: string, field: string): number | null => {
+  const d = data[key] as Record<string, unknown> | undefined;
+  return fin(d?.[field]);
+};
+
+export function evalscopeReadMetric(
+  kind: MetricKind,
+  data: Record<string, unknown>,
+): number | null {
+  switch (kind) {
+    case "ttft.p50":
+      return dist(data, "ttft", "p50");
+    case "ttft.p90":
+      return dist(data, "ttft", "p90");
+    case "ttft.p95":
+      return dist(data, "ttft", "p95");
+    case "ttft.p99":
+      return dist(data, "ttft", "p99");
+    case "itl.p50":
+      return dist(data, "itl", "p50");
+    case "itl.p95":
+      return dist(data, "itl", "p95");
+    case "e2e.p50":
+      return dist(data, "e2eLatency", "p50");
+    case "e2e.p90":
+      return dist(data, "e2eLatency", "p90");
+    case "e2e.p95":
+      return dist(data, "e2eLatency", "p95");
+    case "e2e.p99":
+      return dist(data, "e2eLatency", "p99");
+    case "errorRate": {
+      // evalscope's normalized schema already exposes errorRate as 0-1.
+      const r = data.requests as { errorRate?: number } | undefined;
+      return fin(r?.errorRate);
+    }
+    case "requestsPerSec": {
+      const t = data.throughput as { requestsPerSec?: number } | undefined;
+      return fin(t?.requestsPerSec);
+    }
+    case "outputTokensPerSec": {
+      const t = data.throughput as { outputTokensPerSec?: number } | undefined;
+      return fin(t?.outputTokensPerSec);
+    }
+    case "tailRatio": {
+      const p50 = dist(data, "e2eLatency", "p50");
+      const p99 = dist(data, "e2eLatency", "p99");
+      return p50 === null || p99 === null || p50 === 0 ? null : p99 / p50;
+    }
+    default: {
+      const _exhaustive: never = kind;
+      void _exhaustive;
+      return null;
+    }
+  }
+}

--- a/packages/tool-adapters/src/evalscope/runtime.spec.ts
+++ b/packages/tool-adapters/src/evalscope/runtime.spec.ts
@@ -83,8 +83,15 @@ describe("evalscope.buildCommand", () => {
     expect(result.argv).toContain("http://10.0.0.5:8000/v1/completions");
   });
 
-  it("omits --dataset-path when dataset is not longalpaca (lets evalscope use its own default)", () => {
+  it("passes --dataset-path for openqa (baked HC3-Chinese open_qa.jsonl)", () => {
     const result = buildCommand({ ...plan, params: { ...baseParams, dataset: "openqa" } });
+    const idx = result.argv.indexOf("--dataset-path");
+    expect(idx).toBeGreaterThan(-1);
+    expect(result.argv[idx + 1]).toBe("/opt/evalscope-datasets/openqa/open_qa.jsonl");
+  });
+
+  it("does not pass --dataset-path for random (synthetic dataset)", () => {
+    const result = buildCommand({ ...plan, params: { ...baseParams, dataset: "random" } });
     expect(result.argv).not.toContain("--dataset-path");
   });
 

--- a/packages/tool-adapters/src/evalscope/runtime.ts
+++ b/packages/tool-adapters/src/evalscope/runtime.ts
@@ -6,12 +6,13 @@ import type {
 } from "../core/interface.js";
 import { type EvalscopeParams, evalscopeReportSchema } from "./schema.js";
 
-// LongAlpaca-12k is baked into the evalscope runner image at build time
-// (apps/benchmark-runner/images/evalscope.Dockerfile). Other datasets
-// (openqa / random) are tiny or fully synthetic; we let evalscope handle
-// them via its built-in dataset registry.
+// LongAlpaca-12k + HC3-Chinese (openqa) are baked into the evalscope runner
+// image at build time (apps/benchmark-runner/images/evalscope.Dockerfile)
+// so air-gapped clusters never hit modelscope.cn at run time. `random` is
+// fully synthetic and needs no dataset path.
 const BAKED_DATASET_PATHS: Record<string, string> = {
   longalpaca: "/opt/evalscope-datasets/longalpaca",
+  openqa: "/opt/evalscope-datasets/openqa/open_qa.jsonl",
 };
 
 const OUTPUTS_DIR = "out";

--- a/packages/tool-adapters/src/guidellm/index.spec.ts
+++ b/packages/tool-adapters/src/guidellm/index.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { guidellmAdapter } from "./index.js";
+
+// Sample mirrors guidellmReportSchema (see ./schema.ts). Each distribution
+// (ttft/itl/e2eLatency) carries mean/p50/p90/p95/p99 in milliseconds.
+const sample: Record<string, unknown> = {
+  ttft: { mean: 100, p50: 80, p90: 150, p95: 200, p99: 300 },
+  itl: { mean: 30, p50: 28, p90: 40, p95: 45, p99: 60 },
+  e2eLatency: { mean: 1000, p50: 900, p90: 1400, p95: 1600, p99: 2000 },
+  requestsPerSecond: { mean: 8 },
+  outputTokensPerSecond: { mean: 1200 },
+  inputTokensPerSecond: { mean: 800 },
+  totalTokensPerSecond: { mean: 2000 },
+  concurrency: { mean: 5, max: 8 },
+  requests: { total: 100, success: 95, error: 5, incomplete: 0 },
+};
+
+describe("guidellmAdapter.readMetric", () => {
+  it("ttft.p95", () => {
+    expect(guidellmAdapter.readMetric("ttft.p95", sample)).toBe(200);
+  });
+  it("ttft.p99", () => {
+    expect(guidellmAdapter.readMetric("ttft.p99", sample)).toBe(300);
+  });
+  it("itl.p95", () => {
+    expect(guidellmAdapter.readMetric("itl.p95", sample)).toBe(45);
+  });
+  it("e2e.p95", () => {
+    expect(guidellmAdapter.readMetric("e2e.p95", sample)).toBe(1600);
+  });
+  it("e2e.p99", () => {
+    expect(guidellmAdapter.readMetric("e2e.p99", sample)).toBe(2000);
+  });
+  it("errorRate (computed from requests.error / requests.total)", () => {
+    expect(guidellmAdapter.readMetric("errorRate", sample)).toBeCloseTo(0.05);
+  });
+  it("requestsPerSec", () => {
+    expect(guidellmAdapter.readMetric("requestsPerSec", sample)).toBe(8);
+  });
+  it("outputTokensPerSec", () => {
+    expect(guidellmAdapter.readMetric("outputTokensPerSec", sample)).toBe(1200);
+  });
+  it("tailRatio (e2e p99/p50)", () => {
+    expect(guidellmAdapter.readMetric("tailRatio", sample)).toBeCloseTo(2000 / 900, 4);
+  });
+  it("null on missing data", () => {
+    expect(guidellmAdapter.readMetric("ttft.p95", {})).toBeNull();
+    expect(guidellmAdapter.readMetric("e2e.p99", {})).toBeNull();
+    expect(guidellmAdapter.readMetric("requestsPerSec", {})).toBeNull();
+  });
+  it("errorRate returns null when requests.total is zero", () => {
+    expect(
+      guidellmAdapter.readMetric("errorRate", {
+        requests: { total: 0, error: 0, success: 0, incomplete: 0 },
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/tool-adapters/src/guidellm/index.spec.ts
+++ b/packages/tool-adapters/src/guidellm/index.spec.ts
@@ -16,14 +16,29 @@ const sample: Record<string, unknown> = {
 };
 
 describe("guidellmAdapter.readMetric", () => {
+  it("ttft.p50", () => {
+    expect(guidellmAdapter.readMetric("ttft.p50", sample)).toBe(80);
+  });
+  it("ttft.p90", () => {
+    expect(guidellmAdapter.readMetric("ttft.p90", sample)).toBe(150);
+  });
   it("ttft.p95", () => {
     expect(guidellmAdapter.readMetric("ttft.p95", sample)).toBe(200);
   });
   it("ttft.p99", () => {
     expect(guidellmAdapter.readMetric("ttft.p99", sample)).toBe(300);
   });
+  it("itl.p50", () => {
+    expect(guidellmAdapter.readMetric("itl.p50", sample)).toBe(28);
+  });
   it("itl.p95", () => {
     expect(guidellmAdapter.readMetric("itl.p95", sample)).toBe(45);
+  });
+  it("e2e.p50", () => {
+    expect(guidellmAdapter.readMetric("e2e.p50", sample)).toBe(900);
+  });
+  it("e2e.p90", () => {
+    expect(guidellmAdapter.readMetric("e2e.p90", sample)).toBe(1400);
   });
   it("e2e.p95", () => {
     expect(guidellmAdapter.readMetric("e2e.p95", sample)).toBe(1600);

--- a/packages/tool-adapters/src/guidellm/index.ts
+++ b/packages/tool-adapters/src/guidellm/index.ts
@@ -1,57 +1,9 @@
-import type { MetricKind, ToolAdapter } from "../core/interface.js";
+import type { ToolAdapter } from "../core/interface.js";
+import { guidellmReadMetric } from "./read-metric.js";
 import { buildCommand, getMaxDurationSeconds, parseFinalReport, parseProgress } from "./runtime.js";
 import { guidellmParamDefaults, guidellmParamsSchema, guidellmReportSchema } from "./schema.js";
 
-const fin = (v: unknown): number | null =>
-  typeof v === "number" && Number.isFinite(v) ? v : null;
-
-const dist = (
-  data: Record<string, unknown>,
-  key: string,
-  field: string,
-): number | null => {
-  const d = data[key] as Record<string, unknown> | undefined;
-  return fin(d?.[field]);
-};
-
-function readMetric(kind: MetricKind, data: Record<string, unknown>): number | null {
-  switch (kind) {
-    case "ttft.p95":
-      return dist(data, "ttft", "p95");
-    case "ttft.p99":
-      return dist(data, "ttft", "p99");
-    case "itl.p95":
-      return dist(data, "itl", "p95");
-    case "e2e.p95":
-      return dist(data, "e2eLatency", "p95");
-    case "e2e.p99":
-      return dist(data, "e2eLatency", "p99");
-    case "errorRate": {
-      const r = data.requests as { total?: number; error?: number } | undefined;
-      const t = fin(r?.total);
-      const e = fin(r?.error);
-      return t === null || e === null || t === 0 ? null : e / t;
-    }
-    case "requestsPerSec": {
-      const r = data.requestsPerSecond as { mean?: number } | undefined;
-      return fin(r?.mean);
-    }
-    case "outputTokensPerSec": {
-      const r = data.outputTokensPerSecond as { mean?: number } | undefined;
-      return fin(r?.mean);
-    }
-    case "tailRatio": {
-      const p50 = dist(data, "e2eLatency", "p50");
-      const p99 = dist(data, "e2eLatency", "p99");
-      return p50 === null || p99 === null || p50 === 0 ? null : p99 / p50;
-    }
-    default: {
-      const _exhaustive: never = kind;
-      void _exhaustive;
-      return null;
-    }
-  }
-}
+export { guidellmReadMetric } from "./read-metric.js";
 
 export const guidellmAdapter: ToolAdapter = {
   name: "guidellm",
@@ -63,7 +15,7 @@ export const guidellmAdapter: ToolAdapter = {
   parseProgress,
   parseFinalReport,
   getMaxDurationSeconds,
-  readMetric,
+  readMetric: guidellmReadMetric,
 };
 
 export type { GuidellmParams, GuidellmReport } from "./schema.js";

--- a/packages/tool-adapters/src/guidellm/index.ts
+++ b/packages/tool-adapters/src/guidellm/index.ts
@@ -1,6 +1,57 @@
-import type { ToolAdapter } from "../core/interface.js";
+import type { MetricKind, ToolAdapter } from "../core/interface.js";
 import { buildCommand, getMaxDurationSeconds, parseFinalReport, parseProgress } from "./runtime.js";
 import { guidellmParamDefaults, guidellmParamsSchema, guidellmReportSchema } from "./schema.js";
+
+const fin = (v: unknown): number | null =>
+  typeof v === "number" && Number.isFinite(v) ? v : null;
+
+const dist = (
+  data: Record<string, unknown>,
+  key: string,
+  field: string,
+): number | null => {
+  const d = data[key] as Record<string, unknown> | undefined;
+  return fin(d?.[field]);
+};
+
+function readMetric(kind: MetricKind, data: Record<string, unknown>): number | null {
+  switch (kind) {
+    case "ttft.p95":
+      return dist(data, "ttft", "p95");
+    case "ttft.p99":
+      return dist(data, "ttft", "p99");
+    case "itl.p95":
+      return dist(data, "itl", "p95");
+    case "e2e.p95":
+      return dist(data, "e2eLatency", "p95");
+    case "e2e.p99":
+      return dist(data, "e2eLatency", "p99");
+    case "errorRate": {
+      const r = data.requests as { total?: number; error?: number } | undefined;
+      const t = fin(r?.total);
+      const e = fin(r?.error);
+      return t === null || e === null || t === 0 ? null : e / t;
+    }
+    case "requestsPerSec": {
+      const r = data.requestsPerSecond as { mean?: number } | undefined;
+      return fin(r?.mean);
+    }
+    case "outputTokensPerSec": {
+      const r = data.outputTokensPerSecond as { mean?: number } | undefined;
+      return fin(r?.mean);
+    }
+    case "tailRatio": {
+      const p50 = dist(data, "e2eLatency", "p50");
+      const p99 = dist(data, "e2eLatency", "p99");
+      return p50 === null || p99 === null || p50 === 0 ? null : p99 / p50;
+    }
+    default: {
+      const _exhaustive: never = kind;
+      void _exhaustive;
+      return null;
+    }
+  }
+}
 
 export const guidellmAdapter: ToolAdapter = {
   name: "guidellm",
@@ -12,6 +63,7 @@ export const guidellmAdapter: ToolAdapter = {
   parseProgress,
   parseFinalReport,
   getMaxDurationSeconds,
+  readMetric,
 };
 
 export type { GuidellmParams, GuidellmReport } from "./schema.js";

--- a/packages/tool-adapters/src/guidellm/read-metric.ts
+++ b/packages/tool-adapters/src/guidellm/read-metric.ts
@@ -1,0 +1,57 @@
+import type { MetricKind } from "../core/metric-extractor.js";
+
+const fin = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
+
+const dist = (data: Record<string, unknown>, key: string, field: string): number | null => {
+  const d = data[key] as Record<string, unknown> | undefined;
+  return fin(d?.[field]);
+};
+
+export function guidellmReadMetric(kind: MetricKind, data: Record<string, unknown>): number | null {
+  switch (kind) {
+    case "ttft.p50":
+      return dist(data, "ttft", "p50");
+    case "ttft.p90":
+      return dist(data, "ttft", "p90");
+    case "ttft.p95":
+      return dist(data, "ttft", "p95");
+    case "ttft.p99":
+      return dist(data, "ttft", "p99");
+    case "itl.p50":
+      return dist(data, "itl", "p50");
+    case "itl.p95":
+      return dist(data, "itl", "p95");
+    case "e2e.p50":
+      return dist(data, "e2eLatency", "p50");
+    case "e2e.p90":
+      return dist(data, "e2eLatency", "p90");
+    case "e2e.p95":
+      return dist(data, "e2eLatency", "p95");
+    case "e2e.p99":
+      return dist(data, "e2eLatency", "p99");
+    case "errorRate": {
+      const r = data.requests as { total?: number; error?: number } | undefined;
+      const t = fin(r?.total);
+      const e = fin(r?.error);
+      return t === null || e === null || t === 0 ? null : e / t;
+    }
+    case "requestsPerSec": {
+      const r = data.requestsPerSecond as { mean?: number } | undefined;
+      return fin(r?.mean);
+    }
+    case "outputTokensPerSec": {
+      const r = data.outputTokensPerSecond as { mean?: number } | undefined;
+      return fin(r?.mean);
+    }
+    case "tailRatio": {
+      const p50 = dist(data, "e2eLatency", "p50");
+      const p99 = dist(data, "e2eLatency", "p99");
+      return p50 === null || p99 === null || p50 === 0 ? null : p99 / p50;
+    }
+    default: {
+      const _exhaustive: never = kind;
+      void _exhaustive;
+      return null;
+    }
+  }
+}

--- a/packages/tool-adapters/src/index.ts
+++ b/packages/tool-adapters/src/index.ts
@@ -4,14 +4,66 @@ export * from "./core/interface.js";
 export * from "./core/registry.js";
 export * from "./core/progress-event.js";
 
-export { guidellmAdapter } from "./guidellm/index.js";
-export { vegetaAdapter } from "./vegeta/index.js";
-export { prefixCacheProbeAdapter } from "./prefix-cache-probe/index.js";
-export { evalscopeAdapter } from "./evalscope/index.js";
-export { aiperfAdapter } from "./aiperf/index.js";
+export { guidellmAdapter, guidellmReadMetric } from "./guidellm/index.js";
+export { vegetaAdapter, vegetaReadMetric } from "./vegeta/index.js";
+export {
+  prefixCacheProbeAdapter,
+  prefixCacheProbeReadMetric,
+} from "./prefix-cache-probe/index.js";
+export { evalscopeAdapter, evalscopeReadMetric } from "./evalscope/index.js";
+export { aiperfAdapter, aiperfReadMetric } from "./aiperf/index.js";
 
 // Re-export schemas + types for convenience (so `apps/api` doesn't need to
 // reach into subpaths to validate `req.params`).
-export * from "./schemas-entry.js";
+// NOTE: cherry-picked to avoid the `readMetricSafe` re-export from
+// schemas-entry conflicting with the runtime variant we expose below
+// (each entry uses a different adapter-resolution mechanism: schemas
+// drives off pure per-tool functions, runtime drives off byTool).
+export {
+  guidellmParamsSchema,
+  guidellmReportSchema,
+  guidellmParamDefaults,
+  guidellmRateTypes,
+  type GuidellmParams,
+  type GuidellmReport,
+  vegetaParamsSchema,
+  vegetaReportSchema,
+  vegetaParamDefaults,
+  type VegetaParams,
+  type VegetaReport,
+  prefixCacheProbeParamsSchema,
+  prefixCacheProbeReportSchema,
+  prefixCacheProbeParamDefaults,
+  type PrefixCacheProbeParams,
+  type PrefixCacheProbeReport,
+  evalscopeParamsSchema,
+  evalscopeReportSchema,
+  evalscopeParamDefaults,
+  type EvalscopeParams,
+  type EvalscopeReport,
+  aiperfParamsSchema,
+  aiperfReportSchema,
+  aiperfParamDefaults,
+  type AiperfParams,
+  type AiperfReport,
+  progressEventSchema,
+  SCENARIOS,
+  scenarioIdSchema,
+  type ScenarioId,
+  type ScenarioConfig,
+  VEGETA_API_TYPE_TO_BODY,
+  VEGETA_API_TYPE_TO_PATH,
+  migrateVegetaParams,
+  GUIDELLM_CATEGORY_DEFAULTS,
+  VEGETA_CATEGORY_DEFAULTS,
+  PREFIX_CACHE_PROBE_CATEGORY_DEFAULTS,
+  EVALSCOPE_CATEGORY_DEFAULTS,
+  AIPERF_CATEGORY_DEFAULTS,
+} from "./schemas-entry.js";
+
+// Shared readMetricSafe — api side resolves adapters via the registry,
+// so a future tool registration is picked up automatically without a
+// parallel table.
+export { readMetricSafe } from "./core/read-metric-safe.runtime.js";
 
 export * from "./scenarios.js";

--- a/packages/tool-adapters/src/prefix-cache-probe/index.spec.ts
+++ b/packages/tool-adapters/src/prefix-cache-probe/index.spec.ts
@@ -6,9 +6,14 @@ import { prefixCacheProbeAdapter } from "./index.js";
 // of the load-generator inference metrics. Every MetricKind must return
 // null regardless of input.
 const allKinds: readonly MetricKind[] = [
+  "ttft.p50",
+  "ttft.p90",
   "ttft.p95",
   "ttft.p99",
+  "itl.p50",
   "itl.p95",
+  "e2e.p50",
+  "e2e.p90",
   "e2e.p95",
   "e2e.p99",
   "errorRate",

--- a/packages/tool-adapters/src/prefix-cache-probe/index.spec.ts
+++ b/packages/tool-adapters/src/prefix-cache-probe/index.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import type { MetricKind } from "../core/interface.js";
+import { prefixCacheProbeAdapter } from "./index.js";
+
+// prefix-cache-probe is a routing-stickiness diagnostic and carries NONE
+// of the load-generator inference metrics. Every MetricKind must return
+// null regardless of input.
+const allKinds: readonly MetricKind[] = [
+  "ttft.p95",
+  "ttft.p99",
+  "itl.p95",
+  "e2e.p95",
+  "e2e.p99",
+  "errorRate",
+  "requestsPerSec",
+  "outputTokensPerSec",
+  "tailRatio",
+];
+
+describe("prefixCacheProbeAdapter.readMetric", () => {
+  it("returns null for every MetricKind (no inference metrics)", () => {
+    // Even with a fully populated synthetic payload that resembles other
+    // tools' reports, prefix-cache-probe MUST refuse to surface these
+    // metrics — its semantics are pod-stickiness, not throughput.
+    const fakeFull: Record<string, unknown> = {
+      ttft: { p95: 100, p99: 200 },
+      itl: { p95: 30 },
+      e2eLatency: { p50: 800, p95: 1000, p99: 1500 },
+      latencies: { p50: 800, p95: 1000, p99: 1500 },
+      requests: { total: 100, error: 5, errorRate: 0.05 },
+      requestsPerSecond: { mean: 10 },
+      throughput: { requestsPerSec: 10, outputTokensPerSec: 500 },
+      success: 95,
+    };
+    for (const kind of allKinds) {
+      expect(prefixCacheProbeAdapter.readMetric(kind, fakeFull)).toBeNull();
+      expect(prefixCacheProbeAdapter.readMetric(kind, {})).toBeNull();
+    }
+  });
+});

--- a/packages/tool-adapters/src/prefix-cache-probe/index.ts
+++ b/packages/tool-adapters/src/prefix-cache-probe/index.ts
@@ -1,4 +1,5 @@
-import type { MetricKind, ToolAdapter } from "../core/interface.js";
+import type { ToolAdapter } from "../core/interface.js";
+import { prefixCacheProbeReadMetric } from "./read-metric.js";
 import { buildCommand, getMaxDurationSeconds, parseFinalReport, parseProgress } from "./runtime.js";
 import {
   prefixCacheProbeParamDefaults,
@@ -6,29 +7,7 @@ import {
   prefixCacheProbeReportSchema,
 } from "./schema.js";
 
-// prefix-cache-probe is a routing-stickiness diagnostic, NOT a load
-// generator. None of the inference-shape MetricKinds apply, but we
-// still keep an exhaustive switch so the next MetricKind added causes
-// a type error here too (forcing a deliberate decision per tool).
-function readMetric(kind: MetricKind, _data: Record<string, unknown>): number | null {
-  switch (kind) {
-    case "ttft.p95":
-    case "ttft.p99":
-    case "itl.p95":
-    case "e2e.p95":
-    case "e2e.p99":
-    case "errorRate":
-    case "requestsPerSec":
-    case "outputTokensPerSec":
-    case "tailRatio":
-      return null;
-    default: {
-      const _exhaustive: never = kind;
-      void _exhaustive;
-      return null;
-    }
-  }
-}
+export { prefixCacheProbeReadMetric } from "./read-metric.js";
 
 export const prefixCacheProbeAdapter: ToolAdapter = {
   name: "prefix-cache-probe",
@@ -40,7 +19,7 @@ export const prefixCacheProbeAdapter: ToolAdapter = {
   parseProgress,
   parseFinalReport,
   getMaxDurationSeconds,
-  readMetric,
+  readMetric: prefixCacheProbeReadMetric,
 };
 
 export type {

--- a/packages/tool-adapters/src/prefix-cache-probe/index.ts
+++ b/packages/tool-adapters/src/prefix-cache-probe/index.ts
@@ -1,10 +1,34 @@
-import type { ToolAdapter } from "../core/interface.js";
+import type { MetricKind, ToolAdapter } from "../core/interface.js";
 import { buildCommand, getMaxDurationSeconds, parseFinalReport, parseProgress } from "./runtime.js";
 import {
   prefixCacheProbeParamDefaults,
   prefixCacheProbeParamsSchema,
   prefixCacheProbeReportSchema,
 } from "./schema.js";
+
+// prefix-cache-probe is a routing-stickiness diagnostic, NOT a load
+// generator. None of the inference-shape MetricKinds apply, but we
+// still keep an exhaustive switch so the next MetricKind added causes
+// a type error here too (forcing a deliberate decision per tool).
+function readMetric(kind: MetricKind, _data: Record<string, unknown>): number | null {
+  switch (kind) {
+    case "ttft.p95":
+    case "ttft.p99":
+    case "itl.p95":
+    case "e2e.p95":
+    case "e2e.p99":
+    case "errorRate":
+    case "requestsPerSec":
+    case "outputTokensPerSec":
+    case "tailRatio":
+      return null;
+    default: {
+      const _exhaustive: never = kind;
+      void _exhaustive;
+      return null;
+    }
+  }
+}
 
 export const prefixCacheProbeAdapter: ToolAdapter = {
   name: "prefix-cache-probe",
@@ -16,6 +40,7 @@ export const prefixCacheProbeAdapter: ToolAdapter = {
   parseProgress,
   parseFinalReport,
   getMaxDurationSeconds,
+  readMetric,
 };
 
 export type {

--- a/packages/tool-adapters/src/prefix-cache-probe/read-metric.ts
+++ b/packages/tool-adapters/src/prefix-cache-probe/read-metric.ts
@@ -1,0 +1,33 @@
+import type { MetricKind } from "../core/metric-extractor.js";
+
+// prefix-cache-probe is a routing-stickiness diagnostic, NOT a load
+// generator. None of the inference-shape MetricKinds apply, but we
+// still keep an exhaustive switch so the next MetricKind added causes
+// a type error here too (forcing a deliberate decision per tool).
+export function prefixCacheProbeReadMetric(
+  kind: MetricKind,
+  _data: Record<string, unknown>,
+): number | null {
+  switch (kind) {
+    case "ttft.p50":
+    case "ttft.p90":
+    case "ttft.p95":
+    case "ttft.p99":
+    case "itl.p50":
+    case "itl.p95":
+    case "e2e.p50":
+    case "e2e.p90":
+    case "e2e.p95":
+    case "e2e.p99":
+    case "errorRate":
+    case "requestsPerSec":
+    case "outputTokensPerSec":
+    case "tailRatio":
+      return null;
+    default: {
+      const _exhaustive: never = kind;
+      void _exhaustive;
+      return null;
+    }
+  }
+}

--- a/packages/tool-adapters/src/schemas-entry.ts
+++ b/packages/tool-adapters/src/schemas-entry.ts
@@ -4,7 +4,7 @@
 // IMPORTANT: do NOT import anything from `runtime.ts` files transitively
 // from this entry point. We don't want `child_process` / `fs` / etc to
 // be reachable from the FE bundle. Keep this file's imports limited to
-// schema files.
+// schema files and pure metric extractors.
 
 export {
   guidellmParamsSchema,
@@ -69,3 +69,17 @@ export {
   EVALSCOPE_CATEGORY_DEFAULTS,
   AIPERF_CATEGORY_DEFAULTS,
 } from "./category-defaults.js";
+
+// Metric kinds + pure per-tool extractors. These files have NO runtime
+// dependencies (no child_process, no fs) so FE can safely import them.
+export type { MetricKind, ToolMetricExtractor } from "./core/metric-extractor.js";
+export { guidellmReadMetric } from "./guidellm/read-metric.js";
+export { vegetaReadMetric } from "./vegeta/read-metric.js";
+export { prefixCacheProbeReadMetric } from "./prefix-cache-probe/read-metric.js";
+export { evalscopeReadMetric } from "./evalscope/read-metric.js";
+export { aiperfReadMetric } from "./aiperf/read-metric.js";
+
+// FE-safe variant of `readMetricSafe` — drives off the pure per-tool
+// readMetric exports above, NOT `byTool` (which would pull in adapter
+// runtimes via `registry.js`).
+export { readMetricSafe } from "./core/read-metric-safe.fe.js";

--- a/packages/tool-adapters/src/vegeta/index.spec.ts
+++ b/packages/tool-adapters/src/vegeta/index.spec.ts
@@ -15,14 +15,29 @@ const sample: Record<string, unknown> = {
 };
 
 describe("vegetaAdapter.readMetric", () => {
+  it("ttft.p50 returns null (vegeta has no token semantics)", () => {
+    expect(vegetaAdapter.readMetric("ttft.p50", sample)).toBeNull();
+  });
+  it("ttft.p90 returns null", () => {
+    expect(vegetaAdapter.readMetric("ttft.p90", sample)).toBeNull();
+  });
   it("ttft.p95 returns null (vegeta has no token semantics)", () => {
     expect(vegetaAdapter.readMetric("ttft.p95", sample)).toBeNull();
   });
   it("ttft.p99 returns null", () => {
     expect(vegetaAdapter.readMetric("ttft.p99", sample)).toBeNull();
   });
+  it("itl.p50 returns null", () => {
+    expect(vegetaAdapter.readMetric("itl.p50", sample)).toBeNull();
+  });
   it("itl.p95 returns null", () => {
     expect(vegetaAdapter.readMetric("itl.p95", sample)).toBeNull();
+  });
+  it("e2e.p50 (latencies.p50)", () => {
+    expect(vegetaAdapter.readMetric("e2e.p50", sample)).toBe(180);
+  });
+  it("e2e.p90 (latencies.p90)", () => {
+    expect(vegetaAdapter.readMetric("e2e.p90", sample)).toBe(350);
   });
   it("e2e.p95 (latencies.p95)", () => {
     expect(vegetaAdapter.readMetric("e2e.p95", sample)).toBe(400);

--- a/packages/tool-adapters/src/vegeta/index.spec.ts
+++ b/packages/tool-adapters/src/vegeta/index.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { vegetaAdapter } from "./index.js";
+
+// Sample mirrors vegetaReportSchema (see ./schema.ts). All latencies in ms.
+// `success` is a 0-100 percent (vegeta CLI semantics), NOT a 0-1 ratio.
+const sample: Record<string, unknown> = {
+  requests: { total: 300, rate: 10, throughput: 9.8 },
+  duration: { totalSeconds: 30, attackSeconds: 30, waitSeconds: 0 },
+  latencies: { min: 50, mean: 200, p50: 180, p90: 350, p95: 400, p99: 800, max: 1200 },
+  bytesIn: { total: 0, mean: 0 },
+  bytesOut: { total: 0, mean: 0 },
+  success: 98, // 98% success → errorRate 0.02
+  statusCodes: { "200": 294, "500": 6 },
+  errors: [],
+};
+
+describe("vegetaAdapter.readMetric", () => {
+  it("ttft.p95 returns null (vegeta has no token semantics)", () => {
+    expect(vegetaAdapter.readMetric("ttft.p95", sample)).toBeNull();
+  });
+  it("ttft.p99 returns null", () => {
+    expect(vegetaAdapter.readMetric("ttft.p99", sample)).toBeNull();
+  });
+  it("itl.p95 returns null", () => {
+    expect(vegetaAdapter.readMetric("itl.p95", sample)).toBeNull();
+  });
+  it("e2e.p95 (latencies.p95)", () => {
+    expect(vegetaAdapter.readMetric("e2e.p95", sample)).toBe(400);
+  });
+  it("e2e.p99 (latencies.p99)", () => {
+    expect(vegetaAdapter.readMetric("e2e.p99", sample)).toBe(800);
+  });
+  it("errorRate (1 - success/100)", () => {
+    expect(vegetaAdapter.readMetric("errorRate", sample)).toBeCloseTo(0.02, 4);
+  });
+  it("requestsPerSec (requests.throughput)", () => {
+    expect(vegetaAdapter.readMetric("requestsPerSec", sample)).toBe(9.8);
+  });
+  it("outputTokensPerSec returns null", () => {
+    expect(vegetaAdapter.readMetric("outputTokensPerSec", sample)).toBeNull();
+  });
+  it("tailRatio (latencies p99/p50)", () => {
+    expect(vegetaAdapter.readMetric("tailRatio", sample)).toBeCloseTo(800 / 180, 4);
+  });
+  it("null on missing data", () => {
+    expect(vegetaAdapter.readMetric("e2e.p95", {})).toBeNull();
+    expect(vegetaAdapter.readMetric("errorRate", {})).toBeNull();
+    expect(vegetaAdapter.readMetric("requestsPerSec", {})).toBeNull();
+  });
+});

--- a/packages/tool-adapters/src/vegeta/index.ts
+++ b/packages/tool-adapters/src/vegeta/index.ts
@@ -1,52 +1,9 @@
-import type { MetricKind, ToolAdapter } from "../core/interface.js";
+import type { ToolAdapter } from "../core/interface.js";
+import { vegetaReadMetric } from "./read-metric.js";
 import { buildCommand, getMaxDurationSeconds, parseFinalReport, parseProgress } from "./runtime.js";
 import { vegetaParamDefaults, vegetaParamsSchema, vegetaReportSchema } from "./schema.js";
 
-const fin = (v: unknown): number | null =>
-  typeof v === "number" && Number.isFinite(v) ? v : null;
-
-const dist = (
-  data: Record<string, unknown>,
-  key: string,
-  field: string,
-): number | null => {
-  const d = data[key] as Record<string, unknown> | undefined;
-  return fin(d?.[field]);
-};
-
-function readMetric(kind: MetricKind, data: Record<string, unknown>): number | null {
-  switch (kind) {
-    // vegeta is generic HTTP — no token-level instrumentation.
-    case "ttft.p95":
-    case "ttft.p99":
-    case "itl.p95":
-    case "outputTokensPerSec":
-      return null;
-    case "e2e.p95":
-      return dist(data, "latencies", "p95");
-    case "e2e.p99":
-      return dist(data, "latencies", "p99");
-    case "errorRate": {
-      // `data.success` is a 0-100 percentage in vegeta's normalized schema.
-      const success = fin(data.success);
-      return success === null ? null : 1 - success / 100;
-    }
-    case "requestsPerSec": {
-      const r = data.requests as { throughput?: number } | undefined;
-      return fin(r?.throughput);
-    }
-    case "tailRatio": {
-      const p50 = dist(data, "latencies", "p50");
-      const p99 = dist(data, "latencies", "p99");
-      return p50 === null || p99 === null || p50 === 0 ? null : p99 / p50;
-    }
-    default: {
-      const _exhaustive: never = kind;
-      void _exhaustive;
-      return null;
-    }
-  }
-}
+export { vegetaReadMetric } from "./read-metric.js";
 
 export const vegetaAdapter: ToolAdapter = {
   name: "vegeta",
@@ -58,7 +15,7 @@ export const vegetaAdapter: ToolAdapter = {
   parseProgress,
   parseFinalReport,
   getMaxDurationSeconds,
-  readMetric,
+  readMetric: vegetaReadMetric,
 };
 
 export type { VegetaParams, VegetaReport } from "./schema.js";

--- a/packages/tool-adapters/src/vegeta/index.ts
+++ b/packages/tool-adapters/src/vegeta/index.ts
@@ -1,6 +1,52 @@
-import type { ToolAdapter } from "../core/interface.js";
+import type { MetricKind, ToolAdapter } from "../core/interface.js";
 import { buildCommand, getMaxDurationSeconds, parseFinalReport, parseProgress } from "./runtime.js";
 import { vegetaParamDefaults, vegetaParamsSchema, vegetaReportSchema } from "./schema.js";
+
+const fin = (v: unknown): number | null =>
+  typeof v === "number" && Number.isFinite(v) ? v : null;
+
+const dist = (
+  data: Record<string, unknown>,
+  key: string,
+  field: string,
+): number | null => {
+  const d = data[key] as Record<string, unknown> | undefined;
+  return fin(d?.[field]);
+};
+
+function readMetric(kind: MetricKind, data: Record<string, unknown>): number | null {
+  switch (kind) {
+    // vegeta is generic HTTP — no token-level instrumentation.
+    case "ttft.p95":
+    case "ttft.p99":
+    case "itl.p95":
+    case "outputTokensPerSec":
+      return null;
+    case "e2e.p95":
+      return dist(data, "latencies", "p95");
+    case "e2e.p99":
+      return dist(data, "latencies", "p99");
+    case "errorRate": {
+      // `data.success` is a 0-100 percentage in vegeta's normalized schema.
+      const success = fin(data.success);
+      return success === null ? null : 1 - success / 100;
+    }
+    case "requestsPerSec": {
+      const r = data.requests as { throughput?: number } | undefined;
+      return fin(r?.throughput);
+    }
+    case "tailRatio": {
+      const p50 = dist(data, "latencies", "p50");
+      const p99 = dist(data, "latencies", "p99");
+      return p50 === null || p99 === null || p50 === 0 ? null : p99 / p50;
+    }
+    default: {
+      const _exhaustive: never = kind;
+      void _exhaustive;
+      return null;
+    }
+  }
+}
 
 export const vegetaAdapter: ToolAdapter = {
   name: "vegeta",
@@ -12,6 +58,7 @@ export const vegetaAdapter: ToolAdapter = {
   parseProgress,
   parseFinalReport,
   getMaxDurationSeconds,
+  readMetric,
 };
 
 export type { VegetaParams, VegetaReport } from "./schema.js";

--- a/packages/tool-adapters/src/vegeta/read-metric.ts
+++ b/packages/tool-adapters/src/vegeta/read-metric.ts
@@ -1,0 +1,49 @@
+import type { MetricKind } from "../core/metric-extractor.js";
+
+const fin = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
+
+const dist = (data: Record<string, unknown>, key: string, field: string): number | null => {
+  const d = data[key] as Record<string, unknown> | undefined;
+  return fin(d?.[field]);
+};
+
+export function vegetaReadMetric(kind: MetricKind, data: Record<string, unknown>): number | null {
+  switch (kind) {
+    // vegeta is generic HTTP — no token-level instrumentation.
+    case "ttft.p50":
+    case "ttft.p90":
+    case "ttft.p95":
+    case "ttft.p99":
+    case "itl.p50":
+    case "itl.p95":
+    case "outputTokensPerSec":
+      return null;
+    case "e2e.p50":
+      return dist(data, "latencies", "p50");
+    case "e2e.p90":
+      return dist(data, "latencies", "p90");
+    case "e2e.p95":
+      return dist(data, "latencies", "p95");
+    case "e2e.p99":
+      return dist(data, "latencies", "p99");
+    case "errorRate": {
+      // `data.success` is a 0-100 percentage in vegeta's normalized schema.
+      const success = fin(data.success);
+      return success === null ? null : 1 - success / 100;
+    }
+    case "requestsPerSec": {
+      const r = data.requests as { throughput?: number } | undefined;
+      return fin(r?.throughput);
+    }
+    case "tailRatio": {
+      const p50 = dist(data, "latencies", "p50");
+      const p99 = dist(data, "latencies", "p99");
+      return p50 === null || p99 === null || p50 === 0 ? null : p99 / p50;
+    }
+    default: {
+      const _exhaustive: never = kind;
+      void _exhaustive;
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to PR #183. Closes every deferred / non-blocking item from that branch's code review (15 tasks across 4 phases):

### Phase 1 · Air-gapped image readiness (4 commits)

Production target has no internet egress; bake every external dataset into the runner images so `--public-dataset sharegpt` / `--dataset openqa` etc. don't try to call out.

- `cc04d99` evalscope bakes `AI-ModelScope/HC3-Chinese:open_qa.jsonl` (~50 MB) + passes `--dataset-path` from the adapter so the runtime plugin skips its download attempt
- `8727470` aiperf bakes `ShareGPT_V3_unfiltered_cleaned_split.json` (~672 MB) into `/app/.cache/aiperf/datasets/` (where `ShareGPTLoader` resolves the relative cache)
- `fa10b51` adds `apps/benchmark-runner/scripts/verify-airgap.sh` — `docker run --network none` per-dataset bake check, catches future regressions
- `ac72138` docs/README adds an "Air-gapped clusters" section with the dataset → path → source matrix

### Phase 2 · ToolName exhaustiveness refactor (5 commits)

PR #183 caught a class drift: deleting `genai-perf` updated six runtime `switch (tool)` blocks correctly but adding `evalscope+aiperf` silently missed several of them. Fix the root cause by moving metric extraction into adapter responsibility.

- `c11a650` adds `adapter.readMetric(kind, data)` interface — every `ToolAdapter extends ToolMetricExtractor`. ~50 new tests cover the per-tool field paths.
- `c835593` widens `MetricKind` to include p50/p90 buckets, introduces shared `readMetricSafe` (FE + runtime variants)
- `6c9c2f6` `d27bdfa` `d697c84` refactor 5 consumer files (api benchmark/insights/saved-compares metrics + FE compare/metrics + insights checks) to delegate. Net **−175 lines** across consumers.
- `298551e` extracts `<InferenceMetricsGrid>` shared component — three per-tool `InferenceMetrics.tsx` files collapse from ~85 lines each to ~30 lines via `NormalizedInferenceData`

### Phase 3 · User-facing completeness (2 commits)

- `3728005` 1 official aiperf inference template (`tpl_inf_aiperf_baseline`)
- `d372495` `reports.shared.*` + `reports.kvCacheStress.*` i18n keys (32 per locale), wires `useTranslation` into `InferenceMetricsGrid` + `KvCacheStressReport`

### Phase 4 · Polish (3 commits)

- `053f453` `numberField()` helper — Evalscope+Aiperf forms shrink ~50 lines each
- `24633ba` trim stale Dockerfile header
- `50465c2` `rm -rf dist && tsc` in build scripts so stale `.d.ts` from deleted source files can't accumulate

## Test plan

- [x] pnpm -r build clean
- [x] tool-adapters 204/204
- [x] api 647/647
- [x] web 794/794
- [x] type-check across all three workspaces
- [x] biome lint clean
- [x] i18n parity OK
- [ ] Operator runs verify-airgap.sh against locally-built images
- [ ] Manual smoke against dev k3d cluster

refs #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)