### PR TITLE
feat: Connection.kind — gateway / Prometheus / Alertmanager as first-class connections (refs #189)

### DIFF
--- a/apps/api/prisma/migrations/20260517085542_connection_kind/migration.sql
+++ b/apps/api/prisma/migrations/20260517085542_connection_kind/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "connections" ADD COLUMN     "kind" TEXT NOT NULL DEFAULT 'model',
+ALTER COLUMN "model" SET DEFAULT '',
+ALTER COLUMN "category" DROP NOT NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -67,13 +67,25 @@ model RefreshToken {
 model Connection {
   id            String   @id @default(cuid())
   userId        String   @map("user_id")
+  // What kind of LLM-stack member this connection points at — see
+  // connectionKindSchema in @modeldoctor/contracts. Defaults to 'model'
+  // for backward compat: every pre-existing row predates the enum and is
+  // a model endpoint by construction.
+  kind          String   @default("model")
   name          String
   baseUrl       String   @map("base_url")
+  // Cipher is empty-string for kinds that don't carry an apiKey (prometheus,
+  // alertmanager); the runtime contract layer enforces required-ness per
+  // kind, not the DB schema.
   apiKeyCipher  String   @map("api_key_cipher") // AES-256-GCM v1, see common/crypto/aes-gcm.ts
-  model         String
+  // Empty-string default lets non-model kinds skip model name without a
+  // nullable column. Contract layer rejects empty model on kind=model writes.
+  model         String   @default("")
   customHeaders String   @default("") @map("custom_headers")
   queryParams   String   @default("") @map("query_params")
-  category      String // ModalityCategory: 'chat' | 'embeddings' | 'rerank' | 'images' | 'audio' | ...
+  // Nullable so the DB doesn't need a placeholder ModalityCategory for a
+  // Prometheus or Alertmanager connection.
+  category      String?  // ModalityCategory: 'chat' | 'embeddings' | 'rerank' | 'images' | 'audio' | ...
   tags          String[] @default([])
 
   // Reserved for #60 Prometheus integration. Nullable on purpose: existing

--- a/apps/api/src/modules/connection/connection.controller.spec.ts
+++ b/apps/api/src/modules/connection/connection.controller.spec.ts
@@ -20,6 +20,7 @@ const USER: JwtPayload = { sub: "u_1", email: "alice@example.com", roles: [] };
 
 const PUBLIC_FIXTURE: ConnectionPublic = {
   id: "c_1",
+  kind: "model",
   userId: "u_1",
   name: "vllm-prod",
   baseUrl: "http://10.0.0.1:8000",
@@ -105,6 +106,7 @@ describe("ConnectionController", () => {
     it("calls service.create(userId, body) and returns ConnectionWithSecret", async () => {
       svc.create.mockResolvedValue(SECRET_FIXTURE);
       const body = {
+        kind: "model" as const,
         name: "vllm-prod",
         baseUrl: "http://10.0.0.1:8000",
         apiKey: "sk-secret-12345",
@@ -170,6 +172,7 @@ describe("ConnectionController", () => {
     it("create: response includes tokenizerHfId: null when not supplied", async () => {
       svc.create.mockResolvedValue(SECRET_FIXTURE);
       const body = {
+        kind: "model" as const,
         name: "vllm-prod",
         baseUrl: "http://10.0.0.1:8000",
         apiKey: "sk-secret-12345",
@@ -190,6 +193,7 @@ describe("ConnectionController", () => {
       };
       svc.create.mockResolvedValue(fixtureWithTokenizer);
       const body = {
+        kind: "model" as const,
         name: "vllm-prod",
         baseUrl: "http://10.0.0.1:8000",
         apiKey: "sk-secret-12345",

--- a/apps/api/src/modules/connection/connection.controller.ts
+++ b/apps/api/src/modules/connection/connection.controller.ts
@@ -7,9 +7,12 @@ import {
   type DiscoverConnectionResponse,
   type ListConnectionsResponse,
   type UpdateConnection,
+  type VerifyKindRequest,
+  type VerifyKindResponse,
   createConnectionSchema,
   discoverConnectionRequestSchema,
   updateConnectionSchema,
+  verifyKindRequestSchema,
 } from "@modeldoctor/contracts";
 import {
   Body,
@@ -30,6 +33,7 @@ import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
 import type { JwtPayload } from "../auth/jwt.strategy.js";
 import { ConnectionService } from "./connection.service.js";
 import { DiscoveryService } from "./discovery/discovery.service.js";
+import { verifyConnectionKind } from "./discovery/verify-kind.js";
 
 @Controller("connections")
 @UseGuards(JwtAuthGuard)
@@ -72,6 +76,18 @@ export class ConnectionController {
     @Body(new ZodValidationPipe(discoverConnectionRequestSchema)) body: DiscoverConnectionRequest,
   ): Promise<DiscoverConnectionResponse> {
     return this.discoveryService.discover(body);
+  }
+
+  // Shallow probe for non-model kinds (gateway / Prometheus / Alertmanager).
+  // The full `discover` flow above is heavy and model-shaped; this endpoint
+  // returns a yes/no + version + a few facts, suitable for an inline "Verify"
+  // button next to the kind dropdown.
+  @Throttle({ default: { limit: 20, ttl: 60_000 } })
+  @Post("verify-kind")
+  async verifyKind(
+    @Body(new ZodValidationPipe(verifyKindRequestSchema)) body: VerifyKindRequest,
+  ): Promise<VerifyKindResponse> {
+    return verifyConnectionKind(body);
   }
 
   @Patch(":id")

--- a/apps/api/src/modules/connection/connection.service.spec.ts
+++ b/apps/api/src/modules/connection/connection.service.spec.ts
@@ -29,6 +29,7 @@ function makeRow(overrides: Partial<RowWithProfile> = {}): RowWithProfile {
   return {
     id: "c_1",
     userId: "u_1",
+    kind: "model",
     name: "vllm-prod",
     baseUrl: "http://10.x.x.x:30888",
     apiKeyCipher: "v1:placeholder",
@@ -82,6 +83,7 @@ describe("ConnectionService", () => {
         },
       );
       const out = await service.create("u_1", {
+        kind: "model",
         name: "vllm-prod",
         baseUrl: "http://10.x.x.x:30888",
         apiKey: PLAINTEXT,
@@ -110,6 +112,7 @@ describe("ConnectionService", () => {
         },
       );
       const out = await service.create("u_1", {
+        kind: "model",
         name: "vllm-prod",
         baseUrl: "http://10.x.x.x:30888",
         apiKey: "sk-abc",
@@ -134,6 +137,7 @@ describe("ConnectionService", () => {
         },
       );
       const out = await service.create("u_1", {
+        kind: "model",
         name: "x",
         baseUrl: "http://x",
         apiKey: "k",
@@ -332,6 +336,7 @@ describe("ConnectionService", () => {
         },
       );
       const out = await service.create("u_1", {
+        kind: "model",
         name: "vllm-prod",
         baseUrl: "http://10.x.x.x:30888",
         apiKey: "sk-abc",
@@ -355,6 +360,7 @@ describe("ConnectionService", () => {
         },
       );
       const out = await service.create("u_1", {
+        kind: "model",
         name: "x",
         baseUrl: "http://x",
         apiKey: "k",

--- a/apps/api/src/modules/connection/connection.service.ts
+++ b/apps/api/src/modules/connection/connection.service.ts
@@ -9,7 +9,12 @@ import type {
   ServerKind,
   UpdateConnection,
 } from "@modeldoctor/contracts";
-import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from "@nestjs/common";
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import type { Prisma, Connection as PrismaConnection } from "@prisma/client";
 import { decodeKey, decrypt, encrypt } from "../../common/crypto/aes-gcm.js";

--- a/apps/api/src/modules/connection/connection.service.ts
+++ b/apps/api/src/modules/connection/connection.service.ts
@@ -9,7 +9,7 @@ import type {
   ServerKind,
   UpdateConnection,
 } from "@modeldoctor/contracts";
-import { ForbiddenException, Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import type { Prisma, Connection as PrismaConnection } from "@prisma/client";
 import { decodeKey, decrypt, encrypt } from "../../common/crypto/aes-gcm.js";
@@ -98,7 +98,24 @@ export class ConnectionService {
     id: string,
     input: UpdateConnection,
   ): Promise<ConnectionWithSecret | ConnectionPublic> {
-    await this.findOwnedRow(userId, id);
+    const existing = await this.findOwnedRow(userId, id);
+    // updateConnectionSchema is `.partial()`, so its superRefine only fires
+    // when `kind` is present in the body. A PATCH like `{"model": ""}` against
+    // an existing kind=model row would otherwise slip past validation and
+    // clear required fields. Compute the effective kind (patch.kind ?? row.kind)
+    // and re-enforce the same gate the create path uses.
+    const effectiveKind = (input.kind ?? existing.kind) as ConnectionKind;
+    if (effectiveKind === "model") {
+      if (input.model !== undefined && input.model.trim().length === 0) {
+        throw new BadRequestException("model is required for kind=model");
+      }
+      if (input.category === null) {
+        throw new BadRequestException("category is required for kind=model");
+      }
+      if (input.apiKey !== undefined && input.apiKey.length === 0) {
+        throw new BadRequestException("apiKey is required for kind=model");
+      }
+    }
     const data: Prisma.ConnectionUncheckedUpdateInput = {};
     if (input.kind !== undefined) data.kind = input.kind;
     if (input.name !== undefined) data.name = input.name;

--- a/apps/api/src/modules/connection/connection.service.ts
+++ b/apps/api/src/modules/connection/connection.service.ts
@@ -1,4 +1,5 @@
 import type {
+  ConnectionKind,
   ConnectionPublic,
   ConnectionRevealKeyResponse,
   ConnectionWithSecret,
@@ -17,13 +18,16 @@ import { PrismaService } from "../../database/prisma.service.js";
 
 export interface DecryptedConnection {
   id: string;
+  kind: ConnectionKind;
   name: string;
   baseUrl: string;
   apiKey: string;
   model: string;
   customHeaders: string;
   queryParams: string;
-  category: ModalityCategory;
+  // null for non-model kinds; consumers that need a category must check
+  // `kind === "model"` first.
+  category: ModalityCategory | null;
   tokenizerHfId: string | null;
   prometheusUrl: string | null;
   serverKind: ServerKind | null;
@@ -45,17 +49,21 @@ export class ConnectionService {
   }
 
   async create(userId: string, input: CreateConnection): Promise<ConnectionWithSecret> {
-    const apiKeyCipher = encrypt(input.apiKey, this.key);
+    // Non-model kinds may omit apiKey; persist an empty cipher in that case
+    // so the column stays NOT NULL and decrypt() returns "".
+    const plaintextKey = input.apiKey ?? "";
+    const apiKeyCipher = plaintextKey ? encrypt(plaintextKey, this.key) : "";
     const row = await this.prisma.connection.create({
       data: {
         userId,
+        kind: input.kind,
         name: input.name,
         baseUrl: input.baseUrl,
         apiKeyCipher,
-        model: input.model,
+        model: input.model ?? "",
         customHeaders: input.customHeaders,
         queryParams: input.queryParams,
-        category: input.category,
+        category: input.category ?? null,
         tags: input.tags,
         prometheusUrl: input.prometheusUrl ?? null,
         serverKind: input.serverKind ?? null,
@@ -66,7 +74,7 @@ export class ConnectionService {
       },
       include: { evaluationProfile: true },
     });
-    return this.toContractWithSecret(row, input.apiKey);
+    return this.toContractWithSecret(row, plaintextKey);
   }
 
   async list(userId: string): Promise<ListConnectionsResponse> {
@@ -92,6 +100,7 @@ export class ConnectionService {
   ): Promise<ConnectionWithSecret | ConnectionPublic> {
     await this.findOwnedRow(userId, id);
     const data: Prisma.ConnectionUncheckedUpdateInput = {};
+    if (input.kind !== undefined) data.kind = input.kind;
     if (input.name !== undefined) data.name = input.name;
     if (input.baseUrl !== undefined) data.baseUrl = input.baseUrl;
     if (input.model !== undefined) data.model = input.model;
@@ -104,7 +113,9 @@ export class ConnectionService {
     if (input.tokenizerHfId !== undefined) data.tokenizerHfId = input.tokenizerHfId;
     if (input.evaluationProfileId !== undefined)
       data.evaluationProfileId = input.evaluationProfileId;
-    if (input.apiKey !== undefined) data.apiKeyCipher = encrypt(input.apiKey, this.key);
+    if (input.apiKey !== undefined) {
+      data.apiKeyCipher = input.apiKey ? encrypt(input.apiKey, this.key) : "";
+    }
 
     const row = await this.prisma.connection.update({
       where: { id },
@@ -142,13 +153,14 @@ export class ConnectionService {
     const row = await this.findOwnedRow(userId, id);
     return {
       id: row.id,
+      kind: row.kind as ConnectionKind,
       name: row.name,
       baseUrl: row.baseUrl,
-      apiKey: decrypt(row.apiKeyCipher, this.key),
+      apiKey: row.apiKeyCipher ? decrypt(row.apiKeyCipher, this.key) : "",
       model: row.model,
       customHeaders: row.customHeaders,
       queryParams: row.queryParams,
-      category: row.category as ModalityCategory,
+      category: row.category as ModalityCategory | null,
       tokenizerHfId: row.tokenizerHfId,
       prometheusUrl: row.prometheusUrl,
       serverKind: row.serverKind as ServerKind | null,
@@ -177,16 +189,21 @@ export class ConnectionService {
       evaluationProfile: { id: string; slug: string; name: string; nameKey: string | null } | null;
     },
   ): ConnectionPublic {
+    // Non-model kinds may have an empty cipher; decrypt() requires non-empty input.
+    const apiKeyPreview = row.apiKeyCipher
+      ? this.makePreview(decrypt(row.apiKeyCipher, this.key))
+      : "";
     return {
       id: row.id,
       userId: row.userId,
+      kind: row.kind as ConnectionKind,
       name: row.name,
       baseUrl: row.baseUrl,
-      apiKeyPreview: this.makePreview(decrypt(row.apiKeyCipher, this.key)),
+      apiKeyPreview,
       model: row.model,
       customHeaders: row.customHeaders,
       queryParams: row.queryParams,
-      category: row.category as ModalityCategory,
+      category: row.category as ModalityCategory | null,
       tags: row.tags,
       prometheusUrl: row.prometheusUrl,
       serverKind: row.serverKind as ConnectionPublic["serverKind"],

--- a/apps/api/src/modules/connection/discovery/verify-kind.ts
+++ b/apps/api/src/modules/connection/discovery/verify-kind.ts
@@ -1,0 +1,168 @@
+import type { ConnectionKind } from "@modeldoctor/contracts";
+import { safeFetch } from "./safe-fetch.js";
+
+export interface VerifyKindInput {
+  kind: ConnectionKind;
+  baseUrl: string;
+  apiKey?: string;
+  /** Raw newline-separated `key: value` header lines, same format as
+   * `ConnectionInput.customHeaders`. */
+  customHeaders?: string;
+}
+
+export interface VerifyKindResult {
+  kind: ConnectionKind;
+  ok: boolean;
+  version?: string;
+  /** Free-form per-kind facts surfaced in the UI (e.g. number of upstream model
+   * endpoints for a gateway, build commit for Prometheus). Always best-effort,
+   * never required for `ok=true`. */
+  details?: Record<string, unknown>;
+  /** When `ok=false`, a short human-readable reason. */
+  reason?: string;
+}
+
+/**
+ * Probe a connection target to verify it is what the user said it is.
+ *
+ * Each kind has a known "health" path:
+ *   model         — N/A here; use the full discover flow instead
+ *   gateway       — Higress: /v1/models (gateway exposes a unified list)
+ *   prometheus    — /api/v1/status/buildinfo
+ *   alertmanager  — /api/v2/status
+ *
+ * Verification is deliberately shallow: we only confirm the endpoint
+ * responds with the shape that distinguishes the target product. Deeper
+ * checks (datasource reachable, receivers configured, etc.) belong in a
+ * later "deep-verify" path.
+ */
+export async function verifyConnectionKind(input: VerifyKindInput): Promise<VerifyKindResult> {
+  const { kind, baseUrl, apiKey, customHeaders } = input;
+  const trimmed = baseUrl.replace(/\/$/, "");
+
+  if (kind === "model") {
+    return {
+      kind,
+      ok: false,
+      reason: "verifyConnectionKind is for non-model kinds; use POST /api/connections/discover",
+    };
+  }
+
+  const fetchOpts = {
+    apiKey,
+    extraHeaders: parseCustomHeaders(customHeaders),
+    method: "GET" as const,
+  };
+
+  try {
+    if (kind === "gateway") return await verifyGateway(trimmed, fetchOpts);
+    if (kind === "prometheus") return await verifyPrometheus(trimmed, fetchOpts);
+    if (kind === "alertmanager") return await verifyAlertmanager(trimmed, fetchOpts);
+  } catch (err) {
+    return {
+      kind,
+      ok: false,
+      reason: (err as Error).message,
+    };
+  }
+
+  return {
+    kind,
+    ok: false,
+    reason: `unknown kind: ${kind}`,
+  };
+}
+
+type FetchOpts = { apiKey?: string; extraHeaders?: Record<string, string>; method: "GET" };
+
+// Mirrors parseCustomHeaders in discovery.service.ts; kept local so this
+// module has no dependency on discovery internals. If a third copy is
+// needed, extract to a shared file.
+function parseCustomHeaders(raw: string | undefined): Record<string, string> | undefined {
+  if (!raw) return undefined;
+  const out: Record<string, string> = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const colon = trimmed.indexOf(":");
+    if (colon <= 0) continue;
+    const key = trimmed.slice(0, colon).trim();
+    const value = trimmed.slice(colon + 1).trim();
+    if (key && value) out[key] = value;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+async function verifyGateway(base: string, opts: FetchOpts): Promise<VerifyKindResult> {
+  // Higress exposes the OpenAI-shape model list at /v1/models on the gateway
+  // port. A 200 with a `{ data: [...] }` body is enough to confirm the
+  // target speaks the LLM gateway protocol. We deliberately probe the
+  // open route rather than /admin/* (which requires auth and is not always
+  // exposed on the same port).
+  const url = `${base}/v1/models`;
+  const res = await safeFetch(url, opts);
+  if (!res.ok) {
+    return { kind: "gateway", ok: false, reason: `HTTP ${res.status} from ${url}` };
+  }
+  const body = (await res.json().catch(() => null)) as { data?: unknown[] } | null;
+  const modelCount = Array.isArray(body?.data) ? body!.data!.length : undefined;
+  return {
+    kind: "gateway",
+    ok: true,
+    details: modelCount !== undefined ? { modelCount } : undefined,
+  };
+}
+
+async function verifyPrometheus(base: string, opts: FetchOpts): Promise<VerifyKindResult> {
+  // GET /api/v1/status/buildinfo returns { status: "success", data: {
+  //   version, revision, branch, buildUser, buildDate, goVersion } }.
+  // Presence of `data.version` confirms this is a Prometheus instance, not
+  // a generic HTTP endpoint.
+  const url = `${base}/api/v1/status/buildinfo`;
+  const res = await safeFetch(url, opts);
+  if (!res.ok) {
+    return { kind: "prometheus", ok: false, reason: `HTTP ${res.status} from ${url}` };
+  }
+  const body = (await res.json().catch(() => null)) as {
+    status?: string;
+    data?: { version?: string; revision?: string };
+  } | null;
+  if (body?.status !== "success" || !body?.data?.version) {
+    return { kind: "prometheus", ok: false, reason: "buildinfo did not return a Prometheus shape" };
+  }
+  return {
+    kind: "prometheus",
+    ok: true,
+    version: body.data.version,
+    details: body.data.revision ? { revision: body.data.revision } : undefined,
+  };
+}
+
+async function verifyAlertmanager(base: string, opts: FetchOpts): Promise<VerifyKindResult> {
+  // GET /api/v2/status returns { cluster, versionInfo, config, uptime, ... }.
+  // `versionInfo.version` is the distinguishing field; clusterPeers count
+  // (when present) is a useful operational detail.
+  const url = `${base}/api/v2/status`;
+  const res = await safeFetch(url, opts);
+  if (!res.ok) {
+    return { kind: "alertmanager", ok: false, reason: `HTTP ${res.status} from ${url}` };
+  }
+  const body = (await res.json().catch(() => null)) as {
+    versionInfo?: { version?: string };
+    cluster?: { peers?: unknown[] };
+  } | null;
+  if (!body?.versionInfo?.version) {
+    return {
+      kind: "alertmanager",
+      ok: false,
+      reason: "status endpoint did not return an Alertmanager shape",
+    };
+  }
+  const peers = Array.isArray(body.cluster?.peers) ? body.cluster!.peers!.length : undefined;
+  return {
+    kind: "alertmanager",
+    ok: true,
+    version: body.versionInfo.version,
+    details: peers !== undefined ? { clusterPeers: peers } : undefined,
+  };
+}

--- a/apps/api/src/modules/connection/discovery/verify-kind.ts
+++ b/apps/api/src/modules/connection/discovery/verify-kind.ts
@@ -105,7 +105,7 @@ async function verifyGateway(base: string, opts: FetchOpts): Promise<VerifyKindR
     return { kind: "gateway", ok: false, reason: `HTTP ${res.status} from ${url}` };
   }
   const body = (await res.json().catch(() => null)) as { data?: unknown[] } | null;
-  const modelCount = Array.isArray(body?.data) ? body!.data!.length : undefined;
+  const modelCount = Array.isArray(body?.data) ? body.data.length : undefined;
   return {
     kind: "gateway",
     ok: true,
@@ -158,7 +158,7 @@ async function verifyAlertmanager(base: string, opts: FetchOpts): Promise<Verify
       reason: "status endpoint did not return an Alertmanager shape",
     };
   }
-  const peers = Array.isArray(body.cluster?.peers) ? body.cluster!.peers!.length : undefined;
+  const peers = Array.isArray(body.cluster?.peers) ? body.cluster.peers.length : undefined;
   return {
     kind: "alertmanager",
     ok: true,

--- a/apps/api/src/modules/connection/discovery/verify-kind.ts
+++ b/apps/api/src/modules/connection/discovery/verify-kind.ts
@@ -158,6 +158,8 @@ async function verifyAlertmanager(base: string, opts: FetchOpts): Promise<Verify
       reason: "status endpoint did not return an Alertmanager shape",
     };
   }
+  // body is non-null here (narrowed by the versionInfo guard above), but stay
+  // defensive on `cluster` since it's optional in the AM /api/v2/status shape.
   const peers = Array.isArray(body.cluster?.peers) ? body.cluster.peers.length : undefined;
   return {
     kind: "alertmanager",

--- a/apps/api/src/modules/diagnostics/diagnostics.service.spec.ts
+++ b/apps/api/src/modules/diagnostics/diagnostics.service.spec.ts
@@ -9,6 +9,7 @@ import { DiagnosticsService } from "./diagnostics.service.js";
 
 function makeConn(overrides: Partial<DecryptedConnection> & { id: string }): DecryptedConnection {
   return {
+    kind: "model",
     name: "test-conn",
     baseUrl: "http://localhost:8000",
     apiKey: "test-key",

--- a/apps/api/src/modules/engine-metrics/engine-metrics.service.spec.ts
+++ b/apps/api/src/modules/engine-metrics/engine-metrics.service.spec.ts
@@ -8,6 +8,7 @@ import { PromClient } from "./prom-client.js";
 function makeConn(over: Partial<DecryptedConnection> = {}): DecryptedConnection {
   return {
     id: "c1",
+    kind: "model",
     name: "test",
     baseUrl: "http://m:8000",
     apiKey: "x",

--- a/apps/api/src/modules/playground/audio.controller.spec.ts
+++ b/apps/api/src/modules/playground/audio.controller.spec.ts
@@ -29,6 +29,7 @@ function makeFile(overrides: Partial<MulterFile> = {}): MulterFile {
 function makeConn(): DecryptedConnection {
   return {
     id: "conn-1",
+    kind: "model",
     name: "test",
     baseUrl: "http://x",
     apiKey: "k",

--- a/apps/api/src/modules/playground/audio.service.spec.ts
+++ b/apps/api/src/modules/playground/audio.service.spec.ts
@@ -5,6 +5,7 @@ import { AudioService } from "./audio.service.js";
 function makeConn(overrides: Partial<DecryptedConnection> = {}): DecryptedConnection {
   return {
     id: "conn-1",
+    kind: "model",
     name: "test",
     baseUrl: "http://x",
     apiKey: "k",

--- a/apps/api/src/modules/playground/chat.service.spec.ts
+++ b/apps/api/src/modules/playground/chat.service.spec.ts
@@ -5,6 +5,7 @@ import { ChatService } from "./chat.service.js";
 function makeConn(overrides: Partial<DecryptedConnection> = {}): DecryptedConnection {
   return {
     id: "conn-1",
+    kind: "model",
     name: "test",
     baseUrl: "http://upstream.test",
     apiKey: "sk-1",

--- a/apps/api/src/modules/playground/embeddings.service.spec.ts
+++ b/apps/api/src/modules/playground/embeddings.service.spec.ts
@@ -5,6 +5,7 @@ import { EmbeddingsService } from "./embeddings.service.js";
 function makeConn(overrides: Partial<DecryptedConnection> = {}): DecryptedConnection {
   return {
     id: "conn-1",
+    kind: "model",
     name: "test",
     baseUrl: "http://x.test",
     apiKey: "k",

--- a/apps/api/src/modules/playground/images.controller.spec.ts
+++ b/apps/api/src/modules/playground/images.controller.spec.ts
@@ -29,6 +29,7 @@ function makeFile(overrides: Partial<MulterFile> = {}): MulterFile {
 function makeConn(): DecryptedConnection {
   return {
     id: "conn-1",
+    kind: "model",
     name: "test",
     baseUrl: "http://x",
     apiKey: "k",

--- a/apps/api/src/modules/playground/images.service.spec.ts
+++ b/apps/api/src/modules/playground/images.service.spec.ts
@@ -5,6 +5,7 @@ import { ImagesService } from "./images.service.js";
 function makeConn(overrides: Partial<DecryptedConnection> = {}): DecryptedConnection {
   return {
     id: "conn-1",
+    kind: "model",
     name: "test",
     baseUrl: "http://x",
     apiKey: "k",

--- a/apps/api/src/modules/playground/rerank.service.spec.ts
+++ b/apps/api/src/modules/playground/rerank.service.spec.ts
@@ -5,6 +5,7 @@ import { RerankService } from "./rerank.service.js";
 function makeConn(overrides: Partial<DecryptedConnection> = {}): DecryptedConnection {
   return {
     id: "conn-1",
+    kind: "model",
     name: "test",
     baseUrl: "http://x",
     apiKey: "k",

--- a/apps/api/test/e2e/connection-kind.e2e-spec.ts
+++ b/apps/api/test/e2e/connection-kind.e2e-spec.ts
@@ -195,6 +195,39 @@ describe("Connection.kind e2e", () => {
     expect(res.body.reason).toMatch(/Prometheus shape/);
   });
 
+  it("PATCH on kind=model rejects clearing model/category/apiKey even when kind is omitted", async () => {
+    const created = await request(ctx.app.getHttpServer())
+      .post("/api/connections")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        kind: "model",
+        name: "patch-guard",
+        baseUrl: "http://x.test",
+        apiKey: "sk-orig",
+        model: "qwen-orig",
+        category: "chat",
+      })
+      .expect(201);
+
+    // PATCH without `kind` — superRefine alone would let this through;
+    // the service-layer invariant must reject it.
+    await request(ctx.app.getHttpServer())
+      .patch(`/api/connections/${created.body.id}`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ model: "" })
+      .expect(400);
+    await request(ctx.app.getHttpServer())
+      .patch(`/api/connections/${created.body.id}`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ category: null })
+      .expect(400);
+    await request(ctx.app.getHttpServer())
+      .patch(`/api/connections/${created.body.id}`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ apiKey: "" })
+      .expect(400);
+  });
+
   it("verify-kind for gateway returns model count from /v1/models", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(

--- a/apps/api/test/e2e/connection-kind.e2e-spec.ts
+++ b/apps/api/test/e2e/connection-kind.e2e-spec.ts
@@ -1,0 +1,215 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+// SSRF guard mock so we can hit a non-resolvable hostname in the verify-kind
+// probe without flaky DNS in CI.
+vi.mock("../../src/modules/connection/discovery/ssrf-guard.js", () => ({
+  assertSafeUrl: vi.fn(async (url: string) => ({
+    safeUrl: new URL(url),
+    resolvedIp: "10.0.0.1",
+  })),
+  PRIVATE_HOSTS: new Set<string>(),
+}));
+
+import request from "supertest";
+import { PrismaService } from "../../src/database/prisma.service.js";
+import { type E2EContext, bootE2E, registerUser } from "../helpers/app.js";
+
+describe("Connection.kind e2e", () => {
+  let ctx: E2EContext;
+  let prisma: PrismaService;
+  let token: string;
+
+  beforeAll(async () => {
+    ctx = await bootE2E();
+    prisma = ctx.app.get(PrismaService);
+    const u = await registerUser(ctx.app, "kind@example.com");
+    token = u.token;
+  }, 120_000);
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  afterAll(async () => {
+    await ctx.teardown();
+  });
+
+  it("create kind=model still requires apiKey + model + category", async () => {
+    await request(ctx.app.getHttpServer())
+      .post("/api/connections")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        kind: "model",
+        name: "model-bad",
+        baseUrl: "http://x.test",
+        // missing apiKey, model, category
+      })
+      .expect(400);
+  });
+
+  it("create kind=model succeeds with all required fields", async () => {
+    const res = await request(ctx.app.getHttpServer())
+      .post("/api/connections")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        kind: "model",
+        name: "model-good",
+        baseUrl: "http://x.test",
+        apiKey: "sk-test",
+        model: "qwen-test",
+        category: "chat",
+      })
+      .expect(201);
+    expect(res.body.kind).toBe("model");
+    expect(res.body.model).toBe("qwen-test");
+    expect(res.body.category).toBe("chat");
+  });
+
+  it("create kind=prometheus skips apiKey/model/category", async () => {
+    const res = await request(ctx.app.getHttpServer())
+      .post("/api/connections")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        kind: "prometheus",
+        name: "prom-1",
+        baseUrl: "http://prom.test:9090",
+      })
+      .expect(201);
+    expect(res.body.kind).toBe("prometheus");
+    expect(res.body.apiKeyPreview).toBe("");
+    expect(res.body.model).toBe("");
+    expect(res.body.category).toBeNull();
+  });
+
+  it("create kind=alertmanager works without apiKey/model/category", async () => {
+    const res = await request(ctx.app.getHttpServer())
+      .post("/api/connections")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        kind: "alertmanager",
+        name: "am-1",
+        baseUrl: "http://am.test:9093",
+      })
+      .expect(201);
+    expect(res.body.kind).toBe("alertmanager");
+  });
+
+  it("create kind=gateway carries model/apiKey when supplied", async () => {
+    const res = await request(ctx.app.getHttpServer())
+      .post("/api/connections")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        kind: "gateway",
+        name: "higress-1",
+        baseUrl: "http://higress.test",
+        apiKey: "gateway-key",
+        model: "qwen3-32b-via-higress",
+        category: "chat",
+        serverKind: "higress",
+      })
+      .expect(201);
+    expect(res.body.kind).toBe("gateway");
+    expect(res.body.serverKind).toBe("higress");
+  });
+
+  it("legacy GET /api/connections still works (kind exposed on each row)", async () => {
+    const res = await request(ctx.app.getHttpServer())
+      .get("/api/connections")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+    expect(Array.isArray(res.body.items)).toBe(true);
+    for (const row of res.body.items) {
+      expect(row.kind).toBeDefined();
+    }
+  });
+
+  it("POST /api/connections/verify-kind rejects kind=model", async () => {
+    const res = await request(ctx.app.getHttpServer())
+      .post("/api/connections/verify-kind")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ kind: "model", baseUrl: "http://x.test" })
+      .expect(201);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.reason).toMatch(/non-model/);
+  });
+
+  it("verify-kind reports Prometheus version from buildinfo", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "success",
+          data: { version: "2.51.0", revision: "abc123" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await request(ctx.app.getHttpServer())
+      .post("/api/connections/verify-kind")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ kind: "prometheus", baseUrl: "http://prom.test:9090" })
+      .expect(201);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.version).toBe("2.51.0");
+    expect(res.body.details).toMatchObject({ revision: "abc123" });
+  });
+
+  it("verify-kind reports Alertmanager version from /api/v2/status", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          versionInfo: { version: "0.27.0" },
+          cluster: { peers: [{ name: "peer-a" }] },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await request(ctx.app.getHttpServer())
+      .post("/api/connections/verify-kind")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ kind: "alertmanager", baseUrl: "http://am.test:9093" })
+      .expect(201);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.version).toBe("0.27.0");
+    expect(res.body.details).toMatchObject({ clusterPeers: 1 });
+  });
+
+  it("verify-kind returns ok=false when target shape is wrong", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ not: "prometheus shape" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await request(ctx.app.getHttpServer())
+      .post("/api/connections/verify-kind")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ kind: "prometheus", baseUrl: "http://prom.test:9090" })
+      .expect(201);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.reason).toMatch(/Prometheus shape/);
+  });
+
+  it("verify-kind for gateway returns model count from /v1/models", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: [{ id: "m1" }, { id: "m2" }, { id: "m3" }] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await request(ctx.app.getHttpServer())
+      .post("/api/connections/verify-kind")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ kind: "gateway", baseUrl: "http://higress.test" })
+      .expect(201);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.details).toMatchObject({ modelCount: 3 });
+  });
+});

--- a/apps/web/src/components/connection/EndpointPicker.test.tsx
+++ b/apps/web/src/components/connection/EndpointPicker.test.tsx
@@ -23,6 +23,7 @@ import { EndpointPicker } from "./EndpointPicker";
 const SAMPLE = {
   id: "c1",
   userId: "u1",
+  kind: "model",
   name: "vllm-prod",
   baseUrl: "http://example.com",
   apiKeyPreview: "sk-...abcd",

--- a/apps/web/src/components/connection/__tests__/ConnectionPicker.test.tsx
+++ b/apps/web/src/components/connection/__tests__/ConnectionPicker.test.tsx
@@ -22,6 +22,7 @@ import { ConnectionPicker } from "../ConnectionPicker";
 const conn: ConnectionPublic = {
   id: "c_1",
   userId: "u_1",
+  kind: "model",
   name: "bge-by-mis-tei",
   baseUrl: "http://183.240.109.2:30888",
   apiKeyPreview: "sk-...bc8d",

--- a/apps/web/src/features/benchmarks/__tests__/BenchmarkCreatePage.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/BenchmarkCreatePage.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@/features/connections/queries", () => ({
   useCreateConnection: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
   useUpdateConnection: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
   useDiscoverConnection: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+  useVerifyKind: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 const mockMutate = vi.fn();

--- a/apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
@@ -132,6 +132,7 @@ function Wrapper({ children }: { children: ReactNode }) {
 const defaultConnectionData = {
   id: "c1",
   userId: "u_1",
+  kind: "model",
   name: "test-conn",
   baseUrl: "http://x",
   apiKeyPreview: "sk-...test",

--- a/apps/web/src/features/benchmarks/__tests__/RequestDetailsSection.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/RequestDetailsSection.test.tsx
@@ -13,6 +13,7 @@ import { api } from "@/lib/api-client";
 const CONNECTION: ConnectionPublic = {
   id: "c_emb",
   userId: "u_1",
+  kind: "model",
   name: "bge-by-mis-tei",
   baseUrl: "http://gw",
   apiKeyPreview: "sk-...bc8d",

--- a/apps/web/src/features/benchmarks/__tests__/forms/VegetaParamsForm.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/forms/VegetaParamsForm.test.tsx
@@ -24,6 +24,7 @@ const wrapperSchema = z.object({
 const baseConnection: ConnectionPublic = {
   id: "c_emb",
   userId: "u_1",
+  kind: "model",
   name: "bge-by-mis-tei",
   baseUrl: "http://example/v1",
   apiKeyPreview: "sk-...bc8d",

--- a/apps/web/src/features/benchmarks/forms/GuidellmParamsForm.tsx
+++ b/apps/web/src/features/benchmarks/forms/GuidellmParamsForm.tsx
@@ -71,6 +71,7 @@ export function GuidellmParamsForm({ fieldPrefix = "params" }: GuidellmParamsFor
     if (!connection) return;
     if (lastConnectionId.current === connection.id) return;
     lastConnectionId.current = connection.id;
+    if (!connection.category) return; // non-model kinds aren't benchmarkable here
     const def = GUIDELLM_CATEGORY_DEFAULTS[connection.category];
     if ("apiType" in def) {
       setValue(`${fieldPrefix}.apiType`, def.apiType, { shouldDirty: false });

--- a/apps/web/src/features/benchmarks/forms/ToolParamsEditor.tsx
+++ b/apps/web/src/features/benchmarks/forms/ToolParamsEditor.tsx
@@ -123,6 +123,7 @@ export function ToolSelectorField({
     : undefined;
   const isToolUnsupported = (tn: ToolName): boolean => {
     if (!connection) return false;
+    if (!connection.category) return true; // non-model kinds: no benchmark applies
     const def = TOOL_CATEGORY_DEFAULTS[tn][connection.category];
     return "unsupported" in def;
   };
@@ -180,7 +181,7 @@ export function ToolSelectorField({
                     {unsupported && connection ? (
                       <span className="text-[11px] text-amber-600 dark:text-amber-400">
                         {t("create.unsupportedToolForCategory", {
-                          category: connection.category,
+                          category: connection.category ?? "—",
                         })}
                       </span>
                     ) : null}
@@ -229,12 +230,14 @@ export function useToolUnsupported(
     ? connections.data?.find((c) => c.id === connectionId)
     : undefined;
   if (!connection) return null;
+  if (!connection.category) return null; // non-model kinds: not benchmarkable here
   const def = TOOL_CATEGORY_DEFAULTS[tool][connection.category];
   if (!("unsupported" in def)) return null;
+  const cat = connection.category;
   const alternatives = SCENARIOS[scenario].tools.filter(
-    (t) => !("unsupported" in TOOL_CATEGORY_DEFAULTS[t][connection.category]),
+    (t) => !("unsupported" in TOOL_CATEGORY_DEFAULTS[t][cat]),
   );
-  return { tool, category: connection.category, alternatives };
+  return { tool, category: cat, alternatives };
 }
 
 /** Tool-specific parameter form (no tool selector, no section heading).

--- a/apps/web/src/features/benchmarks/forms/VegetaParamsForm.tsx
+++ b/apps/web/src/features/benchmarks/forms/VegetaParamsForm.tsx
@@ -62,6 +62,7 @@ export function VegetaParamsForm({ fieldPrefix = "params" }: VegetaParamsFormPro
     // Case 1: connection changed. Reset everything atomically.
     if (connection && lastConnectionId.current !== connection.id) {
       lastConnectionId.current = connection.id;
+      if (!connection.category) return; // non-model kinds aren't benchmarkable here
       const def = VEGETA_CATEGORY_DEFAULTS[connection.category];
       const nextApiType = def.apiType;
       setValue(`${fieldPrefix}.apiType`, nextApiType, { shouldDirty: false });

--- a/apps/web/src/features/connections/ConnectionSheet.test.tsx
+++ b/apps/web/src/features/connections/ConnectionSheet.test.tsx
@@ -30,6 +30,10 @@ vi.mock("./queries", () => ({
     mutateAsync: discoverMutate,
     isPending: discoverIsPending,
   }),
+  useVerifyKind: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
 }));
 
 // SubscribersSection (rendered in edit mode) reads from React Query hooks.
@@ -55,6 +59,7 @@ async function fillBaseFields(user: ReturnType<typeof userEvent.setup>) {
 const EXISTING: ConnectionPublic = {
   id: "c1",
   userId: "u1",
+  kind: "model",
   name: "preexisting",
   baseUrl: "http://old.test",
   apiKeyPreview: "sk-...wxyz",

--- a/apps/web/src/features/connections/ConnectionSheet.tsx
+++ b/apps/web/src/features/connections/ConnectionSheet.tsx
@@ -554,7 +554,7 @@ export function ConnectionSheet({
                     control={form.control}
                     name="apiBaseUrl"
                     render={({ field }) => (
-                      <FormItem>
+                      <FormItem className={showModelFields ? undefined : "md:col-span-2"}>
                         <FormLabel required>{t("dialog.fields.apiBaseUrl")}</FormLabel>
                         <FormControl>
                           <Input

--- a/apps/web/src/features/connections/ConnectionSheet.tsx
+++ b/apps/web/src/features/connections/ConnectionSheet.tsx
@@ -25,20 +25,36 @@ import { type EndpointKey, applyCurlToEndpoint } from "@/lib/apply-curl-to-endpo
 import { parseCurlCommand, toApiBaseUrl } from "@/lib/curl-parser";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type {
+  ConnectionKind,
   ConnectionPublic,
   ConnectionWithSecret,
+  CreateConnection,
   DiscoverConnectionResponse,
   ModalityCategory,
   ServerKind,
   UpdateConnection,
+  VerifyKindResponse,
 } from "@modeldoctor/contracts";
 import { ENGINE_DISPLAY_NAME } from "@modeldoctor/contracts";
-import { AlertTriangle, Eye, EyeOff, Loader2, Sparkles, X as XIcon } from "lucide-react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Eye,
+  EyeOff,
+  Loader2,
+  Sparkles,
+  X as XIcon,
+} from "lucide-react";
 import { Fragment, useEffect, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-import { useCreateConnection, useDiscoverConnection, useUpdateConnection } from "./queries";
+import {
+  useCreateConnection,
+  useDiscoverConnection,
+  useUpdateConnection,
+  useVerifyKind,
+} from "./queries";
 import {
   type ConnectionInput,
   connectionInputCreateSchema,
@@ -66,6 +82,7 @@ interface ConnectionSheetProps {
 }
 
 const empty: Partial<ConnectionInput> = {
+  kind: "model",
   name: "",
   apiBaseUrl: "",
   apiKey: "",
@@ -75,10 +92,12 @@ const empty: Partial<ConnectionInput> = {
   tokenizerHfId: "",
   prometheusUrl: null,
   serverKind: null,
+  category: null,
   tags: [],
 };
 
 const CATEGORIES: ModalityCategory[] = ["chat", "audio", "embeddings", "rerank", "image"];
+const KINDS: ConnectionKind[] = ["model", "gateway", "prometheus", "alertmanager"];
 const MAX_SUGGESTION_CHIPS = 8;
 
 const SERVER_KIND_OPTIONS: ReadonlyArray<{ value: ServerKind; label: string }> = [
@@ -112,6 +131,7 @@ const PRESET_TAGS = [
 /** ConnectionPublic → form-shape default values (note: no apiKey is exposed by the server). */
 function existingToFormValues(c: ConnectionPublic): Partial<ConnectionInput> {
   return {
+    kind: c.kind,
     name: c.name,
     apiBaseUrl: c.baseUrl,
     apiKey: "", // never sent in PATCH unless reset toggle is on
@@ -148,7 +168,9 @@ export function ConnectionSheet({
   const [tagDraft, setTagDraft] = useState("");
   const [discoverResult, setDiscoverResult] = useState<DiscoverConnectionResponse | null>(null);
   const [discoverError, setDiscoverError] = useState<string | null>(null);
+  const [verifyResult, setVerifyResult] = useState<VerifyKindResponse | null>(null);
   const discoverMut = useDiscoverConnection();
+  const verifyMut = useVerifyKind();
 
   const form = useForm<ConnectionInput>({
     resolver: zodResolver(isEdit ? connectionInputEditSchema : connectionInputCreateSchema),
@@ -171,6 +193,7 @@ export function ConnectionSheet({
     setTagDraft("");
     setDiscoverResult(null);
     setDiscoverError(null);
+    setVerifyResult(null);
   }, [open, existing, initialValues]);
 
   // Re-validate when toggling the reset-apiKey switch in edit mode.
@@ -183,6 +206,15 @@ export function ConnectionSheet({
   const baseUrlValue = form.watch("apiBaseUrl");
   const apiKeyValue = form.watch("apiKey");
   const customHeadersValue = form.watch("customHeaders");
+  const kindValue: ConnectionKind = (form.watch("kind") as ConnectionKind | undefined) ?? "model";
+  const isModelKind = kindValue === "model";
+  const isGatewayKind = kindValue === "gateway";
+  const showModelFields = isModelKind || isGatewayKind; // gateway also routes by model
+  const showApiKeyField = isModelKind || isGatewayKind;
+  const showServerKindField = isModelKind || isGatewayKind;
+  const showTokenizerField = isModelKind;
+  const showCategoryField = isModelKind || isGatewayKind;
+  const showPrometheusUrlField = isModelKind || isGatewayKind;
 
   // -- Discover helpers ------------------------------------------------------
   const countFilledFields = (r: DiscoverConnectionResponse): number =>
@@ -313,18 +345,23 @@ export function ConnectionSheet({
   const onSubmit = form.handleSubmit(async (values) => {
     setSubmitError(null);
     const sanitizedBaseUrl = toApiBaseUrl(values.apiBaseUrl);
+    const kind: ConnectionKind = (values.kind as ConnectionKind | undefined) ?? "model";
+    const submitIsModelKind = kind === "model";
+    const submitIsGatewayKind = kind === "gateway";
+    const submitShowModelFields = submitIsModelKind || submitIsGatewayKind;
     try {
       if (existing) {
         const body: UpdateConnection = {
+          kind,
           name: values.name,
           baseUrl: sanitizedBaseUrl,
-          model: values.model,
+          model: submitShowModelFields ? values.model : "",
           customHeaders: values.customHeaders,
           queryParams: values.queryParams,
-          tokenizerHfId: values.tokenizerHfId.trim() || null,
-          prometheusUrl: values.prometheusUrl ?? null,
-          serverKind: values.serverKind ?? null,
-          category: values.category,
+          tokenizerHfId: submitIsModelKind ? values.tokenizerHfId.trim() || null : null,
+          prometheusUrl: submitShowModelFields ? (values.prometheusUrl ?? null) : null,
+          serverKind: submitShowModelFields ? (values.serverKind ?? null) : null,
+          category: submitShowModelFields ? (values.category ?? null) : null,
           tags: values.tags,
         };
         if (resetApiKey) {
@@ -337,19 +374,21 @@ export function ConnectionSheet({
         const saved = await updateMut.mutateAsync({ id: existing.id, body });
         onSaved?.(saved);
       } else {
-        const saved = await createMut.mutateAsync({
+        const create: CreateConnection = {
+          kind,
           name: values.name,
           baseUrl: sanitizedBaseUrl,
-          apiKey: values.apiKey,
-          model: values.model,
+          apiKey: submitShowModelFields ? values.apiKey : "",
+          model: submitShowModelFields ? values.model : "",
           customHeaders: values.customHeaders,
           queryParams: values.queryParams,
-          tokenizerHfId: values.tokenizerHfId.trim() || null,
-          prometheusUrl: values.prometheusUrl ?? null,
-          serverKind: values.serverKind ?? null,
-          category: values.category,
+          tokenizerHfId: submitIsModelKind ? values.tokenizerHfId.trim() || null : null,
+          prometheusUrl: submitShowModelFields ? (values.prometheusUrl ?? null) : null,
+          serverKind: submitShowModelFields ? (values.serverKind ?? null) : null,
+          category: submitShowModelFields ? (values.category ?? null) : null,
           tags: values.tags,
-        });
+        };
+        const saved = await createMut.mutateAsync(create);
         onSaved?.(saved);
       }
       onOpenChange(false);
@@ -358,6 +397,38 @@ export function ConnectionSheet({
       setSubmitError(msg);
     }
   });
+
+  const handleVerifyKind = async () => {
+    const baseUrl = baseUrlValue?.trim();
+    if (!baseUrl) return;
+    setVerifyResult(null);
+    try {
+      const res = await verifyMut.mutateAsync({
+        kind: kindValue,
+        baseUrl,
+        apiKey: apiKeyValue?.trim() || undefined,
+        customHeaders: customHeadersValue?.trim() || undefined,
+      });
+      setVerifyResult(res);
+      if (res.ok) {
+        const parts: string[] = [];
+        if (res.version) parts.push(t("dialog.verify.version", { version: res.version }));
+        if (res.details && typeof res.details.modelCount === "number") {
+          parts.push(t("dialog.verify.modelCount", { count: res.details.modelCount }));
+        }
+        if (res.details && typeof res.details.clusterPeers === "number") {
+          parts.push(t("dialog.verify.clusterPeers", { count: res.details.clusterPeers }));
+        }
+        const summary = parts.length > 0 ? parts.join(" · ") : t(`kinds.${res.kind}`);
+        toast.success(t("dialog.verify.ok", { summary }));
+      } else {
+        toast.error(t("dialog.verify.fail", { reason: res.reason ?? "" }));
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : tc("errors.unknown");
+      toast.error(t("dialog.verify.fail", { reason: msg }));
+    }
+  };
 
   const apiKeyDisabled = isEdit && !resetApiKey;
   const apiKeyPlaceholder = isEdit
@@ -427,23 +498,56 @@ export function ConnectionSheet({
               </details>
 
               <FormSection>
-                <FormField
-                  control={form.control}
-                  name="name"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel required>{t("dialog.fields.name")}</FormLabel>
-                      <FormControl>
-                        <Input
-                          autoComplete="off"
-                          placeholder={t("dialog.fields.namePlaceholder")}
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                  <FormField
+                    control={form.control}
+                    name="kind"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel required>{t("dialog.fields.kind")}</FormLabel>
+                        <FormControl>
+                          <Select
+                            value={(field.value as ConnectionKind | undefined) ?? "model"}
+                            onValueChange={(v) => field.onChange(v as ConnectionKind)}
+                          >
+                            <SelectTrigger aria-label={t("dialog.fields.kind")}>
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {KINDS.map((k) => (
+                                <SelectItem key={k} value={k}>
+                                  {t(`kinds.${k}`)}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </FormControl>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {t("dialog.fields.kindHelp")}
+                        </p>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="name"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel required>{t("dialog.fields.name")}</FormLabel>
+                        <FormControl>
+                          <Input
+                            autoComplete="off"
+                            placeholder={t("dialog.fields.namePlaceholder")}
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
 
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                   <FormField
@@ -467,24 +571,71 @@ export function ConnectionSheet({
                     )}
                   />
 
-                  <FormField
-                    control={form.control}
-                    name="model"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel required>{t("dialog.fields.model")}</FormLabel>
-                        <FormControl>
-                          <Input
-                            autoComplete="off"
-                            placeholder={t("dialog.fields.modelPlaceholder")}
-                            {...field}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
+                  {showModelFields ? (
+                    <FormField
+                      control={form.control}
+                      name="model"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel required={isModelKind}>{t("dialog.fields.model")}</FormLabel>
+                          <FormControl>
+                            <Input
+                              autoComplete="off"
+                              placeholder={t("dialog.fields.modelPlaceholder")}
+                              {...field}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  ) : null}
                 </div>
+
+                {verifyResult ? (
+                  <div
+                    className={`flex items-start gap-2 rounded-md border p-2 text-xs ${
+                      verifyResult.ok
+                        ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+                        : "border-destructive/30 bg-destructive/10 text-destructive"
+                    }`}
+                  >
+                    {verifyResult.ok ? (
+                      <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
+                    ) : (
+                      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                    )}
+                    <span className="flex-1">
+                      {verifyResult.ok
+                        ? [
+                            verifyResult.version
+                              ? t("dialog.verify.version", { version: verifyResult.version })
+                              : null,
+                            typeof verifyResult.details?.modelCount === "number"
+                              ? t("dialog.verify.modelCount", {
+                                  count: verifyResult.details.modelCount,
+                                })
+                              : null,
+                            typeof verifyResult.details?.clusterPeers === "number"
+                              ? t("dialog.verify.clusterPeers", {
+                                  count: verifyResult.details.clusterPeers,
+                                })
+                              : null,
+                          ]
+                            .filter(Boolean)
+                            .join(" · ") || t(`kinds.${verifyResult.kind}`)
+                        : (verifyResult.reason ?? "")}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => setVerifyResult(null)}
+                      aria-label={t("dialog.discover.dismiss")}
+                      className="opacity-70 hover:opacity-100"
+                    >
+                      <XIcon className="h-4 w-4" />
+                    </button>
+                  </div>
+                ) : null}
 
                 <FormField
                   control={form.control}
@@ -522,62 +673,64 @@ export function ConnectionSheet({
                   )}
                 />
 
-                <FormField
-                  control={form.control}
-                  name="apiKey"
-                  render={({ field }) => (
-                    <FormItem>
-                      <div className="flex items-center justify-between">
-                        <FormLabel required={!apiKeyDisabled}>
-                          {t("dialog.fields.apiKey")}
-                        </FormLabel>
-                        {isEdit ? (
-                          <label className="flex items-center gap-1 text-xs text-muted-foreground">
-                            <input
-                              type="checkbox"
-                              checked={resetApiKey}
-                              onChange={(e) => {
-                                const next = e.target.checked;
-                                setResetApiKey(next);
-                                if (!next) form.setValue("apiKey", "");
-                              }}
+                {showApiKeyField ? (
+                  <FormField
+                    control={form.control}
+                    name="apiKey"
+                    render={({ field }) => (
+                      <FormItem>
+                        <div className="flex items-center justify-between">
+                          <FormLabel required={isModelKind && !apiKeyDisabled}>
+                            {t("dialog.fields.apiKey")}
+                          </FormLabel>
+                          {isEdit ? (
+                            <label className="flex items-center gap-1 text-xs text-muted-foreground">
+                              <input
+                                type="checkbox"
+                                checked={resetApiKey}
+                                onChange={(e) => {
+                                  const next = e.target.checked;
+                                  setResetApiKey(next);
+                                  if (!next) form.setValue("apiKey", "");
+                                }}
+                              />
+                              {t("dialog.resetApiKey")}
+                            </label>
+                          ) : null}
+                        </div>
+                        <div className="relative">
+                          <FormControl>
+                            <Input
+                              autoComplete="new-password"
+                              type={revealKey ? "text" : "password"}
+                              placeholder={apiKeyPlaceholder}
+                              disabled={apiKeyDisabled}
+                              {...field}
                             />
-                            {t("dialog.resetApiKey")}
-                          </label>
-                        ) : null}
-                      </div>
-                      <div className="relative">
-                        <FormControl>
-                          <Input
-                            autoComplete="new-password"
-                            type={revealKey ? "text" : "password"}
-                            placeholder={apiKeyPlaceholder}
-                            disabled={apiKeyDisabled}
-                            {...field}
-                          />
-                        </FormControl>
-                        {!apiKeyDisabled ? (
-                          <button
-                            type="button"
-                            onClick={() => setRevealKey((v) => !v)}
-                            className="absolute inset-y-0 right-2 flex items-center text-muted-foreground hover:text-foreground"
-                            aria-label={revealKey ? "hide" : "show"}
-                          >
-                            {revealKey ? (
-                              <EyeOff className="h-4 w-4" />
-                            ) : (
-                              <Eye className="h-4 w-4" />
-                            )}
-                          </button>
-                        ) : null}
-                      </div>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        {t("dialog.apiKeyEncryptedNotice")}
-                      </p>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
+                          </FormControl>
+                          {!apiKeyDisabled ? (
+                            <button
+                              type="button"
+                              onClick={() => setRevealKey((v) => !v)}
+                              className="absolute inset-y-0 right-2 flex items-center text-muted-foreground hover:text-foreground"
+                              aria-label={revealKey ? "hide" : "show"}
+                            >
+                              {revealKey ? (
+                                <EyeOff className="h-4 w-4" />
+                              ) : (
+                                <Eye className="h-4 w-4" />
+                              )}
+                            </button>
+                          ) : null}
+                        </div>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {t("dialog.apiKeyEncryptedNotice")}
+                        </p>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                ) : null}
 
                 <div>
                   <Label htmlFor="tags">{t("dialog.fields.tags")}</Label>
@@ -653,115 +806,136 @@ export function ConnectionSheet({
                   </p>
                 </div>
 
-                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                  <FormField
-                    control={form.control}
-                    name="category"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel required>{t("dialog.fields.category")}</FormLabel>
-                        <FormControl>
-                          <Select value={field.value ?? ""} onValueChange={field.onChange}>
-                            <SelectTrigger aria-label={t("dialog.fields.category")}>
-                              <SelectValue placeholder={t("dialog.fields.categoryPlaceholder")} />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {CATEGORIES.map((c) => (
-                                <SelectItem key={c} value={c}>
-                                  {t(`dialog.categoryOptions.${c}`)}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        </FormControl>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          {t("dialog.fields.categoryHelp")}
-                        </p>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
+                {showCategoryField || showServerKindField ? (
+                  <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                    {showCategoryField ? (
+                      <FormField
+                        control={form.control}
+                        name="category"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel required={isModelKind}>
+                              {t("dialog.fields.category")}
+                            </FormLabel>
+                            <FormControl>
+                              <Select
+                                value={field.value ?? ""}
+                                onValueChange={(v) => field.onChange(v === "" ? null : v)}
+                              >
+                                <SelectTrigger aria-label={t("dialog.fields.category")}>
+                                  <SelectValue
+                                    placeholder={t("dialog.fields.categoryPlaceholder")}
+                                  />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {CATEGORIES.map((c) => (
+                                    <SelectItem key={c} value={c}>
+                                      {t(`dialog.categoryOptions.${c}`)}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </FormControl>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              {t("dialog.fields.categoryHelp")}
+                            </p>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    ) : null}
 
-                  <FormField
-                    control={form.control}
-                    name="serverKind"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>{t("dialog.fields.serverKind")}</FormLabel>
-                        <FormControl>
-                          <Select
-                            value={field.value ?? ""}
-                            onValueChange={(v) => field.onChange(v === "" ? null : v)}
-                          >
-                            <SelectTrigger>
-                              <SelectValue placeholder={t("dialog.fields.serverKindPlaceholder")} />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {SERVER_KIND_OPTIONS.map((o) => (
-                                <SelectItem key={o.value} value={o.value}>
-                                  {o.label}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        </FormControl>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          {t("dialog.fields.serverKindHelp")}
-                        </p>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
+                    {showServerKindField ? (
+                      <FormField
+                        control={form.control}
+                        name="serverKind"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>{t("dialog.fields.serverKind")}</FormLabel>
+                            <FormControl>
+                              <Select
+                                value={field.value ?? ""}
+                                onValueChange={(v) => field.onChange(v === "" ? null : v)}
+                              >
+                                <SelectTrigger>
+                                  <SelectValue
+                                    placeholder={t("dialog.fields.serverKindPlaceholder")}
+                                  />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {SERVER_KIND_OPTIONS.map((o) => (
+                                    <SelectItem key={o.value} value={o.value}>
+                                      {o.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </FormControl>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              {t("dialog.fields.serverKindHelp")}
+                            </p>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    ) : null}
+                  </div>
+                ) : null}
 
-                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                  <FormField
-                    control={form.control}
-                    name="tokenizerHfId"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>{t("dialog.fields.tokenizerHfId")}</FormLabel>
-                        <FormControl>
-                          <Input
-                            autoComplete="off"
-                            placeholder={t("dialog.fields.tokenizerHfIdPlaceholder")}
-                            {...field}
-                          />
-                        </FormControl>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          {t("dialog.fields.tokenizerHfIdHelp")}
-                        </p>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
+                {showTokenizerField || showPrometheusUrlField ? (
+                  <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                    {showTokenizerField ? (
+                      <FormField
+                        control={form.control}
+                        name="tokenizerHfId"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>{t("dialog.fields.tokenizerHfId")}</FormLabel>
+                            <FormControl>
+                              <Input
+                                autoComplete="off"
+                                placeholder={t("dialog.fields.tokenizerHfIdPlaceholder")}
+                                {...field}
+                              />
+                            </FormControl>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              {t("dialog.fields.tokenizerHfIdHelp")}
+                            </p>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    ) : null}
 
-                  <FormField
-                    control={form.control}
-                    name="prometheusUrl"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>{t("dialog.fields.prometheusUrl")}</FormLabel>
-                        <FormControl>
-                          <Input
-                            type="url"
-                            autoComplete="off"
-                            placeholder={t("dialog.fields.prometheusUrlPlaceholder")}
-                            {...field}
-                            value={field.value ?? ""}
-                            onChange={(e) =>
-                              field.onChange(e.target.value === "" ? null : e.target.value)
-                            }
-                          />
-                        </FormControl>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          {t("dialog.fields.prometheusUrlHelp")}
-                        </p>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
+                    {showPrometheusUrlField ? (
+                      <FormField
+                        control={form.control}
+                        name="prometheusUrl"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>{t("dialog.fields.prometheusUrl")}</FormLabel>
+                            <FormControl>
+                              <Input
+                                type="url"
+                                autoComplete="off"
+                                placeholder={t("dialog.fields.prometheusUrlPlaceholder")}
+                                {...field}
+                                value={field.value ?? ""}
+                                onChange={(e) =>
+                                  field.onChange(e.target.value === "" ? null : e.target.value)
+                                }
+                              />
+                            </FormControl>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              {t("dialog.fields.prometheusUrlHelp")}
+                            </p>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    ) : null}
+                  </div>
+                ) : null}
 
                 {submitError ? (
                   <p className="text-sm text-destructive">
@@ -804,25 +978,49 @@ export function ConnectionSheet({
                 submitLabel={tc("actions.save")}
                 pending={createMut.isPending || updateMut.isPending}
                 leading={
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={handleDiscover}
-                    disabled={!baseUrlValue?.trim() || discoverMut.isPending}
-                    title={!baseUrlValue?.trim() ? t("dialog.discover.missingBaseUrl") : undefined}
-                  >
-                    {discoverMut.isPending ? (
-                      <>
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                        {t("dialog.discover.running")}
-                      </>
-                    ) : (
-                      <>
-                        <Sparkles className="mr-2 h-4 w-4" />
-                        {t("dialog.discover.button")}
-                      </>
-                    )}
-                  </Button>
+                  showModelFields ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={handleDiscover}
+                      disabled={!baseUrlValue?.trim() || discoverMut.isPending}
+                      title={
+                        !baseUrlValue?.trim() ? t("dialog.discover.missingBaseUrl") : undefined
+                      }
+                    >
+                      {discoverMut.isPending ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          {t("dialog.discover.running")}
+                        </>
+                      ) : (
+                        <>
+                          <Sparkles className="mr-2 h-4 w-4" />
+                          {t("dialog.discover.button")}
+                        </>
+                      )}
+                    </Button>
+                  ) : (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={handleVerifyKind}
+                      disabled={!baseUrlValue?.trim() || verifyMut.isPending}
+                      title={!baseUrlValue?.trim() ? t("dialog.verify.missingBaseUrl") : undefined}
+                    >
+                      {verifyMut.isPending ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          {t("dialog.verify.running")}
+                        </>
+                      ) : (
+                        <>
+                          <CheckCircle2 className="mr-2 h-4 w-4" />
+                          {t("dialog.verify.button")}
+                        </>
+                      )}
+                    </Button>
+                  )
                 }
               />
             </SheetFooter>

--- a/apps/web/src/features/connections/ConnectionsPage.test.tsx
+++ b/apps/web/src/features/connections/ConnectionsPage.test.tsx
@@ -9,6 +9,7 @@ const seedList: ConnectionPublic[] = [
   {
     id: "c1",
     userId: "u1",
+    kind: "model",
     name: "chat-prod",
     baseUrl: "http://a",
     apiKeyPreview: "sk-...1234",
@@ -28,6 +29,7 @@ const seedList: ConnectionPublic[] = [
   {
     id: "c2",
     userId: "u1",
+    kind: "model",
     name: "embed-test",
     baseUrl: "http://b",
     apiKeyPreview: "sk-...5678",

--- a/apps/web/src/features/connections/ConnectionsPage.tsx
+++ b/apps/web/src/features/connections/ConnectionsPage.tsx
@@ -34,7 +34,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import type { ConnectionPublic, ModalityCategory } from "@modeldoctor/contracts";
+import type { ConnectionKind, ConnectionPublic, ModalityCategory } from "@modeldoctor/contracts";
 import { Database, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -50,6 +50,7 @@ export function ConnectionsPage() {
 
   const [filterCategory, setFilterCategory] = useState<ModalityCategory | "all">("all");
   const [filterTag, setFilterTag] = useState<string | "all">("all");
+  const [filterKind, setFilterKind] = useState<ConnectionKind | "all">("all");
 
   const allTags = Array.from(new Set(list.flatMap((c) => c.tags))).sort();
 
@@ -60,6 +61,7 @@ export function ConnectionsPage() {
   }, [allTags, filterTag]);
 
   const filtered = list.filter((c) => {
+    if (filterKind !== "all" && c.kind !== filterKind) return false;
     if (filterCategory !== "all" && c.category !== filterCategory) return false;
     if (filterTag !== "all" && !c.tags.includes(filterTag)) return false;
     return true;
@@ -112,6 +114,24 @@ export function ConnectionsPage() {
             <div className="mb-3 flex items-center gap-2">
               <span className="text-xs text-muted-foreground">{t("filters.label")}:</span>
               <Select
+                value={filterKind}
+                onValueChange={(v) => setFilterKind(v as ConnectionKind | "all")}
+              >
+                <SelectTrigger className="h-8 w-40 text-xs" aria-label={t("table.kind")}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t("filters.allKinds")}</SelectItem>
+                  {(["model", "gateway", "prometheus", "alertmanager"] as ConnectionKind[]).map(
+                    (k) => (
+                      <SelectItem key={k} value={k}>
+                        {t(`kinds.${k}`)}
+                      </SelectItem>
+                    ),
+                  )}
+                </SelectContent>
+              </Select>
+              <Select
                 value={filterCategory}
                 onValueChange={(v) => setFilterCategory(v as ModalityCategory | "all")}
               >
@@ -150,8 +170,9 @@ export function ConnectionsPage() {
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>{t("table.model")}</TableHead>
+                    <TableHead>{t("table.kind")}</TableHead>
                     <TableHead>{t("table.name")}</TableHead>
+                    <TableHead>{t("table.model")}</TableHead>
                     <TableHead>{t("table.apiBaseUrl")}</TableHead>
                     <TableHead>{t("table.apiKey")}</TableHead>
                     <TableHead>{t("table.category")}</TableHead>
@@ -164,24 +185,36 @@ export function ConnectionsPage() {
                 <TableBody>
                   {filtered.map((c) => (
                     <TableRow key={c.id}>
+                      <TableCell>
+                        <Badge
+                          variant={c.kind === "model" ? "success" : "default"}
+                          className="text-xs"
+                        >
+                          {t(`kinds.${c.kind}`)}
+                        </Badge>
+                      </TableCell>
                       <TableCell className="font-medium">
                         <button
                           type="button"
                           className="text-left hover:text-primary hover:underline"
                           onClick={() => setDialogMode({ kind: "edit", existing: c })}
                         >
-                          {c.model}
+                          {c.name}
                         </button>
                       </TableCell>
-                      <TableCell className="text-muted-foreground">{c.name}</TableCell>
+                      <TableCell className="text-muted-foreground">{c.model || "—"}</TableCell>
                       <TableCell className="font-mono text-xs">{c.baseUrl}</TableCell>
                       <TableCell className="font-mono text-xs text-muted-foreground">
-                        {c.apiKeyPreview}
+                        {c.apiKeyPreview || "—"}
                       </TableCell>
                       <TableCell>
-                        <Badge variant="outline" className="text-xs">
-                          {t(`dialog.categoryOptions.${c.category}`)}
-                        </Badge>
+                        {c.category ? (
+                          <Badge variant="outline" className="text-xs">
+                            {t(`dialog.categoryOptions.${c.category}`)}
+                          </Badge>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">—</span>
+                        )}
                       </TableCell>
                       <TableCell>
                         <div className="flex flex-wrap gap-1">

--- a/apps/web/src/features/connections/ConnectionsPage.tsx
+++ b/apps/web/src/features/connections/ConnectionsPage.tsx
@@ -187,7 +187,7 @@ export function ConnectionsPage() {
                     <TableRow key={c.id}>
                       <TableCell>
                         <Badge
-                          variant={c.kind === "model" ? "success" : "default"}
+                          variant={c.kind === "model" ? "outline" : "default"}
                           className="text-xs"
                         >
                           {t(`kinds.${c.kind}`)}

--- a/apps/web/src/features/connections/queries.test.tsx
+++ b/apps/web/src/features/connections/queries.test.tsx
@@ -61,6 +61,7 @@ describe("useCreateConnection", () => {
     (api.post as any).mockResolvedValue({ id: "c1", apiKey: "sk-x" });
     const { result } = renderHook(() => useCreateConnection(), { wrapper: wrap() });
     await result.current.mutateAsync({
+      kind: "model",
       name: "n",
       baseUrl: "http://x",
       apiKey: "sk-x",

--- a/apps/web/src/features/connections/queries.ts
+++ b/apps/web/src/features/connections/queries.ts
@@ -8,6 +8,8 @@ import type {
   DiscoverConnectionResponse,
   ListConnectionsResponse,
   UpdateConnection,
+  VerifyKindRequest,
+  VerifyKindResponse,
 } from "@modeldoctor/contracts";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -73,5 +75,12 @@ export function useDiscoverConnection() {
   return useMutation({
     mutationFn: (input: DiscoverConnectionRequest) =>
       api.post<DiscoverConnectionResponse>("/api/connections/discover", input),
+  });
+}
+
+export function useVerifyKind() {
+  return useMutation({
+    mutationFn: (input: VerifyKindRequest) =>
+      api.post<VerifyKindResponse>("/api/connections/verify-kind", input),
   });
 }

--- a/apps/web/src/features/connections/schema.test.ts
+++ b/apps/web/src/features/connections/schema.test.ts
@@ -153,3 +153,55 @@ describe("connectionInputEditSchema apiKey refine (edit-mode)", () => {
     expect(result.success).toBe(true);
   });
 });
+
+describe("connectionInputSchema kind=non-model", () => {
+  const base = {
+    name: "prom-1",
+    apiBaseUrl: "http://prom:9090",
+    customHeaders: "",
+    queryParams: "",
+    tokenizerHfId: "",
+    tags: [],
+  };
+
+  it("kind=prometheus accepts empty apiKey/model/category", () => {
+    const r = connectionInputSchema.safeParse({
+      ...base,
+      kind: "prometheus",
+      apiKey: "",
+      model: "",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("kind=alertmanager accepts empty apiKey/model/category", () => {
+    const r = connectionInputSchema.safeParse({
+      ...base,
+      kind: "alertmanager",
+      apiKey: "",
+      model: "",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("kind=gateway accepts empty apiKey/model/category", () => {
+    const r = connectionInputSchema.safeParse({
+      ...base,
+      kind: "gateway",
+      apiKey: "",
+      model: "",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("defaults kind to 'model' when omitted", () => {
+    const r = connectionInputSchema.safeParse({
+      ...base,
+      apiKey: "sk-x",
+      model: "m1",
+      category: "chat" as const,
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.kind).toBe("model");
+  });
+});

--- a/apps/web/src/features/connections/schema.ts
+++ b/apps/web/src/features/connections/schema.ts
@@ -1,19 +1,25 @@
-import { ModalityCategorySchema, serverKindSchema } from "@modeldoctor/contracts";
+import {
+  ModalityCategorySchema,
+  connectionKindSchema,
+  serverKindSchema,
+} from "@modeldoctor/contracts";
 import { z } from "zod";
 
 const baseShape = {
+  kind: connectionKindSchema.default("model"),
   name: z
     .string()
     .transform((v) => v.trim())
     .pipe(z.string().min(1)),
   apiBaseUrl: z.string().url(),
-  model: z.string().min(1),
+  // model/category/apiKey are required only for kind=model — see superRefine below.
+  model: z.string().default(""),
   customHeaders: z.string(),
   queryParams: z.string(),
   tokenizerHfId: z.string(),
   prometheusUrl: z.string().url().nullable().optional(),
   serverKind: serverKindSchema.nullable().optional(),
-  category: ModalityCategorySchema,
+  category: ModalityCategorySchema.nullable().optional(),
   tags: z
     .array(z.string().trim())
     .default([])
@@ -29,32 +35,54 @@ const baseShape = {
     }),
 };
 
+function requireForModelKind<
+  T extends { kind?: string; apiKey?: string; model?: string; category?: unknown },
+>(v: T, ctx: z.RefinementCtx, opts: { apiKeyRequired: boolean }) {
+  if (v.kind !== "model") return;
+  if (opts.apiKeyRequired && (!v.apiKey || v.apiKey.trim().length === 0)) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["apiKey"], message: "validation.required" });
+  }
+  if (!v.model || v.model.trim().length === 0) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["model"], message: "validation.required" });
+  }
+  if (!v.category) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["category"],
+      message: "validation.required",
+    });
+  }
+}
+
 /**
- * Create-mode form schema. apiKey is required because the server has nothing
- * stored yet.
+ * Create-mode form schema. apiKey is required for kind=model because the server
+ * has nothing stored yet; non-model kinds skip the apiKey/model/category gate.
  */
-export const connectionInputCreateSchema = z.object({
-  ...baseShape,
-  apiKey: z
-    .string()
-    .min(1)
-    .refine((v) => !/\p{Cc}/u.test(v), { message: "validation.apiKeyControlChar" })
-    .refine((v) => v === v.trim(), { message: "validation.apiKeyTrim" }),
-});
+export const connectionInputCreateSchema = z
+  .object({
+    ...baseShape,
+    apiKey: z
+      .string()
+      .default("")
+      .refine((v) => !/\p{Cc}/u.test(v), { message: "validation.apiKeyControlChar" })
+      .refine((v) => v === v.trim(), { message: "validation.apiKeyTrim" }),
+  })
+  .superRefine((v, ctx) => requireForModelKind(v, ctx, { apiKeyRequired: true }));
 
 /**
  * Edit-mode form schema. apiKey is optional: when the user did NOT toggle
  * "Reset apiKey", the field is empty and the PATCH body must omit it.
- * Empty string is the "no-reset" signal and must pass; non-empty values
- * get the same control-char + edge-whitespace refines as create-mode.
  */
-export const connectionInputEditSchema = z.object({
-  ...baseShape,
-  apiKey: z
-    .string()
-    .refine((v) => v === "" || !/\p{Cc}/u.test(v), { message: "validation.apiKeyControlChar" })
-    .refine((v) => v === "" || v === v.trim(), { message: "validation.apiKeyTrim" }),
-});
+export const connectionInputEditSchema = z
+  .object({
+    ...baseShape,
+    apiKey: z
+      .string()
+      .default("")
+      .refine((v) => v === "" || !/\p{Cc}/u.test(v), { message: "validation.apiKeyControlChar" })
+      .refine((v) => v === "" || v === v.trim(), { message: "validation.apiKeyTrim" }),
+  })
+  .superRefine((v, ctx) => requireForModelKind(v, ctx, { apiKeyRequired: false }));
 
 /** Backwards-compatible alias used by callers that need the create shape. */
 export const connectionInputSchema = connectionInputCreateSchema;

--- a/apps/web/src/features/diagnostics/DiagnosticsPage.test.tsx
+++ b/apps/web/src/features/diagnostics/DiagnosticsPage.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@/lib/api-client", () => {
 const SAMPLE_CONN: ConnectionPublic = {
   id: "c1",
   userId: "u1",
+  kind: "model",
   name: "smoke-1",
   baseUrl: "http://host",
   apiKeyPreview: "sk-...test",
@@ -48,6 +49,7 @@ vi.mock("@/features/connections/queries", () => ({
   useCreateConnection: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useUpdateConnection: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useDiscoverConnection: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useVerifyKind: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useDeleteConnection: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 

--- a/apps/web/src/features/playground/CategoryEndpointSelector.test.tsx
+++ b/apps/web/src/features/playground/CategoryEndpointSelector.test.tsx
@@ -8,6 +8,7 @@ const list: ConnectionPublic[] = [
   {
     id: "c-chat",
     userId: "u1",
+    kind: "model",
     name: "chat-A",
     baseUrl: "http://a",
     apiKeyPreview: "sk-...1234",
@@ -27,6 +28,7 @@ const list: ConnectionPublic[] = [
   {
     id: "c-embed",
     userId: "u1",
+    kind: "model",
     name: "embed-B",
     baseUrl: "http://b",
     apiKeyPreview: "sk-...5678",
@@ -47,6 +49,7 @@ const list: ConnectionPublic[] = [
 
 vi.mock("@/features/connections/queries", () => ({
   useConnections: () => ({ data: list, isLoading: false, error: null }),
+  useVerifyKind: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 import { CategoryEndpointSelector } from "./CategoryEndpointSelector";

--- a/apps/web/src/features/playground/audio/AudioPage.test.tsx
+++ b/apps/web/src/features/playground/audio/AudioPage.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/features/connections/queries", () => ({
   useConnections: () => ({ data: [], isLoading: false, error: null }),
+  useVerifyKind: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useConnection: () => ({ data: null, isLoading: false, error: null }),
 }));
 

--- a/apps/web/src/features/playground/chat-compare/ChatComparePage.test.tsx
+++ b/apps/web/src/features/playground/chat-compare/ChatComparePage.test.tsx
@@ -13,6 +13,7 @@ vi.mock("@/lib/playground-stream", () => ({
 const CONN_A: ConnectionPublic = {
   id: "ca",
   userId: "u1",
+  kind: "model",
   name: "A",
   baseUrl: "http://a",
   apiKeyPreview: "sk-...1234",
@@ -33,6 +34,7 @@ const CONN_B: ConnectionPublic = { ...CONN_A, id: "cb", name: "B", baseUrl: "htt
 
 vi.mock("@/features/connections/queries", () => ({
   useConnections: () => ({ data: [CONN_A, CONN_B], isLoading: false, error: null }),
+  useVerifyKind: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useConnection: (id: string | null | undefined) => ({
     data: id === "ca" ? CONN_A : id === "cb" ? CONN_B : null,
     isLoading: false,

--- a/apps/web/src/features/playground/chat-compare/ChatPanel.test.tsx
+++ b/apps/web/src/features/playground/chat-compare/ChatPanel.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/features/connections/queries", () => ({
   useConnections: () => ({ data: [], isLoading: false, error: null }),
+  useVerifyKind: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useConnection: () => ({ data: null, isLoading: false, error: null }),
 }));
 

--- a/apps/web/src/features/playground/chat-compare/CompareHistory.test.tsx
+++ b/apps/web/src/features/playground/chat-compare/CompareHistory.test.tsx
@@ -19,6 +19,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/features/connections/queries", () => ({
   useConnections: () => ({ data: [], isLoading: false, error: null }),
+  useVerifyKind: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useConnection: () => ({ data: null, isLoading: false, error: null }),
 }));
 

--- a/apps/web/src/features/playground/chat/ChatPage.test.tsx
+++ b/apps/web/src/features/playground/chat/ChatPage.test.tsx
@@ -22,6 +22,7 @@ vi.mock("@/lib/api-client", () => {
 const SAMPLE_CONN: ConnectionPublic = {
   id: "c1",
   userId: "u1",
+  kind: "model",
   name: "chat-1",
   baseUrl: "http://x",
   apiKeyPreview: "sk-...1234",
@@ -41,6 +42,7 @@ const SAMPLE_CONN: ConnectionPublic = {
 
 vi.mock("@/features/connections/queries", () => ({
   useConnections: () => ({ data: [SAMPLE_CONN], isLoading: false, error: null }),
+  useVerifyKind: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useConnection: (id: string | null | undefined) => ({
     data: id === "c1" ? SAMPLE_CONN : null,
     isLoading: false,

--- a/apps/web/src/features/playground/embeddings/EmbeddingsPage.test.tsx
+++ b/apps/web/src/features/playground/embeddings/EmbeddingsPage.test.tsx
@@ -19,6 +19,7 @@ vi.mock("echarts-for-react", () => ({
 const SAMPLE_CONN: ConnectionPublic = {
   id: "c1",
   userId: "u1",
+  kind: "model",
   name: "emb-1",
   baseUrl: "http://x",
   apiKeyPreview: "sk-...1234",
@@ -38,6 +39,7 @@ const SAMPLE_CONN: ConnectionPublic = {
 
 vi.mock("@/features/connections/queries", () => ({
   useConnections: () => ({ data: [SAMPLE_CONN], isLoading: false, error: null }),
+  useVerifyKind: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useConnection: (id: string | null | undefined) => ({
     data: id === "c1" ? SAMPLE_CONN : null,
     isLoading: false,

--- a/apps/web/src/features/playground/image/ImagePage.test.tsx
+++ b/apps/web/src/features/playground/image/ImagePage.test.tsx
@@ -13,6 +13,7 @@ vi.mock("@/lib/api-client", () => {
 const SAMPLE_CONN: ConnectionPublic = {
   id: "c1",
   userId: "u1",
+  kind: "model",
   name: "img-1",
   baseUrl: "http://x",
   apiKeyPreview: "sk-...1234",
@@ -32,6 +33,7 @@ const SAMPLE_CONN: ConnectionPublic = {
 
 vi.mock("@/features/connections/queries", () => ({
   useConnections: () => ({ data: [SAMPLE_CONN], isLoading: false, error: null }),
+  useVerifyKind: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useConnection: (id: string | null | undefined) => ({
     data: id === "c1" ? SAMPLE_CONN : null,
     isLoading: false,

--- a/apps/web/src/features/playground/rerank/RerankPage.test.tsx
+++ b/apps/web/src/features/playground/rerank/RerankPage.test.tsx
@@ -13,6 +13,7 @@ vi.mock("@/lib/api-client", () => {
 const SAMPLE_CONN: ConnectionPublic = {
   id: "c1",
   userId: "u1",
+  kind: "model",
   name: "rk-1",
   baseUrl: "http://x",
   apiKeyPreview: "sk-...1234",
@@ -32,6 +33,7 @@ const SAMPLE_CONN: ConnectionPublic = {
 
 vi.mock("@/features/connections/queries", () => ({
   useConnections: () => ({ data: [SAMPLE_CONN], isLoading: false, error: null }),
+  useVerifyKind: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useConnection: (id: string | null | undefined) => ({
     data: id === "c1" ? SAMPLE_CONN : null,
     isLoading: false,

--- a/apps/web/src/features/quality-gate/__tests__/RunCreatePage.test.tsx
+++ b/apps/web/src/features/quality-gate/__tests__/RunCreatePage.test.tsx
@@ -27,6 +27,7 @@ vi.mock("@/features/connections/queries", () => ({
   useDeleteConnection: () => ({ mutateAsync: vi.fn() }),
   useRevealApiKey: () => ({ mutateAsync: vi.fn() }),
   useDiscoverConnection: () => ({ mutateAsync: vi.fn() }),
+  useVerifyKind: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 beforeAll(async () => {

--- a/apps/web/src/features/quality-gate/__tests__/RunsListPage.test.tsx
+++ b/apps/web/src/features/quality-gate/__tests__/RunsListPage.test.tsx
@@ -62,6 +62,7 @@ vi.mock("@/features/connections/queries", () => ({
   useConnections: () => ({
     data: [{ id: "c1", name: "Local", model: "qwen2.5-7b", baseUrl: "http://x" }],
   }),
+  useVerifyKind: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 beforeAll(async () => {

--- a/apps/web/src/locales/en-US/connections.json
+++ b/apps/web/src/locales/en-US/connections.json
@@ -10,7 +10,14 @@
     "createdAt": "Created",
     "actions": "Actions",
     "category": "Category",
-    "tags": "Tags"
+    "tags": "Tags",
+    "kind": "Kind"
+  },
+  "kinds": {
+    "model": "Model",
+    "gateway": "Gateway",
+    "prometheus": "Prometheus",
+    "alertmanager": "Alertmanager"
   },
   "dialog": {
     "createTitle": "New connection",
@@ -22,6 +29,8 @@
     "saveAsNewConnection": "Save as new connection",
     "savedConnectionMissing": "Saved connection no longer exists",
     "fields": {
+      "kind": "Kind",
+      "kindHelp": "model = inference endpoint; gateway = LLM gateway (e.g. Higress); prometheus / alertmanager = monitoring & alerting components.",
       "name": "Name",
       "namePlaceholder": "e.g. prod-vllm",
       "apiBaseUrl": "API Base URL",
@@ -71,6 +80,16 @@
       "empty": "Paste a curl command first",
       "invalid": "Could not extract parameters from curl command",
       "autoParseHint": "Auto-parses and triggers Discover after paste"
+    },
+    "verify": {
+      "button": "Verify kind",
+      "running": "Verifying…",
+      "ok": "Verified: {{summary}}",
+      "fail": "Verification failed: {{reason}}",
+      "missingBaseUrl": "Please enter baseUrl first",
+      "version": "version {{version}}",
+      "modelCount": "{{count}} models",
+      "clusterPeers": "{{count}} cluster peers"
     },
     "discover": {
       "button": "🔍 Discover",
@@ -129,6 +148,7 @@
   "filters": {
     "label": "Filter",
     "allCategories": "All categories",
-    "allTags": "All tags"
+    "allTags": "All tags",
+    "allKinds": "All kinds"
   }
 }

--- a/apps/web/src/locales/zh-CN/connections.json
+++ b/apps/web/src/locales/zh-CN/connections.json
@@ -10,7 +10,14 @@
     "createdAt": "创建时间",
     "actions": "操作",
     "category": "分类",
-    "tags": "标签"
+    "tags": "标签",
+    "kind": "类型"
+  },
+  "kinds": {
+    "model": "模型",
+    "gateway": "网关",
+    "prometheus": "Prometheus",
+    "alertmanager": "Alertmanager"
   },
   "dialog": {
     "createTitle": "新建连接",
@@ -22,6 +29,8 @@
     "saveAsNewConnection": "另存为新连接",
     "savedConnectionMissing": "保存的连接已被删除，请选择其他连接",
     "fields": {
+      "kind": "类型",
+      "kindHelp": "model = 推理端点；gateway = LLM 网关（如 Higress）；prometheus / alertmanager = 监控告警组件。",
       "name": "名称",
       "namePlaceholder": "例如 prod-vllm",
       "apiBaseUrl": "API Base URL",
@@ -71,6 +80,16 @@
       "empty": "请先粘贴 curl 命令",
       "invalid": "无法从 curl 命令中解析参数",
       "autoParseHint": "粘贴后自动解析并触发 Discover"
+    },
+    "verify": {
+      "button": "校验类型",
+      "running": "校验中…",
+      "ok": "校验通过：{{summary}}",
+      "fail": "校验失败：{{reason}}",
+      "missingBaseUrl": "请先填写 baseUrl",
+      "version": "版本 {{version}}",
+      "modelCount": "{{count}} 个模型",
+      "clusterPeers": "{{count}} 个集群节点"
     },
     "discover": {
       "button": "🔍 自动发现",
@@ -129,6 +148,7 @@
   "filters": {
     "label": "筛选",
     "allCategories": "全部分类",
-    "allTags": "全部标签"
+    "allTags": "全部标签",
+    "allKinds": "全部类型"
   }
 }

--- a/packages/contracts/src/connection.spec.ts
+++ b/packages/contracts/src/connection.spec.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  connectionKindSchema,
   createConnectionSchema,
   discoverConnectionRequestSchema,
   discoverConnectionResponseSchema,
   inferenceConfidenceSchema,
   serverKindSchema,
+  updateConnectionSchema,
+  verifyKindRequestSchema,
 } from "./connection.js";
 import { ENGINE_IDS } from "./engine.js";
 
@@ -134,6 +137,94 @@ describe("inferenceConfidenceSchema", () => {
 
   it("rejects unknown value", () => {
     expect(() => inferenceConfidenceSchema.parse("maybe")).toThrow();
+  });
+});
+
+describe("connectionKindSchema", () => {
+  it.each(["model", "gateway", "prometheus", "alertmanager"] as const)("accepts %s", (v) => {
+    expect(connectionKindSchema.parse(v)).toBe(v);
+  });
+
+  it("rejects unknown kind", () => {
+    expect(() => connectionKindSchema.parse("database")).toThrow();
+  });
+});
+
+describe("createConnectionSchema — kind=non-model relaxes required fields", () => {
+  const nonModelBase = {
+    name: "prom-1",
+    baseUrl: "http://prom:9090",
+    customHeaders: "",
+    queryParams: "",
+    tags: [],
+  };
+
+  it("kind=prometheus accepts omitted apiKey/model/category", () => {
+    const r = createConnectionSchema.safeParse({ ...nonModelBase, kind: "prometheus" });
+    expect(r.success).toBe(true);
+  });
+
+  it("kind=alertmanager accepts omitted apiKey/model/category", () => {
+    const r = createConnectionSchema.safeParse({ ...nonModelBase, kind: "alertmanager" });
+    expect(r.success).toBe(true);
+  });
+
+  it("kind=gateway accepts omitted apiKey/model/category", () => {
+    // gateway is auth-optional (apiKey may live in upstream model, not gateway).
+    const r = createConnectionSchema.safeParse({ ...nonModelBase, kind: "gateway" });
+    expect(r.success).toBe(true);
+  });
+
+  it("kind defaults to 'model' when omitted, still requiring full v1 contract", () => {
+    const r = createConnectionSchema.safeParse(nonModelBase);
+    expect(r.success).toBe(false); // missing apiKey/model/category for kind=model
+  });
+
+  it("kind=model still requires apiKey/model/category", () => {
+    const r = createConnectionSchema.safeParse({ ...nonModelBase, kind: "model" });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("updateConnectionSchema — partial PATCH semantics", () => {
+  it("accepts a single-field PATCH without kind", () => {
+    // This is exactly the shape the gemini security comment flagged: a
+    // partial PATCH without kind passes the contract layer; the service
+    // layer is responsible for re-enforcing kind-specific invariants.
+    const r = updateConnectionSchema.safeParse({ model: "" });
+    expect(r.success).toBe(true);
+  });
+
+  it("when kind=model is explicit in the PATCH, refine fires (empty apiKey rejected)", () => {
+    const r = updateConnectionSchema.safeParse({ kind: "model", apiKey: "" });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("verifyKindRequestSchema", () => {
+  it("accepts kind + baseUrl alone", () => {
+    const r = verifyKindRequestSchema.parse({
+      kind: "prometheus",
+      baseUrl: "http://prom:9090",
+    });
+    expect(r.kind).toBe("prometheus");
+  });
+
+  it("accepts optional apiKey + customHeaders", () => {
+    const r = verifyKindRequestSchema.parse({
+      kind: "gateway",
+      baseUrl: "http://higress",
+      apiKey: "sk-x",
+      customHeaders: "X-Project: p1",
+    });
+    expect(r.apiKey).toBe("sk-x");
+    expect(r.customHeaders).toBe("X-Project: p1");
+  });
+
+  it("rejects empty apiKey when supplied", () => {
+    expect(() =>
+      verifyKindRequestSchema.parse({ kind: "gateway", baseUrl: "http://x", apiKey: "" }),
+    ).toThrow();
   });
 });
 

--- a/packages/contracts/src/connection.ts
+++ b/packages/contracts/src/connection.ts
@@ -5,17 +5,41 @@ import { ModalityCategorySchema } from "./modality.js";
 export const serverKindSchema = z.enum([...ENGINE_IDS, "higress", "generic"] as const);
 export type ServerKind = z.infer<typeof serverKindSchema>;
 
+/**
+ * A Connection's `kind` records what kind of LLM-stack component it points at.
+ *
+ * - `model`       — model-serving endpoint (the original v1 meaning). Required:
+ *                   model, apiKey, category.
+ * - `gateway`     — LLM gateway in front of one or more model servers
+ *                   (e.g. Higress). apiKey/model/category remain meaningful
+ *                   when routing through the gateway. `serverKind=higress`
+ *                   is the canonical first instance.
+ * - `prometheus`  — Prometheus instance scraping engine/gateway metrics.
+ *                   apiKey/model/category are not used; baseUrl is the
+ *                   Prometheus API root.
+ * - `alertmanager` — Alertmanager instance routing alerts to ModelDoctor's
+ *                    webhook. apiKey/model/category are not used.
+ */
+export const connectionKindSchema = z.enum([
+  "model",
+  "gateway",
+  "prometheus",
+  "alertmanager",
+]);
+export type ConnectionKind = z.infer<typeof connectionKindSchema>;
+
 /** What clients see on list / detail. No plaintext apiKey, only preview. */
 export const connectionPublicSchema = z.object({
   id: z.string(),
   userId: z.string(),
+  kind: connectionKindSchema,
   name: z.string().min(1).max(120),
   baseUrl: z.string().url(),
   apiKeyPreview: z.string(),
-  model: z.string().min(1),
+  model: z.string(),
   customHeaders: z.string(),
   queryParams: z.string(),
-  category: ModalityCategorySchema,
+  category: ModalityCategorySchema.nullable(),
   tags: z.array(z.string()),
   prometheusUrl: z.string().url().nullable(),
   serverKind: serverKindSchema.nullable(),
@@ -40,31 +64,76 @@ export const connectionWithSecretSchema = connectionPublicSchema.extend({
 });
 export type ConnectionWithSecret = z.infer<typeof connectionWithSecretSchema>;
 
-export const createConnectionSchema = z.object({
+// apiKey shape validation lives here so create + update share it. Required-ness
+// is enforced separately via .superRefine() because non-model kinds skip it.
+const apiKeyStringSchema = z
+  .string()
+  .refine((v) => !/\p{Cc}/u.test(v), {
+    message: "apiKey must not contain control characters",
+  })
+  .refine((v) => v === v.trim(), {
+    message: "apiKey must not have leading or trailing whitespace",
+  });
+
+const createConnectionShape = z.object({
+  kind: connectionKindSchema.default("model"),
   name: z.string().min(1).max(120),
   baseUrl: z.string().url(),
-  apiKey: z
-    .string()
-    .min(1)
-    .refine((v) => !/\p{Cc}/u.test(v), {
-      message: "apiKey must not contain control characters",
-    })
-    .refine((v) => v === v.trim(), {
-      message: "apiKey must not have leading or trailing whitespace",
-    }),
-  model: z.string().min(1),
+  // Optional at the schema level so non-model kinds can omit. Required-ness for
+  // kind=model is enforced via superRefine below.
+  apiKey: apiKeyStringSchema.optional(),
+  model: z.string().optional(),
   customHeaders: z.string().default(""),
   queryParams: z.string().default(""),
-  category: ModalityCategorySchema,
+  category: ModalityCategorySchema.nullable().optional(),
   tags: z.array(z.string()).default([]),
   prometheusUrl: z.string().url().nullable().optional(),
   serverKind: serverKindSchema.nullable().optional(),
   tokenizerHfId: z.string().nullable().optional(),
   evaluationProfileId: z.string().nullable().optional(),
 });
+
+// kind=model retains the v1 contract: apiKey/model/category are required.
+// kind=gateway/prometheus/alertmanager have looser shape since the entity
+// being pointed at is not a model-serving endpoint.
+function refineKindFields(
+  v: z.infer<typeof createConnectionShape>,
+  ctx: z.RefinementCtx,
+) {
+  if (v.kind === "model") {
+    if (!v.apiKey || v.apiKey.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["apiKey"],
+        message: "apiKey is required for kind=model",
+      });
+    }
+    if (!v.model || v.model.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["model"],
+        message: "model is required for kind=model",
+      });
+    }
+    if (!v.category) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["category"],
+        message: "category is required for kind=model",
+      });
+    }
+  }
+}
+
+export const createConnectionSchema = createConnectionShape.superRefine(refineKindFields);
 export type CreateConnection = z.infer<typeof createConnectionSchema>;
 
-export const updateConnectionSchema = createConnectionSchema.partial();
+// Update accepts a partial create shape; the same refine still applies when
+// `kind` is being changed (or implicitly model when omitted on partial — but
+// partial means kind may be absent; refine only fires when kind is supplied).
+export const updateConnectionSchema = createConnectionShape.partial().superRefine((v, ctx) => {
+  if (v.kind === "model") refineKindFields(v as z.infer<typeof createConnectionShape>, ctx);
+});
 export type UpdateConnection = z.infer<typeof updateConnectionSchema>;
 
 export const listConnectionsResponseSchema = z.object({
@@ -93,6 +162,23 @@ const inferredListFieldSchema = z.object({
   confidence: inferenceConfidenceSchema,
   evidence: z.string(),
 });
+
+export const verifyKindRequestSchema = z.object({
+  kind: connectionKindSchema,
+  baseUrl: z.string().url(),
+  apiKey: z.string().min(1).optional(),
+  customHeaders: z.string().optional(),
+});
+export type VerifyKindRequest = z.infer<typeof verifyKindRequestSchema>;
+
+export const verifyKindResponseSchema = z.object({
+  kind: connectionKindSchema,
+  ok: z.boolean(),
+  version: z.string().optional(),
+  details: z.record(z.unknown()).optional(),
+  reason: z.string().optional(),
+});
+export type VerifyKindResponse = z.infer<typeof verifyKindResponseSchema>;
 
 export const discoverConnectionRequestSchema = z.object({
   baseUrl: z.string().url(),

--- a/packages/contracts/src/connection.ts
+++ b/packages/contracts/src/connection.ts
@@ -20,12 +20,7 @@ export type ServerKind = z.infer<typeof serverKindSchema>;
  * - `alertmanager` — Alertmanager instance routing alerts to ModelDoctor's
  *                    webhook. apiKey/model/category are not used.
  */
-export const connectionKindSchema = z.enum([
-  "model",
-  "gateway",
-  "prometheus",
-  "alertmanager",
-]);
+export const connectionKindSchema = z.enum(["model", "gateway", "prometheus", "alertmanager"]);
 export type ConnectionKind = z.infer<typeof connectionKindSchema>;
 
 /** What clients see on list / detail. No plaintext apiKey, only preview. */
@@ -96,10 +91,7 @@ const createConnectionShape = z.object({
 // kind=model retains the v1 contract: apiKey/model/category are required.
 // kind=gateway/prometheus/alertmanager have looser shape since the entity
 // being pointed at is not a model-serving endpoint.
-function refineKindFields(
-  v: z.infer<typeof createConnectionShape>,
-  ctx: z.RefinementCtx,
-) {
+function refineKindFields(v: z.infer<typeof createConnectionShape>, ctx: z.RefinementCtx) {
   if (v.kind === "model") {
     if (!v.apiKey || v.apiKey.length === 0) {
       ctx.addIssue({


### PR DESCRIPTION
## Summary

Extends `Connection` from "model endpoint only" to the four kinds the V1 alert loop needs:

- **model** — inference endpoint (unchanged v1 contract).
- **gateway** — LLM gateway (e.g. Higress) in front of model servers. Still carries apiKey/model/category.
- **prometheus** — Prometheus instance scraping engine/gateway metrics. No apiKey/model/category.
- **alertmanager** — Alertmanager instance routing alerts to ModelDoctor's webhook. No apiKey/model/category.

This unblocks per-connection alert routing (PR #191) so subscribers can be defined against the Alertmanager / Prometheus connection that fired the alert, instead of needing a model row as a stand-in.

## Pieces

- **contracts** — `connectionKindSchema` enum, `verifyKindRequest/Response`, kind-conditional `.superRefine()` for create/update.
- **api** — `Connection.kind` migration (NOT NULL, default `"model"`), service tolerates empty apiKey cipher + empty model + null category for non-model kinds, `POST /api/connections/verify-kind` for shallow probes (Higress `/v1/models`, Prometheus `/api/v1/status/buildinfo`, Alertmanager `/api/v2/status`).
- **web** — kind dropdown + conditional fields in `ConnectionSheet`, kind column + filter + Badge on `ConnectionsPage`, kind-aware payload normalization on submit. Benchmark forms guard against `category === null` so non-model rows surface as unsupported there.

## Test plan

- [x] api unit: 649 tests pass (incl. updated service/controller spec fixtures).
- [x] api e2e: 84 tests pass (11 new in `connection-kind.e2e-spec.ts` covering kind=model validation, kind=prometheus/alertmanager/gateway creation, and the four verify-kind branches with mocked fetches).
- [x] web unit: 800 tests pass (incl. updated `kind: "model"` defaults across mocks).
- [x] contracts + tool-adapters: 132 + 209 tests pass.
- [x] Workspace `pnpm -r type-check` clean.
- [x] Workspace `pnpm -F @modeldoctor/web lint` clean.
- [ ] Manual browser smoke — not run from CLI; reviewer to verify kind dropdown + conditional fields + verify-kind toast against a local Prometheus + Alertmanager.

Refs #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)