### PR TITLE
feat(mcp): set_default_prometheus_datasource tool + CLAUDE.md Sheet vs Dialog doc fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ All forms (page-style and dialog-style alike) follow the unified shadcn `<Form>`
 ### Page vs Dialog (creation flows)
 
 - **Page-style** when: > 5 fields, multiple sections, contains a dynamic sub-form (e.g. `ToolParamsEditor`), needs deep-link URL params, submit navigates to a detail page. Examples: `BenchmarkCreatePage`, `TemplateCreatePage` / `TemplateEditPage`.
-- **Dialog-style** when: ≤ 5 fields (or all same-category), no sub-form, submit stays in the originating list/detail context. Examples: `ConnectionDialog`, `SetBaselineDialog`.
+- **Sheet/Dialog-style** when: ≤ 5 fields (or all same-category), no sub-form, submit stays in the originating list/detail context. Most entity create/edit use shadcn `<Sheet>` (right-side drawer) for the extra vertical space — examples: `ConnectionSheet`, `DatasourceSheet`, `ChannelSheet`. Reserve `<Dialog>` (modal) for transient one-off operations that aren't full entity edits — example: `SetBaselineDialog`.
 
 Field-count is a guideline, not a hard rule — final call is "needs sections / sub-form / deep-link".
 

--- a/apps/api/src/modules/mcp/mcp.service.ts
+++ b/apps/api/src/modules/mcp/mcp.service.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { Injectable } from "@nestjs/common";
+import { PrismaService } from "../../database/prisma.service.js";
 import { AlertsService } from "../alerts/alerts.service.js";
 import { SubscribersService } from "../alerts/subscribers.service.js";
 import { BenchmarkService } from "../benchmark/benchmark.service.js";
@@ -24,6 +25,7 @@ import { registerListConnections } from "./tools/list-connections.tool.js";
 import { registerListPrometheusDatasources } from "./tools/list-prometheus-datasources.tool.js";
 import { registerRunDiagnostics } from "./tools/run-diagnostics.tool.js";
 import { registerSetConnectionPrometheusSource } from "./tools/set-connection-prometheus-source.tool.js";
+import { registerSetDefaultPrometheusDatasource } from "./tools/set-default-prometheus-datasource.tool.js";
 import { registerSubscribeConnection } from "./tools/subscribe-connection.tool.js";
 import { registerSubscribe } from "./tools/subscribe.tool.js";
 import { registerTestChannel } from "./tools/test-channel.tool.js";
