### PR TITLE
refactor(runtime): RuntimeConnection.prometheusUrl → prometheusDatasource (closes #208)

### DIFF
--- a/apps/api/src/modules/benchmark/benchmark.service.spec.ts
+++ b/apps/api/src/modules/benchmark/benchmark.service.spec.ts
@@ -168,7 +168,7 @@ const mockConnections: ConnectionService = {
     customHeaders: "{}",
     queryParams: "",
     tokenizerHfId: null,
-    prometheusUrl: null,
+    prometheusDatasource: null,
     prometheusDatasourceId: null,
     serverKind: null,
     category: "text" as const,

--- a/apps/api/src/modules/benchmark/benchmark.service.ts
+++ b/apps/api/src/modules/benchmark/benchmark.service.ts
@@ -228,7 +228,7 @@ export class BenchmarkService {
           customHeaders: conn.customHeaders,
           queryParams: conn.queryParams,
           tokenizerHfId: conn.tokenizerHfId,
-          prometheusUrl: conn.prometheusUrl,
+          prometheusDatasource: conn.prometheusDatasource,
         },
         callback: { url: this.callbackUrl, token: callbackToken },
       });

--- a/apps/api/src/modules/connection/connection.service.ts
+++ b/apps/api/src/modules/connection/connection.service.ts
@@ -61,14 +61,17 @@ export interface DecryptedConnection {
   category: ModalityCategory | null;
   tokenizerHfId: string | null;
   /**
-   * Derived: bound datasource's baseUrl, or null when no datasource is bound.
-   * The underlying `prometheusUrl` column was dropped in Task 4 of #189;
-   * this field is preserved on DecryptedConnection so tool-adapters consumers
-   * (engine-metrics, benchmark, prefix-cache-probe) don't need migrating this
-   * turn — to be removed in a follow-up that migrates them to read
-   * `prometheusDatasource.baseUrl` directly.
+   * Bound Prometheus datasource (admin-managed entity from #199), with the
+   * bearer token DECRYPTED at api side. Mirrors the `apiKey` plaintext shape
+   * so adapters can forward to runners via `secretEnv` (never argv).
+   * Null when no datasource is bound; bearerToken null when the datasource
+   * is anonymous (no bearer configured).
    */
-  readonly prometheusUrl: string | null;
+  prometheusDatasource: {
+    id: string;
+    baseUrl: string;
+    bearerToken: string | null;
+  } | null;
   prometheusDatasourceId: string | null;
   serverKind: ServerKind | null;
 }
@@ -231,13 +234,40 @@ export class ConnectionService {
       queryParams: row.queryParams,
       category: row.category as ModalityCategory | null,
       tokenizerHfId: row.tokenizerHfId,
-      // Derived: bound datasource's baseUrl, or null when no datasource is bound.
-      // Downstream consumers (engine-metrics, benchmark adapters) continue to
-      // read this field unchanged after the v1 `prometheusUrl` column drop.
-      prometheusUrl: row.prometheusDatasource?.baseUrl ?? null,
+      // Decrypt the datasource bearer once here so adapters / downstream
+      // consumers get plaintext (same shape as `apiKey` above). Returning
+      // ciphertext would force every consumer to import the decrypt helper
+      // and the encryption key, defeating the boundary.
+      // Defensive: if a row mid-migration has a bearerCipher that decrypts
+      // with a rotated key, we surface `null` rather than throwing — the
+      // upstream PrometheusFetcherService already logs that failure mode.
+      prometheusDatasource: row.prometheusDatasource
+        ? {
+            id: row.prometheusDatasource.id,
+            baseUrl: row.prometheusDatasource.baseUrl,
+            bearerToken: this.tryDecryptBearer(row.prometheusDatasource.bearerCipher),
+          }
+        : null,
       prometheusDatasourceId: row.prometheusDatasourceId,
       serverKind: row.serverKind as ServerKind | null,
     };
