### PR TITLE
feat(observability): metrics survey + PrometheusRule baseline (refs #189)

### DIFF
--- a/deploy/k8s/prometheus-rules/README.md
+++ b/deploy/k8s/prometheus-rules/README.md
@@ -1,0 +1,101 @@
+# ModelDoctor PrometheusRule baseline
+
+PrometheusRule CRDs (kube-prometheus-operator format) that normalize raw
+inference-engine, gateway, and accelerator metrics into the
+`modeldoctor:*` namespace, then declare SLO alerts on top.
+
+Background and design rationale:
+[`docs/superpowers/research/2026-05-15-inference-engine-metrics-survey.md`](../../../docs/superpowers/research/2026-05-15-inference-engine-metrics-survey.md).
+
+## Layout
+
+```
+recording/
+  engines/                        ← apply ONE per engine type per replica
+    vllm-v0.yaml                  ← vLLM 0.5.x / 0.6.x
+    vllm-v1.yaml                  ← vLLM 0.7.x+
+    sglang-legacy.yaml            ← SGLang ≤ 0.5.3 (sglang: prefix)
+    sglang-v0.5.4plus.yaml        ← SGLang ≥ 0.5.4 (sglang_ prefix)
+    tgi.yaml                      ← HuggingFace TGI 1.x / 2.x
+  gateway/
+    higress.yaml                  ← apply if you run Higress AI Statistics
+  accelerator/
+    accelerator.yaml              ← unified NVIDIA + Ascend; safe to always apply
+alerts/                           ← apply all four; they consume `modeldoctor:*` only
+  request-slo.yaml                ← TTFT, queue, hang, preemption
+  cache.yaml                      ← KV / prefix cache pressure
+  accelerator.yaml                ← GPU/NPU health, thermal, memory
+  gateway-consumer.yaml           ← multi-tenant isolation (Higress only)
+```
+
+## Design principle: version is engine
+
+Do NOT apply both `vllm-v0.yaml` and `vllm-v1.yaml` against the same
+inference replica. The two engine types are mutually exclusive — they
+target different raw metric names. Pick the one matching your deployed
+vLLM version. Same for `sglang-legacy.yaml` vs `sglang-v0.5.4plus.yaml`.
+
+Why: each rule file hard-codes its `engine` label and reads the raw
+metric names from the specific vLLM/SGLang major version. Layering two
+files would produce duplicate normalized series with different `engine`
+label values, which breaks downstream alert grouping and AI context join.
+
+## How to apply
+
+```bash
+# 1. Pick one engine recording file matching your inference workload
+kubectl apply -f recording/engines/vllm-v1.yaml -n monitoring
+
+# 2. (Optional) Apply gateway recording if you use Higress
+kubectl apply -f recording/gateway/higress.yaml -n monitoring
+
+# 3. Apply accelerator recording (safe regardless of vendor)
+kubectl apply -f recording/accelerator/accelerator.yaml -n monitoring
+
+# 4. Apply all four alert files
+kubectl apply -f alerts/ -n monitoring
+```
+
+The namespace `monitoring` is the kube-prometheus-stack default; adjust
+to wherever your Prometheus instance reads PrometheusRule from
+(check `Prometheus.spec.ruleSelector` + `ruleNamespaceSelector` on
+your `Prometheus` resource).
+
+## Prerequisites
+
+- **Prometheus Operator** (kube-prometheus-stack, rancher-monitoring,
+  Coreweave, OpenShift Monitoring — anything that consumes the
+  `monitoring.coreos.com/v1 PrometheusRule` CRD).
+- Source metrics scraped into the same Prometheus instance:
+  - For vLLM/SGLang/TGI: a `ServiceMonitor` or `PodMonitor` against the
+    inference service's `/metrics` endpoint, with a `model_name` label
+    (or `instance` if the engine doesn't export model name natively —
+    see survey §9).
+  - For Higress: the AI Statistics plugin enabled and its `/stats`
+    endpoint scraped.
+  - For DCGM: `nvidia-dcgm-exporter` running as DaemonSet.
+  - For Huawei NPU: `npu-exporter` running as DaemonSet.
+
+## Unit conventions (verify before production)
+
+- Higress LLM duration counters are converted **microseconds → seconds**
+  (divide by `1e6`). Some legacy plugin builds report milliseconds —
+  if your normalized `modeldoctor:gateway:llm_duration_seconds:avg`
+  is suspiciously 1000x off, change the divisor to `1e3` in
+  `recording/gateway/higress.yaml`.
+- DCGM `FB_USED` / `FB_TOTAL` are MiB; we convert to bytes.
+- NPU `used_memory` / `total_memory` are MB (decimal); we treat them
+  as MiB for symmetry with DCGM (i.e. `* 1024 * 1024`). The 5% drift
+  is irrelevant for alerting but flag it if you build a billing-grade
+  dashboard.
+
+## Alert routing (next step)
+
+Alert labels include `modeldoctor_scenario` (`ttft-jitter`,
+`kv-cache-pressure`, `prefix-cache-regression`, `accelerator-fault`,
+`accelerator-thermal`, `consumer-isolation`, …). Alertmanager will use
+these to route everything to ModelDoctor's webhook receiver, where the
+AI recommendation layer enriches with connection context.
+
+The Alertmanager `receivers:` snippet and webhook contract are
+not in this PR — see follow-up.

--- a/deploy/k8s/prometheus-rules/alerts/accelerator.yaml
+++ b/deploy/k8s/prometheus-rules/alerts/accelerator.yaml
@@ -1,0 +1,85 @@
+# PrometheusRule: Accelerator (GPU/NPU) alerts
+#
+# Queries `modeldoctor:accelerator:*` only — vendor-agnostic.
+# Distinguishes NVIDIA vs Ascend via the `device_kind` label.
+#
+# Scenario covered (per survey §8):
+#   - D: GPU/NPU physical anomaly (XID errors, NPU error_code, thermal)
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: modeldoctor-alerts-accelerator
+  labels:
+    app.kubernetes.io/name: modeldoctor
+    app.kubernetes.io/component: prometheus-rules
+    modeldoctor.io/kind: alert
+spec:
+  groups:
+    - name: modeldoctor.alerts.accelerator
+      rules:
+        - alert: ModelDoctorAcceleratorUnhealthy
+          expr: modeldoctor:accelerator:health_status == 0
+          for: 2m
+          labels:
+            severity: critical
+            modeldoctor_scenario: accelerator-fault
+          annotations:
+            summary: "{{ $labels.device_kind }} accelerator unhealthy on {{ $labels.instance }}"
+            description: |
+              Accelerator health flag is 0 for {{ $labels.device_kind }}
+              device on {{ $labels.instance }} (gpu/UUID/id={{ $labels.UUID }}{{ $labels.id }}).
+              NVIDIA: XID error in the last 5m. Ascend: explicit health bit.
+            modeldoctor_required_context: "accelerator:error_total, accelerator:temperature_celsius"
+
+        - alert: ModelDoctorAcceleratorTempHigh
+          expr: modeldoctor:accelerator:temperature_celsius > 85
+          for: 5m
+          labels:
+            severity: warning
+            modeldoctor_scenario: accelerator-thermal
+          annotations:
+            summary: "{{ $labels.device_kind }} temp {{ $value }}°C on {{ $labels.instance }}"
+            description: |
+              Accelerator temperature {{ $value }}°C sustained for 5m on
+              {{ $labels.device_kind }} device {{ $labels.instance }}.
+              Throttling may engage; performance will degrade.
+
+        - alert: ModelDoctorAcceleratorTempCritical
+          # NVIDIA H100 throttle is ~87°C; A100 ~85°C; Ascend 910B ~85°C.
+          # 95° is a conservative critical line — adjust per device class.
+          expr: modeldoctor:accelerator:temperature_celsius > 95
+          for: 1m
+          labels:
+            severity: critical
+            modeldoctor_scenario: accelerator-thermal
+          annotations:
+            summary: "{{ $labels.device_kind }} temp critical {{ $value }}°C on {{ $labels.instance }}"
+            description: |
+              Temperature {{ $value }}°C is in shutdown-risk territory. Check
+              cooling and consider draining workloads from this node.
+
+        - alert: ModelDoctorAcceleratorMemoryHigh
+          expr: modeldoctor:accelerator:memory_usage_ratio > 0.95
+          for: 5m
+          labels:
+            severity: warning
+            modeldoctor_scenario: accelerator-memory
+          annotations:
+            summary: '{{ $labels.device_kind }} memory {{ $value | printf "%.0f%%" }} on {{ $labels.instance }}'
+            description: |
+              Device memory at {{ $value | printf "%.2f" }} sustained for 5m.
+              KV cache will start evicting; OOM imminent if load grows.
+
+        - alert: ModelDoctorAcceleratorErrors
+          expr: increase(modeldoctor:accelerator:error_total[5m]) > 0
+          for: 1m
+          labels:
+            severity: warning
+            modeldoctor_scenario: accelerator-fault
+          annotations:
+            summary: "{{ $labels.device_kind }} error count increasing on {{ $labels.instance }}"
+            description: |
+              Accelerator error counter increased in the last 5m.
+              NVIDIA: XID error. Ascend: chip_info_error_code != 0.
+              Investigate `nvidia-smi -q` / `npu-smi info` output.

--- a/deploy/k8s/prometheus-rules/alerts/cache.yaml
+++ b/deploy/k8s/prometheus-rules/alerts/cache.yaml
@@ -1,0 +1,67 @@
+# PrometheusRule: KV cache + prefix cache alerts
+#
+# Queries `modeldoctor:cache:*` only — engine-agnostic.
+# TGI and SGLang-without-prefix-cache will naturally produce empty
+# series and these alerts stay silent for those engines.
+#
+# Scenarios covered (per survey §8):
+#   - A: TTFT jitter + KV exhaustion (kv_usage_ratio leg)
+#   - B: prefix cache miss surge
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: modeldoctor-alerts-cache
+  labels:
+    app.kubernetes.io/name: modeldoctor
+    app.kubernetes.io/component: prometheus-rules
+    modeldoctor.io/kind: alert
+spec:
+  groups:
+    - name: modeldoctor.alerts.cache
+      rules:
+        - alert: ModelDoctorKvCacheHigh
+          expr: modeldoctor:cache:kv_usage_ratio > 0.85
+          for: 5m
+          labels:
+            severity: warning
+            modeldoctor_scenario: kv-cache-pressure
+          annotations:
+            summary: 'KV cache {{ $value | printf "%.0f%%" }} on {{ $labels.model_name }} ({{ $labels.engine }})'
+            description: |
+              KV cache utilization at {{ $value | printf "%.2f" }} sustained
+              for 5m. New requests will start queueing; TTFT will degrade
+              and preemptions may kick in.
+            modeldoctor_required_context: "request:ttft_seconds, request:preempted_total"
+
+        - alert: ModelDoctorKvCacheCritical
+          expr: modeldoctor:cache:kv_usage_ratio > 0.95
+          for: 1m
+          labels:
+            severity: critical
+            modeldoctor_scenario: kv-cache-pressure
+          annotations:
+            summary: 'KV cache near-full ({{ $value | printf "%.0f%%" }}) on {{ $labels.model_name }}'
+            description: |
+              KV cache at {{ $value | printf "%.2f" }} — system is on the
+              edge of OOM-by-eviction. Either scale out or reduce concurrent
+              load immediately.
+
+        - alert: ModelDoctorPrefixCacheRegression
+          # Drops below 30% hit rate AND there's meaningful traffic.
+          # Without the rate guard, idle systems trip this trivially.
+          expr: |
+            modeldoctor:cache:prefix_hit_ratio < 0.3
+            and on (engine, model_name, instance)
+            rate(modeldoctor:throughput:prompt_tokens_total[5m]) > 10
+          for: 10m
+          labels:
+            severity: info
+            modeldoctor_scenario: prefix-cache-regression
+          annotations:
+            summary: 'Prefix cache hit rate {{ $value | printf "%.0f%%" }} on {{ $labels.model_name }}'
+            description: |
+              Prefix cache hit rate dropped to {{ $value | printf "%.2f" }}
+              over the last 10m with meaningful traffic. Workload pattern
+              may have shifted (new client, new prompt template), or cache
+              size is too small. Compare with prior period.

--- a/deploy/k8s/prometheus-rules/alerts/gateway-consumer.yaml
+++ b/deploy/k8s/prometheus-rules/alerts/gateway-consumer.yaml
@@ -1,0 +1,64 @@
+# PrometheusRule: Gateway / multi-tenant alerts
+#
+# Queries `modeldoctor:gateway:*` only — Higress-sourced. This is the
+# only layer that knows ai_consumer (tenant / API key) identity, so
+# tenant-isolation alerts must live here.
+#
+# Scenario covered (per survey §8):
+#   - C: a single consumer monopolizing capacity
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: modeldoctor-alerts-gateway-consumer
+  labels:
+    app.kubernetes.io/name: modeldoctor
+    app.kubernetes.io/component: prometheus-rules
+    modeldoctor.io/kind: alert
+spec:
+  groups:
+    - name: modeldoctor.alerts.gateway-consumer
+      rules:
+        - alert: ModelDoctorConsumerTokenSurge
+          # A single consumer driving > 70% of input tokens on a model
+          # for 10 minutes = noisy neighbor.
+          expr: |
+            modeldoctor:gateway:input_tokens_rate
+            /
+            ignoring (ai_consumer) group_left
+            sum by (ai_route, ai_cluster, ai_model) (modeldoctor:gateway:input_tokens_rate)
+            > 0.7
+          for: 10m
+          labels:
+            severity: info
+            modeldoctor_scenario: consumer-isolation
+          annotations:
+            summary: 'Consumer {{ $labels.ai_consumer }} = {{ $value | printf "%.0f%%" }} of traffic on {{ $labels.ai_model }}'
+            description: |
+              Tenant {{ $labels.ai_consumer }} is contributing
+              {{ $value | printf "%.2f" }} of total input-token rate
+              on model {{ $labels.ai_model }} via route {{ $labels.ai_route }}
+              for 10m. Confirm if expected (large customer) or runaway client.
+            modeldoctor_required_context: "request:running, cache:kv_usage_ratio for same ai_model"
+
+        - alert: ModelDoctorConsumerLatencyDegraded
+          # A consumer's avg TTFT regresses while others on the same
+          # model are fine = likely consumer-specific prompt pattern
+          # (long context, no prefix cache hit).
+          expr: |
+            modeldoctor:gateway:ttft_seconds:avg
+            >
+            (avg by (ai_route, ai_cluster, ai_model) (modeldoctor:gateway:ttft_seconds:avg)) * 2
+            and
+            modeldoctor:gateway:ttft_seconds:avg > 2
+          for: 10m
+          labels:
+            severity: info
+            modeldoctor_scenario: consumer-isolation
+          annotations:
+            summary: 'Consumer {{ $labels.ai_consumer }} TTFT {{ $value | printf "%.2f" }}s — 2x others'
+            description: |
+              Tenant {{ $labels.ai_consumer }} on model {{ $labels.ai_model }}
+              has avg TTFT {{ $value | printf "%.2f" }}s, more than 2x the
+              cohort average. Likely cause: long prompts, cold prefix cache,
+              or large output token requests.

--- a/deploy/k8s/prometheus-rules/alerts/request-slo.yaml
+++ b/deploy/k8s/prometheus-rules/alerts/request-slo.yaml
@@ -1,0 +1,99 @@
+# PrometheusRule: Request-level SLO alerts
+#
+# Queries the normalized `modeldoctor:request:*` namespace ONLY — engine-
+# agnostic. As long as at least one recording rule (vllm-v0 / vllm-v1 /
+# sglang-* / tgi) is applied, these alerts will fire correctly. If no
+# engine recording rule is applied, the underlying series are simply
+# missing and these alerts stay silent (no false positives).
+#
+# Thresholds are starting defaults; tune per workload. Annotations carry
+# the model_name + engine + instance so the AI recommendation layer can
+# join with connection metadata downstream.
+#
+# Scenarios covered (per survey §8):
+#   - A: TTFT jitter + KV exhaustion
+#   - E: engine hang / OOM degradation
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: modeldoctor-alerts-request-slo
+  labels:
+    app.kubernetes.io/name: modeldoctor
+    app.kubernetes.io/component: prometheus-rules
+    modeldoctor.io/kind: alert
+spec:
+  groups:
+    - name: modeldoctor.alerts.request-slo
+      rules:
+        - alert: ModelDoctorTtftP99High
+          expr: modeldoctor:request:ttft_seconds:p99 > 5
+          for: 5m
+          labels:
+            severity: warning
+            modeldoctor_scenario: ttft-jitter
+          annotations:
+            summary: "TTFT P99 above 5s for {{ $labels.model_name }} on {{ $labels.engine }}"
+            description: |
+              5-minute P99 time-to-first-token is {{ $value | printf "%.2f" }}s
+              on model={{ $labels.model_name }} engine={{ $labels.engine }}
+              instance={{ $labels.instance }}. Check KV cache pressure and
+              queue depth.
+            modeldoctor_required_context: "kv_usage_ratio, request:waiting, request:preempted_total"
+
+        - alert: ModelDoctorTtftP99Critical
+          expr: modeldoctor:request:ttft_seconds:p99 > 15
+          for: 2m
+          labels:
+            severity: critical
+            modeldoctor_scenario: ttft-jitter
+          annotations:
+            summary: "TTFT P99 above 15s for {{ $labels.model_name }} on {{ $labels.engine }}"
+            description: |
+              P99 TTFT is {{ $value | printf "%.2f" }}s — user-perceived stall.
+              Likely cause: KV cache saturated + queue backed up, or upstream
+              dependency degraded.
+
+        - alert: ModelDoctorQueueBacklog
+          expr: modeldoctor:request:waiting > 50
+          for: 5m
+          labels:
+            severity: warning
+            modeldoctor_scenario: queue-backlog
+          annotations:
+            summary: "{{ $value }} requests queued on {{ $labels.engine }} ({{ $labels.model_name }})"
+            description: |
+              Waiting queue depth {{ $value }} sustained for 5m. Either
+              autoscale or reduce concurrent client load.
+
+        - alert: ModelDoctorEngineHang
+          # No requests running AND no traffic completed in 10m =
+          # engine is hung or completely idle. AI layer can disambiguate
+          # by checking external traffic counters.
+          expr: |
+            (modeldoctor:request:running == 0)
+            and on (engine, model_name, instance)
+            (rate(modeldoctor:throughput:generation_tokens_total[10m]) == 0)
+          for: 10m
+          labels:
+            severity: warning
+            modeldoctor_scenario: engine-hang
+          annotations:
+            summary: "Engine {{ $labels.engine }} ({{ $labels.model_name }}) idle for 10m"
+            description: |
+              No running requests AND no generation tokens emitted in the
+              last 10 minutes. Either traffic legitimately stopped or
+              the engine is hung. Cross-check with gateway QPS.
+
+        - alert: ModelDoctorPreemptionStorm
+          expr: rate(modeldoctor:request:preempted_total[5m]) > 0.1
+          for: 5m
+          labels:
+            severity: warning
+            modeldoctor_scenario: preemption-storm
+          annotations:
+            summary: "vLLM preempting >0.1 req/s on {{ $labels.model_name }}"
+            description: |
+              Preemption rate {{ $value | printf "%.3f" }} req/s sustained
+              for 5m. KV cache is over-subscribed; consider reducing
+              max-num-seqs or increasing gpu-memory-utilization.

--- a/deploy/k8s/prometheus-rules/recording/accelerator/accelerator.yaml
+++ b/deploy/k8s/prometheus-rules/recording/accelerator/accelerator.yaml
@@ -1,0 +1,101 @@
+# PrometheusRule: Accelerator unified (NVIDIA DCGM + Huawei NPU Exporter)
+#
+# Normalizes hardware metrics from both NVIDIA GPUs (via DCGM Exporter)
+# and Huawei Ascend NPUs (via npu-exporter) into a single
+# `modeldoctor:accelerator:*` namespace, distinguished by the
+# `device_kind` label:
+#   - device_kind="nvidia"  → sourced from DCGM_FI_*
+#   - device_kind="ascend"  → sourced from npu_chip_info_*
+#
+# Apply BOTH halves if you have both vendors. Each half's recording
+# rule only fires if the source metric exists, so applying both on a
+# pure-NVIDIA cluster will simply leave the Ascend rules silent.
+#
+# We deliberately do not produce engine-level alerts in this file —
+# alerts that query `modeldoctor:accelerator:*` live in
+# alerts/accelerator.yaml.
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: modeldoctor-accelerator
+  labels:
+    app.kubernetes.io/name: modeldoctor
+    app.kubernetes.io/component: prometheus-rules
+    modeldoctor.io/kind: recording
+spec:
+  groups:
+    - name: modeldoctor.accelerator.nvidia
+      interval: 30s
+      rules:
+        - record: modeldoctor:accelerator:utilization_ratio
+          expr: DCGM_FI_DEV_GPU_UTIL / 100
+          labels:
+            device_kind: nvidia
+        - record: modeldoctor:accelerator:memory_used_bytes
+          # DCGM reports MiB; convert to bytes.
+          expr: DCGM_FI_DEV_FB_USED * 1024 * 1024
+          labels:
+            device_kind: nvidia
+        - record: modeldoctor:accelerator:memory_total_bytes
+          expr: DCGM_FI_DEV_FB_TOTAL * 1024 * 1024
+          labels:
+            device_kind: nvidia
+        - record: modeldoctor:accelerator:memory_usage_ratio
+          expr: DCGM_FI_DEV_FB_USED / clamp_min(DCGM_FI_DEV_FB_TOTAL, 1)
+          labels:
+            device_kind: nvidia
+        - record: modeldoctor:accelerator:temperature_celsius
+          expr: DCGM_FI_DEV_GPU_TEMP
+          labels:
+            device_kind: nvidia
+        - record: modeldoctor:accelerator:power_watts
+          expr: DCGM_FI_DEV_POWER_USAGE
+          labels:
+            device_kind: nvidia
+        # Health = 1 when no XID errors in the last 5m, else 0.
+        - record: modeldoctor:accelerator:health_status
+          expr: (increase(DCGM_FI_DEV_XID_ERRORS[5m]) == bool 0)
+          labels:
+            device_kind: nvidia
+        - record: modeldoctor:accelerator:error_total
+          expr: DCGM_FI_DEV_XID_ERRORS
+          labels:
+            device_kind: nvidia
+
+    - name: modeldoctor.accelerator.ascend
+      interval: 30s
+      rules:
+        - record: modeldoctor:accelerator:utilization_ratio
+          expr: npu_chip_info_utilization / 100
+          labels:
+            device_kind: ascend
+        - record: modeldoctor:accelerator:memory_used_bytes
+          # npu-exporter reports DDR in MB; convert to bytes (1 MB = 1024*1024).
+          expr: npu_chip_info_used_memory * 1024 * 1024
+          labels:
+            device_kind: ascend
+        - record: modeldoctor:accelerator:memory_total_bytes
+          expr: npu_chip_info_total_memory * 1024 * 1024
+          labels:
+            device_kind: ascend
+        - record: modeldoctor:accelerator:memory_usage_ratio
+          expr: npu_chip_info_used_memory / clamp_min(npu_chip_info_total_memory, 1)
+          labels:
+            device_kind: ascend
+        - record: modeldoctor:accelerator:temperature_celsius
+          expr: npu_chip_info_temperature
+          labels:
+            device_kind: ascend
+        - record: modeldoctor:accelerator:power_watts
+          expr: npu_chip_info_power
+          labels:
+            device_kind: ascend
+        - record: modeldoctor:accelerator:health_status
+          expr: npu_chip_info_health_status
+          labels:
+            device_kind: ascend
+        - record: modeldoctor:accelerator:error_total
+          expr: npu_chip_info_error_code != bool 0
+          labels:
+            device_kind: ascend

--- a/deploy/k8s/prometheus-rules/recording/engines/sglang-legacy.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/sglang-legacy.yaml
@@ -1,0 +1,96 @@
+# PrometheusRule: SGLang legacy (v0.4.x – v0.5.3)
+#
+# Metric prefix in this version is `sglang:` (colon).
+# For v0.5.4+ apply sglang-v0.5.4plus.yaml instead — the prefix changed
+# to `sglang_` (underscore) and the two engine types are NOT compatible.
+#
+# Hard-coded label `engine="sglang-legacy"` is injected on every recorded
+# metric.
+#
+# SGLang typically binds one process to one model; if your scrape config
+# doesn't add a `model_name` label, downstream by-model queries will collapse
+# all replicas. Recommend adding `model_name` via relabel_configs in the
+# scrape job.
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: modeldoctor-sglang-legacy
+  labels:
+    app.kubernetes.io/name: modeldoctor
+    app.kubernetes.io/component: prometheus-rules
+    modeldoctor.io/engine: sglang-legacy
+    modeldoctor.io/kind: recording
+spec:
+  groups:
+    - name: modeldoctor.sglang-legacy.request
+      interval: 30s
+      rules:
+        - record: modeldoctor:request:running
+          expr: sglang:num_running_reqs
+          labels:
+            engine: sglang-legacy
+        - record: modeldoctor:request:waiting
+          expr: sglang:num_queue_reqs
+          labels:
+            engine: sglang-legacy
+        - record: modeldoctor:request:ttft_seconds:p50
+          expr: histogram_quantile(0.50, sum by (le, instance) (rate(sglang:time_to_first_token_seconds_bucket[5m])))
+          labels:
+            engine: sglang-legacy
+        - record: modeldoctor:request:ttft_seconds:p95
+          expr: histogram_quantile(0.95, sum by (le, instance) (rate(sglang:time_to_first_token_seconds_bucket[5m])))
+          labels:
+            engine: sglang-legacy
+        - record: modeldoctor:request:ttft_seconds:p99
+          expr: histogram_quantile(0.99, sum by (le, instance) (rate(sglang:time_to_first_token_seconds_bucket[5m])))
+          labels:
+            engine: sglang-legacy
+        - record: modeldoctor:request:itl_seconds:p50
+          expr: histogram_quantile(0.50, sum by (le, instance) (rate(sglang:time_per_output_token_seconds_bucket[5m])))
+          labels:
+            engine: sglang-legacy
+        - record: modeldoctor:request:itl_seconds:p95
+          expr: histogram_quantile(0.95, sum by (le, instance) (rate(sglang:time_per_output_token_seconds_bucket[5m])))
+          labels:
+            engine: sglang-legacy
+        - record: modeldoctor:request:itl_seconds:p99
+          expr: histogram_quantile(0.99, sum by (le, instance) (rate(sglang:time_per_output_token_seconds_bucket[5m])))
+          labels:
+            engine: sglang-legacy
+        - record: modeldoctor:request:e2e_seconds:p95
+          expr: histogram_quantile(0.95, sum by (le, instance) (rate(sglang:e2e_request_latency_seconds_bucket[5m])))
+          labels:
+            engine: sglang-legacy
+        - record: modeldoctor:request:e2e_seconds:p99
+          expr: histogram_quantile(0.99, sum by (le, instance) (rate(sglang:e2e_request_latency_seconds_bucket[5m])))
+          labels:
+            engine: sglang-legacy
+
+    - name: modeldoctor.sglang-legacy.throughput
+      interval: 30s
+      rules:
+        - record: modeldoctor:throughput:prompt_tokens_total
+          expr: sglang:prompt_tokens_total
+          labels:
+            engine: sglang-legacy
+        - record: modeldoctor:throughput:generation_tokens_total
+          expr: sglang:generation_tokens_total
+          labels:
+            engine: sglang-legacy
+        - record: modeldoctor:throughput:generation_rate_tps
+          expr: sglang:gen_throughput
+          labels:
+            engine: sglang-legacy
+
+    - name: modeldoctor.sglang-legacy.cache
+      interval: 30s
+      rules:
+        - record: modeldoctor:cache:kv_usage_ratio
+          expr: sglang:token_usage
+          labels:
+            engine: sglang-legacy
+        - record: modeldoctor:cache:prefix_hit_ratio
+          expr: sglang:cache_hit_rate
+          labels:
+            engine: sglang-legacy

--- a/deploy/k8s/prometheus-rules/recording/engines/sglang-legacy.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/sglang-legacy.yaml
@@ -35,35 +35,35 @@ spec:
           labels:
             engine: sglang-legacy
         - record: modeldoctor:request:ttft_seconds:p50
-          expr: histogram_quantile(0.50, sum by (le, instance) (rate(sglang:time_to_first_token_seconds_bucket[5m])))
+          expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(sglang:time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
         - record: modeldoctor:request:ttft_seconds:p95
-          expr: histogram_quantile(0.95, sum by (le, instance) (rate(sglang:time_to_first_token_seconds_bucket[5m])))
+          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(sglang:time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
         - record: modeldoctor:request:ttft_seconds:p99
-          expr: histogram_quantile(0.99, sum by (le, instance) (rate(sglang:time_to_first_token_seconds_bucket[5m])))
+          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(sglang:time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
         - record: modeldoctor:request:itl_seconds:p50
-          expr: histogram_quantile(0.50, sum by (le, instance) (rate(sglang:time_per_output_token_seconds_bucket[5m])))
+          expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(sglang:time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
         - record: modeldoctor:request:itl_seconds:p95
-          expr: histogram_quantile(0.95, sum by (le, instance) (rate(sglang:time_per_output_token_seconds_bucket[5m])))
+          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(sglang:time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
         - record: modeldoctor:request:itl_seconds:p99
-          expr: histogram_quantile(0.99, sum by (le, instance) (rate(sglang:time_per_output_token_seconds_bucket[5m])))
+          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(sglang:time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
         - record: modeldoctor:request:e2e_seconds:p95
-          expr: histogram_quantile(0.95, sum by (le, instance) (rate(sglang:e2e_request_latency_seconds_bucket[5m])))
+          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(sglang:e2e_request_latency_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
         - record: modeldoctor:request:e2e_seconds:p99
-          expr: histogram_quantile(0.99, sum by (le, instance) (rate(sglang:e2e_request_latency_seconds_bucket[5m])))
+          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(sglang:e2e_request_latency_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
 

--- a/deploy/k8s/prometheus-rules/recording/engines/sglang-v0.5.4plus.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/sglang-v0.5.4plus.yaml
@@ -30,35 +30,35 @@ spec:
           labels:
             engine: sglang-v0.5.4plus
         - record: modeldoctor:request:ttft_seconds:p50
-          expr: histogram_quantile(0.50, sum by (le, instance) (rate(sglang_time_to_first_token_seconds_bucket[5m])))
+          expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(sglang_time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
         - record: modeldoctor:request:ttft_seconds:p95
-          expr: histogram_quantile(0.95, sum by (le, instance) (rate(sglang_time_to_first_token_seconds_bucket[5m])))
+          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(sglang_time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
         - record: modeldoctor:request:ttft_seconds:p99
-          expr: histogram_quantile(0.99, sum by (le, instance) (rate(sglang_time_to_first_token_seconds_bucket[5m])))
+          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(sglang_time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
         - record: modeldoctor:request:itl_seconds:p50
-          expr: histogram_quantile(0.50, sum by (le, instance) (rate(sglang_time_per_output_token_seconds_bucket[5m])))
+          expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(sglang_time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
         - record: modeldoctor:request:itl_seconds:p95
-          expr: histogram_quantile(0.95, sum by (le, instance) (rate(sglang_time_per_output_token_seconds_bucket[5m])))
+          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(sglang_time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
         - record: modeldoctor:request:itl_seconds:p99
-          expr: histogram_quantile(0.99, sum by (le, instance) (rate(sglang_time_per_output_token_seconds_bucket[5m])))
+          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(sglang_time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
         - record: modeldoctor:request:e2e_seconds:p95
-          expr: histogram_quantile(0.95, sum by (le, instance) (rate(sglang_e2e_request_latency_seconds_bucket[5m])))
+          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(sglang_e2e_request_latency_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
         - record: modeldoctor:request:e2e_seconds:p99
-          expr: histogram_quantile(0.99, sum by (le, instance) (rate(sglang_e2e_request_latency_seconds_bucket[5m])))
+          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(sglang_e2e_request_latency_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
 

--- a/deploy/k8s/prometheus-rules/recording/engines/sglang-v0.5.4plus.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/sglang-v0.5.4plus.yaml
@@ -1,0 +1,91 @@
+# PrometheusRule: SGLang v0.5.4+
+#
+# Metric prefix in this version is `sglang_` (underscore).
+# For v0.5.3 and earlier apply sglang-legacy.yaml instead — the two engine
+# types are NOT compatible and must not be applied simultaneously.
+#
+# Hard-coded label `engine="sglang-v0.5.4plus"` is injected on every recorded
+# metric.
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: modeldoctor-sglang-v0-5-4plus
+  labels:
+    app.kubernetes.io/name: modeldoctor
+    app.kubernetes.io/component: prometheus-rules
+    modeldoctor.io/engine: sglang-v0.5.4plus
+    modeldoctor.io/kind: recording
+spec:
+  groups:
+    - name: modeldoctor.sglang-v0-5-4plus.request
+      interval: 30s
+      rules:
+        - record: modeldoctor:request:running
+          expr: sglang_num_running_reqs
+          labels:
+            engine: sglang-v0.5.4plus
+        - record: modeldoctor:request:waiting
+          expr: sglang_num_queue_reqs
+          labels:
+            engine: sglang-v0.5.4plus
+        - record: modeldoctor:request:ttft_seconds:p50
+          expr: histogram_quantile(0.50, sum by (le, instance) (rate(sglang_time_to_first_token_seconds_bucket[5m])))
+          labels:
+            engine: sglang-v0.5.4plus
+        - record: modeldoctor:request:ttft_seconds:p95
+          expr: histogram_quantile(0.95, sum by (le, instance) (rate(sglang_time_to_first_token_seconds_bucket[5m])))
+          labels:
+            engine: sglang-v0.5.4plus
+        - record: modeldoctor:request:ttft_seconds:p99
+          expr: histogram_quantile(0.99, sum by (le, instance) (rate(sglang_time_to_first_token_seconds_bucket[5m])))
+          labels:
+            engine: sglang-v0.5.4plus
+        - record: modeldoctor:request:itl_seconds:p50
+          expr: histogram_quantile(0.50, sum by (le, instance) (rate(sglang_time_per_output_token_seconds_bucket[5m])))
+          labels:
+            engine: sglang-v0.5.4plus
+        - record: modeldoctor:request:itl_seconds:p95
+          expr: histogram_quantile(0.95, sum by (le, instance) (rate(sglang_time_per_output_token_seconds_bucket[5m])))
+          labels:
+            engine: sglang-v0.5.4plus
+        - record: modeldoctor:request:itl_seconds:p99
+          expr: histogram_quantile(0.99, sum by (le, instance) (rate(sglang_time_per_output_token_seconds_bucket[5m])))
+          labels:
+            engine: sglang-v0.5.4plus
+        - record: modeldoctor:request:e2e_seconds:p95
+          expr: histogram_quantile(0.95, sum by (le, instance) (rate(sglang_e2e_request_latency_seconds_bucket[5m])))
+          labels:
+            engine: sglang-v0.5.4plus
+        - record: modeldoctor:request:e2e_seconds:p99
+          expr: histogram_quantile(0.99, sum by (le, instance) (rate(sglang_e2e_request_latency_seconds_bucket[5m])))
+          labels:
+            engine: sglang-v0.5.4plus
+
+    - name: modeldoctor.sglang-v0-5-4plus.throughput
+      interval: 30s
+      rules:
+        - record: modeldoctor:throughput:prompt_tokens_total
+          expr: sglang_prompt_tokens_total
+          labels:
+            engine: sglang-v0.5.4plus
+        - record: modeldoctor:throughput:generation_tokens_total
+          expr: sglang_generation_tokens_total
+          labels:
+            engine: sglang-v0.5.4plus
+        - record: modeldoctor:throughput:generation_rate_tps
+          expr: sglang_gen_throughput
+          labels:
+            engine: sglang-v0.5.4plus
+
+    - name: modeldoctor.sglang-v0-5-4plus.cache
+      interval: 30s
+      rules:
+        - record: modeldoctor:cache:kv_usage_ratio
+          expr: sglang_token_usage
+          labels:
+            engine: sglang-v0.5.4plus
+        - record: modeldoctor:cache:prefix_hit_ratio
+          expr: sglang_cache_hit_rate
+          labels:
+            engine: sglang-v0.5.4plus

--- a/deploy/k8s/prometheus-rules/recording/engines/tgi.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/tgi.yaml
@@ -39,36 +39,36 @@ spec:
         # "prefill" vs "decode".
         - record: modeldoctor:request:ttft_seconds:p95
           expr: |
-            histogram_quantile(0.95, sum by (le, instance) (rate(tgi_request_queue_duration_bucket[5m])))
+            histogram_quantile(0.95, sum by (le, model_name, instance) (rate(tgi_request_queue_duration_bucket[5m])))
             +
-            histogram_quantile(0.95, sum by (le, instance) (rate(tgi_batch_forward_duration_bucket{stage="prefill"}[5m])))
+            histogram_quantile(0.95, sum by (le, model_name, instance) (rate(tgi_batch_forward_duration_bucket{stage="prefill"}[5m])))
           labels:
             engine: tgi
         - record: modeldoctor:request:ttft_seconds:p99
           expr: |
-            histogram_quantile(0.99, sum by (le, instance) (rate(tgi_request_queue_duration_bucket[5m])))
+            histogram_quantile(0.99, sum by (le, model_name, instance) (rate(tgi_request_queue_duration_bucket[5m])))
             +
-            histogram_quantile(0.99, sum by (le, instance) (rate(tgi_batch_forward_duration_bucket{stage="prefill"}[5m])))
+            histogram_quantile(0.99, sum by (le, model_name, instance) (rate(tgi_batch_forward_duration_bucket{stage="prefill"}[5m])))
           labels:
             engine: tgi
         - record: modeldoctor:request:itl_seconds:p95
-          expr: histogram_quantile(0.95, sum by (le, instance) (rate(tgi_request_mean_time_per_token_duration_bucket[5m])))
+          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(tgi_request_mean_time_per_token_duration_bucket[5m])))
           labels:
             engine: tgi
         - record: modeldoctor:request:itl_seconds:p99
-          expr: histogram_quantile(0.99, sum by (le, instance) (rate(tgi_request_mean_time_per_token_duration_bucket[5m])))
+          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(tgi_request_mean_time_per_token_duration_bucket[5m])))
           labels:
             engine: tgi
         - record: modeldoctor:request:e2e_seconds:p95
-          expr: histogram_quantile(0.95, sum by (le, instance) (rate(tgi_request_duration_bucket[5m])))
+          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(tgi_request_duration_bucket[5m])))
           labels:
             engine: tgi
         - record: modeldoctor:request:e2e_seconds:p99
-          expr: histogram_quantile(0.99, sum by (le, instance) (rate(tgi_request_duration_bucket[5m])))
+          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(tgi_request_duration_bucket[5m])))
           labels:
             engine: tgi
         - record: modeldoctor:request:queue_seconds:p95
-          expr: histogram_quantile(0.95, sum by (le, instance) (rate(tgi_request_queue_duration_bucket[5m])))
+          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(tgi_request_queue_duration_bucket[5m])))
           labels:
             engine: tgi
 
@@ -76,14 +76,14 @@ spec:
       interval: 30s
       rules:
         - record: modeldoctor:throughput:prompt_tokens_total
-          expr: sum by (instance) (tgi_request_input_length_sum)
+          expr: sum by (model_name, instance)(tgi_request_input_length_sum)
           labels:
             engine: tgi
         - record: modeldoctor:throughput:generation_tokens_total
-          expr: sum by (instance) (tgi_request_generated_tokens_sum)
+          expr: sum by (model_name, instance)(tgi_request_generated_tokens_sum)
           labels:
             engine: tgi
         - record: modeldoctor:throughput:generation_rate_tps
-          expr: sum by (instance) (rate(tgi_request_generated_tokens_sum[1m]))
+          expr: sum by (model_name, instance)(rate(tgi_request_generated_tokens_sum[1m]))
           labels:
             engine: tgi

--- a/deploy/k8s/prometheus-rules/recording/engines/tgi.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/tgi.yaml
@@ -1,0 +1,89 @@
+# PrometheusRule: TGI (Text Generation Inference) 1.x / 2.x
+#
+# Normalizes TGI raw metrics into the `modeldoctor:*` namespace.
+# Hard-coded label `engine="tgi"` is injected on every recorded metric.
+#
+# TGI quirks (see docs/superpowers/research/2026-05-15-inference-engine-metrics-survey.md §3):
+# - No native TTFT metric. We derive it from queue_duration + prefill
+#   forward duration. This is an approximation — for strict SLO use a
+#   client-side probe.
+# - No KV cache utilization metric. The `modeldoctor:cache:*` namespace
+#   stays empty for TGI (PagedAttention is internal black-box).
+# - The metric for ITL is `tgi_request_mean_time_per_token_duration`
+#   (a histogram of per-request average), not strict inter-token timing.
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: modeldoctor-tgi
+  labels:
+    app.kubernetes.io/name: modeldoctor
+    app.kubernetes.io/component: prometheus-rules
+    modeldoctor.io/engine: tgi
+    modeldoctor.io/kind: recording
+spec:
+  groups:
+    - name: modeldoctor.tgi.request
+      interval: 30s
+      rules:
+        - record: modeldoctor:request:running
+          expr: tgi_batch_current_size
+          labels:
+            engine: tgi
+        - record: modeldoctor:request:waiting
+          expr: tgi_queue_size
+          labels:
+            engine: tgi
+        # Derived TTFT: queue + prefill forward.
+        # tgi_batch_forward_duration has a `stage` label distinguishing
+        # "prefill" vs "decode".
+        - record: modeldoctor:request:ttft_seconds:p95
+          expr: |
+            histogram_quantile(0.95, sum by (le, instance) (rate(tgi_request_queue_duration_bucket[5m])))
+            +
+            histogram_quantile(0.95, sum by (le, instance) (rate(tgi_batch_forward_duration_bucket{stage="prefill"}[5m])))
+          labels:
+            engine: tgi
+        - record: modeldoctor:request:ttft_seconds:p99
+          expr: |
+            histogram_quantile(0.99, sum by (le, instance) (rate(tgi_request_queue_duration_bucket[5m])))
+            +
+            histogram_quantile(0.99, sum by (le, instance) (rate(tgi_batch_forward_duration_bucket{stage="prefill"}[5m])))
+          labels:
+            engine: tgi
+        - record: modeldoctor:request:itl_seconds:p95
+          expr: histogram_quantile(0.95, sum by (le, instance) (rate(tgi_request_mean_time_per_token_duration_bucket[5m])))
+          labels:
+            engine: tgi
+        - record: modeldoctor:request:itl_seconds:p99
+          expr: histogram_quantile(0.99, sum by (le, instance) (rate(tgi_request_mean_time_per_token_duration_bucket[5m])))
+          labels:
+            engine: tgi
+        - record: modeldoctor:request:e2e_seconds:p95
+          expr: histogram_quantile(0.95, sum by (le, instance) (rate(tgi_request_duration_bucket[5m])))
+          labels:
+            engine: tgi
+        - record: modeldoctor:request:e2e_seconds:p99
+          expr: histogram_quantile(0.99, sum by (le, instance) (rate(tgi_request_duration_bucket[5m])))
+          labels:
+            engine: tgi
+        - record: modeldoctor:request:queue_seconds:p95
+          expr: histogram_quantile(0.95, sum by (le, instance) (rate(tgi_request_queue_duration_bucket[5m])))
+          labels:
+            engine: tgi
+
+    - name: modeldoctor.tgi.throughput
+      interval: 30s
+      rules:
+        - record: modeldoctor:throughput:prompt_tokens_total
+          expr: sum by (instance) (tgi_request_input_length_sum)
+          labels:
+            engine: tgi
+        - record: modeldoctor:throughput:generation_tokens_total
+          expr: sum by (instance) (tgi_request_generated_tokens_sum)
+          labels:
+            engine: tgi
+        - record: modeldoctor:throughput:generation_rate_tps
+          expr: sum by (instance) (rate(tgi_request_generated_tokens_sum[1m]))
+          labels:
+            engine: tgi

--- a/deploy/k8s/prometheus-rules/recording/engines/vllm-v0.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/vllm-v0.yaml
@@ -1,0 +1,116 @@
+# PrometheusRule: vLLM V0 (0.5.x – 0.6.x legacy engine)
+#
+# Normalizes vLLM V0 raw metrics into the `modeldoctor:*` namespace.
+# Apply ONLY when your inference workload is vLLM 0.5.x or 0.6.x.
+# For vLLM 0.7+ (V1 engine), apply vllm-v1.yaml instead — do not apply both.
+#
+# Hard-coded label `engine="vllm-v0"` is injected on every recorded
+# metric so downstream alert/dashboard queries can select by engine.
+#
+# Source label expectations:
+# - Scrape config must expose `model_name` on all vllm:* metrics
+#   (vLLM exports it by default in V0).
+# - `instance` label distinguishes replicas.
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: modeldoctor-vllm-v0
+  labels:
+    app.kubernetes.io/name: modeldoctor
+    app.kubernetes.io/component: prometheus-rules
+    modeldoctor.io/engine: vllm-v0
+    modeldoctor.io/kind: recording
+spec:
+  groups:
+    - name: modeldoctor.vllm-v0.request
+      interval: 30s
+      rules:
+        - record: modeldoctor:request:running
+          expr: vllm:num_requests_running
+          labels:
+            engine: vllm-v0
+        - record: modeldoctor:request:waiting
+          expr: vllm:num_requests_waiting
+          labels:
+            engine: vllm-v0
+        - record: modeldoctor:request:swapped
+          expr: vllm:num_requests_swapped
+          labels:
+            engine: vllm-v0
+        - record: modeldoctor:request:preempted_total
+          expr: vllm:num_preemptions_total
+          labels:
+            engine: vllm-v0
+        # TTFT P50 / P95 / P99 over 5m
+        - record: modeldoctor:request:ttft_seconds:p50
+          expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
+          labels:
+            engine: vllm-v0
+        - record: modeldoctor:request:ttft_seconds:p95
+          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
+          labels:
+            engine: vllm-v0
+        - record: modeldoctor:request:ttft_seconds:p99
+          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
+          labels:
+            engine: vllm-v0
+        # ITL (inter-token latency, i.e. TPOT)
+        - record: modeldoctor:request:itl_seconds:p50
+          expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(vllm:time_per_output_token_seconds_bucket[5m])))
+          labels:
+            engine: vllm-v0
+        - record: modeldoctor:request:itl_seconds:p95
+          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:time_per_output_token_seconds_bucket[5m])))
+          labels:
+            engine: vllm-v0
+        - record: modeldoctor:request:itl_seconds:p99
+          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:time_per_output_token_seconds_bucket[5m])))
+          labels:
+            engine: vllm-v0
+        # E2E latency
+        - record: modeldoctor:request:e2e_seconds:p95
+          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:e2e_request_latency_seconds_bucket[5m])))
+          labels:
+            engine: vllm-v0
+        - record: modeldoctor:request:e2e_seconds:p99
+          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:e2e_request_latency_seconds_bucket[5m])))
+          labels:
+            engine: vllm-v0
+        # Queue time
+        - record: modeldoctor:request:queue_seconds:p95
+          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:request_queue_time_seconds_bucket[5m])))
+          labels:
+            engine: vllm-v0
+
+    - name: modeldoctor.vllm-v0.throughput
+      interval: 30s
+      rules:
+        - record: modeldoctor:throughput:prompt_tokens_total
+          expr: vllm:prompt_tokens_total
+          labels:
+            engine: vllm-v0
+        - record: modeldoctor:throughput:generation_tokens_total
+          expr: vllm:generation_tokens_total
+          labels:
+            engine: vllm-v0
+        - record: modeldoctor:throughput:generation_rate_tps
+          expr: sum by (model_name, instance) (rate(vllm:generation_tokens_total[1m]))
+          labels:
+            engine: vllm-v0
+
+    - name: modeldoctor.vllm-v0.cache
+      interval: 30s
+      rules:
+        - record: modeldoctor:cache:kv_usage_ratio
+          expr: vllm:gpu_cache_usage_perc
+          labels:
+            engine: vllm-v0
+        - record: modeldoctor:cache:prefix_hit_ratio
+          expr: vllm:gpu_prefix_cache_hit_rate
+          labels:
+            engine: vllm-v0
+        - record: modeldoctor:cache:swap_usage_ratio
+          expr: vllm:cpu_cache_usage_perc
+          labels:
+            engine: vllm-v0

