### PR TITLE
style(sidebar): bolder UserPanel — pink avatar + chevron hint

### DIFF
--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -160,14 +160,14 @@ function UserPanel({ railCollapsed }: { railCollapsed: boolean }) {
         className={cn(
           "flex w-full items-center rounded-md text-sm",
           "text-foreground hover:bg-accent/50",
-          railCollapsed ? "justify-center px-0 py-2" : "gap-2 px-2 py-1.5",
+          railCollapsed ? "justify-center px-0 py-2" : "gap-2 px-3 py-1.5",
         )}
         aria-label={label}
       >
         {avatar}
         {railCollapsed ? null : (
           <>
-            <span className="min-w-0 flex-1 truncate text-left text-sm font-medium">{label}</span>
+            <span className="min-w-0 flex-1 truncate text-left font-medium">{label}</span>
             <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" strokeWidth={2} />
           </>
         )}

--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -144,7 +144,7 @@ function UserPanel({ railCollapsed }: { railCollapsed: boolean }) {
   const label = user.displayName?.trim() || user.email;
 
   const avatar = (
-    <div className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted text-[10px] font-semibold text-muted-foreground">
+    <div className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full bg-pink-500 text-xs font-bold text-white">
       {user.avatarUrl ? (
         <img src={user.avatarUrl} alt="" className="h-full w-full object-cover" />
       ) : (
@@ -159,14 +159,17 @@ function UserPanel({ railCollapsed }: { railCollapsed: boolean }) {
         type="button"
         className={cn(
           "flex w-full items-center rounded-md text-sm",
-          "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-          railCollapsed ? "justify-center px-0 py-2" : "gap-2 px-3 py-1.5",
+          "text-foreground hover:bg-accent/50",
+          railCollapsed ? "justify-center px-0 py-2" : "gap-2 px-2 py-1.5",
         )}
         aria-label={label}
       >
         {avatar}
         {railCollapsed ? null : (
-          <span className="min-w-0 flex-1 truncate text-left text-xs">{label}</span>
+          <>
+            <span className="min-w-0 flex-1 truncate text-left text-sm font-medium">{label}</span>
+            <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" strokeWidth={2} />
+          </>
         )}
       </button>
     </DropdownMenuTrigger>


### PR DESCRIPTION
## Summary

Tracking a user feedback: the bottom-of-rail user widget was too quiet — `h-7` muted-gray circle with `text-[10px]` muted initials and `text-xs` muted label made the only entry point to the user center (`/me` + its notifications sub-page) easy to miss.

Restyle, **position unchanged**:

- Avatar `h-7 → h-8`, `bg-muted → bg-pink-500`, `text-[10px] muted-foreground → text-xs font-bold text-white`.
- Label `text-xs muted → text-sm font-medium text-foreground`.
- Add `ChevronDown` after the label to hint the dropdown affordance.
- Trigger hover state simplified to foreground-on-accent.

Avatar-image case unchanged — only the initials fallback gets the new bg.

Reference (before / after expected):

| Before | After (reference) |
|---|---|
| Muted gray pill, tiny label | Pink pill with bold white initials + bigger label + chevron, like the screenshot the user shared |

## Test plan

- [x] \`pnpm -F @modeldoctor/web type-check\` clean.
- [x] \`pnpm -F @modeldoctor/web test\` 800 passing.
- [x] Workspace \`pnpm -r lint\` clean.
- [ ] Visual verify in browser — not run from CLI; reviewer pulls the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)