+  }
+
+  /**
+   * Defensive decryption of a Prometheus datasource bearer cipher. Returns
+   * null when the cipher is empty (anonymous datasource) OR when decryption
+   * fails (env key rotated, corrupted cipher, etc.) — same graceful-
+   * degradation contract PrometheusFetcherService uses. Logging the
+   * specific failure mode lives upstream in that service to avoid double-
+   * logging from every connection read.
+   */
+  private tryDecryptBearer(cipher: string | null): string | null {
+    if (!cipher) return null;
+    try {
+      return decrypt(cipher, this.key);
+    } catch {
+      return null;
+    }
   }
 
   private async findOwnedRow(userId: string, id: string): Promise<ConnectionRow> {

--- a/apps/api/src/modules/diagnostics/diagnostics.service.spec.ts
+++ b/apps/api/src/modules/diagnostics/diagnostics.service.spec.ts
@@ -18,7 +18,7 @@ function makeConn(overrides: Partial<DecryptedConnection> & { id: string }): Dec
     queryParams: "",
     category: "chat",
     tokenizerHfId: null,
-    prometheusUrl: null,
+    prometheusDatasource: null,
     prometheusDatasourceId: null,
     serverKind: null,
     ...overrides,

--- a/apps/api/src/modules/engine-metrics/engine-metrics.service.spec.ts
+++ b/apps/api/src/modules/engine-metrics/engine-metrics.service.spec.ts
@@ -17,7 +17,11 @@ function makeConn(over: Partial<DecryptedConnection> = {}): DecryptedConnection 
     queryParams: "",
     category: "chat",
     tokenizerHfId: null,
-    prometheusUrl: "http://prom:9090",
+    prometheusDatasource: {
+      id: "ds_1",
+      baseUrl: "http://prom:9090",
+      bearerToken: null,
+    },
     prometheusDatasourceId: "ds_1",
     serverKind: "vllm",
     ...over,
@@ -43,8 +47,10 @@ describe("EngineMetricsService", () => {
   });
   afterEach(() => vi.clearAllMocks());
 
-  it("rejects when connection lacks prometheusUrl (422)", async () => {
-    connections.getOwnedDecrypted.mockResolvedValueOnce(makeConn({ prometheusUrl: null }));
+  it("rejects when connection has no prometheusDatasource bound (422)", async () => {
+    connections.getOwnedDecrypted.mockResolvedValueOnce(
+      makeConn({ prometheusDatasource: null, prometheusDatasourceId: null }),
+    );
     await expect(
       svc.fetchSnapshot("u1", "c1", {
         from: "2026-05-09T00:00:00.000Z",

--- a/apps/api/src/modules/engine-metrics/engine-metrics.service.ts
+++ b/apps/api/src/modules/engine-metrics/engine-metrics.service.ts
@@ -28,9 +28,12 @@ export class EngineMetricsService {
   ): Promise<EngineMetricsSnapshotResponse> {
     const conn = await this.connections.getOwnedDecrypted(userId, connectionId);
 
-    if (!conn.prometheusUrl) {
+    if (!conn.prometheusDatasource) {
       throw new HttpException(
-        { reason: "engine_metrics_not_configured", detail: "missing prometheusUrl" },
+        {
+          reason: "engine_metrics_not_configured",
+          detail: "no Prometheus datasource bound to this connection",
+        },
         422,
       );
     }
@@ -51,7 +54,7 @@ export class EngineMetricsService {
     const from = new Date(q.from);
     const to = new Date(q.to);
     const step = q.step ?? DEFAULT_STEP_SECONDS;
-    const promBaseUrl = conn.prometheusUrl;
+    const promBaseUrl = conn.prometheusDatasource.baseUrl;
     const model = conn.model;
 
     const settled = await Promise.allSettled(

--- a/apps/api/src/modules/playground/audio.controller.spec.ts
+++ b/apps/api/src/modules/playground/audio.controller.spec.ts
@@ -38,7 +38,7 @@ function makeConn(): DecryptedConnection {
     queryParams: "",
     category: "audio",
     tokenizerHfId: null,
-    prometheusUrl: null,
+    prometheusDatasource: null,
     prometheusDatasourceId: null,
     serverKind: null,
   };

--- a/apps/api/src/modules/playground/audio.service.spec.ts
+++ b/apps/api/src/modules/playground/audio.service.spec.ts
@@ -14,7 +14,7 @@ function makeConn(overrides: Partial<DecryptedConnection> = {}): DecryptedConnec
     queryParams: "",
     category: "audio",
     tokenizerHfId: null,
-    prometheusUrl: null,
+    prometheusDatasource: null,
     prometheusDatasourceId: null,
     serverKind: null,
     ...overrides,

--- a/apps/api/src/modules/playground/chat.service.spec.ts
+++ b/apps/api/src/modules/playground/chat.service.spec.ts
@@ -14,7 +14,7 @@ function makeConn(overrides: Partial<DecryptedConnection> = {}): DecryptedConnec
     queryParams: "",
     category: "chat",
     tokenizerHfId: null,
-    prometheusUrl: null,
+    prometheusDatasource: null,
     prometheusDatasourceId: null,
     serverKind: null,
     ...overrides,

--- a/apps/api/src/modules/playground/embeddings.service.spec.ts
+++ b/apps/api/src/modules/playground/embeddings.service.spec.ts
@@ -14,7 +14,7 @@ function makeConn(overrides: Partial<DecryptedConnection> = {}): DecryptedConnec
     queryParams: "",
     category: "embeddings",
     tokenizerHfId: null,
-    prometheusUrl: null,
+    prometheusDatasource: null,
     prometheusDatasourceId: null,
     serverKind: null,
     ...overrides,

--- a/apps/api/src/modules/playground/images.controller.spec.ts
+++ b/apps/api/src/modules/playground/images.controller.spec.ts
@@ -38,7 +38,7 @@ function makeConn(): DecryptedConnection {
     queryParams: "",
     category: "image",
     tokenizerHfId: null,
-    prometheusUrl: null,
+    prometheusDatasource: null,
     prometheusDatasourceId: null,
     serverKind: null,
   };

--- a/apps/api/src/modules/playground/images.service.spec.ts
+++ b/apps/api/src/modules/playground/images.service.spec.ts
@@ -14,7 +14,7 @@ function makeConn(overrides: Partial<DecryptedConnection> = {}): DecryptedConnec
     queryParams: "",
     category: "image",
     tokenizerHfId: null,
-    prometheusUrl: null,
+    prometheusDatasource: null,
     prometheusDatasourceId: null,
     serverKind: null,
     ...overrides,

--- a/apps/api/src/modules/playground/rerank.service.spec.ts
+++ b/apps/api/src/modules/playground/rerank.service.spec.ts
@@ -14,7 +14,7 @@ function makeConn(overrides: Partial<DecryptedConnection> = {}): DecryptedConnec
     queryParams: "",
     category: "rerank",
     tokenizerHfId: null,
-    prometheusUrl: null,
+    prometheusDatasource: null,
     prometheusDatasourceId: null,
     serverKind: null,
     ...overrides,

--- a/packages/tool-adapters/src/aiperf/runtime.spec.ts
+++ b/packages/tool-adapters/src/aiperf/runtime.spec.ts
@@ -30,7 +30,7 @@ const plan: BuildCommandPlan<AiperfParams> = {
     customHeaders: "",
     queryParams: "",
     tokenizerHfId: null,
-    prometheusUrl: null,
+    prometheusDatasource: null,
   },
   callback: { url: "http://api/", token: "tk" },
 };

--- a/packages/tool-adapters/src/core/interface.ts
+++ b/packages/tool-adapters/src/core/interface.ts
@@ -51,10 +51,21 @@ export interface BuildCommandPlan<TParams = unknown> {
      */
     tokenizerHfId: string | null;
     /**
-     * Required by tools that read per-pod metrics (prefix-cache-probe);
-     * other adapters ignore it. Null when the user hasn't configured one.
+     * Bound Prometheus datasource (admin-managed entity introduced in #199).
+     * Null when the connection has no datasource bound. Adapters that pull
+     * per-pod metrics (prefix-cache-probe today) read
+     * `prometheusDatasource.baseUrl` for the URL and forward `bearerToken`
+     * to the runner via `secretEnv` (NEVER argv) for authenticated scrapes.
+     *
+     * `bearerToken` is plaintext after api-side decryption — same trust
+     * boundary as `apiKey` above. Adapters MUST NOT log it or pass it via
+     * argv; secretEnv only.
      */
-    prometheusUrl: string | null;
+    prometheusDatasource: {
+      id: string;
+      baseUrl: string;
+      bearerToken: string | null;
+    } | null;
   };
   callback: { url: string; token: string };
 }

--- a/packages/tool-adapters/src/evalscope/runtime.spec.ts
+++ b/packages/tool-adapters/src/evalscope/runtime.spec.ts
@@ -30,7 +30,7 @@ const plan: BuildCommandPlan<EvalscopeParams> = {
     customHeaders: "",
     queryParams: "",
     tokenizerHfId: null,
-    prometheusUrl: null,
+    prometheusDatasource: null,
   },
   callback: { url: "http://api/", token: "tk" },
 };

--- a/packages/tool-adapters/src/guidellm/runtime.spec.ts
+++ b/packages/tool-adapters/src/guidellm/runtime.spec.ts
@@ -14,7 +14,7 @@ const baseConn = {
   customHeaders: "",
   queryParams: "",
   tokenizerHfId: null,
-  prometheusUrl: null,
+  prometheusDatasource: null,
 };
 
 const defaultParams = {
@@ -152,7 +152,7 @@ describe("guidellm.buildCommand", () => {
         customHeaders: "",
         queryParams: "",
         tokenizerHfId: null,
-        prometheusUrl: null,
+        prometheusDatasource: null,
       },
       callback: { url: "http://cb", token: "t" },
     });
@@ -186,7 +186,7 @@ describe("guidellm.buildCommand", () => {
         customHeaders: "",
         queryParams: "",
         tokenizerHfId: null,
-        prometheusUrl: null,
+        prometheusDatasource: null,
       },
       callback: { url: "http://cb", token: "t" },
     });
@@ -206,7 +206,7 @@ describe("guidellm.buildCommand", () => {
         customHeaders: "",
         queryParams: "",
         tokenizerHfId: "Qwen/Connection",
-        prometheusUrl: null,
+        prometheusDatasource: null,
       },
       callback: { url: "http://cb", token: "t" },
     });
@@ -224,7 +224,7 @@ describe("guidellm.buildCommand", () => {
         customHeaders: "",
         queryParams: "",
         tokenizerHfId: "Qwen/Connection",
-        prometheusUrl: null,
+        prometheusDatasource: null,
       },
       callback: { url: "http://cb", token: "t" },
     });
@@ -242,7 +242,7 @@ describe("guidellm.buildCommand", () => {
         customHeaders: "",
         queryParams: "",
         tokenizerHfId: null,
-        prometheusUrl: null,
+        prometheusDatasource: null,
       },
       callback: { url: "http://cb", token: "t" },
     });

--- a/packages/tool-adapters/src/prefix-cache-probe/runtime.spec.ts
+++ b/packages/tool-adapters/src/prefix-cache-probe/runtime.spec.ts
@@ -14,7 +14,11 @@ const baseConn = {
   customHeaders: "",
   queryParams: "",
   tokenizerHfId: null,
-  prometheusUrl: "http://10.100.121.67:30121",
+  prometheusDatasource: {
+    id: "ds_test",
+    baseUrl: "http://10.100.121.67:30121",
+    bearerToken: null,
+  } as { id: string; baseUrl: string; bearerToken: string | null } | null,
 };
 
 const baseParams = {
@@ -55,8 +59,8 @@ describe("prefix-cache-probe.buildCommand", () => {
     expect(r.secretEnv.OPENAI_API_KEY).toBe("sk-test");
   });
 
-  it("throws when connection.prometheusUrl is null/undefined", () => {
-    const conn = { ...baseConn, prometheusUrl: null };
+  it("throws when connection has no prometheusDatasource bound", () => {
+    const conn = { ...baseConn, prometheusDatasource: null };
     expect(() =>
       buildCommand({
         runId: "r1",
@@ -64,7 +68,42 @@ describe("prefix-cache-probe.buildCommand", () => {
         connection: conn,
         callback: { url: "http://api/", token: "tk" },
       }),
-    ).toThrow(/prometheusUrl/);
+    ).toThrow(/Prometheus datasource/);
+  });
+
+  it("forwards bearerToken via secretEnv.PROM_BEARER_TOKEN (never argv) when set", () => {
+    // Acceptance hook for #208: runners now have a path to authenticated
+    // Prometheus scrapes. We lock both (a) the token reaches the env, and
+    // (b) it never appears in the argv (kubelet logs / `ps` would leak it).
+    const conn = {
+      ...baseConn,
+      prometheusDatasource: {
+        id: "ds_secure",
+        baseUrl: "http://10.100.121.67:30121",
+        bearerToken: "supersecret",
+      },
+    };
+    const r = buildCommand({
+      runId: "r1",
+      params: baseParams,
+      connection: conn,
+      callback: { url: "http://api/", token: "tk" },
+    });
+    expect(r.secretEnv.PROM_BEARER_TOKEN).toBe("supersecret");
+    expect(r.argv.join(" ")).not.toContain("supersecret");
+  });
+
+  it("omits PROM_BEARER_TOKEN entirely when the datasource is anonymous (bearerToken=null)", () => {
+    // Anonymous Prometheus is the common dev-cluster case; we don't want to
+    // export an empty PROM_BEARER_TOKEN that probe.py might interpret as
+    // "Authorization: Bearer " (literal empty bearer).
+    const r = buildCommand({
+      runId: "r1",
+      params: baseParams,
+      connection: baseConn,
+      callback: { url: "http://api/", token: "tk" },
+    });
+    expect(r.secretEnv.PROM_BEARER_TOKEN).toBeUndefined();
   });
 
   it("outputFiles.result is result.json", () => {

--- a/packages/tool-adapters/src/prefix-cache-probe/runtime.ts
+++ b/packages/tool-adapters/src/prefix-cache-probe/runtime.ts
@@ -8,20 +8,23 @@ import { type PrefixCacheProbeParams, prefixCacheProbeReportSchema } from "./sch
 
 export function buildCommand(plan: BuildCommandPlan<PrefixCacheProbeParams>): BuildCommandResult {
   const { params, connection } = plan;
-  if (!connection.prometheusUrl) {
-    throw new Error("prefix-cache-probe requires connection.prometheusUrl to be configured");
+  if (!connection.prometheusDatasource) {
+    throw new Error(
+      "prefix-cache-probe requires the connection to be bound to a Prometheus datasource",
+    );
   }
 
-  // Argv passes user-supplied strings (baseUrl, prometheusUrl, model) as
+  // Argv passes user-supplied strings (baseUrl, prom baseUrl, model) as
   // separate argv entries — Python argparse doesn't shell-expand them, so
-  // there's no injection surface.
+  // there's no injection surface. Bearer (when present) ships via
+  // secretEnv below so it never lands on the kubelet's command line.
   const argv = [
     "python",
     "/app/probe.py",
     "--url",
     connection.baseUrl,
     "--prom",
-    connection.prometheusUrl,
+    connection.prometheusDatasource.baseUrl,
     "--model",
     connection.model,
     "--rounds",
@@ -36,12 +39,23 @@ export function buildCommand(plan: BuildCommandPlan<PrefixCacheProbeParams>): Bu
     "result.json",
   ];
 
+  const secretEnv: Record<string, string> = {
+    OPENAI_API_KEY: connection.apiKey,
+  };
+  // Forward the datasource bearer when configured. probe.py reads
+  // PROM_BEARER_TOKEN and adds an `Authorization: Bearer ...` header to
+  // its Prom client when set. Env-only handoff (vs an argv flag) keeps the
+  // token off the kubelet command line, matches the OPENAI_API_KEY shape
+  // above, and lets older probe.py builds stay backward-compatible — they
+  // simply ignore the var when no auth is needed.
+  if (connection.prometheusDatasource.bearerToken) {
+    secretEnv.PROM_BEARER_TOKEN = connection.prometheusDatasource.bearerToken;
+  }
+
   return {
     argv,
     env: {},
-    secretEnv: {
-      OPENAI_API_KEY: connection.apiKey,
-    },
+    secretEnv,
     outputFiles: {
       result: "result.json",
     },

--- a/packages/tool-adapters/src/vegeta/runtime.spec.ts
+++ b/packages/tool-adapters/src/vegeta/runtime.spec.ts
@@ -17,7 +17,7 @@ const baseConn = {
   customHeaders: "",
   queryParams: "",
   tokenizerHfId: null,
-  prometheusUrl: null,
+  prometheusDatasource: null,
 };
 
 const baseParams = {


### PR DESCRIPTION
## Summary
- Drop the derived `prometheusUrl: string | null` from `DecryptedConnection` and `BuildCommandPlan.connection`; replace with the full bound-datasource shape `{ id, baseUrl, bearerToken } | null` (bearer decrypted once at the api boundary, mirroring `apiKey`).
- Migrate the three runtime consumers (`engine-metrics`, `benchmark` adapter handoff, `prefix-cache-probe`) to read `prometheusDatasource.baseUrl`.
- `prefix-cache-probe` now forwards the bearer to `probe.py` via `secretEnv.PROM_BEARER_TOKEN` when the bound datasource has one configured. **Never argv** — keeps the token off the kubelet command line, same trust-boundary discipline as `OPENAI_API_KEY`.
- 2 new acceptance tests in `prefix-cache-probe/runtime.spec.ts` pin the behavior: (a) bearer reaches `secretEnv` and never the argv, (b) `PROM_BEARER_TOKEN` is omitted entirely when the datasource is anonymous (avoids `Authorization: Bearer ` literal-empty-bearer).
- All adapter spec fixtures updated to the new `prometheusDatasource` shape.

## Why
Until now the only piece of the bound datasource that survived `DecryptedConnection` was its `baseUrl`, exposed as the legacy-named `prometheusUrl`. That meant runners had no path to read the datasource's bearer token — authenticated Prometheus scrapes were impossible. Issue #208 is the last cleanup of PR #199's datasource migration.

## Test plan
- [x] `pnpm -F @modeldoctor/tool-adapters test` — 211/211 pass (incl. 2 new bearer tests)
- [x] `pnpm -F @modeldoctor/api test` — 722/722 pass
- [x] `pnpm -F @modeldoctor/web test` — 838/838 pass
- [x] `pnpm lint` — exit 0 (warnings are pre-existing in apps/web/connections/queries.test.tsx)
- [ ] CI green
- [ ] Manually verify in dev: connection with bound datasource that has a bearer token → `prefix-cache-probe` run reaches Prometheus successfully (covered by integration; acceptance test pins the unit-level wiring)

closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)