--- a/deploy/k8s/prometheus-rules/recording/engines/vllm-v1.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/vllm-v1.yaml
@@ -1,0 +1,117 @@
+# PrometheusRule: vLLM V1 (0.7.x+ default engine)
+#
+# Normalizes vLLM V1 raw metrics into the `modeldoctor:*` namespace.
+# Apply ONLY when your inference workload is vLLM 0.7+ (V1 engine on by
+# default). For vLLM 0.6.x and earlier, apply vllm-v0.yaml instead.
+#
+# Hard-coded label `engine="vllm-v1"` is injected on every recorded
+# metric so downstream alert/dashboard queries can select by engine.
+#
+# Breaking changes from V0 handled here:
+# - vllm:gpu_cache_usage_perc → vllm:kv_cache_usage_perc
+# - vllm:time_per_output_token_seconds → vllm:inter_token_latency_seconds
+# - vllm:gpu_prefix_cache_hit_rate (gauge) → rate(vllm:prefix_cache_hits)
+#   / rate(vllm:prefix_cache_queries) (counter pair)
+#
+# Source label expectations:
+# - V1 metrics natively carry `model_name` and `engine` labels.
+# - This file's hard-coded `engine: vllm-v1` overrides any source `engine`
+#   label so the normalized layer has a single consistent value.
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: modeldoctor-vllm-v1
+  labels:
+    app.kubernetes.io/name: modeldoctor
+    app.kubernetes.io/component: prometheus-rules
+    modeldoctor.io/engine: vllm-v1
+    modeldoctor.io/kind: recording
+spec:
+  groups:
+    - name: modeldoctor.vllm-v1.request
+      interval: 30s
+      rules:
+        - record: modeldoctor:request:running
+          expr: vllm:num_requests_running
+          labels:
+            engine: vllm-v1
+        - record: modeldoctor:request:waiting
+          expr: vllm:num_requests_waiting
+          labels:
+            engine: vllm-v1
+        - record: modeldoctor:request:preempted_total
+          expr: vllm:num_preemptions_total
+          labels:
+            engine: vllm-v1
+        - record: modeldoctor:request:ttft_seconds:p50
+          expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
+          labels:
+            engine: vllm-v1
+        - record: modeldoctor:request:ttft_seconds:p95
+          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
+          labels:
+            engine: vllm-v1
+        - record: modeldoctor:request:ttft_seconds:p99
+          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
+          labels:
+            engine: vllm-v1
+        # V1: time_per_output_token_seconds renamed to inter_token_latency_seconds
+        - record: modeldoctor:request:itl_seconds:p50
+          expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(vllm:inter_token_latency_seconds_bucket[5m])))
+          labels:
+            engine: vllm-v1
+        - record: modeldoctor:request:itl_seconds:p95
+          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:inter_token_latency_seconds_bucket[5m])))
+          labels:
+            engine: vllm-v1
+        - record: modeldoctor:request:itl_seconds:p99
+          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:inter_token_latency_seconds_bucket[5m])))
+          labels:
+            engine: vllm-v1
+        - record: modeldoctor:request:e2e_seconds:p95
+          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:e2e_request_latency_seconds_bucket[5m])))
+          labels:
+            engine: vllm-v1
+        - record: modeldoctor:request:e2e_seconds:p99
+          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:e2e_request_latency_seconds_bucket[5m])))
+          labels:
+            engine: vllm-v1
+        - record: modeldoctor:request:queue_seconds:p95
+          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:request_queue_time_seconds_bucket[5m])))
+          labels:
+            engine: vllm-v1
+
+    - name: modeldoctor.vllm-v1.throughput
+      interval: 30s
+      rules:
+        - record: modeldoctor:throughput:prompt_tokens_total
+          expr: vllm:prompt_tokens_total
+          labels:
+            engine: vllm-v1
+        - record: modeldoctor:throughput:generation_tokens_total
+          expr: vllm:generation_tokens_total
+          labels:
+            engine: vllm-v1
+        - record: modeldoctor:throughput:generation_rate_tps
+          expr: sum by (model_name, instance) (rate(vllm:generation_tokens_total[1m]))
+          labels:
+            engine: vllm-v1
+
+    - name: modeldoctor.vllm-v1.cache
+      interval: 30s
+      rules:
+        # V1: kv_cache_usage_perc replaces gpu_cache_usage_perc (no CPU split)
+        - record: modeldoctor:cache:kv_usage_ratio
+          expr: vllm:kv_cache_usage_perc
+          labels:
+            engine: vllm-v1
+        # V1: prefix cache hit rate must be derived from two counters.
+        # Guard against divide-by-zero with a 0 fallback when queries are idle.
+        - record: modeldoctor:cache:prefix_hit_ratio
+          expr: |
+            sum by (model_name, instance) (rate(vllm:prefix_cache_hits[5m]))
+            /
+            clamp_min(sum by (model_name, instance) (rate(vllm:prefix_cache_queries[5m])), 1)
+          labels:
+            engine: vllm-v1

