### PR TITLE
test(api): fold MCP_* into E2E_ENV_DEFAULTS fixture (closes #206)

### DIFF
--- a/apps/api/test/e2e/mcp.e2e-spec.ts
+++ b/apps/api/test/e2e/mcp.e2e-spec.ts
@@ -1,66 +1,32 @@
 import request from "supertest";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { type E2EContext, bootE2E } from "../helpers/app.js";
+import { E2E_ENV_DEFAULTS } from "../setup/e2e-env-defaults.js";
 
 /**
- * MCP route smoke tests. The full JSON-RPC handshake + tool roundtrip is
- * the SDK's responsibility (covered by its own tests); we verify our own
- * additions: the McpAuthGuard's 503 / 401 paths and that the route exists
- * at the expected path.
- */
-describe("MCP /mcp (e2e)", () => {
-  let ctx: E2EContext;
-
-  beforeAll(async () => {
-    // Ensure MCP env vars are unset so the 503-when-unconfigured branch is exercised.
-    delete process.env.MCP_BEARER_TOKEN;
-    delete process.env.MCP_USER_ID;
-    ctx = await bootE2E();
-  }, 120_000);
-
-  afterAll(async () => {
-    await ctx.teardown();
-  });
-
-  it("503 when MCP_BEARER_TOKEN / MCP_USER_ID are unset", async () => {
-    const res = await request(ctx.app.getHttpServer())
-      .post("/api/mcp")
-      .set("Authorization", "Bearer anything")
-      .send({});
-    expect(res.status).toBe(503);
-    // The AllExceptionsFilter wraps the message in various shapes; match
-    // any string field in the body.
-    expect(JSON.stringify(res.body)).toMatch(/MCP is not configured/i);
-  });
-});
-
-/**
- * Tool registry smoke test — boot the app with MCP env vars set, send a
- * `tools/list` JSON-RPC request, and verify all expected tool names
- * appear (catches "forgot to register a tool" regressions). Full per-tool
- * behavior is covered by the underlying service specs.
- */
-/**
- * Tool registry happy-path: set the env vars BEFORE bootE2E so the
- * McpAuthGuard sees them at app init, then drive a real `tools/list`
- * JSON-RPC request and assert the alert-loop tools are registered.
- * No user row is needed — the registry handshake doesn't invoke any
- * tool handler, so MCP_USER_ID is opaque at this layer.
+ * MCP route smoke tests. The full JSON-RPC handshake + tool roundtrip is the
+ * SDK's responsibility (covered by its own tests); we verify our own additions:
+ * that all expected tools are registered and exposed at the configured path.
+ *
+ * The McpAuthGuard's 503-when-unset and 401 bearer-mismatch branches are
+ * unit-tested in apps/api/src/modules/mcp/mcp.guard.spec.ts — no need to
+ * re-assert them through the HTTP layer (and doing so would force the brittle
+ * `delete process.env.MCP_*` carve-out we deliberately removed).
+ *
+ * MCP_BEARER_TOKEN / MCP_USER_ID come from E2E_ENV_DEFAULTS so the Bearer the
+ * test sends matches the value ConfigService loaded at app boot. Mutating
+ * process.env in beforeAll is the anti-pattern E2E_ENV_DEFAULTS exists to
+ * prevent (see that file's docstring for the alerts 401 backstory).
  */
 describe("MCP /mcp tools registry (e2e)", () => {
   let ctx: E2EContext;
-  const TOKEN = "test-mcp-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-  const FAKE_USER_ID = "mcp-test-user";
+  const TOKEN = E2E_ENV_DEFAULTS.MCP_BEARER_TOKEN;
 
   beforeAll(async () => {
-    process.env.MCP_BEARER_TOKEN = TOKEN;
-    process.env.MCP_USER_ID = FAKE_USER_ID;
     ctx = await bootE2E();
   }, 120_000);
 
   afterAll(async () => {
-    delete process.env.MCP_BEARER_TOKEN;
-    delete process.env.MCP_USER_ID;
     await ctx.teardown();
   });
 

--- a/apps/api/test/setup/e2e-env-defaults.ts
+++ b/apps/api/test/setup/e2e-env-defaults.ts
@@ -13,10 +13,6 @@
  *
  * NOT included by design:
  * - DATABASE_URL — computed dynamically by pickTestDatabaseUrl()
- * - MCP_BEARER_TOKEN / MCP_USER_ID — mcp.e2e-spec relies on the
- *   "ConfigService falls back to live process.env when validatedEnv is undefined"
- *   path (since .env doesn't define MCP_*). Adding them here would BREAK the
- *   existing "503 when unset" test because validatedEnv would lock them.
  */
 export const E2E_ENV_DEFAULTS = {
   // passport-jwt validates secretOrKey at strategy-construction time, so
@@ -43,4 +39,12 @@ export const E2E_ENV_DEFAULTS = {
   // return that dev value (validatedConfig caches it at forRoot time) and the
   // spec's "Bearer X" wouldn't match.
   ALERTMANAGER_WEBHOOK_SECRET: "alertmanager-test-secret-padded-to-32-chars-min",
+  // McpAuthGuard.canActivate() reads both MCP_BEARER_TOKEN and MCP_USER_ID via
+  // ConfigService. mcp.e2e-spec.ts sends `Bearer ${MCP_BEARER_TOKEN}` and
+  // expects mcpUserId to be stamped from MCP_USER_ID; both must match exactly,
+  // so they live here for a single source of truth. The "missing secret → 503"
+  // branch is unit-covered by mcp.guard.spec.ts, so the fixture safely defines
+  // real values here without losing coverage.
+  MCP_BEARER_TOKEN: "test-mcp-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  MCP_USER_ID: "e2e-mcp-test-user",
 } as const;

--- a/apps/api/vitest.e2e.config.mts
+++ b/apps/api/vitest.e2e.config.mts
@@ -32,7 +32,7 @@ export default defineConfig({
       DATABASE_URL: TEST_DATABASE_URL,
       // Shared fixture so spec files can import the same constants they
       // expect ConfigService to see. See test/setup/e2e-env-defaults.ts for
-      // per-key rationale and the MCP_* carve-out.
+      // per-key rationale.
       ...E2E_ENV_DEFAULTS,
     },
   },

--- a/docs/superpowers/plans/2026-05-19-mcp-fixture-fold.md
+++ b/docs/superpowers/plans/2026-05-19-mcp-fixture-fold.md
@@ -1,0 +1,360 @@
+# MCP e2e fixture fold-in Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fold `MCP_BEARER_TOKEN` / `MCP_USER_ID` into `E2E_ENV_DEFAULTS`, delete the redundant `503-when-unset` e2e block, and make the fixture the single source of truth for ALL e2e secrets.
+
+**Architecture:** Pure test refactor. The "missing secret → 503" path is already covered by `apps/api/src/modules/mcp/mcp.guard.spec.ts` (L34–44), so the matching e2e `describe` block in `mcp.e2e-spec.ts` adds no unique coverage and only forces the `process.env` carve-out. Delete it, then move MCP_* into the shared fixture and rewrite the surviving `tools registry` block to import the fixture constants instead of mutating `process.env` in lifecycle hooks.
+
+**Tech Stack:** Vitest 2 (api e2e via supertest + Nest TestingModule), TypeScript, pnpm workspaces.
+
+**Spec:** `docs/superpowers/specs/2026-05-19-mcp-fixture-fold-design.md`
+**Issue:** [#206](https://github.com/weetime/modeldoctor/issues/206)
+**Branch:** `test/206-mcp-fixture-fold` (worktree at `/Users/fangyong/vllm/modeldoctor/test-206-mcp-fixture-fold`)
+
+---
+
+## File Structure
+
+**Modified files (3):**
+- `apps/api/test/setup/e2e-env-defaults.ts` — add MCP_* keys, drop carve-out docstring
+- `apps/api/test/e2e/mcp.e2e-spec.ts` — delete first `describe`, refactor second to use fixture
+- `apps/api/vitest.e2e.config.mts` — drop MCP_* carve-out from inline comment
+
+**Read-only references:**
+- `apps/api/src/modules/mcp/mcp.guard.spec.ts` — pre-existing unit coverage for the unset path
+- `apps/api/test/e2e/alerts.e2e-spec.ts` — exemplar of "import constant from fixture" pattern (L23, 29)
+
+**Not touched:**
+- `apps/api/src/modules/mcp/mcp.guard.ts` — runtime behaviour unchanged
+- Any other e2e spec — they already use the fixture
+
+---
+
+## Task 0: Workspace baseline
+
+**Files:** none (preflight)
+
+- [ ] **Step 1: Confirm worktree is on the right branch**
+
+```bash
+cd /Users/fangyong/vllm/modeldoctor/test-206-mcp-fixture-fold
+git status
+git log --oneline -3
+```
+
+Expected: working tree clean, HEAD on `test/206-mcp-fixture-fold`, top commit is `docs: spec for #206 — fold MCP_* into E2E_ENV_DEFAULTS fixture`.
+
+- [ ] **Step 2: Install deps + build packages (worktree-first-run requirement)**
+
+```bash
+pnpm install
+pnpm -r build
+```
+
+Expected: install completes, `packages/contracts/dist/` and `packages/tool-adapters/dist/` populated. (Per project memory: a fresh worktree's first api typecheck fails until `pnpm -r build` runs once.)
+
+- [ ] **Step 3: Baseline — run the MCP unit guard spec to lock the safety net**
+
+```bash
+pnpm -F @modeldoctor/api test -- src/modules/mcp/mcp.guard.spec.ts --run
+```
+
+Expected: 6 tests pass (503-token-unset, 503-user-unset, 401-no-header, 401-mismatch, 401-prefix-shorter, pass+stamp). This is the coverage the refactor will lean on.
+
+- [ ] **Step 4: Baseline — run the current MCP e2e to confirm it's green pre-refactor**
+
+```bash
+pnpm -F @modeldoctor/api test:e2e -- test/e2e/mcp.e2e-spec.ts --run
+```
+
+Expected: 2 tests pass — `503 when MCP_BEARER_TOKEN / MCP_USER_ID are unset` and `tools/list exposes the alert-loop tools (...)`. If the baseline fails, **stop and surface the failure** — do not start the refactor on a red baseline.
+
+---
+
+## Task 1: Fold MCP_* into `E2E_ENV_DEFAULTS`
+
+**Files:**
+- Modify: `apps/api/test/setup/e2e-env-defaults.ts`
+
+- [ ] **Step 1: Replace the docstring carve-out + add the two new keys**
+
+Edit `apps/api/test/setup/e2e-env-defaults.ts`. Replace the "NOT included by design" block in the file-level docstring so it reads:
+
+```ts
+ * NOT included by design:
+ * - DATABASE_URL — computed dynamically by pickTestDatabaseUrl()
+ */
+```
+
+(The MCP_* paragraph is gone; DATABASE_URL stays — it's still computed per-run by `pickTestDatabaseUrl`.)
+
+Append the two new keys to the `E2E_ENV_DEFAULTS` object, after `ALERTMANAGER_WEBHOOK_SECRET`:
+
+```ts
+  // McpAuthGuard.canActivate() reads both MCP_BEARER_TOKEN and MCP_USER_ID
+  // via ConfigService. mcp.e2e-spec.ts sends `Bearer ${MCP_BEARER_TOKEN}` and
+  // expects mcpUserId to be stamped from MCP_USER_ID; both must match exactly,
+  // so they live here for a single source of truth. The "missing secret → 503"
+  // branch is covered by the guard's unit spec (mcp.guard.spec.ts), so the
+  // fixture safely defines real values here without losing coverage.
+  MCP_BEARER_TOKEN: "test-mcp-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  MCP_USER_ID: "e2e-mcp-test-user",
+```
+
+(40-char token, same shape as the prior inline literal in the e2e spec. The user id is opaque to `tools/list` — no DB row needed.)
+
+- [ ] **Step 2: Verify the file compiles standalone**
+
+```bash
+pnpm -F @modeldoctor/api exec tsc --noEmit -p tsconfig.json
+```
+
+Expected: no errors. The fixture is a typed `as const` literal, so a typo in the new keys would surface as a TS error at any importing call site once Task 2 lands.
+
+- [ ] **Step 3: Do NOT commit yet**
+
+Task 2's edits to `mcp.e2e-spec.ts` will reference these new keys via import. Commit at the end of Task 2 so the fixture-addition and its consumer ship as one atomic change. (No commit step here.)
+
+---
+
+## Task 2: Rewrite `mcp.e2e-spec.ts` to use the fixture
+
+**Files:**
+- Modify: `apps/api/test/e2e/mcp.e2e-spec.ts`
+
+- [ ] **Step 1: Rewrite the file**
+
+Replace the entire contents of `apps/api/test/e2e/mcp.e2e-spec.ts` with:
+
+```ts
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type E2EContext, bootE2E } from "../helpers/app.js";
+import { E2E_ENV_DEFAULTS } from "../setup/e2e-env-defaults.js";
+
+/**
+ * MCP route smoke tests. The full JSON-RPC handshake + tool roundtrip is the
+ * SDK's responsibility (covered by its own tests); we verify our own additions:
+ * that all expected tools are registered and exposed at the configured path.
+ *
+ * The McpAuthGuard's 503-when-unset and 401 bearer-mismatch branches are
+ * unit-tested in apps/api/src/modules/mcp/mcp.guard.spec.ts — no need to
+ * re-assert them through the HTTP layer (and doing so would force the
+ * brittle `delete process.env.MCP_*` carve-out we deliberately removed).
+ *
+ * MCP_BEARER_TOKEN / MCP_USER_ID come from E2E_ENV_DEFAULTS so the Bearer the
+ * test sends matches the value ConfigService loaded at app boot. Mutating
+ * process.env in beforeAll is the anti-pattern E2E_ENV_DEFAULTS exists to
+ * prevent (see that file's docstring for the alerts 401 backstory).
+ */
+describe("MCP /mcp tools registry (e2e)", () => {
+  let ctx: E2EContext;
+  const TOKEN = E2E_ENV_DEFAULTS.MCP_BEARER_TOKEN;
+
+  beforeAll(async () => {
+    ctx = await bootE2E();
+  }, 120_000);
+
+  afterAll(async () => {
+    await ctx.teardown();
+  });
+
+  it("tools/list exposes the alert-loop tools (list_alerts / get_alert_explanation / subscribe_connection)", async () => {
+    const res = await request(ctx.app.getHttpServer())
+      .post("/api/mcp")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .set("Accept", "application/json, text/event-stream")
+      .send({ jsonrpc: "2.0", method: "tools/list", id: 1, params: {} })
+      .buffer(true);
+
+    // StreamableHTTPServerTransport responds as SSE; supertest captures
+    // the raw body in res.text. Pluck the first `data:` line and parse.
+    const raw = (res.text ?? "").toString();
+    const m = raw.match(/^data:\s*(\{.*\})\s*$/m);
+    expect(m).not.toBeNull();
+    const json = JSON.parse(m?.[1] ?? "{}") as {
+      result?: { tools?: Array<{ name: string }> };
+    };
+    const names = (json.result?.tools ?? []).map((t) => t.name);
+    expect(names).toContain("list_alerts");
+    expect(names).toContain("get_alert_explanation");
+    expect(names).toContain("subscribe_connection");
+  });
+});
+```
+
+Diff summary (for the reviewer):
+- Deleted the entire first `describe("MCP /mcp (e2e)")` block including its `beforeAll` that called `delete process.env.MCP_*`.
+- In the surviving block: removed the `FAKE_USER_ID` local constant (unused — `tools/list` doesn't care about the user id), removed `process.env.MCP_BEARER_TOKEN = TOKEN` and `process.env.MCP_USER_ID = FAKE_USER_ID` from `beforeAll`, removed the matching `delete` lines from `afterAll`.
+- Replaced the inline `const TOKEN = "test-mcp-token-..."` with `const TOKEN = E2E_ENV_DEFAULTS.MCP_BEARER_TOKEN`.
+- Top docstring rewritten to explain why no 503/401 e2e (and pointers back to the unit spec + fixture).
+
+- [ ] **Step 2: Type-check the e2e spec**
+
+```bash
+pnpm -F @modeldoctor/api exec tsc --noEmit -p tsconfig.json
+```
+
+Expected: no errors. The new `E2E_ENV_DEFAULTS.MCP_BEARER_TOKEN` reference resolves to a `string` literal via the `as const` typing.
+
+- [ ] **Step 3: Run the MCP e2e**
+
+```bash
+pnpm -F @modeldoctor/api test:e2e -- test/e2e/mcp.e2e-spec.ts --run
+```
+
+Expected: 1 test passes (`tools/list exposes the alert-loop tools (...)`). The deleted 503 test no longer runs; the surviving test runs against a fixture-loaded `MCP_BEARER_TOKEN` instead of `beforeAll`-mutated `process.env`.
+
+- [ ] **Step 4: Run the guard unit spec to confirm the unset coverage is still green**
+
+```bash
+pnpm -F @modeldoctor/api test -- src/modules/mcp/mcp.guard.spec.ts --run
+```
+
+Expected: 6 tests pass, including `503 when MCP_BEARER_TOKEN is unset` and `503 when MCP_USER_ID is unset`. These are the assertions the deleted e2e block was duplicating.
+
+---
+
+## Task 3: Drop the carve-out comment in `vitest.e2e.config.mts`
+
+**Files:**
+- Modify: `apps/api/vitest.e2e.config.mts`
+
+- [ ] **Step 1: Update the inline comment**
+
+Replace the 3-line inline comment above `...E2E_ENV_DEFAULTS,` (currently lines 33–35) with:
+
+```ts
+      // Shared fixture so spec files can import the same constants they
+      // expect ConfigService to see. See test/setup/e2e-env-defaults.ts for
+      // per-key rationale.
+```
+
+(Removed: the trailing "and the MCP_* carve-out" sentence — there is no carve-out anymore.)
+
+- [ ] **Step 2: Final full-suite verification**
+
+Run, from the worktree root:
+
+```bash
+pnpm -F @modeldoctor/api lint
+pnpm -F @modeldoctor/api exec tsc --noEmit -p tsconfig.json
+pnpm -F @modeldoctor/api test -- src/modules/mcp --run
+pnpm -F @modeldoctor/api test:e2e -- test/e2e/mcp.e2e-spec.ts --run
+```
+
+Expected: lint clean, no TS errors, MCP unit specs all pass, MCP e2e (1 test) passes.
+
+- [ ] **Step 3: Sanity-grep for residual `process.env.MCP_`**
+
+```bash
+grep -rn "process\.env\.MCP_" apps/api/ --include="*.ts"
+```
+
+Expected: **zero hits** under `apps/api/`. (The only legitimate read of those env vars is via `ConfigService` inside `mcp.guard.ts`, which goes through `this.config.get(...)`, not `process.env`.)
+
+- [ ] **Step 4: Sanity-grep that `E2E_ENV_DEFAULTS` now covers MCP_***
+
+```bash
+grep -n "MCP_BEARER_TOKEN\|MCP_USER_ID" apps/api/test/setup/e2e-env-defaults.ts
+```
+
+Expected: 2 hits inside the object (the new fields), plus any docstring references.
+
+---
+
+## Task 4: Commit + push + PR
+
+**Files:** none (delivery)
+
+- [ ] **Step 1: Stage the three modified files**
+
+```bash
+git add \
+  apps/api/test/setup/e2e-env-defaults.ts \
+  apps/api/test/e2e/mcp.e2e-spec.ts \
+  apps/api/vitest.e2e.config.mts
+git status
+```
+
+Expected: those three files staged, nothing else.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+test(api): fold MCP_* into E2E_ENV_DEFAULTS fixture (closes #206)
+
+The McpAuthGuard "missing secret → 503" path is already covered by
+mcp.guard.spec.ts. The matching e2e describe block in mcp.e2e-spec.ts
+only existed to exercise that same canActivate branch through HTTP,
+and it required keeping MCP_BEARER_TOKEN / MCP_USER_ID out of the
+shared E2E_ENV_DEFAULTS fixture so the unset path stayed reachable.
+
+Delete the redundant e2e block, fold both env vars into the fixture,
+and rewrite the surviving tools/list e2e to import the fixture's
+MCP_BEARER_TOKEN instead of mutating process.env in beforeAll. The
+fixture is now the single source of truth for ALL e2e secrets — no
+more brittle "set process.env in beforeAll" anti-pattern.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 3: Push branch**
+
+```bash
+git push -u origin test/206-mcp-fixture-fold
+```
+
+- [ ] **Step 4: Open PR**
+
+```bash
+gh pr create --title "test(api): fold MCP_* into E2E_ENV_DEFAULTS fixture (closes #206)" --body "$(cat <<'EOF'
+## Summary
+
+- Delete the redundant `503-when-unset` e2e describe in `mcp.e2e-spec.ts` — `mcp.guard.spec.ts` already unit-covers that branch end-to-end (`503 when MCP_BEARER_TOKEN is unset`, `503 when MCP_USER_ID is unset`).
+- Fold `MCP_BEARER_TOKEN` / `MCP_USER_ID` into `E2E_ENV_DEFAULTS`. Rewrite the surviving `tools/list` e2e to read `E2E_ENV_DEFAULTS.MCP_BEARER_TOKEN` instead of mutating `process.env` in `beforeAll`.
+- Drop the carve-out paragraph from the fixture docstring and the matching reference in `vitest.e2e.config.mts`. The fixture is now the single source of truth for every e2e secret.
+
+Closes #206.
+
+## Test plan
+
+- [ ] `pnpm -F @modeldoctor/api test -- src/modules/mcp/mcp.guard.spec.ts --run` — 6 unit tests green (incl. both 503-unset cases)
+- [ ] `pnpm -F @modeldoctor/api test:e2e -- test/e2e/mcp.e2e-spec.ts --run` — `tools/list` e2e green
+- [ ] `grep -rn "process\.env\.MCP_" apps/api/ --include="*.ts"` — zero hits
+- [ ] `pnpm -F @modeldoctor/api lint` clean
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: PR follow-through**
+
+After `gh pr create` returns a URL:
+
+```bash
+PR=$(gh pr view --json number -q .number)
+gh pr view "$PR" --json comments,reviews,statusCheckRollup,mergeStateStatus
+gh pr checks "$PR"
+```
+
+Watch CI to green. If a check fails, treat the CI signal as authoritative (per `main/CLAUDE.md`) and fix in a follow-up commit; do not declare done while red.
+
+---
+
+## Self-review summary
+
+- **Spec coverage:**
+  - "Add MCP_BEARER_TOKEN + MCP_USER_ID to E2E_ENV_DEFAULTS" → Task 1
+  - "Remove their process.env = lines from mcp.e2e-spec.ts" → Task 2
+  - "Update fixture docstring to drop the carve-out" → Task 1 step 1
+  - "vitest.e2e.config.mts carve-out comment" → Task 3 step 1
+  - "503 guarantee still has test coverage" → leaned on existing `mcp.guard.spec.ts`; Tasks 0/2/3 all re-run it as part of verification
+- **Placeholder scan:** every code block contains full, runnable code or full commands; no TODOs.
+- **Type consistency:** `E2E_ENV_DEFAULTS.MCP_BEARER_TOKEN` is the same name used in both Task 1 (definition) and Task 2 (consumer).
+- **Scope:** pure test refactor; no runtime changes; one atomic commit.

--- a/docs/superpowers/specs/2026-05-19-mcp-fixture-fold-design.md
+++ b/docs/superpowers/specs/2026-05-19-mcp-fixture-fold-design.md
@@ -1,0 +1,85 @@
+# MCP e2e fixture fold-in (#206)
+
+**Date:** 2026-05-19
+**Issue:** [#206](https://github.com/weetime/modeldoctor/issues/206) — `e2e: fold MCP_BEARER_TOKEN / MCP_USER_ID into E2E_ENV_DEFAULTS fixture`
+**Labels:** area/api, P3, refactor, test
+
+## Problem
+
+`apps/api/test/setup/e2e-env-defaults.ts` (introduced in PR #201) pre-injects e2e
+secrets via vitest's `env:` block so they reach `NestConfigModule.forRoot`
+before any spec's `beforeAll` runs. All e2e secrets use this fixture **except**
+`MCP_BEARER_TOKEN` / `MCP_USER_ID` — those two are the last hold-outs of the
+"set `process.env.X` in `beforeAll`" anti-pattern.
+
+Why the carve-out existed: `mcp.e2e-spec.ts` has a `503 when MCP_* unset` test
+that depends on `ConfigService` falling back to live `process.env`. If
+`E2E_ENV_DEFAULTS` defined `MCP_*`, `validatedEnv` would lock those values at
+forRoot time and the unset path would no longer be reachable.
+
+Risk: a future MCP e2e test that runs in a different file ordering can trip
+the same root cause that originally caused the alerts webhook 401 fixed by
+PR #201.
+
+## Resolution: delete the redundant e2e + fold the fixture
+
+The "503 when unset" path is **already** unit-covered comprehensively by
+`apps/api/src/modules/mcp/mcp.guard.spec.ts`:
+
+- L34–38: `MCP_BEARER_TOKEN` unset → `ServiceUnavailableException`
+- L40–44: `MCP_USER_ID` unset → `ServiceUnavailableException`
+
+The matching e2e in `mcp.e2e-spec.ts` (`describe "MCP /mcp (e2e)"`, L11–35)
+re-asserts the same `canActivate` branch through the HTTP layer. The
+`ServiceUnavailableException → 503` mapping is a Nest framework guarantee
+covered by the global `AllExceptionsFilter` spec. Net: the e2e block adds no
+unique coverage — it only forces the `process.env` carve-out.
+
+Once that block is gone, MCP_* can join the fixture and the second describe
+block (`MCP /mcp tools registry (e2e)`) drops its `process.env` mutations in
+favour of importing from `E2E_ENV_DEFAULTS`, matching the pattern that
+`alerts.e2e-spec.ts` and `subscribers.e2e-spec.ts` already follow.
+
+## Changes
+
+### 1. `apps/api/test/setup/e2e-env-defaults.ts`
+
+- Add `MCP_BEARER_TOKEN` (40-char placeholder) and `MCP_USER_ID` ("e2e-mcp-test-user") to the constant.
+- Drop the "MCP_BEARER_TOKEN / MCP_USER_ID" paragraph from the "NOT included by design" docstring block.
+
+### 2. `apps/api/test/e2e/mcp.e2e-spec.ts`
+
+- Delete `describe("MCP /mcp (e2e)")` (the 503-when-unset block, lines 11–35).
+- In the remaining `describe("MCP /mcp tools registry (e2e)")`:
+  - Remove `process.env.MCP_BEARER_TOKEN = TOKEN` / `process.env.MCP_USER_ID = FAKE_USER_ID` lines from `beforeAll`.
+  - Remove the matching `delete process.env.MCP_*` lines from `afterAll`.
+  - Replace local `const TOKEN = "test-mcp-token-…"` / `const FAKE_USER_ID = "mcp-test-user"` with imports from `../setup/e2e-env-defaults.js`.
+
+### 3. `apps/api/vitest.e2e.config.mts`
+
+- Update the inline comment near `...E2E_ENV_DEFAULTS` to drop the "MCP_* carve-out" reference (currently lines 33–35).
+
+### 4. No new tests
+
+The "missing secret → 503" guarantee is already covered by the existing
+`mcp.guard.spec.ts` unit tests. Adding more would be redundant.
+
+## Acceptance (from issue)
+
+- [x] `mcp.e2e-spec.ts` no longer mutates `process.env.MCP_*`
+- [x] "missing secret → 503" still has explicit test coverage (unit, in `mcp.guard.spec.ts`)
+- [x] `E2E_ENV_DEFAULTS` is the single source of truth for ALL e2e secrets
+
+## Out of scope
+
+- Spawn-subprocess approach (issue's option 2) — rejected: high cost, no
+  additional coverage beyond what the guard unit spec already provides.
+- Any change to MCP guard runtime behaviour. This is a pure test refactor.
+- Adding new MCP e2e coverage — separate concern.
+
+## Verification plan
+
+1. `pnpm -F @modeldoctor/api test -- mcp.guard.spec` — unit tests still pass.
+2. `pnpm test:e2e:api` — full api e2e suite passes, including the surviving
+   tools/list test in `mcp.e2e-spec.ts`.
+3. `pnpm -F @modeldoctor/api lint` / `type-check`.


### PR DESCRIPTION
## Summary

- Delete the redundant `503-when-unset` e2e describe in `mcp.e2e-spec.ts` — `mcp.guard.spec.ts` already unit-covers that branch (`503 when MCP_BEARER_TOKEN is unset`, `503 when MCP_USER_ID is unset`).
- Fold `MCP_BEARER_TOKEN` / `MCP_USER_ID` into `E2E_ENV_DEFAULTS`. Rewrite the surviving `tools/list` e2e to read `E2E_ENV_DEFAULTS.MCP_BEARER_TOKEN` instead of mutating `process.env` in `beforeAll`.
- Drop the carve-out paragraph from the fixture docstring and the matching reference in `vitest.e2e.config.mts`. The fixture is now the single source of truth for every e2e secret — the last hold-out of the "set process.env in beforeAll" anti-pattern is gone.

Closes #206.

## Test plan

- [x] `pnpm -F @modeldoctor/api test -- src/modules/mcp/mcp.guard.spec.ts --run` — 6 unit tests green (incl. both 503-unset cases)
- [x] `pnpm -F @modeldoctor/api test:e2e -- test/e2e/mcp.e2e-spec.ts --run` — `tools/list` e2e green (1 test, was 2 pre-refactor)
- [x] `grep -rn "process\.env\.MCP_" apps/api/ --include="*.ts"` — only a docstring reference explaining the removal, no code mutations
- [x] `pnpm -F @modeldoctor/api lint` clean, `pnpm -F @modeldoctor/api type-check` clean

Spec: \`docs/superpowers/specs/2026-05-19-mcp-fixture-fold-design.md\`
Plan: \`docs/superpowers/plans/2026-05-19-mcp-fixture-fold.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)