### PR TITLE
test: critical coverage — verifyPrometheus + DatasourcesPage mutations (audit A1 + B1)

### DIFF
--- a/apps/api/src/modules/connection/discovery/verify-kind.spec.ts
+++ b/apps/api/src/modules/connection/discovery/verify-kind.spec.ts
@@ -21,12 +21,12 @@ function promResponse(
   init: { status?: number; contentType?: string } = {},
 ): Response {
   const text = typeof body === "string" ? body : JSON.stringify(body);
+  // Intentionally do NOT set content-length manually — string.length is the
+  // char count, not the byte count, and would lie under multi-byte UTF-8.
+  // The Response constructor computes the correct byte length itself.
   return new Response(text, {
     status: init.status ?? 200,
-    headers: {
-      "content-type": init.contentType ?? "application/json",
-      "content-length": String(text.length),
-    },
+    headers: { "content-type": init.contentType ?? "application/json" },
   });
 }
 

--- a/apps/api/src/modules/connection/discovery/verify-kind.spec.ts
+++ b/apps/api/src/modules/connection/discovery/verify-kind.spec.ts
@@ -1,0 +1,112 @@
+// Mock the SSRF guard so unit tests don't try to actually resolve the
+// placeholder hostnames we pass in. The probe code calls `safeFetch` →
+// `assertSafeUrl` → DNS, which would fail on `prom.example.test`.
+import { vi } from "vitest";
+vi.mock("./ssrf-guard.js", () => ({
+  assertSafeUrl: vi.fn(async (url: string) => ({
+    safeUrl: new URL(url),
+    resolvedIp: "10.0.0.1",
+  })),
+  PRIVATE_HOSTS: new Set<string>(),
+}));
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { verifyPrometheus } from "./verify-kind.js";
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+function promResponse(
+  body: unknown,
+  init: { status?: number; contentType?: string } = {},
+): Response {
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  return new Response(text, {
+    status: init.status ?? 200,
+    headers: {
+      "content-type": init.contentType ?? "application/json",
+      "content-length": String(text.length),
+    },
+  });
+}
+
+describe("verifyPrometheus", () => {
+  beforeEach(() => fetchMock.mockReset());
+
+  it("ok with version + revision when buildinfo is well-formed", async () => {
+    fetchMock.mockResolvedValueOnce(
+      promResponse({
+        status: "success",
+        data: { version: "2.51.0", revision: "abc123", branch: "HEAD" },
+      }),
+    );
+    const r = await verifyPrometheus("https://prom.example.test", { method: "GET" });
+    expect(r.ok).toBe(true);
+    expect(r.version).toBe("2.51.0");
+    expect(r.details).toEqual({ revision: "abc123" });
+    expect(r.reason).toBeUndefined();
+    // Hits the documented buildinfo path, not /api/v1/query or anything else.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe("https://prom.example.test/api/v1/status/buildinfo");
+  });
+
+  it("ok without details when buildinfo has version but no revision", async () => {
+    fetchMock.mockResolvedValueOnce(
+      promResponse({ status: "success", data: { version: "3.0.0" } }),
+    );
+    const r = await verifyPrometheus("https://prom.example.test", { method: "GET" });
+    expect(r.ok).toBe(true);
+    expect(r.version).toBe("3.0.0");
+    expect(r.details).toBeUndefined();
+  });
+
+  it("ok=false with HTTP status surfaced when upstream returns non-2xx", async () => {
+    fetchMock.mockResolvedValueOnce(
+      promResponse("forbidden", { status: 401, contentType: "text/plain" }),
+    );
+    const r = await verifyPrometheus("https://prom.example.test", { method: "GET" });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/HTTP 401/);
+    expect(r.reason).toMatch(/\/api\/v1\/status\/buildinfo/);
+    expect(r.version).toBeUndefined();
+  });
+
+  it("ok=false when status field is not 'success' (Prometheus error envelope)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      promResponse({ status: "error", errorType: "internal", error: "broken" }),
+    );
+    const r = await verifyPrometheus("https://prom.example.test", { method: "GET" });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/Prometheus shape/);
+  });
+
+  it("ok=false when data.version is missing (looks-like-prom but isn't)", async () => {
+    fetchMock.mockResolvedValueOnce(promResponse({ status: "success", data: { revision: "xyz" } }));
+    const r = await verifyPrometheus("https://prom.example.test", { method: "GET" });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/Prometheus shape/);
+  });
+
+  it("ok=false when body is not JSON (treated as missing shape)", async () => {
+    // res.json() throws → the inline `.catch(() => null)` makes body null and
+    // the shape check fires.
+    fetchMock.mockResolvedValueOnce(
+      promResponse("<html>nginx default page</html>", { contentType: "text/html" }),
+    );
+    const r = await verifyPrometheus("https://prom.example.test", { method: "GET" });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/Prometheus shape/);
+  });
+
+  it("trailing slash on baseUrl is NOT stripped by verifyPrometheus itself", async () => {
+    // The controller in prometheus-datasource.controller.ts trims trailing
+    // slashes before calling verifyPrometheus. We assert verifyPrometheus
+    // does NOT do it again — that responsibility lives at the controller
+    // boundary so probe internals can stay focused.
+    fetchMock.mockResolvedValueOnce(
+      promResponse({ status: "success", data: { version: "2.51.0" } }),
+    );
+    await verifyPrometheus("https://prom.example.test/", { method: "GET" });
+    expect(fetchMock.mock.calls[0][0]).toBe("https://prom.example.test//api/v1/status/buildinfo");
+  });
+});