--- a/deploy/k8s/prometheus-rules/recording/gateway/higress.yaml
+++ b/deploy/k8s/prometheus-rules/recording/gateway/higress.yaml
@@ -1,0 +1,91 @@
+# PrometheusRule: Higress AI Statistics gateway
+#
+# Normalizes Higress AI Statistics plugin metrics into the
+# `modeldoctor:gateway:*` namespace. This is the route/consumer dimension
+# — it does NOT replace engine-side metrics. Apply this in addition to
+# (not instead of) your engine recording rule.
+#
+# All Higress AI metrics carry these source labels:
+#   ai_route, ai_cluster, ai_model, ai_consumer
+# We preserve them on the normalized output so per-tenant queries work.
+#
+# Limitation: Higress exposes only sum/count counter pairs, no histograms.
+# Avg latency works (sum/count), but per-route P99 is unavailable from
+# this layer — get it from the engine side via `model_name == ai_model`.
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: modeldoctor-higress
+  labels:
+    app.kubernetes.io/name: modeldoctor
+    app.kubernetes.io/component: prometheus-rules
+    modeldoctor.io/source: higress
+    modeldoctor.io/kind: recording
+spec:
+  groups:
+    - name: modeldoctor.gateway.higress.tokens
+      interval: 30s
+      rules:
+        - record: modeldoctor:gateway:input_tokens_total
+          expr: route_upstream_model_consumer_metric_input_token
+          labels:
+            source: higress
+        - record: modeldoctor:gateway:output_tokens_total
+          expr: route_upstream_model_consumer_metric_output_token
+          labels:
+            source: higress
+        # Token rate per consumer — most useful series for spotting a
+        # noisy-neighbor tenant.
+        - record: modeldoctor:gateway:input_tokens_rate
+          expr: sum by (ai_route, ai_cluster, ai_model, ai_consumer) (rate(route_upstream_model_consumer_metric_input_token[1m]))
+          labels:
+            source: higress
+        - record: modeldoctor:gateway:output_tokens_rate
+          expr: sum by (ai_route, ai_cluster, ai_model, ai_consumer) (rate(route_upstream_model_consumer_metric_output_token[1m]))
+          labels:
+            source: higress
+
+    - name: modeldoctor.gateway.higress.latency
+      interval: 30s
+      rules:
+        # Cumulative LLM service duration; downstream uses this with
+        # llm_duration_count to compute average.
+        - record: modeldoctor:gateway:llm_duration_total_seconds
+          # Higress reports microseconds in the source counter; convert to seconds.
+          # Verify your plugin build's unit before applying (some legacy
+          # builds report milliseconds — divide by 1000 instead).
+          expr: route_upstream_model_consumer_metric_llm_service_duration / 1e6
+          labels:
+            source: higress
+        - record: modeldoctor:gateway:llm_request_count_total
+          expr: route_upstream_model_consumer_metric_llm_duration_count
+          labels:
+            source: higress
+        - record: modeldoctor:gateway:ttft_total_seconds
+          expr: route_upstream_model_consumer_metric_llm_first_token_duration / 1e6
+          labels:
+            source: higress
+        - record: modeldoctor:gateway:streaming_count_total
+          expr: route_upstream_model_consumer_metric_llm_stream_duration_count
+          labels:
+            source: higress
+        # Avg latency derived: total_duration / request_count (over 5m).
+        # Histogram-quantile is impossible from sum/count alone — for P99
+        # query the engine side via ai_model == model_name.
+        - record: modeldoctor:gateway:llm_duration_seconds:avg
+          expr: |
+            sum by (ai_route, ai_cluster, ai_model, ai_consumer) (rate(route_upstream_model_consumer_metric_llm_service_duration[5m]))
+            /
+            clamp_min(sum by (ai_route, ai_cluster, ai_model, ai_consumer) (rate(route_upstream_model_consumer_metric_llm_duration_count[5m])), 1)
+            / 1e6
+          labels:
+            source: higress
+        - record: modeldoctor:gateway:ttft_seconds:avg
+          expr: |
+            sum by (ai_route, ai_cluster, ai_model, ai_consumer) (rate(route_upstream_model_consumer_metric_llm_first_token_duration[5m]))
+            /
+            clamp_min(sum by (ai_route, ai_cluster, ai_model, ai_consumer) (rate(route_upstream_model_consumer_metric_llm_duration_count[5m])), 1)
+            / 1e6
+          labels:
+            source: higress