@@ -53,6 +55,7 @@ const SERVER_VERSION = (() => {
 @Injectable()
 export class McpService {
   constructor(
+    private readonly prisma: PrismaService,
     private readonly discovery: DiscoveryService,
     private readonly connections: ConnectionService,
     private readonly benchmarks: BenchmarkService,
@@ -76,8 +79,21 @@ export class McpService {
       { capabilities: { tools: {} } },
     );
 
+    // Look up the configured MCP user's actual roles in the DB so admin-only
+    // tools (e.g. set_default_prometheus_datasource) can gate on real status
+    // rather than hard-coding `isAdmin: false` everywhere. If the user has
+    // been deleted between server start and this call, we treat them as
+    // non-admin — the underlying service will then raise its own NotFound
+    // or Forbidden, which is the same end-state the REST layer presents.
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { roles: true },
+    });
+    const isAdmin = !!user?.roles?.includes("admin");
+
     const deps: McpToolDeps = {
       userId,
+      isAdmin,
       discovery: this.discovery,
       connections: this.connections,
       benchmarks: this.benchmarks,
@@ -114,6 +130,7 @@ export class McpService {
     registerSubscribeConnection(server, deps);
     registerListPrometheusDatasources(server, deps);
     registerSetConnectionPrometheusSource(server, deps);
+    registerSetDefaultPrometheusDatasource(server, deps);
 
     // Stateless mode — every request is a fresh JSON-RPC roundtrip with
     // no cross-request session state. Matches Claude Code's typical
@@ -136,6 +153,13 @@ export class McpService {
 
 export interface McpToolDeps {
   userId: string;
+  /**
+   * Whether the configured MCP_USER_ID has the "admin" role in the DB.
+   * Resolved per-request from prisma; admin-gated tools (e.g.
+   * `set_default_prometheus_datasource`) check this before mutating
+   * shared/admin-managed resources. Read-only tools may ignore it.
+   */
+  isAdmin: boolean;
   discovery: DiscoveryService;
   connections: ConnectionService;
   benchmarks: BenchmarkService;

--- a/apps/api/src/modules/mcp/tools/set-default-prometheus-datasource.tool.spec.ts
+++ b/apps/api/src/modules/mcp/tools/set-default-prometheus-datasource.tool.spec.ts
@@ -1,0 +1,98 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describe, expect, it, vi } from "vitest";
+import type { McpToolDeps } from "../mcp.service.js";
+import { registerSetDefaultPrometheusDatasource } from "./set-default-prometheus-datasource.tool.js";
+
+// Same captured-handler shim as the sibling tool specs — we don't need a
+// real McpServer, just to record what the wrapper passed to `registerTool`.
+function makeServer() {
+  const calls: Array<{
+    name: string;
+    meta: { title: string; description: string; inputSchema?: unknown };
+    handler: (input: unknown) => Promise<unknown>;
+  }> = [];
+  const server = {
+    registerTool: (name: string, meta: unknown, handler: unknown) => {
+      calls.push({
+        name,
+        meta: meta as { title: string; description: string; inputSchema?: unknown },
+        handler: handler as (input: unknown) => Promise<unknown>,
+      });
+    },
+  } as unknown as McpServer;
+  return { server, calls };
+}
+
+describe("set_default_prometheus_datasource tool", () => {
+  it("registers with the expected name + title + description + input shape", () => {
+    const { server, calls } = makeServer();
+    registerSetDefaultPrometheusDatasource(server, {} as McpToolDeps);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.name).toBe("set_default_prometheus_datasource");
+    expect(calls[0]?.meta.title).toBe("Set the default Prometheus datasource");
+    expect(calls[0]?.meta.description.length).toBeGreaterThan(20);
+    // datasourceId is the single required input.
+    expect(calls[0]?.meta.inputSchema).toBeDefined();
+  });
+
+  it("forwards isAdmin from deps into the service actor (admin path)", async () => {
+    const setDefault = vi.fn().mockResolvedValue({
+      id: "ds1",
+      name: "primary",
+      baseUrl: "https://p.example.com",
+      bearerPreview: "abc...wxyz",
+      customHeaders: "",
+      isDefault: true,
+      consumersCount: 3,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+    const deps = {
+      userId: "u_admin",
+      isAdmin: true,
+      prometheusDatasources: { setDefault },
+    } as unknown as McpToolDeps;
+    const { server, calls } = makeServer();
+    registerSetDefaultPrometheusDatasource(server, deps);
+
+    const result = (await calls[0]?.handler({ datasourceId: "ds1" })) as {
+      content: Array<{ type: "text"; text: string }>;
+      structuredContent: Record<string, unknown>;
+    };
+
+    // Service receives the resolved isAdmin (the WHOLE point of the deps
+    // change in this PR) and the datasourceId from input.
+    expect(setDefault).toHaveBeenCalledWith({ sub: "u_admin", isAdmin: true }, "ds1");
+    // Wire shape is the slim subset — no createdAt/updatedAt/customHeaders.
+    expect(result.structuredContent).toEqual({
+      id: "ds1",
+      name: "primary",
+      baseUrl: "https://p.example.com",
+      isDefault: true,
+      consumersCount: 3,
+    });
+    const text = result.content[0]?.text ?? "";
+    expect(text).not.toContain("customHeaders");
+    expect(text).not.toContain("bearerPreview");
+  });
+
+  it("propagates isAdmin=false → service rejection surfaces to the caller", async () => {
+    // Non-admin path: the service raises ForbiddenException; the tool does
+    // not catch it (the SDK turns thrown errors into JSON-RPC errors). We
+    // lock that the rejection makes it through unmolested rather than being
+    // silently swallowed or downgraded.
+    const setDefault = vi.fn().mockRejectedValue(new Error("admin role required"));
+    const deps = {
+      userId: "u_viewer",
+      isAdmin: false,
+      prometheusDatasources: { setDefault },
+    } as unknown as McpToolDeps;
+    const { server, calls } = makeServer();
+    registerSetDefaultPrometheusDatasource(server, deps);
+
+    await expect(calls[0]?.handler({ datasourceId: "ds1" })).rejects.toThrow(
+      /admin role required/i,
+    );
+    expect(setDefault).toHaveBeenCalledWith({ sub: "u_viewer", isAdmin: false }, "ds1");
+  });
+});

--- a/apps/api/src/modules/mcp/tools/set-default-prometheus-datasource.tool.ts
+++ b/apps/api/src/modules/mcp/tools/set-default-prometheus-datasource.tool.ts
@@ -1,0 +1,64 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { McpToolDeps } from "../mcp.service.js";
+import { registerTool } from "./_register.js";
+
+type SetDefaultPrometheusDatasourceInput = {
+  datasourceId: string;
+};
+
+/**
+ * `set_default_prometheus_datasource` — promote one Prometheus datasource
+ * to the workspace-wide default. The default is the one that newly-created
+ * Connections (kind ∈ {model, gateway}) auto-bind to when the caller
+ * doesn't specify `prometheusDatasourceId` explicitly.
+ *
+ * Admin-gated. The configured `MCP_USER_ID` must have the `"admin"` role in
+ * the DB (mcp.service resolves this per-request from prisma); otherwise the
+ * underlying service raises `ForbiddenException("admin role required")`.
+ * Non-admin callers can still LIST datasources via
+ * `list_prometheus_datasources`; only the promote/demote / create / delete
+ * mutations require admin.
+ *
+ * The set-default operation is transactional at the service layer (a single
+ * Prisma `$transaction` flips every other `isDefault=true` row to false
+ * before flipping the target row to true), so concurrent calls converge to
+ * exactly one default rather than partial-update fan-out.
+ */
+export function registerSetDefaultPrometheusDatasource(server: McpServer, deps: McpToolDeps): void {
+  registerTool<SetDefaultPrometheusDatasourceInput>(
+    server,
+    {
+      name: "set_default_prometheus_datasource",
+      title: "Set the default Prometheus datasource",
+      description:
+        "Promote one Prometheus datasource (by id from list_prometheus_datasources) " +
+        "to the workspace default. New connections (kind=model or gateway) created " +
+        "without an explicit prometheusDatasourceId will auto-bind to this one. " +
+        "Admin-only: the configured MCP_USER_ID must have the admin role in the DB.",
+      inputShape: {
+        datasourceId: z
+          .string()
+          .min(1)
+          .describe("Datasource id from list_prometheus_datasources to promote to default."),
+      },
+    },
+    async (input) => {
+      const updated = await deps.prometheusDatasources.setDefault(
+        { sub: deps.userId, isAdmin: deps.isAdmin },
+        input.datasourceId,
+      );
+      const payload = {
+        id: updated.id,
+        name: updated.name,
+        baseUrl: updated.baseUrl,
+        isDefault: updated.isDefault,
+        consumersCount: updated.consumersCount,
+      };
+      return {
+        content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+        structuredContent: payload as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Two of the post-#199 follow-ups, packaged as one small PR:

- **CLAUDE.md "Sheet vs Dialog" doc fix** (commit 1):  The doc listed \`ConnectionDialog\` as the canonical example, but that file was renamed to \`ConnectionSheet\` long ago. Project convention is shadcn \`<Sheet>\` (right-side drawer) for entity create/edit, with \`<Dialog>\` (modal) reserved for one-off transient operations. Rewrote the section to make that split explicit and update the example list to match what actually exists.
- **\`set_default_prometheus_datasource\` MCP tool** (commit 2): The third (and final) MCP tool for the Prometheus datasource surface — list / set-on-connection / **set-as-default**. Admin-gated. Required a small auth-model extension since the MCP guard previously didn't surface user roles: now \`McpService\` resolves \`isAdmin\` per-request from prisma based on \`MCP_USER_ID\`'s DB row, and \`McpToolDeps\` exposes \`isAdmin: boolean\`. The configured MCP user becomes admin-capable iff their DB row carries the \`"admin"\` role; otherwise the underlying \`PrometheusDatasourceService.setDefault\`'s \`ForbiddenException\` surfaces unchanged.

## Out of scope (one quick-win dropped)

- **DiscoverResultBanner CTA for \`inferred.prometheusUrl\`** — surveyed; turned out to be an architectural mismatch. The banner only mounts on the zero-results path; the CTA would be useful when \`prometheusUrl.value\` is non-null, which is the auto-apply (no-banner) path. Needs separate inline-hint UI design, not a 30-min change. Deferred to a follow-up issue.

## Verification

- \`pnpm -F @modeldoctor/api exec vitest run src/modules/mcp/\` — **15/15** (4 existing tool specs + 3 new for set_default + 6 guard + 2 list)
- \`pnpm test\` (full repo) — **101 api files / 146 web files / 41 package files, all pass**
- \`pnpm -F @modeldoctor/api type-check\` — clean
- \`pnpm lint\` — clean

## Test plan

- [ ] CI passes (api lint + e2e + web build)
- [ ] Reviewer confirms the per-request prisma lookup for \`isAdmin\` is OK overhead (one indexed find by id per MCP request — same shape as the auth-flow user lookup we already do elsewhere)
- [ ] Reviewer confirms the \`isAdmin\` field is properly threaded into \`set_default\` only, not silently changing behavior of existing tools (list still hardcodes \`isAdmin: false\` since listing is open by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)