### PR TITLE
test: important coverage — fetcher edges, error→toast mapping, banner diagnostics (audit A4/A5 + B2/B4/B5)

### DIFF
--- a/apps/api/src/modules/alerts/prometheus-fetcher.service.spec.ts
+++ b/apps/api/src/modules/alerts/prometheus-fetcher.service.spec.ts
@@ -267,4 +267,67 @@ describe("PrometheusFetcherService.fetchAlertContext (query_range + summarise)",
       restoreFetch();
     }
   });
+
+  it("returns null when Prometheus replies 200 with status='error' envelope", async () => {
+    // Mirrors the contract: even on HTTP 200, a Prometheus error envelope
+    // (status: "error", errorType, error) is not a usable result and the
+    // fetcher must drop the snapshot rather than feed garbage to the LLM.
+    globalThis.fetch = mockFetch(true, {
+      status: "error",
+      errorType: "bad_data",
+      error: "parse error at char 1",
+    });
+    try {
+      const ctx = await svc.fetchAlertContext(
+        makeEvent({ annotations: { expr: "broken{" }, connectionId: null }),
+      );
+      expect(ctx).toBeNull();
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  it("returns null when fetch throws (timeout / network) instead of hanging", async () => {
+    // Abort budget is 5s — we don't want to actually wait. Simulate the
+    // post-abort error the global fetch throws when AbortController fires.
+    globalThis.fetch = vi.fn(async () => {
+      throw new DOMException("The operation was aborted.", "AbortError");
+    }) as unknown as typeof globalThis.fetch;
+    try {
+      const ctx = await svc.fetchAlertContext(
+        makeEvent({ annotations: { expr: "up" }, connectionId: null }),
+      );
+      // The catch in queryRange logs + returns null; the explainer keeps
+      // generating a baseline-only narrative without crashing.
+      expect(ctx).toBeNull();
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  it("returns null when bearerCipher decrypt fails (rotated env key)", async () => {
+    // Plant a cipher encrypted under a different key, then construct the
+    // service with our test key. decrypt() throws → the catch in queryRange
+    // returns null without ever calling fetch (we'd notice if it did because
+    // fetch is unmocked here and prom.test isn't reachable from the suite).
+    const otherKey = Buffer.alloc(32, 9).toString("base64"); // ≠ TEST_KEY_B64
+    const { encrypt, decodeKey } = await import("../../common/crypto/aes-gcm.js");
+    const cipher = encrypt("real-bearer-token", decodeKey(otherKey));
+    await prisma.prometheusDatasource.update({
+      where: { id: ds.id },
+      data: { bearerCipher: cipher },
+    });
+
+    const fetchSpy = vi.fn(async () => new Response("{}", { status: 200 }));
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+    try {
+      const ctx = await svc.fetchAlertContext(
+        makeEvent({ annotations: { expr: "up" }, connectionId: null }),
+      );
+      expect(ctx).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      restoreFetch();
+    }
+  });
 });

--- a/apps/api/src/modules/connection/connection.service.spec.ts
+++ b/apps/api/src/modules/connection/connection.service.spec.ts
@@ -330,7 +330,14 @@ describe("ConnectionService", () => {
         name: ds.name,
         baseUrl: ds.baseUrl,
       });
-      expect("prometheusUrl" in r).toBe(false);
+      // Anchor on a positive shape assertion FIRST so a regression that
+      // returned `{}` (or undefined) wouldn't make every subsequent absence
+      // check silently pass. `"prometheusUrl" in {}` is false — without this
+      // anchor, the dropped-field assertion below has nothing real to bite.
+      // (mock's makeRow doesn't echo the input `name`, so we only lock the
+      // fields the mock guarantees: a stable id and the contract's kind.)
+      expect(r).toMatchObject({ id: expect.any(String), kind: "model" });
+      expect(r).not.toHaveProperty("prometheusUrl");
     });
   });
 