--- a/docs/superpowers/research/2026-05-15-inference-engine-metrics-survey.md
+++ b/docs/superpowers/research/2026-05-15-inference-engine-metrics-survey.md
@@ -1,0 +1,449 @@
+# 推理引擎与可观测组件 Prometheus 指标调研
+
+> **目的**:在编写 ModelDoctor 内置 PrometheusRule (recording rules + alert rules) 之前,先对各引擎/各版本暴露的原始指标做一次实证扫描,产出引擎到 `modeldoctor:*` 归一命名空间的映射表。后续 yaml 才不是猜的。
+>
+> **覆盖范围**: vLLM V0/V1、SGLang (pre-v0.5.4 / v0.5.4+)、TGI、Higress AI Statistics、DCGM、Huawei NPU Exporter。
+>
+> **作者**: ModelDoctor team
+> **日期**: 2026-05-15
+
+---
+
+## 0. 调研约束与方法
+
+- 调研以**官方文档 + 引擎源码**为准;Grafana 第三方 dashboard 仅用于交叉验证。
+- **设计原则(版本即引擎)**:同一引擎不同 major 版本指标名变更是常态。我们**不在 PromQL 层做跨版本适配**(不写 `or`、不做 presence-of-metric 检测、不写 `label_replace` 桥接)。我们把每个 (engine, major version) **视为独立的引擎类型**——例如 `vllm-v0` 和 `vllm-v1` 是两个 engine,`sglang-legacy` 和 `sglang-v0.5.4+` 是两个 engine。
+  - 用户在 ModelDoctor connection 上声明引擎类型 + 版本时,我们 apply 对应那一份 PrometheusRule。
+  - 一个引擎类型 = 一份 recording rule yaml + 一份 alert rule yaml,各自独立。
+  - 新增版本 = 新增引擎类型 + 新增 yaml,不改既有文件。
+- 指标分类标尺(全文统一):
+  - **R** (Request lifecycle): 请求计数、TTFT、TPOT/ITL、E2E latency、队列等
+  - **T** (Throughput): tokens/sec, requests/sec
+  - **C** (Capacity/Cache): KV cache 利用率、prefix cache 命中、batch size
+  - **G** (Gateway/Routing): 网关侧路由、限流、租户维度
+  - **H** (Hardware): GPU/NPU 利用率、显存、温度、功率
+- 不在本调研范围:Triton Server (#TODO 后续单独章节)、TensorRT-LLM Backend、LMDeploy。
+
+---
+
+## 1. vLLM
+
+### 1.1 vLLM V0 (0.5.x – 0.6.x,legacy engine)
+
+V0 是 vLLM 的"旧"引擎,2026 年仍是 stable 默认在 ≤0.6.x。指标统一前缀 `vllm:`,所有 histogram 用 `_bucket`/`_sum`/`_count` 三件套。
+
+**Request lifecycle (R):**
+
+| 指标 | 类型 | 描述 | 关键 label |
+|---|---|---|---|
+| `vllm:num_requests_running` | Gauge | 正在 decoding 的请求数 | `model_name` |
+| `vllm:num_requests_waiting` | Gauge | 在 waiting queue 的请求数 | `model_name` |
+| `vllm:num_requests_swapped` | Gauge | 被 swap 出去的请求数 | `model_name` |
+| `vllm:time_to_first_token_seconds` | Histogram | TTFT (含队列+prefill) | `model_name` |
+| `vllm:time_per_output_token_seconds` | Histogram | 每个输出 token 的间隔 (ITL/TPOT) | `model_name` |
+| `vllm:e2e_request_latency_seconds` | Histogram | 端到端 latency | `model_name` |
+| `vllm:request_queue_time_seconds` | Histogram | 仅排队时间 | `model_name` |
+| `vllm:request_prefill_time_seconds` | Histogram | 仅 prefill 时间 | `model_name` |
+| `vllm:request_decode_time_seconds` | Histogram | 仅 decode 时间 | `model_name` |
+| `vllm:request_inference_time_seconds` | Histogram | prefill+decode | `model_name` |
+
+**Throughput (T):**
+
+| 指标 | 类型 | 描述 |
+|---|---|---|
+| `vllm:prompt_tokens_total` | Counter | 累计 prompt tokens |
+| `vllm:generation_tokens_total` | Counter | 累计 generation tokens |
+| `vllm:request_prompt_tokens` | Histogram | 单请求 prompt token 数分布 |
+| `vllm:request_generation_tokens` | Histogram | 单请求 generation token 数分布 |
+| `vllm:request_params_n` | Histogram | n 参数分布 |
+| `vllm:request_params_best_of` | Histogram | best_of 参数分布 |
+
+**Capacity/Cache (C):**
+
+| 指标 | 类型 | 描述 |
+|---|---|---|
+| `vllm:gpu_cache_usage_perc` | Gauge | GPU KV cache 占用率 0-1 |
+| `vllm:cpu_cache_usage_perc` | Gauge | CPU KV cache (swap) 占用率 |
+| `vllm:cpu_prefix_cache_hit_rate` | Gauge | CPU prefix cache 命中率 (实验性) |
+| `vllm:gpu_prefix_cache_hit_rate` | Gauge | GPU prefix cache 命中率 (实验性) |
+| `vllm:num_preemptions_total` | Counter | 因显存不足触发的请求 preemption 次数 |
+
+**LoRA / 其他:**
+
+| 指标 | 类型 |
+|---|---|
+| `vllm:lora_requests_info` | Gauge | LoRA adapter 在用统计 |
+| `vllm:request_success_total` | Counter | 成功结束的请求数 (按 finish_reason 拆) |
+
+### 1.2 vLLM V1 (0.7+ 默认,2025-2026 主线)
+
+V1 全面重构,**多个指标改名 / 重命名 label / 拆分实现**。直接套 V0 的 query 会拿到 0 值,这是过去 6 个月 vLLM 用户报错最多的来源。
+
+**已知 breaking changes (V0 → V1):**
+
+| V0 指标 | V1 替代 | 说明 |
+|---|---|---|
+| `vllm:gpu_cache_usage_perc` | `vllm:kv_cache_usage_perc` | 改名,去掉 GPU/CPU 区分;V1 KV cache 抽象统一 |
+| `vllm:cpu_cache_usage_perc` | — | 在 V1 中去除 (swap 模式不同) |
+| `vllm:time_per_output_token_seconds` | `vllm:inter_token_latency_seconds` | 改名,语义不变 (ITL) |
+| `vllm:cpu_prefix_cache_hit_rate` | — | 删除 |
+| `vllm:gpu_prefix_cache_hit_rate` | `vllm:prefix_cache_queries` + `vllm:prefix_cache_hits` (counters) | 改为两条 counter,命中率必须用 `rate(hits) / rate(queries)` 推导 |
+
+**V1 新增/统一指标:**
+
+| 指标 | 类型 | 备注 |
+|---|---|---|
+| `vllm:request_queue_time_seconds` | Histogram | V1 起加 `engine` label |
+| `vllm:request_inference_time_seconds` | Histogram | V1 |
+| `vllm:request_prefill_time_seconds` | Histogram | V1 |
+| `vllm:request_decode_time_seconds` | Histogram | V1 |
+| `vllm:cache_config_info` | Gauge | KV cache 配置信息 info-style |
+
+**V1 label 重要变化:** 所有 V1 metric 强制带 `model_name` 和 `engine` label。
+
+### 1.3 vLLM 视作两个独立引擎类型
+
+```
+engine type   |  适用 vLLM 版本                |  对应 PrometheusRule 文件
+--------------+--------------------------------+----------------------------
+vllm-v0       |  0.5.x – 0.6.x (legacy default) |  rules/vllm-v0.yaml
+vllm-v1       |  0.7.x – 0.8.x+ (V1 default)    |  rules/vllm-v1.yaml
+```
+
+- ModelDoctor connection 创建时,用户在引擎下拉里直接选 `vllm-v0` 或 `vllm-v1`,没有"自动识别"选项。
+- 两份 yaml 各写各的,不复用、不嵌套、不写 `or`。后续如果出 V2,新增 `vllm-v2.yaml`,前两份完全不动。
+- 用户从 0.6 升级到 0.7,操作流程是:在 connection 上把引擎类型从 `vllm-v0` 改为 `vllm-v1`,ModelDoctor 重新 apply 对应 PrometheusRule。
+
+---
+
+## 2. SGLang
+
+### 2.1 v0.4.x – v0.5.3 (legacy,`sglang:` 冒号前缀)
+
+通过 `--enable-metrics` 启用,默认端点 `:30000/metrics`。
+
+**Engine 指标:**
+
+| 指标 | 类型 | 描述 |
+|---|---|---|
+| `sglang:prompt_tokens_total` | Counter | 累计 prefill input tokens |
+| `sglang:generation_tokens_total` | Counter | 累计 generation tokens |
+| `sglang:cached_tokens_total` | Counter | prefix cache 命中 tokens |
+| `sglang:gen_throughput` | Gauge | 当前生成速率 (tokens/sec) |
+| `sglang:num_running_reqs` | Gauge | 正在处理请求数 |
+| `sglang:num_queue_reqs` | Gauge | 排队请求数 |
+| `sglang:num_used_tokens` | Gauge | KV cache 已用 tokens |
+| `sglang:cache_hit_rate` | Gauge | prefix cache 命中率 0-1 |
+| `sglang:token_usage` | Gauge | KV cache 利用率 0-1 |
+| `sglang:time_to_first_token_seconds` | Histogram | TTFT |
+| `sglang:e2e_request_latency_seconds` | Histogram | E2E latency |
+| `sglang:time_per_output_token_seconds` | Histogram | ITL |
+| `sglang:func_latency_seconds` | Histogram | 内部函数耗时 (调试用) |
+
+**Router 指标(独立服务 `sgl-router`):**
+
+| 指标 | 类型 |
+|---|---|
+| `sgl_router_requests_total` | Counter (by route, method) |
+| `sgl_router_processed_requests_total` | Counter (by worker) |
+| `sgl_router_active_workers` | Gauge |
+| `sgl_router_running_requests` | Gauge (per worker) |
+| `sgl_router_worker_health` | Gauge |
+| `sgl_router_cache_hits_total` | Counter |
+| `sgl_router_cache_misses_total` | Counter |
+| `sgl_router_generate_duration_seconds` | Histogram |
+
+### 2.2 v0.5.4+ Breaking Change → 视作独立引擎类型
+
+**前缀从 `sglang:` 改为 `sglang_`** (下划线)。
+
+```
+sglang:num_running_reqs   →   sglang_num_running_reqs
+sglang:e2e_request_latency_seconds   →   sglang_e2e_request_latency_seconds
+```
+
+```
+engine type            |  适用版本             |  PrometheusRule 文件
+-----------------------+----------------------+-----------------------------
+sglang-legacy          |  v0.4.x – v0.5.3     |  rules/sglang-legacy.yaml
+sglang-v0.5.4plus      |  v0.5.4+             |  rules/sglang-v0.5.4plus.yaml
+```
+
+两份 yaml 各自独立,不做 `label_replace` 跨版本适配。
+
+### 2.3 SGLang 待确认项
+
+- `phase` label 在哪些版本起出现 (用于 prefill/decode 区分),需源码确认。
+- MFU (Model FLOPs Utilization) 指标尚未在主线 release(issue #19286 开放中),不纳入本期归一化。
+
+---
+
+## 3. TGI (Text Generation Inference)
+
+HuggingFace TGI 1.x → 2.x,默认 `/metrics`。
+
+| 指标 | 类型 | 描述 |
+|---|---|---|
+| `tgi_request_count` | Counter | 请求总数 |
+| `tgi_request_success` | Counter | 成功请求数 |
+| `tgi_request_failure` | Counter | 失败请求数 |
+| `tgi_request_duration` | Histogram | E2E 请求耗时 (秒) |
+| `tgi_request_queue_duration` | Histogram | 排队耗时 |
+| `tgi_request_inference_duration` | Histogram | 推理(prefill+decode)耗时 |
+| `tgi_request_mean_time_per_token_duration` | Histogram | 平均每 token 耗时 (~ TPOT) |
+| `tgi_request_input_length` | Histogram | input token 数 |
+| `tgi_request_generated_tokens` | Histogram | 生成 token 数 |
+| `tgi_request_max_new_tokens` | Histogram | max_new_tokens 参数分布 |
+| `tgi_batch_current_size` | Gauge | 当前 batch 大小 |
+| `tgi_batch_next_size` | Histogram | 下一批 batch 大小分布 |
+| `tgi_queue_size` | Gauge | 队列长度 |
+| `tgi_batch_forward_duration` | Histogram | 单次 forward 耗时 (按 stage label) |
+| `tgi_batch_inference_duration` | Histogram | 单次推理耗时 |
+| `tgi_batch_inference_count` | Counter | 推理批次计数 |
+
+**TGI 缺口:**
+- **没有专门的 TTFT 指标**:必须通过 `tgi_request_queue_duration + tgi_batch_forward_duration{stage="prefill"}` 推算。这是归一化里的一个特殊 case。
+- 不暴露 KV cache 利用率 (TGI 内部 PagedAttention 是黑盒)。
+
+---
+
+## 4. Higress (网关层)
+
+Higress AI Statistics WASM plugin (v1.x),为 LLM 流量提供 token 级监控。
+
+**全部 6 个指标,共同 label 维度: `ai_route`, `ai_cluster`, `ai_model`, `ai_consumer`:**
+
+| 指标 | 类型 | 描述 |
+|---|---|---|
+| `route_upstream_model_consumer_metric_input_token` | Counter | 累计 input tokens |
+| `route_upstream_model_consumer_metric_output_token` | Counter | 累计 output tokens |
+| `route_upstream_model_consumer_metric_llm_service_duration` | Counter (sum-like) | 累计 LLM 服务时长 (μs/ms,需确认) |
+| `route_upstream_model_consumer_metric_llm_duration_count` | Counter | 服务调用次数 (与 duration 配对算平均) |
+| `route_upstream_model_consumer_metric_llm_first_token_duration` | Counter (sum-like) | 累计 TTFT 时长 |
+| `route_upstream_model_consumer_metric_llm_stream_duration_count` | Counter | streaming 调用次数 |
+
+**关键含义:**
+- `ai_consumer` 是租户/API key 级维度——这是 Higress 区别于其他网关的核心价值。
+- 没有 histogram,只有 sum/count 对。要算 P99 latency **不可能从 Higress 单独得到**,只能从上游引擎拿。Higress 的指标补充的是"路由维度的总量与平均",不是"分布"。
+- 配额、限流相关指标在另一个 plugin (`quota`),本调研不展开。
+
+**与引擎指标的角色分工:**
+- 引擎维度 (vLLM/SGLang) 知道 GPU 内部发生什么,但不知道是哪个 `ai_consumer` 触发的。
+- Higress 知道 route/consumer,但不知道 KV cache 是否爆了。
+- → 跨维度排障必须依赖 `ai_model` (Higress) ↔ `model_name` (引擎) 做 label join。
+
+---
+
+## 5. DCGM (NVIDIA GPU)
+
+NVIDIA DCGM Exporter,事实标准。所有指标前缀 `DCGM_FI_*`,label `gpu`, `UUID`, `device`, `Hostname`, `instance`, `pod`, `namespace` 等。
+
+| 指标 | 类型 | 描述 |
+|---|---|---|
+| `DCGM_FI_DEV_GPU_UTIL` | Gauge | GPU 利用率 (0-100) |
+| `DCGM_FI_DEV_MEM_COPY_UTIL` | Gauge | 显存拷贝利用率 |
+| `DCGM_FI_DEV_FB_USED` | Gauge | 已用显存 (MiB) |
+| `DCGM_FI_DEV_FB_FREE` | Gauge | 空闲显存 (MiB) |
+| `DCGM_FI_DEV_FB_TOTAL` | Gauge | 总显存 (MiB) |
+| `DCGM_FI_DEV_GPU_TEMP` | Gauge | GPU 温度 (°C) |
+| `DCGM_FI_DEV_POWER_USAGE` | Gauge | 功率 (W) |
+| `DCGM_FI_DEV_SM_CLOCK` | Gauge | SM 频率 (MHz) |
+| `DCGM_FI_DEV_MEM_CLOCK` | Gauge | 显存频率 (MHz) |
+| `DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL` | Counter | NVLink 累计带宽 |
+| `DCGM_FI_PROF_PIPE_TENSOR_ACTIVE` | Gauge | Tensor Core 活跃率 (DCGM Profiler,可选) |
+| `DCGM_FI_PROF_GR_ENGINE_ACTIVE` | Gauge | Graphics Engine 活跃率 |
+| `DCGM_FI_PROF_DRAM_ACTIVE` | Gauge | DRAM 活跃率 |
+| `DCGM_FI_DEV_XID_ERRORS` | Counter | XID 错误码 |
+
+**模板告警最常用的子集:**`GPU_UTIL`, `FB_USED/FB_TOTAL`, `GPU_TEMP`, `POWER_USAGE`, `XID_ERRORS` —— 这 5 个进归一化。Profiler metrics (`PROF_*`) 默认关闭,不纳入必选。
+
+---
+
+## 6. Huawei NPU Exporter (Ascend)
+
+国产化场景必备。npu-exporter 共暴露 **73 个指标**(官方未公开完整 enumeration),按 collector 拆分。本节列出 ModelDoctor 必备子集 + 完整 collector 分类。
+
+**Collector 分类(完整覆盖面):**
+
+| Collector | 覆盖范围 |
+|---|---|
+| `BaseInfoCollector` | chip 基本信息 (id, name, model) |
+| `DdrCollector` | DDR 内存 |
+| `HbmCollector` | HBM 高带宽内存 |
+| `HccsCollector` | HCCS 缓存一致性总线 |
+| `NetworkCollector` | 网络口 |
+| `OpticalCollector` | 光模块 |
+| `PcieCollector` | PCIe 链路 |
+| `RoceCollector` | RoCE / RDMA |
+| `SioCollector` | 串行 I/O |
+| `VersionCollector` | 固件版本 |
+| `VnpuCollector` | 虚拟 NPU |
+
+**已确认的核心 chip 级指标(模板告警子集):**
+
+| 指标 | 类型 | 描述 | 关键 label |
+|---|---|---|---|
+| `npu_chip_info_name` | Info | 名称、id、model_name、vdie_id, pcie_bus_info | `id`, `model_name` |
+| `npu_chip_info_health_status` | Gauge | 健康 (1) / 不健康 (0) | `id`, `model_name` |
+| `npu_chip_info_power` | Gauge | 功耗 (W) | `id`, `model_name` |
+| `npu_chip_info_temperature` | Gauge | 温度 (°C) | `id`, `model_name` |
+| `npu_chip_info_utilization` | Gauge | AI Core 使用率 (%) | `id`, `model_name` |
+| `npu_chip_info_vector_utilization` | Gauge | AI Vector 使用率 (%) | `id`, `model_name` |
+| `npu_chip_info_used_memory` | Gauge | DDR 已用 (MB) | `id`, `model_name` |
+| `npu_chip_info_total_memory` | Gauge | DDR 总量 (MB) | `id`, `model_name` |
+| `machine_npu_nums` | Gauge | 机器上 NPU 数量 | — |
+| `npu_chip_info_error_code` | Gauge | 错误码 (0=正常) | `id`, `model_name` |
+
+**通用 pod-level label**(所有指标都带): `container_name`, `namespace`, `pod_name`。
+
+**⚠️ 待补充完整的指标段(本期归一化暂不覆盖,留待后续 PR):**
+- `npu_chip_info_hbm_used_memory` / `npu_chip_info_hbm_capacity` (HBM 使用,910B 用)
+- `npu_chip_info_aicore_current_freq` (AICore 频率)
+- HCCS / RoCE / 光模块 误码率(链路诊断用)
+- 上述指标存在于 npu-exporter 代码中,但官方 Cloud 文档只列了 chip-level 基础项。**建议落地后用真实集群的 `/metrics` dump 补全本表**。
+
+---
+
+## 7. 归一化:`modeldoctor:*` 命名空间映射
+
+设计原则:
+- **统一前缀 `modeldoctor:`**,后接维度 (`request`, `cache`, `gateway`, `accelerator`),再接具体指标。
+- 所有归一化指标都带 `engine` (= engine type slug,如 `vllm-v1`)、`model_name` 两个核心 label。
+- 仪表盘和告警**只查询归一化指标**,不直接查 `vllm:*` / `sglang:*`。
+- **每张表按 engine type 一行展开**,每个 cell 是这个 engine type 下的具体 source metric 或表达式。空 cell 表示该 engine 暂不支持该归一化指标(留空,而非跨版本拼接)。
+
+### 7.1 Request lifecycle 归一化
+
+| engine type | `request:running` | `request:waiting` | `request:ttft_seconds` | `request:itl_seconds` | `request:e2e_seconds` | `request:queue_seconds` | `request:preempted_total` |
+|---|---|---|---|---|---|---|---|
+| `vllm-v0` | `vllm:num_requests_running` | `vllm:num_requests_waiting` | `vllm:time_to_first_token_seconds` | `vllm:time_per_output_token_seconds` | `vllm:e2e_request_latency_seconds` | `vllm:request_queue_time_seconds` | `vllm:num_preemptions_total` |
+| `vllm-v1` | `vllm:num_requests_running` | `vllm:num_requests_waiting` | `vllm:time_to_first_token_seconds` | `vllm:inter_token_latency_seconds` | `vllm:e2e_request_latency_seconds` | `vllm:request_queue_time_seconds` | `vllm:num_preemptions_total` |
+| `sglang-legacy` | `sglang:num_running_reqs` | `sglang:num_queue_reqs` | `sglang:time_to_first_token_seconds` | `sglang:time_per_output_token_seconds` | `sglang:e2e_request_latency_seconds` | — | — |
+| `sglang-v0.5.4plus` | `sglang_num_running_reqs` | `sglang_num_queue_reqs` | `sglang_time_to_first_token_seconds` | `sglang_time_per_output_token_seconds` | `sglang_e2e_request_latency_seconds` | — | — |
+| `tgi` | `tgi_batch_current_size` | `tgi_queue_size` | `tgi_request_queue_duration + tgi_batch_forward_duration{stage="prefill"}` (derived) | `tgi_request_mean_time_per_token_duration` | `tgi_request_duration` | `tgi_request_queue_duration` | — |
+
+### 7.2 Throughput 归一化
+
+| engine type | `throughput:prompt_tokens_total` | `throughput:generation_tokens_total` | `throughput:generation_rate_tps` |
+|---|---|---|---|
+| `vllm-v0` | `vllm:prompt_tokens_total` | `vllm:generation_tokens_total` | `rate(vllm:generation_tokens_total[1m])` |
+| `vllm-v1` | `vllm:prompt_tokens_total` | `vllm:generation_tokens_total` | `rate(vllm:generation_tokens_total[1m])` |
+| `sglang-legacy` | `sglang:prompt_tokens_total` | `sglang:generation_tokens_total` | `sglang:gen_throughput` |
+| `sglang-v0.5.4plus` | `sglang_prompt_tokens_total` | `sglang_generation_tokens_total` | `sglang_gen_throughput` |
+| `tgi` | derived from `tgi_request_input_length` (sum) | derived from `tgi_request_generated_tokens` (sum) | `rate(...generated_tokens_sum[1m])` |
+
+### 7.3 Cache / Capacity 归一化
+
+| engine type | `cache:kv_usage_ratio` | `cache:prefix_hit_ratio` | `cache:swap_usage_ratio` |
+|---|---|---|---|
+| `vllm-v0` | `vllm:gpu_cache_usage_perc` | `vllm:gpu_prefix_cache_hit_rate` | `vllm:cpu_cache_usage_perc` |
+| `vllm-v1` | `vllm:kv_cache_usage_perc` | `rate(vllm:prefix_cache_hits[1m]) / rate(vllm:prefix_cache_queries[1m])` | — |
+| `sglang-legacy` | `sglang:token_usage` | `sglang:cache_hit_rate` | — |
+| `sglang-v0.5.4plus` | `sglang_token_usage` | `sglang_cache_hit_rate` | — |
+| `tgi` | — (黑盒) | — | — |
+
+### 7.4 Gateway 归一化(Higress)
+
+| `modeldoctor:gateway:*` | 来源 (Higress label 透传: `ai_route`, `ai_consumer`, `ai_model`) |
+|---|---|
+| `modeldoctor:gateway:input_tokens_total` | `route_upstream_model_consumer_metric_input_token` |
+| `modeldoctor:gateway:output_tokens_total` | `route_upstream_model_consumer_metric_output_token` |
+| `modeldoctor:gateway:llm_duration_total_seconds` | `route_upstream_model_consumer_metric_llm_service_duration` (单位需确认,可能需要 `/1e6`) |
+| `modeldoctor:gateway:llm_request_count_total` | `route_upstream_model_consumer_metric_llm_duration_count` |
+| `modeldoctor:gateway:ttft_total_seconds` | `route_upstream_model_consumer_metric_llm_first_token_duration` |
+| `modeldoctor:gateway:streaming_count_total` | `route_upstream_model_consumer_metric_llm_stream_duration_count` |
+
+**注意**: Higress 无 histogram,所以不能给 `gateway:ttft_seconds_histogram`。算 avg TTFT 用 `rate(ttft_total_seconds) / rate(llm_request_count_total)`,P99 必须从引擎侧拿。
+
+### 7.5 Accelerator 归一化(GPU+NPU)
+
+设计:**accelerator namespace 同时覆盖 NVIDIA 和 Ascend**,通过 label `device_kind={nvidia|ascend}` 区分。归一化后告警规则不再需要分两份。
+
+| `modeldoctor:accelerator:*` | NVIDIA (DCGM) | Ascend (npu-exporter) |
+|---|---|---|
+| `modeldoctor:accelerator:utilization_ratio` (0-1) | `DCGM_FI_DEV_GPU_UTIL / 100` | `npu_chip_info_utilization / 100` |
+| `modeldoctor:accelerator:memory_used_bytes` | `DCGM_FI_DEV_FB_USED * 1024 * 1024` | `npu_chip_info_used_memory * 1024 * 1024` |
+| `modeldoctor:accelerator:memory_total_bytes` | `DCGM_FI_DEV_FB_TOTAL * 1024 * 1024` | `npu_chip_info_total_memory * 1024 * 1024` |
+| `modeldoctor:accelerator:memory_usage_ratio` (0-1) | derived | derived |
+| `modeldoctor:accelerator:temperature_celsius` | `DCGM_FI_DEV_GPU_TEMP` | `npu_chip_info_temperature` |
+| `modeldoctor:accelerator:power_watts` | `DCGM_FI_DEV_POWER_USAGE` | `npu_chip_info_power` |
+| `modeldoctor:accelerator:health_status` (1=healthy) | derived from `DCGM_FI_DEV_XID_ERRORS == 0` | `npu_chip_info_health_status` |
+| `modeldoctor:accelerator:error_total` | `DCGM_FI_DEV_XID_ERRORS` | `npu_chip_info_error_code != 0` |
+
+---
+
+## 8. 5 个真实故障场景 → 归一化指标依赖矩阵
+
+我们之前对齐过的 5 个典型场景:
+
+### 场景 A: TTFT 抖动 + KV 爆 → 用户感知到的"卡顿"
+
+依赖:
+- `modeldoctor:request:ttft_seconds` (P99 突增)
+- `modeldoctor:cache:kv_usage_ratio` > 0.9 持续
+- `modeldoctor:request:waiting` 队列堆积
+- `modeldoctor:request:preempted_total` 计数增加
+
+### 场景 B: prefix cache miss 飙升 → 后续优化点
+
+依赖:
+- `modeldoctor:cache:prefix_hit_ratio` 显著下降
+- 配合 `modeldoctor:gateway:input_tokens_total` 看是否 input 模式变化
+
+### 场景 C: 网关侧某 consumer 异常占用资源 → 多租户隔离
+
+依赖(全部 Higress 侧,因为引擎不知道 consumer):
+- `rate(modeldoctor:gateway:input_tokens_total)` by `ai_consumer`
+- `rate(modeldoctor:gateway:output_tokens_total)` by `ai_consumer`
+- 联动引擎: `modeldoctor:request:running` 同时升高确认相关性
+
+### 场景 D: GPU/NPU 物理异常 (XID error, NPU error_code)
+
+依赖:
+- `modeldoctor:accelerator:error_total` 增长 + `health_status == 0`
+- 配合 `modeldoctor:accelerator:temperature_celsius` / `power_watts` 看是否过热触发
+
+### 场景 E: 引擎 hang / OOM 退化
+
+依赖:
+- `modeldoctor:request:running` 长时间 == 0 (引擎 hang)
+- 或 `modeldoctor:request:preempted_total` 持续高位
+- 配合 `modeldoctor:accelerator:memory_usage_ratio` > 0.95
+
+→ 这 5 个场景都能用归一化指标表达,不需要 query 原始引擎指标。**第二步的 alert rules 直接基于本表落地。**
+
+---
+
+## 9. 未覆盖 / 后续
+
+- **Triton Server**: 待加(大量国内用户用 Triton 跑 TensorRT-LLM,指标体系完全不同),将作为独立 engine type `triton`。
+- **LMDeploy**: 待加,独立 engine type `lmdeploy`。
+- **TGI 2.x → 3.x**: 2026 年新版若有指标变更,将拆为 `tgi-v2` / `tgi-v3` 独立 engine type。
+- **NPU Exporter 完整指标 enumeration**: 等真实 Ascend 集群接入后,做一次 `/metrics` dump 补全本表 §6。
+- **`engine` label 注入方式**: 每份 PrometheusRule 在 recording rule expression 里**硬编码** `engine` label (e.g. `labels: { engine: "vllm-v1" }`),不依赖引擎自己暴露 build info。哪份 rule 文件被 apply,哪个 engine label 就被产出,语义自洽。
+- **labels 不一致风险**: vLLM `model_name`、SGLang 暂无 model label(单进程绑定单模型,需用 `instance`)、TGI `model_id`。各 engine type 自己的 recording rule 在产出 `modeldoctor:*` 时,用 `label_replace` 把源 label 改名到统一的 `model_name`——这是 engine-internal 的转换,不是跨版本适配。
+
+---
+
+## 10. Sources
+
+- vLLM V0/V1: https://github.com/vllm-project/vllm — `vllm/engine/metrics.py`、`vllm/v1/metrics/loggers.py`
+- SGLang Production Metrics: https://docs.sglang.ai/references/production_metrics.html
+- SGLang Prometheus Metrics Guide: https://kuncoro.io/blog/sglang-prometheus-metrics-guide/
+- TGI Metrics: HuggingFace TGI repo `router/src/server.rs`
+- Higress AI Statistics: https://higress.cn (plugins/wasm-go/extensions/ai-statistics)
+- DCGM Exporter: https://github.com/NVIDIA/dcgm-exporter
+- Huawei NPU Exporter: https://support.huaweicloud.com/intl/en-us/usermanual-cce/cce_10_0970.html ; https://pkg.go.dev/github.com/professorshandian/npu-exporter/collector/metrics
+
+---
+
+**Review checklist (留给 reviewer):**
+- [ ] §0 "版本即引擎"原则是否接受?后续 ModelDoctor connection UI 上引擎下拉就长这样:`vllm-v0` / `vllm-v1` / `sglang-legacy` / `sglang-v0.5.4plus` / `tgi` / ...
+- [ ] §1 vLLM 拆 `vllm-v0` + `vllm-v1` 两个引擎类型,是否覆盖你团队实际跑的版本?
+- [ ] §2 SGLang 拆 `sglang-legacy` + `sglang-v0.5.4plus` 两个引擎类型,是否合适?
+- [ ] §3 TGI 没有 TTFT 原生指标,通过 queue + prefill duration 推算可接受吗?
+- [ ] §4 Higress label 维度 `ai_consumer` 是否要在 ModelDoctor connection 上做对齐?
+- [ ] §6 NPU 部分缺 HBM、AICore 频率等高阶指标,是否本期推迟到落地后用真实 dump 补全?
+- [ ] §7 归一化映射表是否完整?(每个 engine type 一行)
+- [ ] §7.5 `modeldoctor:accelerator:*` 同时覆盖 NVIDIA 和 Ascend (这是硬件层,不是引擎层,所以不拆 engine type,而是用 `device_kind` label 区分),这个设计是否接受?
+- [ ] §8 5 个场景的依赖矩阵是否完整?有遗漏的场景吗?


### PR DESCRIPTION
## Summary

Lays the foundation for the Anomaly Watcher feature (P0 from #189): a survey document and the PrometheusRule baseline it justifies.

### Two commits

1. **`docs: inference engine metrics survey`** — Catalogues raw Prometheus metrics from vLLM (V0/V1), SGLang (legacy/v0.5.4+), TGI, Higress AI Statistics, NVIDIA DCGM, and Huawei NPU Exporter. Documents breaking changes between major versions and produces the \`modeldoctor:*\` normalized namespace mapping table. Located at \`docs/superpowers/research/2026-05-15-inference-engine-metrics-survey.md\`.

2. **\`feat(observability): PrometheusRule baseline\`** — Implements the §7 mapping. 7 recording rule yamls + 4 alert rule yamls under \`deploy/k8s/prometheus-rules/\`.

### Design principle: version is engine

Different major versions of the same engine are treated as **separate engine types** with separate rule files. We do not adapt across versions in PromQL — no \`or\` fallbacks, no presence-of-metric detection, no \`label_replace\` bridges. Users apply the file matching their deployed version.

```
vllm-v0  (0.5.x – 0.6.x)        vllm-v1  (0.7.x+)
sglang-legacy  (≤ 0.5.3)        sglang-v0.5.4plus  (≥ 0.5.4)
tgi  (1.x / 2.x)
```

Gateway and accelerator are dimensions, not engines:
- \`gateway/higress.yaml\` — adds route/consumer dimension via \`ai_route\`, \`ai_consumer\`, \`ai_model\` labels
- \`accelerator/accelerator.yaml\` — unifies NVIDIA + Ascend via \`device_kind\` label

### Alerts cover the 5 incident scenarios from survey §8

| Scenario | Alert file |
|---|---|
| A — TTFT jitter + KV exhaustion | request-slo.yaml + cache.yaml |
| B — Prefix cache regression | cache.yaml |
| C — Noisy-neighbor consumer | gateway-consumer.yaml |
| D — GPU/NPU physical fault | accelerator.yaml |
| E — Engine hang / OOM | request-slo.yaml |

Every alert carries a \`modeldoctor_scenario\` label so the upcoming Alertmanager webhook receiver can dispatch to the right AI prompt template.

## Test plan

- [ ] All 11 yamls pass \`yaml.safe_load\` (verified locally)
- [ ] \`promtool check rules deploy/k8s/prometheus-rules/**/*.yaml\` clean in CI (no promtool available locally yet — will run during cluster validation)
- [ ] Apply \`vllm-v1.yaml\` + \`accelerator.yaml\` + all alerts against a real vLLM 0.8.x deployment with DCGM running; verify normalized series appear and at least one alert can be made to fire by load test
- [ ] Apply \`higress.yaml\` against a Higress instance with AI Statistics plugin; verify consumer-token-surge alert fires when one client dominates

## Follow-ups (not in this PR)

- Alertmanager receiver config + ModelDoctor webhook contract (next PR)
- AI analysis layer: \`modeldoctor_scenario\` label → context-aware prompt
- UI: inline anomaly panel on connection detail / capacity planning views
- Triton Server, LMDeploy recording rules (deferred — separate engine types)
- Full Huawei NPU metric enumeration (need real Ascend cluster /metrics dump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)