### PR TITLE
fix: align RUNNER_IMAGE_* docs with current 5-tool set

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -54,9 +54,9 @@ BENCHMARK_K8S_NAMESPACE=modeldoctor-benchmarks
 # fallbacks — Pod spec receives the raw string. Use a literal tag.
 RUNNER_IMAGE_GUIDELLM=<replace via ./tools/build-runner-images.sh>
 RUNNER_IMAGE_VEGETA=<replace via ./tools/build-runner-images.sh>
-RUNNER_IMAGE_GENAI_PERF=<replace via ./tools/build-runner-images.sh>
 RUNNER_IMAGE_PREFIX_CACHE_PROBE=<replace via ./tools/build-runner-images.sh>
-RUNNER_IMAGE_KV_CACHE_STRESS=<replace via ./tools/build-runner-images.sh>
+RUNNER_IMAGE_EVALSCOPE=<replace via ./tools/build-runner-images.sh>
+RUNNER_IMAGE_AIPERF=<replace via ./tools/build-runner-images.sh>
 
 # Optional kubeconfig override for out-of-cluster local dev. Leave unset in
 # production (the API runs as a pod and uses its in-cluster ServiceAccount).

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -30,7 +30,7 @@ k3d cluster create modeldoctor
 kubectl create namespace modeldoctor
 kubectl apply -f deploy/k8s/rbac.yaml
 
-# Build the three runner images with the current source tree's git SHA and
+# Build the five runner images with the current source tree's git SHA and
 # import them into k3d. The script prints the matching RUNNER_IMAGE_*
 # tags to paste into your `.env` (one per tool).
 ./tools/build-runner-images.sh --import k3d --cluster modeldoctor
@@ -44,7 +44,9 @@ export BENCHMARK_K8S_NAMESPACE=modeldoctor-benchmarks
 export BENCHMARK_CALLBACK_URL=http://host.k3d.internal:3001
 export RUNNER_IMAGE_GUIDELLM=md-runner-guidellm:<sha-from-script>
 export RUNNER_IMAGE_VEGETA=md-runner-vegeta:<sha-from-script>
-export RUNNER_IMAGE_GENAI_PERF=md-runner-genai-perf:<sha-from-script>
+export RUNNER_IMAGE_PREFIX_CACHE_PROBE=md-runner-prefix-cache-probe:<sha-from-script>
+export RUNNER_IMAGE_EVALSCOPE=md-runner-evalscope:<sha-from-script>
+export RUNNER_IMAGE_AIPERF=md-runner-aiperf:<sha-from-script>
 pnpm -F @modeldoctor/api start:dev
 ```
 


### PR DESCRIPTION
## Summary

- `apps/api/.env.example` still listed retired `RUNNER_IMAGE_GENAI_PERF` / `RUNNER_IMAGE_KV_CACHE_STRESS` and was missing the new `RUNNER_IMAGE_EVALSCOPE` / `RUNNER_IMAGE_AIPERF`. Copying `.env.example -> .env` on a fresh checkout hits `RUNNER_IMAGE_AIPERF is required when NODE_ENV != test` from the env-schema `superRefine`.
- `deploy/k8s/README.md` had the same stale tools-list (genai-perf) and called the set "three runner images" when it's now five.

After this PR, the documented var set matches `tools/build-runner-images.sh` (which already prints the correct 5 vars) and `apps/api/src/config/env.schema.ts` (which already validates the 5 vars).

## Test plan

- [x] `grep -E '(GENAI_PERF|KV_CACHE_STRESS)' apps/api/.env.example deploy/k8s/README.md` returns empty
- [x] `apps/api/.env.example` now lists the same 5 keys as `env.schema.ts` lines 64-68

🤖 Generated with [Claude Code](https://claude.com/claude-code)