--- a/apps/web/src/features/prometheus-datasources/DatasourcesPage.test.tsx
+++ b/apps/web/src/features/prometheus-datasources/DatasourcesPage.test.tsx
@@ -1,12 +1,19 @@
 import "@/lib/i18n";
 import { useAuthStore } from "@/stores/auth-store";
 import type { PrometheusDatasourcePublic } from "@modeldoctor/contracts";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const deleteMutate = vi.fn();
-const setDefaultMutate = vi.fn();
+// vi.hoisted is required for symbols referenced inside vi.mock factories —
+// vi.mock is hoisted above all imports/top-level lets, so plain `const fn = vi.fn()`
+// at module scope would be uninitialized when the factory runs.
+const { deleteMutate, setDefaultMutate, toastSuccess, toastError } = vi.hoisted(() => ({
+  deleteMutate: vi.fn(),
+  setDefaultMutate: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
 
 let mockList: PrometheusDatasourcePublic[] = [];
 
@@ -24,7 +31,36 @@ vi.mock("./queries", () => ({
   useVerifyDatasource: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
+vi.mock("sonner", () => ({
+  toast: { success: toastSuccess, error: toastError },
+}));
+
 import { DatasourcesPage } from "./DatasourcesPage";
+
+const TWO_ROW_FIXTURE: PrometheusDatasourcePublic[] = [
+  {
+    id: "ds1",
+    name: "prom-prod",
+    baseUrl: "https://prom.example.com",
+    bearerPreview: "ey...x",
+    customHeaders: "",
+    isDefault: true,
+    consumersCount: 3,
+    createdAt: "2026-05-01T00:00:00Z",
+    updatedAt: "2026-05-01T00:00:00Z",
+  },
+  {
+    id: "ds2",
+    name: "prom-staging",
+    baseUrl: "https://prom-staging.example.com",
+    bearerPreview: "",
+    customHeaders: "",
+    isDefault: false,
+    consumersCount: 0,
+    createdAt: "2026-05-01T00:00:00Z",
+    updatedAt: "2026-05-01T00:00:00Z",
+  },
+];
 
 function asAdmin() {
   useAuthStore.setState({
@@ -60,6 +96,8 @@ describe("DatasourcesPage", () => {
   beforeEach(() => {
     deleteMutate.mockClear();
     setDefaultMutate.mockClear();
+    toastSuccess.mockClear();
+    toastError.mockClear();
     mockList = [];
     asAdmin();
   });
@@ -77,30 +115,7 @@ describe("DatasourcesPage", () => {
   });
 
   it("renders rows with default badge and consumers count", () => {
-    mockList = [
-      {
-        id: "ds1",
-        name: "prom-prod",
-        baseUrl: "https://prom.example.com",
-        bearerPreview: "ey...x",
-        customHeaders: "",
-        isDefault: true,
-        consumersCount: 3,
-        createdAt: "2026-05-01T00:00:00Z",
-        updatedAt: "2026-05-01T00:00:00Z",
-      },
-      {
-        id: "ds2",
-        name: "prom-staging",
-        baseUrl: "https://prom-staging.example.com",
-        bearerPreview: "",
-        customHeaders: "",
-        isDefault: false,
-        consumersCount: 0,
-        createdAt: "2026-05-01T00:00:00Z",
-        updatedAt: "2026-05-01T00:00:00Z",
-      },
-    ];
+    mockList = TWO_ROW_FIXTURE;
     render(
       <MemoryRouter>
         <DatasourcesPage />
@@ -121,30 +136,7 @@ describe("DatasourcesPage", () => {
 
   it("hides admin-only buttons for non-admin viewers", () => {
     asViewer();
-    mockList = [
-      {
-        id: "ds1",
-        name: "prom-prod",
-        baseUrl: "https://prom.example.com",
-        bearerPreview: "ey...x",
-        customHeaders: "",
-        isDefault: true,
-        consumersCount: 3,
-        createdAt: "2026-05-01T00:00:00Z",
-        updatedAt: "2026-05-01T00:00:00Z",
-      },
-      {
-        id: "ds2",
-        name: "prom-staging",
-        baseUrl: "https://prom-staging.example.com",
-        bearerPreview: "",
-        customHeaders: "",
-        isDefault: false,
-        consumersCount: 0,
-        createdAt: "2026-05-01T00:00:00Z",
-        updatedAt: "2026-05-01T00:00:00Z",
-      },
-    ];
+    mockList = TWO_ROW_FIXTURE;
     render(
       <MemoryRouter>
         <DatasourcesPage />
@@ -159,5 +151,87 @@ describe("DatasourcesPage", () => {
     // Table still renders rows in read-only mode.
     expect(screen.getByText("prom-prod")).toBeInTheDocument();
     expect(screen.getByText("prom-staging")).toBeInTheDocument();
+  });
+
+  it("admin sees the create CTA — positive control matching the viewer test above", () => {
+    // Pair-test to F3 in the test audit: a permissive "queryByText" absence
+    // assertion can silently degrade if the label string drifts (`+ 新增数据源`
+    // → `新增数据源`). A matching positive admin-side `getByRole` lock the
+    // label string at one place; if it drifts, both tests scream at once.
+    mockList = TWO_ROW_FIXTURE;
+    render(
+      <MemoryRouter>
+        <DatasourcesPage />
+      </MemoryRouter>,
+    );
+    expect(
+      screen.getByRole("button", { name: /^\+ 新增数据源|\+ new datasource$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("viewer empty-state suppresses the create CTA", () => {
+    // The empty-state body has its own "+ New datasource" affordance; viewers
+    // should NOT see that either (admin-only creation path).
+    asViewer();
+    mockList = [];
+    render(
+      <MemoryRouter>
+        <DatasourcesPage />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText(/\+ 新增数据源|\+ new datasource/i)).toBeNull();
+    // Empty-state itself still renders so the user sees why the table is blank.
+    expect(
+      screen.getByText(/no prometheus datasource|尚未配置 prometheus 数据源/i),
+    ).toBeInTheDocument();
+  });
+
+  it("clicking 'Set as default' on a non-default row invokes the mutation with its id", async () => {
+    setDefaultMutate.mockResolvedValueOnce(undefined);
+    mockList = TWO_ROW_FIXTURE;
+    render(
+      <MemoryRouter>
+        <DatasourcesPage />
+      </MemoryRouter>,
+    );
+    // Only `prom-staging` (ds2, isDefault=false) renders the Set-default button.
+    const btn = screen.getByRole("button", { name: /^设为默认|^set as default/i });
+    fireEvent.click(btn);
+    await waitFor(() => expect(setDefaultMutate).toHaveBeenCalledTimes(1));
+    expect(setDefaultMutate).toHaveBeenCalledWith("ds2");
+    // Success toast fires with the localized success message.
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    expect(toastSuccess.mock.calls[0][0]).toMatch(/已设为默认|set as default/i);
+  });
+
+  it("delete flow: trash → AlertDialog confirm → mutate + cascade-count toast", async () => {
+    // 2 connections will be detached when ds1 is dropped; the success toast
+    // MUST surface that count (the whole point of returning consumersDetached).
+    deleteMutate.mockResolvedValueOnce({ consumersDetached: 2 });
+    mockList = TWO_ROW_FIXTURE;
+    render(
+      <MemoryRouter>
+        <DatasourcesPage />
+      </MemoryRouter>,
+    );
+
+    // Two trash icons (one per row). Click the first — corresponds to ds1.
+    const trashButtons = screen.getAllByLabelText(/^删除$|^delete$/i);
+    expect(trashButtons.length).toBe(2);
+    fireEvent.click(trashButtons[0]);
+
+    // AlertDialog opens; the confirm button uses t("delete.confirm") = "删除".
+    // Cancel says t.common("actions.cancel") = "取消" / "Cancel".
+    const confirmBtn = await screen.findByRole("button", { name: /^删除$|^delete$/i });
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => expect(deleteMutate).toHaveBeenCalledTimes(1));
+    expect(deleteMutate).toHaveBeenCalledWith("ds1");
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    // The localized message is "已删除,解绑 2 个 connection" / EN equivalent —
+    // we just lock the `2` since the prose may evolve but the count must
+    // always reach the user.
+    expect(toastSuccess.mock.calls[0][0]).toMatch(/\b2\b/);
   });
 });

--- a/apps/web/src/features/prometheus-datasources/DatasourcesPage.test.tsx
+++ b/apps/web/src/features/prometheus-datasources/DatasourcesPage.test.tsx
@@ -143,9 +143,10 @@ describe("DatasourcesPage", () => {
       </MemoryRouter>,
     );
     // "+ New datasource" CTA in the page header is admin-only.
-    expect(screen.queryByText(/\+ 新增数据源|\+ new datasource/i)).toBeNull();
+    // Grouped alternation so ^ / $ apply to BOTH branches, not just one.
+    expect(screen.queryByText(/^(\+ 新增数据源|\+ new datasource)$/i)).toBeNull();
     // The "Set as default" button is admin-only; only the default badge remains.
-    expect(screen.queryByText(/^set as default$|^设为默认$/i)).toBeNull();
+    expect(screen.queryByText(/^(设为默认|set as default)$/i)).toBeNull();
     // No delete buttons — only em-dash placeholders in the action column.
     expect(screen.queryAllByLabelText(/delete|删除/i)).toHaveLength(0);
     // Table still renders rows in read-only mode.
@@ -165,7 +166,7 @@ describe("DatasourcesPage", () => {
       </MemoryRouter>,
     );
     expect(
-      screen.getByRole("button", { name: /^\+ 新增数据源|\+ new datasource$/i }),
+      screen.getByRole("button", { name: /^(\+ 新增数据源|\+ new datasource)$/i }),
     ).toBeInTheDocument();
   });
 
@@ -179,7 +180,7 @@ describe("DatasourcesPage", () => {
         <DatasourcesPage />
       </MemoryRouter>,
     );
-    expect(screen.queryByText(/\+ 新增数据源|\+ new datasource/i)).toBeNull();
+    expect(screen.queryByText(/^(\+ 新增数据源|\+ new datasource)$/i)).toBeNull();
     // Empty-state itself still renders so the user sees why the table is blank.
     expect(
       screen.getByText(/no prometheus datasource|尚未配置 prometheus 数据源/i),
@@ -195,7 +196,7 @@ describe("DatasourcesPage", () => {
       </MemoryRouter>,
     );
     // Only `prom-staging` (ds2, isDefault=false) renders the Set-default button.
-    const btn = screen.getByRole("button", { name: /^设为默认|^set as default/i });
+    const btn = screen.getByRole("button", { name: /^(设为默认|set as default)$/i });
     fireEvent.click(btn);
     await waitFor(() => expect(setDefaultMutate).toHaveBeenCalledTimes(1));
     expect(setDefaultMutate).toHaveBeenCalledWith("ds2");


### PR DESCRIPTION
## Summary

Closes the two **critical** gaps from the 2026-05-19 full-repo test audit:

- **A1 (API)** — `verifyPrometheus` (in `verify-kind.ts`, powers `POST /api/prometheus-datasources/verify`) had no unit test. Only the dropped-in-#199 `kind=prometheus` e2e branch touched it indirectly, and that branch is gone. Added 7 unit cases via the standard ssrf-guard mock + global fetch stub pattern.
- **B1 (Web)** — `DatasourcesPage.test.tsx` had zero behavior coverage for 2 of 3 admin-only mutations (`delete` + `set-default`), and the `consumersDetached` cascade toast — the whole point of returning the count — was never asserted. Added 4 behavior tests + a positive admin control to pair with the existing viewer absence assertion (F3 hardening).

## Approach

- A1 mirrors `metrics.spec.ts` (mock `./ssrf-guard.js`, stub global `fetch`); 7 cases cover happy paths (with/without revision), HTTP non-2xx, Prometheus error envelope, missing version, non-JSON body, and locks the trailing-slash convention (controller's job, not the probe's).
- B1 uses `vi.hoisted` to register sonner spies before the `vi.mock` factory hoists; extracts a shared two-row fixture so new tests reuse it. The cascade toast assertion locks the `\b2\b` count rather than the full message string, so prose evolution doesn't break it but a regression on the count number will.

## Verification

- `pnpm -F @modeldoctor/api exec vitest run src/modules/connection/discovery/verify-kind.spec.ts` — 7/7
- `pnpm -F @modeldoctor/web exec vitest run src/features/prometheus-datasources/DatasourcesPage.test.tsx` — 7/7 (3 pre-existing + 4 new)
- `pnpm -F @modeldoctor/api type-check` — clean
- `pnpm -F @modeldoctor/web type-check` — clean
- `pnpm lint` — clean

## Context

Part of the audit-driven coverage backfill plan after PR #201:
- **PR A (this one):** critical findings A1 + B1
- PR B: important — API (A4/A5/A6) + Web PR#199 (B2/B3/B4/B5)
- PR C: important Web other (C2/C9/C3/C10) + all minor + infrastructure (MCP fixture migration, lint rule exploration)

No production code touched — pure test coverage backfill.

## Test plan

- [ ] CI passes (api lint + e2e + web build)
- [ ] Reviewer confirms the cascade-count assertion (`\b2\b` match) is the right granularity vs full-message match

🤖 Generated with [Claude Code](https://claude.com/claude-code)