### PR TITLE
docs(env): document ALERTMANAGER_WEBHOOK_SECRET in .env.example

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -66,12 +66,22 @@ RUNNER_IMAGE_AIPERF=<replace via ./tools/build-runner-images.sh>
 # Default --max-seconds applied to runs when not otherwise capped.
 BENCHMARK_DEFAULT_MAX_DURATION_SECONDS=1800
 
+# --- Alertmanager webhook receiver (P0 closed loop) ------------------------
+# Shared secret for the Alertmanager → ModelDoctor webhook
+# (POST /api/alerts/webhook). REQUIRED whenever NODE_ENV != "test" — the
+# api refuses to boot without it. Configure your Alertmanager receiver to
+# send `Authorization: Bearer <this value>` so the webhook handler can
+# authenticate the push. Must be >= 32 chars.
+# Generate with: openssl rand -base64 48
+ALERTMANAGER_WEBHOOK_SECRET=<replace with: openssl rand -base64 48>
+
 # --- MCP server (V1) -------------------------------------------------------
 # When BOTH variables are set, /mcp is enabled and accepts requests carrying
 # `Authorization: Bearer <MCP_BEARER_TOKEN>`. Leave BOTH unset to disable MCP
-# entirely (route returns 503). The 4 tools (discover_connection,
-# list_connections, list_benchmarks, run_diagnostics) all operate as
-# MCP_USER_ID.
+# entirely (route returns 503). The tools registered today are documented
+# in apps/api/src/modules/mcp/README.md (12 as of #194: connection /
+# benchmark / diagnostics + notification channels + alert loop). All
+# operate as MCP_USER_ID.
 #
 # WARNING: this is a fixed long-lived secret, NOT a rotating JWT. Only safe
 # when the api binds to localhost / private network.


### PR DESCRIPTION
## Summary

PR #191 made \`ALERTMANAGER_WEBHOOK_SECRET\` required for non-test environments (\`env.schema.superRefine\`) but never updated \`.env.example\`, so anyone running \`pnpm dev\` after a fresh clone / fresh \`cp .env.example .env\` hits a boot failure:

\`\`\`
ERROR [ExceptionHandler] Error: Invalid environment:
  - ALERTMANAGER_WEBHOOK_SECRET: ALERTMANAGER_WEBHOOK_SECRET is required when NODE_ENV is not 'test'
\`\`\`

This is a doc-only fix:

- Add \`ALERTMANAGER_WEBHOOK_SECRET\` with the same \`<replace with: openssl rand -base64 48>\` placeholder pattern used by \`JWT_ACCESS_SECRET\` / \`BENCHMARK_CALLBACK_SECRET\`, plus a one-paragraph note explaining the bearer-token contract Alertmanager needs.
- Refresh the stale MCP comment block — it was pinned at "4 tools" from #173, but #191 / #194 bumped the registered count to 12. Point readers at \`apps/api/src/modules/mcp/README.md\` instead of trying to inline the list (the README itself is now authoritative).

## Test plan

- [x] \`pnpm dev\` from a freshly-copied \`.env\` (with the new line filled in) boots cleanly.
- [x] Tested locally — error gone after appending the new line to my own \`.env\`.

No code paths touched; no test changes warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)