--- a/apps/web/src/features/connections/ConnectionSheet.test.tsx
+++ b/apps/web/src/features/connections/ConnectionSheet.test.tsx
@@ -580,9 +580,47 @@ describe("ConnectionSheet — Discover auto-apply + dirty preservation", () => {
     await waitFor(() => {
       expect(screen.getByLabelText(/^model\b/i)).toHaveValue("llama-3-8b");
     });
-    // The legacy `prometheusUrl` form input is gone; Discover still surfaces
-    // the inferred value through the DiscoverResultBanner (evidence row), not
-    // as an editable field.
+    // The legacy `prometheusUrl` form input is gone. In the success path
+    // the DiscoverResultBanner does NOT render either (see runDiscover —
+    // banner only mounts when `countFilledFields === 0`). The inferred
+    // prometheusUrl is still carried through the contract for the
+    // zero-result diagnostic view; see the next test for that path.
+    expect(screen.queryByText(/请确认|please verify/i)).not.toBeInTheDocument();
+  });
+
+  it("zero-results banner surfaces the prometheusUrl evidence row (e.g. 'no /metrics')", async () => {
+    // Banner mounts only when ALL inferred fields are empty — that's the
+    // pure-diagnostic path. PR #199 kept inferred.prometheusUrl in the
+    // contract precisely so this row is still informative; lock that
+    // guarantee here so a future cleanup can't silently drop it.
+    const user = userEvent.setup();
+    discoverMutate.mockResolvedValue({
+      health: { durationMs: 80, probesAttempted: 4, probesFailed: [], warnings: [] },
+      inferred: {
+        serverKind: { value: null, confidence: "unknown", evidence: "no server header" },
+        models: { values: [], confidence: "unknown", evidence: "/v1/models 404" },
+        category: { value: null, confidence: "unknown", evidence: "no signal" },
+        suggestedTags: { values: [], confidence: "unknown", evidence: "n/a" },
+        // Matches the actual evidence string the backend's prometheus-url
+        // inferrer emits when /metrics is unreachable — see
+        // apps/api/.../discovery/inference/prometheus-url.ts.
+        prometheusUrl: {
+          value: null,
+          confidence: "unknown",
+          evidence: "no /metrics endpoint detected",
+        },
+      },
+    });
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />);
+
+    await user.type(screen.getByLabelText(/api base url/i), "http://nothing-here.test");
+    await user.click(screen.getByRole("button", { name: /Discover|自动发现/i }));
+
+    // Banner mounts with the diagnostic table; the prometheusUrl row's
+    // evidence must surface so the user sees WHY metric inference failed.
+    await waitFor(() => {
+      expect(screen.getByText(/no \/metrics endpoint detected/i)).toBeInTheDocument();
+    });
   });
 
   it("auto-apply preserves user-modified (dirty) model field in edit mode", async () => {

--- a/apps/web/src/features/prometheus-datasources/DatasourceSheet.test.tsx
+++ b/apps/web/src/features/prometheus-datasources/DatasourceSheet.test.tsx
@@ -1,20 +1,37 @@
 import "@/lib/i18n";
+import { ApiError } from "@/lib/api-client";
 import type { PrometheusDatasourcePublic } from "@modeldoctor/contracts";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted so the sonner mock factory can refer to these symbols at hoist-time.
+const { toastSuccess, toastError } = vi.hoisted(() => ({
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
 
 const createMutate = vi.fn(async (body: unknown) => ({ id: "new", ...(body as object) }));
 const updateMutate = vi.fn(async (vars: { id: string; body: unknown }) => ({
   id: vars.id,
   ...(vars.body as object),
 }));
-const verifyMutate = vi.fn(async (_body: unknown) => ({ ok: true, version: "2.50.0" }));
+// Explicit return-type annotation widens the inferred type so per-test
+// mockResolvedValueOnce can return the failure variant `{ ok: false, reason }`
+// without TS narrowing to the happy-path shape.
+type VerifyResult = { ok: boolean; version?: string; reason?: string };
+const verifyMutate = vi.fn(
+  async (_body: unknown): Promise<VerifyResult> => ({ ok: true, version: "2.50.0" }),
+);
 
 vi.mock("./queries", () => ({
   useCreateDatasource: () => ({ mutateAsync: createMutate, isPending: false }),
   useUpdateDatasource: () => ({ mutateAsync: updateMutate, isPending: false }),
   useVerifyDatasource: () => ({ mutateAsync: verifyMutate, isPending: false }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: toastSuccess, error: toastError },
 }));
 
 import { DatasourceSheet } from "./DatasourceSheet";
@@ -36,6 +53,15 @@ describe("DatasourceSheet (create)", () => {
     createMutate.mockClear();
     updateMutate.mockClear();
     verifyMutate.mockClear();
+    toastSuccess.mockClear();
+    toastError.mockClear();
+    // Reset implementations so a prior test's mockRejectedValueOnce doesn't
+    // bleed into the next describe block.
+    createMutate.mockImplementation(async (body: unknown) => ({
+      id: "new",
+      ...(body as object),
+    }));
+    verifyMutate.mockImplementation(async () => ({ ok: true, version: "2.50.0" }));
   });
 
   it("submits create with name, baseUrl, and optional bearer", async () => {
@@ -78,6 +104,67 @@ describe("DatasourceSheet (create)", () => {
     const btn = screen.getByRole("button", { name: /test connection|测试连接/i });
     expect(btn).toBeDisabled();
   });
+
+  it("PROMETHEUS_DATASOURCE_NAME_TAKEN → localized toast.error, no inline submitError", async () => {
+    // The sheet's onSubmit catch routes the known conflict codes through
+    // toastDatasourceError (per-code i18n) instead of dumping the raw
+    // message into the inline error region. Lock that wiring.
+    createMutate.mockRejectedValueOnce(
+      new ApiError(409, "duplicate name", "PROMETHEUS_DATASOURCE_NAME_TAKEN"),
+    );
+    const user = userEvent.setup();
+    render(<DatasourceSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />);
+    await user.type(screen.getByLabelText(/^name|^名称/i), "prom-prod");
+    await user.type(screen.getByLabelText(/prometheus url/i), "https://prom.example.com");
+    await user.click(screen.getByRole("button", { name: /^save$|^保存$/i }));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    // Localized "name taken" message lands in the toast; we lock the
+    // distinctive substring rather than the full prose so future copy
+    // tweaks don't break the test.
+    expect(toastError.mock.calls[0][0]).toMatch(/已被占用|already.*taken/i);
+    // Inline submitError text must NOT also render — codes are toast-routed.
+    expect(screen.queryByText("duplicate name")).toBeNull();
+  });
+
+  it("PROMETHEUS_DATASOURCE_BASEURL_TAKEN → localized toast.error for the baseUrl path", async () => {
+    createMutate.mockRejectedValueOnce(
+      new ApiError(409, "duplicate baseurl", "PROMETHEUS_DATASOURCE_BASEURL_TAKEN"),
+    );
+    const user = userEvent.setup();
+    render(<DatasourceSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />);
+    await user.type(screen.getByLabelText(/^name|^名称/i), "prom-prod");
+    await user.type(screen.getByLabelText(/prometheus url/i), "https://prom.example.com");
+    await user.click(screen.getByRole("button", { name: /^save$|^保存$/i }));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(toastError.mock.calls[0][0]).toMatch(/url 已被登记|already.*registered|already.*taken/i);
+    expect(screen.queryByText("duplicate baseurl")).toBeNull();
+  });
+
+  it("verify resolving { ok: false, reason } surfaces toast.error with the reason", async () => {
+    verifyMutate.mockResolvedValueOnce({ ok: false, reason: "HTTP 401" });
+    const user = userEvent.setup();
+    render(<DatasourceSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />);
+    await user.type(screen.getByLabelText(/prometheus url/i), "https://prom.example.com");
+    await user.click(screen.getByRole("button", { name: /test connection|测试连接/i }));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    // toast.verify.fail template includes {{reason}}; we lock that the
+    // reason string the server returned makes it through to the user.
+    expect(toastError.mock.calls[0][0]).toMatch(/HTTP 401/);
+  });
+
+  it("verify throwing (network/timeout) surfaces toast.error with the thrown message", async () => {
+    verifyMutate.mockRejectedValueOnce(new Error("Network down"));
+    const user = userEvent.setup();
+    render(<DatasourceSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />);
+    await user.type(screen.getByLabelText(/prometheus url/i), "https://prom.example.com");
+    await user.click(screen.getByRole("button", { name: /test connection|测试连接/i }));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(toastError.mock.calls[0][0]).toMatch(/Network down/);
+  });
 });
 
 describe("DatasourceSheet (edit)", () => {
@@ -85,6 +172,15 @@ describe("DatasourceSheet (edit)", () => {
     createMutate.mockClear();
     updateMutate.mockClear();
     verifyMutate.mockClear();
+    toastSuccess.mockClear();
+    toastError.mockClear();
+    // Reset implementations so a prior test's mockRejectedValueOnce doesn't
+    // bleed into the next describe block.
+    createMutate.mockImplementation(async (body: unknown) => ({
+      id: "new",
+      ...(body as object),
+    }));
+    verifyMutate.mockImplementation(async () => ({ ok: true, version: "2.50.0" }));
   });
 
   it("disables bearer field by default and OMITS bearerToken from PATCH body", async () => {

--- a/apps/web/src/features/prometheus-datasources/DatasourceSheet.test.tsx
+++ b/apps/web/src/features/prometheus-datasources/DatasourceSheet.test.tsx
@@ -55,11 +55,18 @@ describe("DatasourceSheet (create)", () => {
     verifyMutate.mockClear();
     toastSuccess.mockClear();
     toastError.mockClear();
-    // Reset implementations so a prior test's mockRejectedValueOnce doesn't
-    // bleed into the next describe block.
+    // Reset implementations for ALL three mutations so a prior test's
+    // mockRejectedValueOnce / mockResolvedValueOnce can't bleed across
+    // describe blocks (matters in watch mode where files can re-run in any
+    // order). Symmetric reset is cheaper than reasoning about which mock
+    // each block touches.
     createMutate.mockImplementation(async (body: unknown) => ({
       id: "new",
       ...(body as object),
+    }));
+    updateMutate.mockImplementation(async (vars: { id: string; body: unknown }) => ({
+      id: vars.id,
+      ...(vars.body as object),
     }));
     verifyMutate.mockImplementation(async () => ({ ok: true, version: "2.50.0" }));
   });
@@ -174,11 +181,18 @@ describe("DatasourceSheet (edit)", () => {
     verifyMutate.mockClear();
     toastSuccess.mockClear();
     toastError.mockClear();
-    // Reset implementations so a prior test's mockRejectedValueOnce doesn't
-    // bleed into the next describe block.
+    // Reset implementations for ALL three mutations so a prior test's
+    // mockRejectedValueOnce / mockResolvedValueOnce can't bleed across
+    // describe blocks (matters in watch mode where files can re-run in any
+    // order). Symmetric reset is cheaper than reasoning about which mock
+    // each block touches.
     createMutate.mockImplementation(async (body: unknown) => ({
       id: "new",
       ...(body as object),
+    }));
+    updateMutate.mockImplementation(async (vars: { id: string; body: unknown }) => ({
+      id: vars.id,
+      ...(vars.body as object),
     }));
     verifyMutate.mockImplementation(async () => ({ ok: true, version: "2.50.0" }));
   });

--- a/apps/web/src/features/prometheus-datasources/errors.test.ts
+++ b/apps/web/src/features/prometheus-datasources/errors.test.ts
@@ -1,0 +1,61 @@
+import { ApiError } from "@/lib/api-client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { toastError, toastSuccess } = vi.hoisted(() => ({
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: toastError, success: toastSuccess },
+}));
+
+import { toastDatasourceError } from "./errors";
+
+// Stand-in for the i18next `t` bound to the prometheus-datasources namespace.
+// Returns the key so we can assert which key was looked up without pulling in
+// the real translation runtime — schema-level coverage, not i18n coverage.
+const t = (key: string, opts?: Record<string, unknown>) =>
+  opts && "message" in opts ? `${key}|${opts.message}` : key;
+
+describe("toastDatasourceError", () => {
+  beforeEach(() => {
+    toastError.mockClear();
+    toastSuccess.mockClear();
+  });
+
+  it("maps PROMETHEUS_DATASOURCE_NAME_TAKEN to toast.errors.nameTaken", () => {
+    toastDatasourceError(t, new ApiError(409, "name taken", "PROMETHEUS_DATASOURCE_NAME_TAKEN"));
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(toastError).toHaveBeenCalledWith("toast.errors.nameTaken");
+  });
+
+  it("maps PROMETHEUS_DATASOURCE_BASEURL_TAKEN to toast.errors.baseUrlTaken", () => {
+    toastDatasourceError(
+      t,
+      new ApiError(409, "baseurl taken", "PROMETHEUS_DATASOURCE_BASEURL_TAKEN"),
+    );
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(toastError).toHaveBeenCalledWith("toast.errors.baseUrlTaken");
+  });
+
+  it("falls back to toast.errors.generic with the error message when code is unknown", () => {
+    toastDatasourceError(t, new Error("boom"));
+    expect(toastError).toHaveBeenCalledTimes(1);
+    // Our stand-in `t` echoes opts.message after a `|` so we can lock both.
+    expect(toastError).toHaveBeenCalledWith("toast.errors.generic|boom");
+  });
+
+  it("falls back to generic with empty message when error is not an Error", () => {
+    toastDatasourceError(t, "string thrown by something else");
+    expect(toastError).toHaveBeenCalledWith("toast.errors.generic|");
+  });
+
+  it("falls back to generic when ApiError carries an unrelated code", () => {
+    // Defends against a future ConflictException codepath that happens to
+    // raise via ApiError but with a code outside the known two — should NOT
+    // accidentally surface as a localized takeover.
+    toastDatasourceError(t, new ApiError(409, "something else", "SOMETHING_UNRELATED_TAKEN"));
+    expect(toastError).toHaveBeenCalledWith("toast.errors.generic|something else");
+  });
+});


### PR DESCRIPTION
## Summary

Closes the **important** findings from the 2026-05-19 full-repo audit:

**API (commit 1):**
- **A4** — `connection.service.spec` "wrong-reason pass": replaced `"prometheusUrl" in r` with a positive shape anchor + `not.toHaveProperty("prometheusUrl")`. Without the anchor, a regression returning `{}` would have passed silently.
- **A5** — `prometheus-fetcher.service.spec` covers timeout (AbortError), `status="error"` envelope, and bearer decrypt failure (env key rotation). MAX_SERIES was actually already covered ("truncates to first 5 series"); audit was slightly off there.
- **A6** — re-survey found `explainer.service.spec.ts` already locks both "omits 告警时段指标 when promSnapshot=null" AND "includes 段 + numeric grounding token when present" (lines 112-132). Audit double-counted; intentionally NOT in this PR.

**Web (commits 2 + 3):**
- **B5** — new `errors.test.ts`: pure-mapper unit for `toastDatasourceError`, 5 cases (two known codes + Error fallback + non-Error fallback + unrelated-code fallback).
- **B2** — `DatasourceSheet.test.tsx`: 4 new behavior tests covering `*_TAKEN` error code → localized toast (no inline leak), verify resolving `{ok:false, reason}`, verify throwing.
- **B4** — `ConnectionSheet.test.tsx`: stale comment fixed (banner only mounts on zero-fields path, not the success path) + new test that locks the `prometheusUrl` evidence row ("no /metrics endpoint detected") so a future cleanup can't silently drop it.

## Verification

- `pnpm -F @modeldoctor/api exec vitest run src/modules/connection/connection.service.spec.ts src/modules/alerts/prometheus-fetcher.service.spec.ts` — 49/49
- `pnpm -F @modeldoctor/web exec vitest run src/features/prometheus-datasources/ src/features/connections/ConnectionSheet.test.tsx` — 55/55
- `pnpm lint` — clean
- `pnpm -r type-check` — clean

## Context

Part of the audit-driven coverage backfill plan:
- PR #202: critical (A1 + B1) ✅ merged
- **PR B (this one):** important
- PR C: important Web other (C2/C9/C3/C10) + all minor + infrastructure (MCP fixture migration, lint rule exploration)

No production code touched — pure test coverage backfill.

## Test plan

- [ ] CI passes (api lint + e2e + web build)
- [ ] Reviewer confirms the A6 carve-out (audit double-counted) is the right call vs adding more redundant coverage
- [ ] Reviewer confirms the bearer-decrypt-failure test correctly anchors on `fetchSpy` never being called (no plaintext leak attempt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)