### PR TITLE
feat(web): Discover → register-as-datasource CTA (closes #207)

### DIFF
--- a/apps/web/src/features/connections/ConnectionSheet.test.tsx
+++ b/apps/web/src/features/connections/ConnectionSheet.test.tsx
@@ -38,6 +38,7 @@ vi.mock("./queries", () => ({
 
 // ConnectionSheet renders a Prometheus-datasource <Select> for kind=model/gateway.
 // Fixture: one default datasource + one alternate so the (默认) suffix test works.
+// Also stub DatasourceSheet query hooks (rendered via the register CTA).
 vi.mock("@/features/prometheus-datasources/queries", () => ({
   useDatasources: () => ({
     data: [
@@ -65,6 +66,9 @@ vi.mock("@/features/prometheus-datasources/queries", () => ({
       },
     ],
   }),
+  useCreateDatasource: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateDatasource: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useVerifyDatasource: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 // SubscribersSection (rendered in edit mode) reads from React Query hooks.
@@ -76,6 +80,12 @@ vi.mock("@/features/alerts/queries", () => ({
 }));
 vi.mock("@/features/notifications/queries", () => ({
   useChannels: () => ({ data: [] }),
+}));
+
+let mockUserRoles: string[] = ["admin"];
+vi.mock("@/stores/auth-store", () => ({
+  useAuthStore: <T,>(selector: (s: { user: { roles: string[] } }) => T) =>
+    selector({ user: { roles: mockUserRoles } }),
 }));
 
 import { ConnectionSheet } from "./ConnectionSheet";
@@ -680,5 +690,37 @@ describe("ConnectionSheet (unified form stack)", () => {
     await user.click(nameInput);
     await user.tab();
     expect(await screen.findByText(/required/i)).toBeInTheDocument();
+  });
+});
+
+describe("Discover register CTA", () => {
+  beforeEach(() => {
+    mockUserRoles = ["admin"];
+    discoverMutate.mockReset();
+  });
+
+  it("shows the pill on the auto-apply path when inferred URL is unregistered", async () => {
+    const user = userEvent.setup();
+    discoverMutate.mockResolvedValue({
+      inferred: {
+        serverKind: { value: "vllm", confidence: "certain", evidence: [] },
+        models: { values: ["m1"], confidence: "certain", evidence: [] },
+        category: { value: null, confidence: "unknown", evidence: [] },
+        suggestedTags: { values: [], confidence: "unknown", evidence: [] },
+        prometheusUrl: {
+          value: "http://discovered-prom:9090",
+          confidence: "likely",
+          evidence: [],
+        },
+      },
+      health: { ok: true, probesFailed: [] },
+    });
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, { wrapper: Wrapper });
+    await fillBaseFields(user);
+    await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/推断到|Detected/)).toBeInTheDocument();
+      expect(screen.getByText(/http:\/\/discovered-prom:9090/)).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/features/connections/ConnectionSheet.test.tsx
+++ b/apps/web/src/features/connections/ConnectionSheet.test.tsx
@@ -743,7 +743,9 @@ describe("Discover register CTA", () => {
       },
       health: { durationMs: 50, probesAttempted: 4, probesFailed: [], warnings: [] },
     });
-    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, { wrapper: Wrapper });
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, {
+      wrapper: Wrapper,
+    });
     await fillBaseFields(user);
     await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
     await waitFor(() => {
@@ -758,7 +760,9 @@ describe("Discover register CTA", () => {
     // "http://prom:9090" with id "ds-default". Use that exact URL so
     // dup-check fires.
     mockDiscoverWithProm("http://prom:9090");
-    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, { wrapper: Wrapper });
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, {
+      wrapper: Wrapper,
+    });
     await fillBaseFields(user);
     await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
     await waitFor(() => {
@@ -771,7 +775,9 @@ describe("Discover register CTA", () => {
     const user = userEvent.setup();
     mockDiscoverWithProm("http://discovered-prom:9090");
     const existing: ConnectionPublic = { ...EXISTING, prometheusDatasourceId: "ds-default" };
-    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "edit", existing }} />, { wrapper: Wrapper });
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "edit", existing }} />, {
+      wrapper: Wrapper,
+    });
     await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
     await waitFor(() => expect(discoverMutate).toHaveBeenCalled());
     expect(screen.queryByText(/推断到|Detected/)).not.toBeInTheDocument();
@@ -781,7 +787,9 @@ describe("Discover register CTA", () => {
     const user = userEvent.setup();
     mockUserRoles = []; // viewer
     mockDiscoverWithProm("http://discovered-prom:9090");
-    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, { wrapper: Wrapper });
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, {
+      wrapper: Wrapper,
+    });
     await fillBaseFields(user);
     await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
     await waitFor(() => expect(discoverMutate).toHaveBeenCalled());
@@ -791,7 +799,9 @@ describe("Discover register CTA", () => {
   it("opens DatasourceSheet pre-populated with the inferred URL + derived name", async () => {
     const user = userEvent.setup();
     mockDiscoverWithProm("http://discovered-prom:9090");
-    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, { wrapper: Wrapper });
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, {
+      wrapper: Wrapper,
+    });
     await fillBaseFields(user);
     await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
     await waitFor(() => expect(screen.getByText(/推断到|Detected/)).toBeInTheDocument());
@@ -807,7 +817,9 @@ describe("Discover register CTA", () => {
   it("onSaved binds the new datasource id and hides the pill", async () => {
     const user = userEvent.setup();
     mockDiscoverWithProm("http://discovered-prom:9090");
-    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, { wrapper: Wrapper });
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, {
+      wrapper: Wrapper,
+    });
     await fillBaseFields(user);
     await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
     await waitFor(() => expect(screen.getByText(/推断到|Detected/)).toBeInTheDocument());

--- a/apps/web/src/features/connections/ConnectionSheet.test.tsx
+++ b/apps/web/src/features/connections/ConnectionSheet.test.tsx
@@ -703,17 +703,17 @@ describe("Discover register CTA", () => {
     const user = userEvent.setup();
     discoverMutate.mockResolvedValue({
       inferred: {
-        serverKind: { value: "vllm", confidence: "certain", evidence: [] },
-        models: { values: ["m1"], confidence: "certain", evidence: [] },
-        category: { value: null, confidence: "unknown", evidence: [] },
-        suggestedTags: { values: [], confidence: "unknown", evidence: [] },
+        serverKind: { value: "vllm", confidence: "certain", evidence: "x" },
+        models: { values: ["m1"], confidence: "certain", evidence: "x" },
+        category: { value: null, confidence: "unknown", evidence: "x" },
+        suggestedTags: { values: [], confidence: "unknown", evidence: "x" },
         prometheusUrl: {
           value: "http://discovered-prom:9090",
           confidence: "likely",
-          evidence: [],
+          evidence: "x",
         },
       },
-      health: { ok: true, probesFailed: [] },
+      health: { durationMs: 50, probesAttempted: 4, probesFailed: [], warnings: [] },
     });
     render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, { wrapper: Wrapper });
     await fillBaseFields(user);

--- a/apps/web/src/features/connections/ConnectionSheet.test.tsx
+++ b/apps/web/src/features/connections/ConnectionSheet.test.tsx
@@ -771,6 +771,23 @@ describe("Discover register CTA", () => {
     expect(screen.queryByText(/推断到|Detected/)).not.toBeInTheDocument();
   });
 
+  it("hides the pill when the inferred URL only differs by trailing slash / case", async () => {
+    // Fixture stores "http://prom:9090". Discover returns the same host with
+    // a trailing slash AND uppercase scheme — normalizeBaseUrl should still
+    // match so the dup-check fires.
+    const user = userEvent.setup();
+    mockDiscoverWithProm("HTTP://Prom:9090/");
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, {
+      wrapper: Wrapper,
+    });
+    await fillBaseFields(user);
+    await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
+    await waitFor(() => {
+      expect(discoverMutate).toHaveBeenCalled();
+    });
+    expect(screen.queryByText(/推断到|Detected/)).not.toBeInTheDocument();
+  });
+
   it("hides the pill when a datasource is already bound", async () => {
     const user = userEvent.setup();
     mockDiscoverWithProm("http://discovered-prom:9090");

--- a/apps/web/src/features/connections/ConnectionSheet.test.tsx
+++ b/apps/web/src/features/connections/ConnectionSheet.test.tsx
@@ -88,6 +88,20 @@ vi.mock("@/stores/auth-store", () => ({
     selector({ user: { roles: mockUserRoles } }),
 }));
 
+type CapturedDatasourceSheetProps = {
+  open: boolean;
+  mode: { kind: string; initial?: { baseUrl?: string; name?: string } };
+  onSaved?: (ds: { id: string; [k: string]: unknown }) => void;
+};
+let lastDatasourceSheetProps: CapturedDatasourceSheetProps | null = null;
+vi.mock("@/features/prometheus-datasources/DatasourceSheet", () => ({
+  DatasourceSheet: (props: CapturedDatasourceSheetProps) => {
+    lastDatasourceSheetProps = props;
+    // Render nothing — we just want to observe props and let tests call onSaved.
+    return null;
+  },
+}));
+
 import { ConnectionSheet } from "./ConnectionSheet";
 
 async function fillBaseFields(user: ReturnType<typeof userEvent.setup>) {
@@ -697,7 +711,21 @@ describe("Discover register CTA", () => {
   beforeEach(() => {
     mockUserRoles = ["admin"];
     discoverMutate.mockReset();
+    lastDatasourceSheetProps = null;
   });
+
+  function mockDiscoverWithProm(url: string | null) {
+    discoverMutate.mockResolvedValue({
+      inferred: {
+        serverKind: { value: "vllm", confidence: "certain", evidence: "x" },
+        models: { values: ["m1"], confidence: "certain", evidence: "x" },
+        category: { value: null, confidence: "unknown", evidence: "x" },
+        suggestedTags: { values: [], confidence: "unknown", evidence: "x" },
+        prometheusUrl: { value: url, confidence: "likely", evidence: "x" },
+      },
+      health: { durationMs: 50, probesAttempted: 4, probesFailed: [], warnings: [] },
+    });
+  }
 
   it("shows the pill on the auto-apply path when inferred URL is unregistered", async () => {
     const user = userEvent.setup();
@@ -722,5 +750,76 @@ describe("Discover register CTA", () => {
       expect(screen.getByText(/推断到|Detected/)).toBeInTheDocument();
       expect(screen.getByText(/http:\/\/discovered-prom:9090/)).toBeInTheDocument();
     });
+  });
+
+  it("hides the pill when the inferred URL is already registered", async () => {
+    const user = userEvent.setup();
+    // Mocked datasources list (top of file) already contains baseUrl
+    // "http://prom:9090" with id "ds-default". Use that exact URL so
+    // dup-check fires.
+    mockDiscoverWithProm("http://prom:9090");
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, { wrapper: Wrapper });
+    await fillBaseFields(user);
+    await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
+    await waitFor(() => {
+      expect(discoverMutate).toHaveBeenCalled();
+    });
+    expect(screen.queryByText(/推断到|Detected/)).not.toBeInTheDocument();
+  });
+
+  it("hides the pill when a datasource is already bound", async () => {
+    const user = userEvent.setup();
+    mockDiscoverWithProm("http://discovered-prom:9090");
+    const existing: ConnectionPublic = { ...EXISTING, prometheusDatasourceId: "ds-default" };
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "edit", existing }} />, { wrapper: Wrapper });
+    await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
+    await waitFor(() => expect(discoverMutate).toHaveBeenCalled());
+    expect(screen.queryByText(/推断到|Detected/)).not.toBeInTheDocument();
+  });
+
+  it("hides the pill for non-admin users", async () => {
+    const user = userEvent.setup();
+    mockUserRoles = []; // viewer
+    mockDiscoverWithProm("http://discovered-prom:9090");
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, { wrapper: Wrapper });
+    await fillBaseFields(user);
+    await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
+    await waitFor(() => expect(discoverMutate).toHaveBeenCalled());
+    expect(screen.queryByText(/推断到|Detected/)).not.toBeInTheDocument();
+  });
+
+  it("opens DatasourceSheet pre-populated with the inferred URL + derived name", async () => {
+    const user = userEvent.setup();
+    mockDiscoverWithProm("http://discovered-prom:9090");
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, { wrapper: Wrapper });
+    await fillBaseFields(user);
+    await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
+    await waitFor(() => expect(screen.getByText(/推断到|Detected/)).toBeInTheDocument());
+    await user.click(screen.getByRole("button", { name: /注册为数据源|register as datasource/i }));
+    await waitFor(() => {
+      expect(lastDatasourceSheetProps?.open).toBe(true);
+      expect(lastDatasourceSheetProps?.mode.kind).toBe("create");
+      expect(lastDatasourceSheetProps?.mode.initial?.baseUrl).toBe("http://discovered-prom:9090");
+      expect(lastDatasourceSheetProps?.mode.initial?.name).toBe("discovered-prom:9090");
+    });
+  });
+
+  it("onSaved binds the new datasource id and hides the pill", async () => {
+    const user = userEvent.setup();
+    mockDiscoverWithProm("http://discovered-prom:9090");
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, { wrapper: Wrapper });
+    await fillBaseFields(user);
+    await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
+    await waitFor(() => expect(screen.getByText(/推断到|Detected/)).toBeInTheDocument());
+    await user.click(screen.getByRole("button", { name: /注册为数据源|register as datasource/i }));
+    await waitFor(() => expect(lastDatasourceSheetProps?.onSaved).toBeDefined());
+    // Simulate the sheet's save callback firing with the new row.
+    lastDatasourceSheetProps?.onSaved?.({
+      id: "ds-new",
+      name: "discovered-prom:9090",
+      baseUrl: "http://discovered-prom:9090",
+    });
+    // Pill goes away because (a) form id is now set and (b) inferred state cleared.
+    await waitFor(() => expect(screen.queryByText(/推断到|Detected/)).not.toBeInTheDocument());
   });
 });

--- a/apps/web/src/features/connections/ConnectionSheet.tsx
+++ b/apps/web/src/features/connections/ConnectionSheet.tsx
@@ -23,6 +23,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { SubscribersSection } from "@/features/alerts/SubscribersSection";
 import { DatasourceSheet } from "@/features/prometheus-datasources/DatasourceSheet";
 import { deriveDatasourceNameFromUrl } from "@/features/prometheus-datasources/derive-name";
+import { normalizeBaseUrl } from "@/features/prometheus-datasources/normalize-base-url";
 import { useDatasources } from "@/features/prometheus-datasources/queries";
 import { type EndpointKey, applyCurlToEndpoint } from "@/lib/apply-curl-to-endpoint";
 import { parseCurlCommand, toApiBaseUrl } from "@/lib/curl-parser";
@@ -462,8 +463,14 @@ export function ConnectionSheet({
   const user = useAuthStore((s) => s.user);
   const isAdmin = (user?.roles ?? []).includes("admin");
   const watchedDsId = form.watch("prometheusDatasourceId");
+  // Compare via normalizeBaseUrl so trailing-slash / case-only variants
+  // ("http://prom:9090/" vs "http://prom:9090") don't slip past the
+  // dup-check and falsely surface a duplicate-register CTA.
   const inferredAlreadyRegistered = inferredPrometheusUrl
-    ? (datasources ?? []).some((d) => d.baseUrl === inferredPrometheusUrl)
+    ? (() => {
+        const target = normalizeBaseUrl(inferredPrometheusUrl);
+        return (datasources ?? []).some((d) => normalizeBaseUrl(d.baseUrl) === target);
+      })()
     : false;
   const showRegisterCta =
     showPrometheusDatasourceField &&

--- a/apps/web/src/features/connections/ConnectionSheet.tsx
+++ b/apps/web/src/features/connections/ConnectionSheet.tsx
@@ -21,7 +21,10 @@ import {
 import { Sheet, SheetContent, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Textarea } from "@/components/ui/textarea";
 import { SubscribersSection } from "@/features/alerts/SubscribersSection";
+import { DatasourceSheet } from "@/features/prometheus-datasources/DatasourceSheet";
+import { deriveDatasourceNameFromUrl } from "@/features/prometheus-datasources/derive-name";
 import { useDatasources } from "@/features/prometheus-datasources/queries";
+import { useAuthStore } from "@/stores/auth-store";
 import { type EndpointKey, applyCurlToEndpoint } from "@/lib/apply-curl-to-endpoint";
 import { parseCurlCommand, toApiBaseUrl } from "@/lib/curl-parser";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -172,6 +175,8 @@ export function ConnectionSheet({
   const [discoverResult, setDiscoverResult] = useState<DiscoverConnectionResponse | null>(null);
   const [discoverError, setDiscoverError] = useState<string | null>(null);
   const [verifyResult, setVerifyResult] = useState<VerifyKindResponse | null>(null);
+  const [inferredPrometheusUrl, setInferredPrometheusUrl] = useState<string | null>(null);
+  const [registerSheetOpen, setRegisterSheetOpen] = useState(false);
   const discoverMut = useDiscoverConnection();
   const verifyMut = useVerifyKind();
 
@@ -197,6 +202,7 @@ export function ConnectionSheet({
     setDiscoverResult(null);
     setDiscoverError(null);
     setVerifyResult(null);
+    setInferredPrometheusUrl(null);
   }, [open, existing, initialValues]);
 
   // Re-validate when toggling the reset-apiKey switch in edit mode.
@@ -262,6 +268,7 @@ export function ConnectionSheet({
     const customHeaders = rawCustomHeaders?.trim() || undefined;
     try {
       const res = await discoverMut.mutateAsync({ baseUrl, apiKey, customHeaders });
+      setInferredPrometheusUrl(res.inferred.prometheusUrl.value ?? null);
 
       const filled = countFilledFields(res);
       if (filled > 0) {
@@ -297,6 +304,7 @@ export function ConnectionSheet({
   const dismissDiscoverFeedback = () => {
     setDiscoverError(null);
     setDiscoverResult(null);
+    setInferredPrometheusUrl(null);
   };
 
   // -- Auto-parse cURL on textarea change ------------------------------------
@@ -447,8 +455,26 @@ export function ConnectionSheet({
     ? (existing?.apiKeyPreview ?? t("dialog.fields.apiKeyPlaceholder"))
     : t("dialog.fields.apiKeyPlaceholder");
 
+  // Discover → register CTA — see issue #207. Show the pill only when all
+  // four conditions hold: an inferred URL exists, it's not already a
+  // registered datasource, the user hasn't picked any datasource yet, and
+  // the current user is an admin (backend requires admin for create).
+  const user = useAuthStore((s) => s.user);
+  const isAdmin = (user?.roles ?? []).includes("admin");
+  const watchedDsId = form.watch("prometheusDatasourceId");
+  const inferredAlreadyRegistered = inferredPrometheusUrl
+    ? (datasources ?? []).some((d) => d.baseUrl === inferredPrometheusUrl)
+    : false;
+  const showRegisterCta =
+    showPrometheusDatasourceField &&
+    inferredPrometheusUrl != null &&
+    !inferredAlreadyRegistered &&
+    watchedDsId == null &&
+    isAdmin;
+
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
+    <>
+      <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-[640px]">
         <SheetHeader>
           <SheetTitle>{isEdit ? t("dialog.editTitle") : t("dialog.createTitle")}</SheetTitle>
@@ -959,6 +985,27 @@ export function ConnectionSheet({
                               {t("dialog.fields.prometheusDatasource.help")}
                             </p>
                             <FormMessage />
+                            {showRegisterCta ? (
+                              <div className="mt-2 flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2 text-sm">
+                                <Sparkles className="h-4 w-4 shrink-0 text-muted-foreground" />
+                                <div className="min-w-0 flex-1">
+                                  <p className="truncate">
+                                    {t("dialog.discover.registerCta.headline", { url: inferredPrometheusUrl })}
+                                  </p>
+                                  <p className="text-xs text-muted-foreground">
+                                    {t("dialog.discover.registerCta.body")}
+                                  </p>
+                                </div>
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => setRegisterSheetOpen(true)}
+                                >
+                                  {t("dialog.discover.registerCta.action")} →
+                                </Button>
+                              </div>
+                            ) : null}
                           </FormItem>
                         )}
                       />
@@ -1057,6 +1104,23 @@ export function ConnectionSheet({
         </Form>
       </SheetContent>
     </Sheet>
+      <DatasourceSheet
+        open={registerSheetOpen}
+        onOpenChange={setRegisterSheetOpen}
+        mode={{
+          kind: "create",
+          initial: {
+            baseUrl: inferredPrometheusUrl ?? "",
+            name: deriveDatasourceNameFromUrl(inferredPrometheusUrl),
+          },
+        }}
+        onSaved={(ds) => {
+          form.setValue("prometheusDatasourceId", ds.id, { shouldDirty: true });
+          setInferredPrometheusUrl(null);
+          setRegisterSheetOpen(false);
+        }}
+      />
+    </>
   );
 }
 

--- a/apps/web/src/features/connections/ConnectionSheet.tsx
+++ b/apps/web/src/features/connections/ConnectionSheet.tsx
@@ -24,9 +24,9 @@ import { SubscribersSection } from "@/features/alerts/SubscribersSection";
 import { DatasourceSheet } from "@/features/prometheus-datasources/DatasourceSheet";
 import { deriveDatasourceNameFromUrl } from "@/features/prometheus-datasources/derive-name";
 import { useDatasources } from "@/features/prometheus-datasources/queries";
-import { useAuthStore } from "@/stores/auth-store";
 import { type EndpointKey, applyCurlToEndpoint } from "@/lib/apply-curl-to-endpoint";
 import { parseCurlCommand, toApiBaseUrl } from "@/lib/curl-parser";
+import { useAuthStore } from "@/stores/auth-store";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type {
   ConnectionKind,
@@ -475,151 +475,109 @@ export function ConnectionSheet({
   return (
     <>
       <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-[640px]">
-        <SheetHeader>
-          <SheetTitle>{isEdit ? t("dialog.editTitle") : t("dialog.createTitle")}</SheetTitle>
-        </SheetHeader>
+        <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-[640px]">
+          <SheetHeader>
+            <SheetTitle>{isEdit ? t("dialog.editTitle") : t("dialog.createTitle")}</SheetTitle>
+          </SheetHeader>
 
-        <Form {...form}>
-          <form
-            onSubmit={onSubmit}
-            autoComplete="off"
-            className="flex min-h-0 flex-1 flex-col gap-4"
-          >
-            {/* Honeypots: Chrome ignores autocomplete=off when a password field is present. */}
-            <input
-              type="text"
-              name="username"
-              autoComplete="username"
-              tabIndex={-1}
-              aria-hidden="true"
-              style={{
-                position: "absolute",
-                opacity: 0,
-                height: 0,
-                width: 0,
-                pointerEvents: "none",
-              }}
-            />
-            <input
-              type="password"
-              name="password"
-              autoComplete="new-password"
-              tabIndex={-1}
-              aria-hidden="true"
-              style={{
-                position: "absolute",
-                opacity: 0,
-                height: 0,
-                width: 0,
-                pointerEvents: "none",
-              }}
-            />
-            <div className="flex-1 space-y-4 overflow-y-auto pr-1">
-              <details className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm">
-                <summary className="cursor-pointer text-xs font-medium text-muted-foreground hover:text-foreground">
-                  {t("dialog.curl.import")}
-                </summary>
-                <div className="mt-2 space-y-2">
-                  <Textarea
-                    rows={5}
-                    value={curlInput}
-                    onChange={(e) => onCurlChange(e.target.value)}
-                    placeholder={t("dialog.curl.placeholder")}
-                    className="font-mono text-xs"
-                    aria-label={t("dialog.curl.import")}
-                  />
-                  <p className="text-[11px] text-muted-foreground">
-                    {t("dialog.curl.autoParseHint")}
-                  </p>
-                </div>
-              </details>
+          <Form {...form}>
+            <form
+              onSubmit={onSubmit}
+              autoComplete="off"
+              className="flex min-h-0 flex-1 flex-col gap-4"
+            >
+              {/* Honeypots: Chrome ignores autocomplete=off when a password field is present. */}
+              <input
+                type="text"
+                name="username"
+                autoComplete="username"
+                tabIndex={-1}
+                aria-hidden="true"
+                style={{
+                  position: "absolute",
+                  opacity: 0,
+                  height: 0,
+                  width: 0,
+                  pointerEvents: "none",
+                }}
+              />
+              <input
+                type="password"
+                name="password"
+                autoComplete="new-password"
+                tabIndex={-1}
+                aria-hidden="true"
+                style={{
+                  position: "absolute",
+                  opacity: 0,
+                  height: 0,
+                  width: 0,
+                  pointerEvents: "none",
+                }}
+              />
+              <div className="flex-1 space-y-4 overflow-y-auto pr-1">
+                <details className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm">
+                  <summary className="cursor-pointer text-xs font-medium text-muted-foreground hover:text-foreground">
+                    {t("dialog.curl.import")}
+                  </summary>
+                  <div className="mt-2 space-y-2">
+                    <Textarea
+                      rows={5}
+                      value={curlInput}
+                      onChange={(e) => onCurlChange(e.target.value)}
+                      placeholder={t("dialog.curl.placeholder")}
+                      className="font-mono text-xs"
+                      aria-label={t("dialog.curl.import")}
+                    />
+                    <p className="text-[11px] text-muted-foreground">
+                      {t("dialog.curl.autoParseHint")}
+                    </p>
+                  </div>
+                </details>
 
-              <FormSection>
-                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                  <FormField
-                    control={form.control}
-                    name="kind"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel required>{t("dialog.fields.kind")}</FormLabel>
-                        <FormControl>
-                          <Select
-                            value={(field.value as ConnectionKind | undefined) ?? "model"}
-                            onValueChange={(v) => field.onChange(v as ConnectionKind)}
-                          >
-                            <SelectTrigger aria-label={t("dialog.fields.kind")}>
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {KINDS.map((k) => (
-                                <SelectItem key={k} value={k}>
-                                  {t(`kinds.${k}`)}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        </FormControl>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          {t("dialog.fields.kindHelp")}
-                        </p>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  <FormField
-                    control={form.control}
-                    name="name"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel required>{t("dialog.fields.name")}</FormLabel>
-                        <FormControl>
-                          <Input
-                            autoComplete="off"
-                            placeholder={t("dialog.fields.namePlaceholder")}
-                            {...field}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
-
-                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                  <FormField
-                    control={form.control}
-                    name="apiBaseUrl"
-                    render={({ field }) => (
-                      <FormItem className={showModelFields ? undefined : "md:col-span-2"}>
-                        <FormLabel required>{t("dialog.fields.apiBaseUrl")}</FormLabel>
-                        <FormControl>
-                          <Input
-                            autoComplete="off"
-                            placeholder={t("dialog.fields.apiBaseUrlPlaceholder")}
-                            {...field}
-                          />
-                        </FormControl>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          {t("dialog.fields.apiBaseUrlHelp")}
-                        </p>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  {showModelFields ? (
+                <FormSection>
+                  <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                     <FormField
                       control={form.control}
-                      name="model"
+                      name="kind"
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel required={isModelKind}>{t("dialog.fields.model")}</FormLabel>
+                          <FormLabel required>{t("dialog.fields.kind")}</FormLabel>
+                          <FormControl>
+                            <Select
+                              value={(field.value as ConnectionKind | undefined) ?? "model"}
+                              onValueChange={(v) => field.onChange(v as ConnectionKind)}
+                            >
+                              <SelectTrigger aria-label={t("dialog.fields.kind")}>
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {KINDS.map((k) => (
+                                  <SelectItem key={k} value={k}>
+                                    {t(`kinds.${k}`)}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </FormControl>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {t("dialog.fields.kindHelp")}
+                          </p>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="name"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel required>{t("dialog.fields.name")}</FormLabel>
                           <FormControl>
                             <Input
                               autoComplete="off"
-                              placeholder={t("dialog.fields.modelPlaceholder")}
+                              placeholder={t("dialog.fields.namePlaceholder")}
                               {...field}
                             />
                           </FormControl>
@@ -627,46 +585,454 @@ export function ConnectionSheet({
                         </FormItem>
                       )}
                     />
-                  ) : null}
-                </div>
+                  </div>
 
-                {verifyResult ? (
-                  <div
-                    className={`flex items-start gap-2 rounded-md border p-2 text-xs ${
-                      verifyResult.ok
-                        ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
-                        : "border-destructive/30 bg-destructive/10 text-destructive"
-                    }`}
-                  >
-                    {verifyResult.ok ? (
-                      <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
-                    ) : (
-                      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                    <FormField
+                      control={form.control}
+                      name="apiBaseUrl"
+                      render={({ field }) => (
+                        <FormItem className={showModelFields ? undefined : "md:col-span-2"}>
+                          <FormLabel required>{t("dialog.fields.apiBaseUrl")}</FormLabel>
+                          <FormControl>
+                            <Input
+                              autoComplete="off"
+                              placeholder={t("dialog.fields.apiBaseUrlPlaceholder")}
+                              {...field}
+                            />
+                          </FormControl>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {t("dialog.fields.apiBaseUrlHelp")}
+                          </p>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    {showModelFields ? (
+                      <FormField
+                        control={form.control}
+                        name="model"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel required={isModelKind}>{t("dialog.fields.model")}</FormLabel>
+                            <FormControl>
+                              <Input
+                                autoComplete="off"
+                                placeholder={t("dialog.fields.modelPlaceholder")}
+                                {...field}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    ) : null}
+                  </div>
+
+                  {verifyResult ? (
+                    <div
+                      className={`flex items-start gap-2 rounded-md border p-2 text-xs ${
+                        verifyResult.ok
+                          ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+                          : "border-destructive/30 bg-destructive/10 text-destructive"
+                      }`}
+                    >
+                      {verifyResult.ok ? (
+                        <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
+                      ) : (
+                        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                      )}
+                      <span className="flex-1">
+                        {verifyResult.ok
+                          ? [
+                              verifyResult.version
+                                ? t("dialog.verify.version", { version: verifyResult.version })
+                                : null,
+                              typeof verifyResult.details?.modelCount === "number"
+                                ? t("dialog.verify.modelCount", {
+                                    count: verifyResult.details.modelCount,
+                                  })
+                                : null,
+                              typeof verifyResult.details?.clusterPeers === "number"
+                                ? t("dialog.verify.clusterPeers", {
+                                    count: verifyResult.details.clusterPeers,
+                                  })
+                                : null,
+                            ]
+                              .filter(Boolean)
+                              .join(" · ") || t(`kinds.${verifyResult.kind}`)
+                          : (verifyResult.reason ?? "")}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => setVerifyResult(null)}
+                        aria-label={t("dialog.discover.dismiss")}
+                        className="opacity-70 hover:opacity-100"
+                      >
+                        <XIcon className="h-4 w-4" />
+                      </button>
+                    </div>
+                  ) : null}
+
+                  <FormField
+                    control={form.control}
+                    name="customHeaders"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("dialog.fields.customHeaders")}</FormLabel>
+                        <FormControl>
+                          <Textarea
+                            rows={3}
+                            placeholder={t("dialog.fields.customHeadersPlaceholder")}
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
                     )}
-                    <span className="flex-1">
-                      {verifyResult.ok
-                        ? [
-                            verifyResult.version
-                              ? t("dialog.verify.version", { version: verifyResult.version })
-                              : null,
-                            typeof verifyResult.details?.modelCount === "number"
-                              ? t("dialog.verify.modelCount", {
-                                  count: verifyResult.details.modelCount,
-                                })
-                              : null,
-                            typeof verifyResult.details?.clusterPeers === "number"
-                              ? t("dialog.verify.clusterPeers", {
-                                  count: verifyResult.details.clusterPeers,
-                                })
-                              : null,
-                          ]
-                            .filter(Boolean)
-                            .join(" · ") || t(`kinds.${verifyResult.kind}`)
-                        : (verifyResult.reason ?? "")}
-                    </span>
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="queryParams"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("dialog.fields.queryParams")}</FormLabel>
+                        <FormControl>
+                          <Textarea
+                            rows={2}
+                            placeholder={t("dialog.fields.queryParamsPlaceholder")}
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  {showApiKeyField ? (
+                    <FormField
+                      control={form.control}
+                      name="apiKey"
+                      render={({ field }) => (
+                        <FormItem>
+                          <div className="flex items-center justify-between">
+                            <FormLabel required={isModelKind && !apiKeyDisabled}>
+                              {t("dialog.fields.apiKey")}
+                            </FormLabel>
+                            {isEdit ? (
+                              <label className="flex items-center gap-1 text-xs text-muted-foreground">
+                                <input
+                                  type="checkbox"
+                                  checked={resetApiKey}
+                                  onChange={(e) => {
+                                    const next = e.target.checked;
+                                    setResetApiKey(next);
+                                    if (!next) form.setValue("apiKey", "");
+                                  }}
+                                />
+                                {t("dialog.resetApiKey")}
+                              </label>
+                            ) : null}
+                          </div>
+                          <div className="relative">
+                            <FormControl>
+                              <Input
+                                autoComplete="new-password"
+                                type={revealKey ? "text" : "password"}
+                                placeholder={apiKeyPlaceholder}
+                                disabled={apiKeyDisabled}
+                                {...field}
+                              />
+                            </FormControl>
+                            {!apiKeyDisabled ? (
+                              <button
+                                type="button"
+                                onClick={() => setRevealKey((v) => !v)}
+                                className="absolute inset-y-0 right-2 flex items-center text-muted-foreground hover:text-foreground"
+                                aria-label={revealKey ? "hide" : "show"}
+                              >
+                                {revealKey ? (
+                                  <EyeOff className="h-4 w-4" />
+                                ) : (
+                                  <Eye className="h-4 w-4" />
+                                )}
+                              </button>
+                            ) : null}
+                          </div>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {t("dialog.apiKeyEncryptedNotice")}
+                          </p>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  ) : null}
+
+                  <div>
+                    <Label htmlFor="tags">{t("dialog.fields.tags")}</Label>
+                    <Controller
+                      control={form.control}
+                      name="tags"
+                      render={({ field }) => {
+                        const current = field.value ?? [];
+                        const tryAdd = (raw: string) => {
+                          const trimmed = raw.trim();
+                          if (!trimmed) return;
+                          if (current.includes(trimmed)) return;
+                          field.onChange([...current, trimmed]);
+                        };
+                        const remove = (tag: string) =>
+                          field.onChange(current.filter((item: string) => item !== tag));
+                        const suggestions = PRESET_TAGS.filter((p) => !current.includes(p));
+                        return (
+                          <div className="space-y-2">
+                            <div className="flex flex-wrap gap-1">
+                              {current.map((tag: string) => (
+                                <span
+                                  key={tag}
+                                  className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 text-xs"
+                                >
+                                  {tag}
+                                  <button
+                                    type="button"
+                                    aria-label={t("dialog.fields.tagsRemove", {
+                                      tag,
+                                      defaultValue: `Remove tag ${tag}`,
+                                    })}
+                                    onClick={() => remove(tag)}
+                                  >
+                                    <XIcon className="h-3 w-3" />
+                                  </button>
+                                </span>
+                              ))}
+                            </div>
+                            <Input
+                              id="tags"
+                              value={tagDraft}
+                              onChange={(e) => setTagDraft(e.target.value)}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") {
+                                  e.preventDefault();
+                                  tryAdd(tagDraft);
+                                  setTagDraft("");
+                                }
+                              }}
+                              placeholder={t("dialog.fields.tagsPlaceholder")}
+                            />
+                            {suggestions.length > 0 ? (
+                              <div className="flex flex-wrap gap-1">
+                                {suggestions.slice(0, MAX_SUGGESTION_CHIPS).map((s) => (
+                                  <button
+                                    type="button"
+                                    key={s}
+                                    onClick={() => tryAdd(s)}
+                                    className="rounded-full border border-dashed border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent/40"
+                                  >
+                                    + {s}
+                                  </button>
+                                ))}
+                              </div>
+                            ) : null}
+                          </div>
+                        );
+                      }}
+                    />
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {t("dialog.fields.tagsHelp")}
+                    </p>
+                  </div>
+
+                  {showCategoryField || showServerKindField ? (
+                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                      {showCategoryField ? (
+                        <FormField
+                          control={form.control}
+                          name="category"
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel required={isModelKind}>
+                                {t("dialog.fields.category")}
+                              </FormLabel>
+                              <FormControl>
+                                <Select
+                                  value={field.value ?? ""}
+                                  onValueChange={(v) => field.onChange(v === "" ? null : v)}
+                                >
+                                  <SelectTrigger aria-label={t("dialog.fields.category")}>
+                                    <SelectValue
+                                      placeholder={t("dialog.fields.categoryPlaceholder")}
+                                    />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {CATEGORIES.map((c) => (
+                                      <SelectItem key={c} value={c}>
+                                        {t(`dialog.categoryOptions.${c}`)}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              </FormControl>
+                              <p className="mt-1 text-xs text-muted-foreground">
+                                {t("dialog.fields.categoryHelp")}
+                              </p>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                      ) : null}
+
+                      {showServerKindField ? (
+                        <FormField
+                          control={form.control}
+                          name="serverKind"
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>{t("dialog.fields.serverKind")}</FormLabel>
+                              <FormControl>
+                                <Select
+                                  value={field.value ?? ""}
+                                  onValueChange={(v) => field.onChange(v === "" ? null : v)}
+                                >
+                                  <SelectTrigger>
+                                    <SelectValue
+                                      placeholder={t("dialog.fields.serverKindPlaceholder")}
+                                    />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {SERVER_KIND_OPTIONS.map((o) => (
+                                      <SelectItem key={o.value} value={o.value}>
+                                        {o.label}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              </FormControl>
+                              <p className="mt-1 text-xs text-muted-foreground">
+                                {t("dialog.fields.serverKindHelp")}
+                              </p>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                      ) : null}
+                    </div>
+                  ) : null}
+
+                  {showTokenizerField || showPrometheusDatasourceField ? (
+                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                      {showTokenizerField ? (
+                        <FormField
+                          control={form.control}
+                          name="tokenizerHfId"
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>{t("dialog.fields.tokenizerHfId")}</FormLabel>
+                              <FormControl>
+                                <Input
+                                  autoComplete="off"
+                                  placeholder={t("dialog.fields.tokenizerHfIdPlaceholder")}
+                                  {...field}
+                                />
+                              </FormControl>
+                              <p className="mt-1 text-xs text-muted-foreground">
+                                {t("dialog.fields.tokenizerHfIdHelp")}
+                              </p>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                      ) : null}
+
+                      {showPrometheusDatasourceField ? (
+                        <FormField
+                          control={form.control}
+                          name="prometheusDatasourceId"
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>{t("dialog.fields.prometheusDatasource.label")}</FormLabel>
+                              <FormControl>
+                                <Select
+                                  value={field.value ?? "__none__"}
+                                  onValueChange={(v) => field.onChange(v === "__none__" ? null : v)}
+                                >
+                                  <SelectTrigger
+                                    aria-label={t("dialog.fields.prometheusDatasource.label")}
+                                  >
+                                    <SelectValue
+                                      placeholder={t(
+                                        "dialog.fields.prometheusDatasource.placeholder",
+                                      )}
+                                    />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    <SelectItem value="__none__">
+                                      {t("dialog.fields.prometheusDatasource.none")}
+                                    </SelectItem>
+                                    {datasources?.map((ds) => (
+                                      <SelectItem key={ds.id} value={ds.id}>
+                                        {ds.name}
+                                        {ds.isDefault
+                                          ? ` (${t("dialog.fields.prometheusDatasource.defaultSuffix")})`
+                                          : ""}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              </FormControl>
+                              <p className="mt-1 text-xs text-muted-foreground">
+                                {t("dialog.fields.prometheusDatasource.help")}
+                              </p>
+                              <FormMessage />
+                              {showRegisterCta ? (
+                                <div className="mt-2 flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2 text-sm">
+                                  <Sparkles className="h-4 w-4 shrink-0 text-muted-foreground" />
+                                  <div className="min-w-0 flex-1">
+                                    <p className="truncate">
+                                      {t("dialog.discover.registerCta.headline", {
+                                        url: inferredPrometheusUrl,
+                                      })}
+                                    </p>
+                                    <p className="text-xs text-muted-foreground">
+                                      {t("dialog.discover.registerCta.body")}
+                                    </p>
+                                  </div>
+                                  <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => setRegisterSheetOpen(true)}
+                                  >
+                                    {t("dialog.discover.registerCta.action")} →
+                                  </Button>
+                                </div>
+                              ) : null}
+                            </FormItem>
+                          )}
+                        />
+                      ) : null}
+                    </div>
+                  ) : null}
+
+                  {submitError ? (
+                    <p className="text-sm text-destructive">
+                      {submitError.toLowerCase().includes("exists")
+                        ? t("dialog.errors.duplicateName")
+                        : submitError}
+                    </p>
+                  ) : null}
+                </FormSection>
+
+                {isEdit && existing ? <SubscribersSection connectionId={existing.id} /> : null}
+
+                {discoverError ? (
+                  <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                    <span className="flex-1">{discoverError}</span>
                     <button
                       type="button"
-                      onClick={() => setVerifyResult(null)}
+                      onClick={dismissDiscoverFeedback}
                       aria-label={t("dialog.discover.dismiss")}
                       className="opacity-70 hover:opacity-100"
                     >
@@ -674,436 +1040,74 @@ export function ConnectionSheet({
                     </button>
                   </div>
                 ) : null}
-
-                <FormField
-                  control={form.control}
-                  name="customHeaders"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>{t("dialog.fields.customHeaders")}</FormLabel>
-                      <FormControl>
-                        <Textarea
-                          rows={3}
-                          placeholder={t("dialog.fields.customHeadersPlaceholder")}
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="queryParams"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>{t("dialog.fields.queryParams")}</FormLabel>
-                      <FormControl>
-                        <Textarea
-                          rows={2}
-                          placeholder={t("dialog.fields.queryParamsPlaceholder")}
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                {showApiKeyField ? (
-                  <FormField
-                    control={form.control}
-                    name="apiKey"
-                    render={({ field }) => (
-                      <FormItem>
-                        <div className="flex items-center justify-between">
-                          <FormLabel required={isModelKind && !apiKeyDisabled}>
-                            {t("dialog.fields.apiKey")}
-                          </FormLabel>
-                          {isEdit ? (
-                            <label className="flex items-center gap-1 text-xs text-muted-foreground">
-                              <input
-                                type="checkbox"
-                                checked={resetApiKey}
-                                onChange={(e) => {
-                                  const next = e.target.checked;
-                                  setResetApiKey(next);
-                                  if (!next) form.setValue("apiKey", "");
-                                }}
-                              />
-                              {t("dialog.resetApiKey")}
-                            </label>
-                          ) : null}
-                        </div>
-                        <div className="relative">
-                          <FormControl>
-                            <Input
-                              autoComplete="new-password"
-                              type={revealKey ? "text" : "password"}
-                              placeholder={apiKeyPlaceholder}
-                              disabled={apiKeyDisabled}
-                              {...field}
-                            />
-                          </FormControl>
-                          {!apiKeyDisabled ? (
-                            <button
-                              type="button"
-                              onClick={() => setRevealKey((v) => !v)}
-                              className="absolute inset-y-0 right-2 flex items-center text-muted-foreground hover:text-foreground"
-                              aria-label={revealKey ? "hide" : "show"}
-                            >
-                              {revealKey ? (
-                                <EyeOff className="h-4 w-4" />
-                              ) : (
-                                <Eye className="h-4 w-4" />
-                              )}
-                            </button>
-                          ) : null}
-                        </div>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          {t("dialog.apiKeyEncryptedNotice")}
-                        </p>
-                        <FormMessage />
-                      </FormItem>
-                    )}
+                {discoverResult && !discoverError ? (
+                  <DiscoverResultBanner
+                    result={discoverResult}
+                    onClose={dismissDiscoverFeedback}
+                    closeLabel={t("dialog.discover.dismiss")}
                   />
                 ) : null}
+              </div>
 
-                <div>
-                  <Label htmlFor="tags">{t("dialog.fields.tags")}</Label>
-                  <Controller
-                    control={form.control}
-                    name="tags"
-                    render={({ field }) => {
-                      const current = field.value ?? [];
-                      const tryAdd = (raw: string) => {
-                        const trimmed = raw.trim();
-                        if (!trimmed) return;
-                        if (current.includes(trimmed)) return;
-                        field.onChange([...current, trimmed]);
-                      };
-                      const remove = (tag: string) =>
-                        field.onChange(current.filter((item: string) => item !== tag));
-                      const suggestions = PRESET_TAGS.filter((p) => !current.includes(p));
-                      return (
-                        <div className="space-y-2">
-                          <div className="flex flex-wrap gap-1">
-                            {current.map((tag: string) => (
-                              <span
-                                key={tag}
-                                className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 text-xs"
-                              >
-                                {tag}
-                                <button
-                                  type="button"
-                                  aria-label={t("dialog.fields.tagsRemove", {
-                                    tag,
-                                    defaultValue: `Remove tag ${tag}`,
-                                  })}
-                                  onClick={() => remove(tag)}
-                                >
-                                  <XIcon className="h-3 w-3" />
-                                </button>
-                              </span>
-                            ))}
-                          </div>
-                          <Input
-                            id="tags"
-                            value={tagDraft}
-                            onChange={(e) => setTagDraft(e.target.value)}
-                            onKeyDown={(e) => {
-                              if (e.key === "Enter") {
-                                e.preventDefault();
-                                tryAdd(tagDraft);
-                                setTagDraft("");
-                              }
-                            }}
-                            placeholder={t("dialog.fields.tagsPlaceholder")}
-                          />
-                          {suggestions.length > 0 ? (
-                            <div className="flex flex-wrap gap-1">
-                              {suggestions.slice(0, MAX_SUGGESTION_CHIPS).map((s) => (
-                                <button
-                                  type="button"
-                                  key={s}
-                                  onClick={() => tryAdd(s)}
-                                  className="rounded-full border border-dashed border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent/40"
-                                >
-                                  + {s}
-                                </button>
-                              ))}
-                            </div>
-                          ) : null}
-                        </div>
-                      );
-                    }}
-                  />
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    {t("dialog.fields.tagsHelp")}
-                  </p>
-                </div>
-
-                {showCategoryField || showServerKindField ? (
-                  <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                    {showCategoryField ? (
-                      <FormField
-                        control={form.control}
-                        name="category"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel required={isModelKind}>
-                              {t("dialog.fields.category")}
-                            </FormLabel>
-                            <FormControl>
-                              <Select
-                                value={field.value ?? ""}
-                                onValueChange={(v) => field.onChange(v === "" ? null : v)}
-                              >
-                                <SelectTrigger aria-label={t("dialog.fields.category")}>
-                                  <SelectValue
-                                    placeholder={t("dialog.fields.categoryPlaceholder")}
-                                  />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  {CATEGORIES.map((c) => (
-                                    <SelectItem key={c} value={c}>
-                                      {t(`dialog.categoryOptions.${c}`)}
-                                    </SelectItem>
-                                  ))}
-                                </SelectContent>
-                              </Select>
-                            </FormControl>
-                            <p className="mt-1 text-xs text-muted-foreground">
-                              {t("dialog.fields.categoryHelp")}
-                            </p>
-                            <FormMessage />
-                          </FormItem>
+              <SheetFooter className="border-t border-border pt-3">
+                <FormActions
+                  onCancel={() => onOpenChange(false)}
+                  cancelLabel={tc("actions.cancel")}
+                  submitLabel={tc("actions.save")}
+                  pending={createMut.isPending || updateMut.isPending}
+                  leading={
+                    showModelFields ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={handleDiscover}
+                        disabled={!baseUrlValue?.trim() || discoverMut.isPending}
+                        title={
+                          !baseUrlValue?.trim() ? t("dialog.discover.missingBaseUrl") : undefined
+                        }
+                      >
+                        {discoverMut.isPending ? (
+                          <>
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            {t("dialog.discover.running")}
+                          </>
+                        ) : (
+                          <>
+                            <Sparkles className="mr-2 h-4 w-4" />
+                            {t("dialog.discover.button")}
+                          </>
                         )}
-                      />
-                    ) : null}
-
-                    {showServerKindField ? (
-                      <FormField
-                        control={form.control}
-                        name="serverKind"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>{t("dialog.fields.serverKind")}</FormLabel>
-                            <FormControl>
-                              <Select
-                                value={field.value ?? ""}
-                                onValueChange={(v) => field.onChange(v === "" ? null : v)}
-                              >
-                                <SelectTrigger>
-                                  <SelectValue
-                                    placeholder={t("dialog.fields.serverKindPlaceholder")}
-                                  />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  {SERVER_KIND_OPTIONS.map((o) => (
-                                    <SelectItem key={o.value} value={o.value}>
-                                      {o.label}
-                                    </SelectItem>
-                                  ))}
-                                </SelectContent>
-                              </Select>
-                            </FormControl>
-                            <p className="mt-1 text-xs text-muted-foreground">
-                              {t("dialog.fields.serverKindHelp")}
-                            </p>
-                            <FormMessage />
-                          </FormItem>
+                      </Button>
+                    ) : (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={handleVerifyKind}
+                        disabled={!baseUrlValue?.trim() || verifyMut.isPending}
+                        title={
+                          !baseUrlValue?.trim() ? t("dialog.verify.missingBaseUrl") : undefined
+                        }
+                      >
+                        {verifyMut.isPending ? (
+                          <>
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            {t("dialog.verify.running")}
+                          </>
+                        ) : (
+                          <>
+                            <CheckCircle2 className="mr-2 h-4 w-4" />
+                            {t("dialog.verify.button")}
+                          </>
                         )}
-                      />
-                    ) : null}
-                  </div>
-                ) : null}
-
-                {showTokenizerField || showPrometheusDatasourceField ? (
-                  <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                    {showTokenizerField ? (
-                      <FormField
-                        control={form.control}
-                        name="tokenizerHfId"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>{t("dialog.fields.tokenizerHfId")}</FormLabel>
-                            <FormControl>
-                              <Input
-                                autoComplete="off"
-                                placeholder={t("dialog.fields.tokenizerHfIdPlaceholder")}
-                                {...field}
-                              />
-                            </FormControl>
-                            <p className="mt-1 text-xs text-muted-foreground">
-                              {t("dialog.fields.tokenizerHfIdHelp")}
-                            </p>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                    ) : null}
-
-                    {showPrometheusDatasourceField ? (
-                      <FormField
-                        control={form.control}
-                        name="prometheusDatasourceId"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>{t("dialog.fields.prometheusDatasource.label")}</FormLabel>
-                            <FormControl>
-                              <Select
-                                value={field.value ?? "__none__"}
-                                onValueChange={(v) => field.onChange(v === "__none__" ? null : v)}
-                              >
-                                <SelectTrigger
-                                  aria-label={t("dialog.fields.prometheusDatasource.label")}
-                                >
-                                  <SelectValue
-                                    placeholder={t(
-                                      "dialog.fields.prometheusDatasource.placeholder",
-                                    )}
-                                  />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  <SelectItem value="__none__">
-                                    {t("dialog.fields.prometheusDatasource.none")}
-                                  </SelectItem>
-                                  {datasources?.map((ds) => (
-                                    <SelectItem key={ds.id} value={ds.id}>
-                                      {ds.name}
-                                      {ds.isDefault
-                                        ? ` (${t("dialog.fields.prometheusDatasource.defaultSuffix")})`
-                                        : ""}
-                                    </SelectItem>
-                                  ))}
-                                </SelectContent>
-                              </Select>
-                            </FormControl>
-                            <p className="mt-1 text-xs text-muted-foreground">
-                              {t("dialog.fields.prometheusDatasource.help")}
-                            </p>
-                            <FormMessage />
-                            {showRegisterCta ? (
-                              <div className="mt-2 flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2 text-sm">
-                                <Sparkles className="h-4 w-4 shrink-0 text-muted-foreground" />
-                                <div className="min-w-0 flex-1">
-                                  <p className="truncate">
-                                    {t("dialog.discover.registerCta.headline", { url: inferredPrometheusUrl })}
-                                  </p>
-                                  <p className="text-xs text-muted-foreground">
-                                    {t("dialog.discover.registerCta.body")}
-                                  </p>
-                                </div>
-                                <Button
-                                  type="button"
-                                  size="sm"
-                                  variant="outline"
-                                  onClick={() => setRegisterSheetOpen(true)}
-                                >
-                                  {t("dialog.discover.registerCta.action")} →
-                                </Button>
-                              </div>
-                            ) : null}
-                          </FormItem>
-                        )}
-                      />
-                    ) : null}
-                  </div>
-                ) : null}
-
-                {submitError ? (
-                  <p className="text-sm text-destructive">
-                    {submitError.toLowerCase().includes("exists")
-                      ? t("dialog.errors.duplicateName")
-                      : submitError}
-                  </p>
-                ) : null}
-              </FormSection>
-
-              {isEdit && existing ? <SubscribersSection connectionId={existing.id} /> : null}
-
-              {discoverError ? (
-                <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
-                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-                  <span className="flex-1">{discoverError}</span>
-                  <button
-                    type="button"
-                    onClick={dismissDiscoverFeedback}
-                    aria-label={t("dialog.discover.dismiss")}
-                    className="opacity-70 hover:opacity-100"
-                  >
-                    <XIcon className="h-4 w-4" />
-                  </button>
-                </div>
-              ) : null}
-              {discoverResult && !discoverError ? (
-                <DiscoverResultBanner
-                  result={discoverResult}
-                  onClose={dismissDiscoverFeedback}
-                  closeLabel={t("dialog.discover.dismiss")}
+                      </Button>
+                    )
+                  }
                 />
-              ) : null}
-            </div>
-
-            <SheetFooter className="border-t border-border pt-3">
-              <FormActions
-                onCancel={() => onOpenChange(false)}
-                cancelLabel={tc("actions.cancel")}
-                submitLabel={tc("actions.save")}
-                pending={createMut.isPending || updateMut.isPending}
-                leading={
-                  showModelFields ? (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={handleDiscover}
-                      disabled={!baseUrlValue?.trim() || discoverMut.isPending}
-                      title={
-                        !baseUrlValue?.trim() ? t("dialog.discover.missingBaseUrl") : undefined
-                      }
-                    >
-                      {discoverMut.isPending ? (
-                        <>
-                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                          {t("dialog.discover.running")}
-                        </>
-                      ) : (
-                        <>
-                          <Sparkles className="mr-2 h-4 w-4" />
-                          {t("dialog.discover.button")}
-                        </>
-                      )}
-                    </Button>
-                  ) : (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={handleVerifyKind}
-                      disabled={!baseUrlValue?.trim() || verifyMut.isPending}
-                      title={!baseUrlValue?.trim() ? t("dialog.verify.missingBaseUrl") : undefined}
-                    >
-                      {verifyMut.isPending ? (
-                        <>
-                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                          {t("dialog.verify.running")}
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle2 className="mr-2 h-4 w-4" />
-                          {t("dialog.verify.button")}
-                        </>
-                      )}
-                    </Button>
-                  )
-                }
-              />
-            </SheetFooter>
-          </form>
-        </Form>
-      </SheetContent>
-    </Sheet>
+              </SheetFooter>
+            </form>
+          </Form>
+        </SheetContent>
+      </Sheet>
       <DatasourceSheet
         open={registerSheetOpen}
         onOpenChange={setRegisterSheetOpen}

--- a/apps/web/src/features/connections/ConnectionsPage.test.tsx
+++ b/apps/web/src/features/connections/ConnectionsPage.test.tsx
@@ -63,9 +63,16 @@ vi.mock("./queries", () => ({
   useVerifyKind: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
-// ConnectionSheet's "Metrics source" picker queries the datasources list.
+// ConnectionSheet's "Metrics source" picker queries the datasources list AND,
+// since #207, mounts a hidden DatasourceSheet (for the register-CTA flow) that
+// calls the create/update/verify mutation hooks at module init time. Stub all
+// four — even though the current ConnectionsPage tests never open the sheet,
+// this keeps the mock self-sufficient if a future test does.
 vi.mock("@/features/prometheus-datasources/queries", () => ({
   useDatasources: () => ({ data: [], isLoading: false }),
+  useCreateDatasource: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateDatasource: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useVerifyDatasource: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 import { ConnectionsPage } from "./ConnectionsPage";

--- a/apps/web/src/features/diagnostics/DiagnosticsPage.test.tsx
+++ b/apps/web/src/features/diagnostics/DiagnosticsPage.test.tsx
@@ -55,10 +55,15 @@ vi.mock("@/features/connections/queries", () => ({
 }));
 
 // ConnectionSheet (rendered when "+ 新建连接" is clicked in the picker) loads
-// the Prometheus datasources list. Stub the hook to keep this test out of the
-// React-Query provider business.
+// the Prometheus datasources list AND, since #207, always mounts a hidden
+// DatasourceSheet for the register-CTA flow — which calls the create/update/
+// verify mutation hooks at module init time. Stub all four to keep this test
+// out of the React-Query provider business.
 vi.mock("@/features/prometheus-datasources/queries", () => ({
   useDatasources: () => ({ data: [], isLoading: false }),
+  useCreateDatasource: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateDatasource: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useVerifyDatasource: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 import { api } from "@/lib/api-client";

--- a/apps/web/src/features/prometheus-datasources/DatasourceSheet.test.tsx
+++ b/apps/web/src/features/prometheus-datasources/DatasourceSheet.test.tsx
@@ -172,6 +172,27 @@ describe("DatasourceSheet (create)", () => {
     await waitFor(() => expect(toastError).toHaveBeenCalled());
     expect(toastError.mock.calls[0][0]).toMatch(/Network down/);
   });
+
+  it("create mode pre-fills baseUrl + name from `initial`", () => {
+    render(
+      <DatasourceSheet
+        open
+        onOpenChange={() => {}}
+        mode={{
+          kind: "create",
+          initial: { baseUrl: "http://discover.example:9090/", name: "discover.example:9090" },
+        }}
+      />,
+    );
+    expect(screen.getByLabelText(/prometheus url/i)).toHaveValue("http://discover.example:9090/");
+    expect(screen.getByLabelText(/^name\b/i)).toHaveValue("discover.example:9090");
+  });
+
+  it("create mode without `initial` still starts with empty form (regression)", () => {
+    render(<DatasourceSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />);
+    expect(screen.getByLabelText(/prometheus url/i)).toHaveValue("");
+    expect(screen.getByLabelText(/^name\b/i)).toHaveValue("");
+  });
 });
 
 describe("DatasourceSheet (edit)", () => {

--- a/apps/web/src/features/prometheus-datasources/DatasourceSheet.tsx
+++ b/apps/web/src/features/prometheus-datasources/DatasourceSheet.tsx
@@ -33,6 +33,15 @@ import { toast } from "sonner";
 import { toastDatasourceError } from "./errors";
 import { useCreateDatasource, useUpdateDatasource, useVerifyDatasource } from "./queries";
 
+/** Form input shape — mirrors the create schema with empty strings for absent values. */
+export interface DatasourceInput {
+  name: string;
+  baseUrl: string;
+  bearerToken: string;
+  customHeaders: string;
+  isDefault: boolean;
+}
+
 /**
  * Sheet mode — `create` for a brand-new row, `edit` to modify an existing
  * one. In edit mode, the bearerToken field is hidden by default (preview
@@ -41,7 +50,7 @@ import { useCreateDatasource, useUpdateDatasource, useVerifyDatasource } from ".
  * preserved.
  */
 export type DatasourceSheetMode =
-  | { kind: "create" }
+  | { kind: "create"; initial?: Partial<DatasourceInput> }
   | { kind: "edit"; existing: PrometheusDatasourcePublic };
 
 interface DatasourceSheetProps {
@@ -49,15 +58,6 @@ interface DatasourceSheetProps {
   onOpenChange: (open: boolean) => void;
   mode: DatasourceSheetMode;
   onSaved?: (ds: PrometheusDatasourcePublic | PrometheusDatasourceWithSecret) => void;
-}
-
-/** Form input shape — mirrors the create schema with empty strings for absent values. */
-interface DatasourceInput {
-  name: string;
-  baseUrl: string;
-  bearerToken: string;
-  customHeaders: string;
-  isDefault: boolean;
 }
 
 const empty: DatasourceInput = {
@@ -98,18 +98,27 @@ export function DatasourceSheet({ open, onOpenChange, mode, onSaved }: Datasourc
       isEdit ? updatePrometheusDatasourceSchema : createPrometheusDatasourceSchema,
     ) as never,
     mode: "onTouched",
-    defaultValues: empty,
+    defaultValues: existing
+      ? existingToFormValues(existing)
+      : { ...empty, ...(mode.kind === "create" ? (mode.initial ?? {}) : {}) },
   });
 
+  // Reseed the form whenever the sheet opens (or `existing` swaps) so a
+  // reopen with a fresh `initial` doesn't stick on stale state. We read
+  // `mode.initial` inside the effect rather than via deps — `mode` is a
+  // fresh object identity per parent render and would cause the effect
+  // to fire on every render. The "open false → true" transition is the
+  // only moment we need a reseed in practice (pill click always toggles
+  // `open` through false-to-true).
   useEffect(() => {
     if (!open) return;
-    if (existing) {
-      form.reset(existingToFormValues(existing));
-    } else {
-      form.reset(empty);
-    }
+    const next: DatasourceInput = existing
+      ? existingToFormValues(existing)
+      : { ...empty, ...(mode.kind === "create" ? (mode.initial ?? {}) : {}) };
+    form.reset(next);
     setSubmitError(null);
     setRotateBearer(false);
+    // biome-ignore lint/correctness/useExhaustiveDependencies: `mode` identity is unstable; we read it inside the effect intentionally
   }, [open, existing, form]);
 
   const baseUrlValue = form.watch("baseUrl");

--- a/apps/web/src/features/prometheus-datasources/derive-name.test.ts
+++ b/apps/web/src/features/prometheus-datasources/derive-name.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { deriveDatasourceNameFromUrl } from "./derive-name";
+
+describe("deriveDatasourceNameFromUrl", () => {
+  it("returns host:port for a typical Prometheus URL", () => {
+    expect(deriveDatasourceNameFromUrl("http://prom.lab:9090/")).toBe("prom.lab:9090");
+  });
+
+  it("returns just the host when the default port is used", () => {
+    expect(deriveDatasourceNameFromUrl("http://prom.example.com/")).toBe("prom.example.com");
+  });
+
+  it("returns empty string for an unparseable URL", () => {
+    expect(deriveDatasourceNameFromUrl("not a url")).toBe("");
+  });
+
+  it("returns empty string for null", () => {
+    expect(deriveDatasourceNameFromUrl(null)).toBe("");
+  });
+
+  it("returns empty string for undefined", () => {
+    expect(deriveDatasourceNameFromUrl(undefined)).toBe("");
+  });
+
+  it("returns empty string for empty string", () => {
+    expect(deriveDatasourceNameFromUrl("")).toBe("");
+  });
+});

--- a/apps/web/src/features/prometheus-datasources/derive-name.ts
+++ b/apps/web/src/features/prometheus-datasources/derive-name.ts
@@ -1,0 +1,11 @@
+// Derive a sensible default Datasource `name` from a Prometheus base URL.
+// Used by the Discover→register CTA so the pre-filled DatasourceSheet
+// already has a reasonable name the admin can accept or edit.
+export function deriveDatasourceNameFromUrl(url: string | null | undefined): string {
+  if (!url) return "";
+  try {
+    return new URL(url).host;
+  } catch {
+    return "";
+  }
+}

--- a/apps/web/src/features/prometheus-datasources/normalize-base-url.test.ts
+++ b/apps/web/src/features/prometheus-datasources/normalize-base-url.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { normalizeBaseUrl } from "./normalize-base-url";
+
+describe("normalizeBaseUrl", () => {
+  it("strips a single trailing slash", () => {
+    expect(normalizeBaseUrl("http://prom:9090/")).toBe("http://prom:9090");
+  });
+
+  it("strips multiple trailing slashes", () => {
+    expect(normalizeBaseUrl("http://prom:9090///")).toBe("http://prom:9090");
+  });
+
+  it("leaves a URL without a trailing slash unchanged", () => {
+    expect(normalizeBaseUrl("http://prom:9090")).toBe("http://prom:9090");
+  });
+
+  it("lowercases protocol and host but preserves path case", () => {
+    expect(normalizeBaseUrl("HTTP://Prom.Lab:9090/Path/Sub/")).toBe(
+      "http://prom.lab:9090/Path/Sub",
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeBaseUrl("  http://prom:9090/  ")).toBe("http://prom:9090");
+  });
+
+  it("preserves query string and hash", () => {
+    expect(normalizeBaseUrl("http://prom:9090/api/?foo=bar#frag")).toBe(
+      "http://prom:9090/api?foo=bar#frag",
+    );
+  });
+
+  it("returns empty string for null", () => {
+    expect(normalizeBaseUrl(null)).toBe("");
+  });
+
+  it("returns empty string for undefined", () => {
+    expect(normalizeBaseUrl(undefined)).toBe("");
+  });
+
+  it("returns empty string for empty / whitespace-only input", () => {
+    expect(normalizeBaseUrl("")).toBe("");
+    expect(normalizeBaseUrl("   ")).toBe("");
+  });
+
+  it("falls back to trimmed + trailing-slash-stripped on unparseable input", () => {
+    expect(normalizeBaseUrl("not a url/")).toBe("not a url");
+  });
+});

--- a/apps/web/src/features/prometheus-datasources/normalize-base-url.ts
+++ b/apps/web/src/features/prometheus-datasources/normalize-base-url.ts
@@ -1,0 +1,21 @@
+// Canonical form for comparing Prometheus base URLs in the UI (e.g. the
+// Discover→register CTA's dup-check). Normalization:
+// - protocol + host lowercased (HTTP scheme/host are case-insensitive)
+// - trailing slashes on the path stripped
+// - path case preserved (HTTP path is case-sensitive per RFC 3986)
+// - query + hash preserved if present
+// When the input is not a parseable URL we still trim and strip any
+// trailing slash so the dup-check degrades to "literal equality after a
+// light wash" rather than missing trivially obvious matches.
+export function normalizeBaseUrl(url: string | null | undefined): string {
+  if (!url) return "";
+  const trimmed = url.trim();
+  if (!trimmed) return "";
+  try {
+    const u = new URL(trimmed);
+    const path = u.pathname.replace(/\/+$/, "");
+    return `${u.protocol.toLowerCase()}//${u.host.toLowerCase()}${path}${u.search}${u.hash}`;
+  } catch {
+    return trimmed.replace(/\/+$/, "");
+  }
+}

--- a/apps/web/src/locales/en-US/connections.json
+++ b/apps/web/src/locales/en-US/connections.json
@@ -117,6 +117,11 @@
       "failedProbesHeading": "Failed probes",
       "noValue": "not detected",
       "dismiss": "Dismiss discover result",
+      "registerCta": {
+        "headline": "Detected {{url}}",
+        "body": "Not registered as a datasource yet",
+        "action": "Register as datasource"
+      },
       "confidence": {
         "certain": "certain",
         "likely": "likely",

--- a/apps/web/src/locales/zh-CN/connections.json
+++ b/apps/web/src/locales/zh-CN/connections.json
@@ -117,6 +117,11 @@
       "failedProbesHeading": "失败的探测",
       "noValue": "未检测到",
       "dismiss": "关闭探测结果",
+      "registerCta": {
+        "headline": "推断到 {{url}}",
+        "body": "尚未注册为数据源",
+        "action": "注册为数据源"
+      },
       "confidence": {
         "certain": "确定",
         "likely": "可能",

--- a/docs/superpowers/plans/2026-05-20-discover-register-datasource-cta.md
+++ b/docs/superpowers/plans/2026-05-20-discover-register-datasource-cta.md
@@ -1,0 +1,802 @@
+# Discover → Register-as-Datasource CTA Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After Connection Discover infers a Prometheus URL that isn't yet a registered datasource, show the admin user a contextual pill below the `prometheusDatasourceId` Select. Clicking it opens `DatasourceSheet` pre-populated with the URL + a derived name; on save, the new datasource id is auto-bound into the Connection form.
+
+**Architecture:**
+- One new tiny pure utility (`derive-name.ts`) for URL → host extraction.
+- One discriminated-union widening (`DatasourceSheetMode.create.initial`) so the existing sheet can be opened with pre-filled values.
+- New state + render block in `ConnectionSheet` that tracks the inferred URL across Discover runs and renders the pill when 4 conditions hold (URL present, not already registered, no datasource bound, user is admin).
+
+**Tech Stack:** React 18 + TypeScript, React Hook Form, react-query (already wired), sonner (toast — not used by this feature), vitest + @testing-library/react, i18next.
+
+---
+
+## Spec reference
+
+`docs/superpowers/specs/2026-05-20-discover-register-datasource-cta-design.md` — read it first if anything below is ambiguous.
+
+## File map
+
+| Path | Action | Purpose |
+|---|---|---|
+| `apps/web/src/features/prometheus-datasources/derive-name.ts` | create | `deriveDatasourceNameFromUrl(url)` — URL→host, empty on parse fail |
+| `apps/web/src/features/prometheus-datasources/derive-name.test.ts` | create | unit tests for the utility |
+| `apps/web/src/features/prometheus-datasources/DatasourceSheet.tsx` | modify | widen `DatasourceSheetMode`, thread `initial` into default values + reset effect |
+| `apps/web/src/features/prometheus-datasources/DatasourceSheet.test.tsx` | modify | tests 7 + 8 from spec (initial pre-fills + create-with-no-initial regression) |
+| `apps/web/src/features/connections/ConnectionSheet.tsx` | modify | `inferredPrometheusUrl` state, Discover wiring, pill render, register-sheet wiring, `onSaved` auto-select |
+| `apps/web/src/features/connections/ConnectionSheet.test.tsx` | modify | tests 1–6 from spec |
+| `apps/web/src/locales/zh-CN/connections.json` | modify | `dialog.discover.registerCta.{headline,body,action}` |
+| `apps/web/src/locales/en-US/connections.json` | modify | same three keys in English (lint enforces parity) |
+
+---
+
+## Task 1: `deriveDatasourceNameFromUrl` utility
+
+**Files:**
+- Create: `apps/web/src/features/prometheus-datasources/derive-name.ts`
+- Create: `apps/web/src/features/prometheus-datasources/derive-name.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/features/prometheus-datasources/derive-name.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { deriveDatasourceNameFromUrl } from "./derive-name";
+
+describe("deriveDatasourceNameFromUrl", () => {
+  it("returns host:port for a typical Prometheus URL", () => {
+    expect(deriveDatasourceNameFromUrl("http://prom.lab:9090/")).toBe("prom.lab:9090");
+  });
+
+  it("returns just the host when the default port is used", () => {
+    expect(deriveDatasourceNameFromUrl("http://prom.example.com/")).toBe("prom.example.com");
+  });
+
+  it("returns empty string for an unparseable URL", () => {
+    expect(deriveDatasourceNameFromUrl("not a url")).toBe("");
+  });
+
+  it("returns empty string for null", () => {
+    expect(deriveDatasourceNameFromUrl(null)).toBe("");
+  });
+
+  it("returns empty string for undefined", () => {
+    expect(deriveDatasourceNameFromUrl(undefined)).toBe("");
+  });
+
+  it("returns empty string for empty string", () => {
+    expect(deriveDatasourceNameFromUrl("")).toBe("");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -F @modeldoctor/web exec vitest run src/features/prometheus-datasources/derive-name.test.ts`
+
+Expected: FAIL — `Cannot find module './derive-name'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/web/src/features/prometheus-datasources/derive-name.ts`:
+
+```ts
+// Derive a sensible default Datasource `name` from a Prometheus base URL.
+// Used by the Discover→register CTA so the pre-filled DatasourceSheet
+// already has a reasonable name the admin can accept or edit.
+export function deriveDatasourceNameFromUrl(url: string | null | undefined): string {
+  if (!url) return "";
+  try {
+    return new URL(url).host;
+  } catch {
+    return "";
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm -F @modeldoctor/web exec vitest run src/features/prometheus-datasources/derive-name.test.ts`
+
+Expected: PASS — 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/features/prometheus-datasources/derive-name.ts \
+        apps/web/src/features/prometheus-datasources/derive-name.test.ts
+git commit -m "feat(web): deriveDatasourceNameFromUrl utility for Discover CTA pre-fill (refs #207)"
+```
+
+---
+
+## Task 2: Widen `DatasourceSheetMode` to accept `initial` on create
+
+**Files:**
+- Modify: `apps/web/src/features/prometheus-datasources/DatasourceSheet.tsx`
+- Modify: `apps/web/src/features/prometheus-datasources/DatasourceSheet.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `apps/web/src/features/prometheus-datasources/DatasourceSheet.test.tsx`, find the existing `describe("DatasourceSheet", ...)` block and add two new tests AT THE END of the block (before the closing `});`):
+
+```tsx
+  it("create mode pre-fills baseUrl + name from `initial`", () => {
+    render(
+      <DatasourceSheet
+        open
+        onOpenChange={() => {}}
+        mode={{
+          kind: "create",
+          initial: { baseUrl: "http://discover.example:9090/", name: "discover.example:9090" },
+        }}
+      />,
+    );
+    expect(screen.getByLabelText(/base url/i)).toHaveValue("http://discover.example:9090/");
+    expect(screen.getByLabelText(/^name\b/i)).toHaveValue("discover.example:9090");
+  });
+
+  it("create mode without `initial` still starts with empty form (regression)", () => {
+    render(<DatasourceSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />);
+    expect(screen.getByLabelText(/base url/i)).toHaveValue("");
+    expect(screen.getByLabelText(/^name\b/i)).toHaveValue("");
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm -F @modeldoctor/web exec vitest run src/features/prometheus-datasources/DatasourceSheet.test.tsx`
+
+Expected: The new "pre-fills" test FAILS (`initial` not a valid prop in current type, or value is `""` because defaults ignore it). The regression test may pass already — that's fine; we need its assertion locked in.
+
+If TypeScript blocks the test from even compiling, that IS the failure — proceed to step 3.
+
+- [ ] **Step 3: Widen the discriminated union**
+
+Edit `apps/web/src/features/prometheus-datasources/DatasourceSheet.tsx`. Locate the type alias around line 43:
+
+```ts
+export type DatasourceSheetMode =
+  | { kind: "create" }
+  | { kind: "edit"; existing: PrometheusDatasourcePublic };
+```
+
+The `interface DatasourceInput { … }` declaration sits below this union (around line 55). Move it ABOVE the union AND `export` it so the widened union can reference it and external consumers (and tests) get the full shape:
+
+```ts
+/** Form input shape — mirrors the create schema with empty strings for absent values. */
+export interface DatasourceInput {
+  name: string;
+  baseUrl: string;
+  bearerToken: string;
+  customHeaders: string;
+  isDefault: boolean;
+}
+
+export type DatasourceSheetMode =
+  | { kind: "create"; initial?: Partial<DatasourceInput> }
+  | { kind: "edit"; existing: PrometheusDatasourcePublic };
+```
+
+- [ ] **Step 4: Thread `initial` into form defaults + reset effect**
+
+Still in `DatasourceSheet.tsx`. The current state (around lines 94-113):
+
+```tsx
+const form = useForm<DatasourceInput>({
+  resolver: zodResolver(
+    isEdit ? updatePrometheusDatasourceSchema : createPrometheusDatasourceSchema,
+  ) as never,
+  mode: "onTouched",
+  defaultValues: empty,
+});
+
+useEffect(() => {
+  if (!open) return;
+  if (existing) {
+    form.reset(existingToFormValues(existing));
+  } else {
+    form.reset(empty);
+  }
+  setSubmitError(null);
+  setRotateBearer(false);
+}, [open, existing, form]);
+```
+
+Replace both blocks with:
+
+```tsx
+const form = useForm<DatasourceInput>({
+  resolver: zodResolver(
+    isEdit ? updatePrometheusDatasourceSchema : createPrometheusDatasourceSchema,
+  ) as never,
+  mode: "onTouched",
+  defaultValues: existing
+    ? existingToFormValues(existing)
+    : { ...empty, ...(mode.kind === "create" ? (mode.initial ?? {}) : {}) },
+});
+
+// Reseed the form whenever the sheet opens (or `existing` swaps) so a
+// reopen with a fresh `initial` doesn't stick on stale state. We read
+// `mode.initial` inside the effect rather than via deps — `mode` is a
+// fresh object identity per parent render and would cause the effect
+// to fire on every render. The "open false → true" transition is the
+// only moment we need a reseed in practice (pill click always toggles
+// `open` through false-to-true).
+useEffect(() => {
+  if (!open) return;
+  const next: DatasourceInput = existing
+    ? existingToFormValues(existing)
+    : { ...empty, ...(mode.kind === "create" ? (mode.initial ?? {}) : {}) };
+  form.reset(next);
+  setSubmitError(null);
+  setRotateBearer(false);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `mode` identity is unstable; we read it inside the effect intentionally
+}, [open, existing, form]);
+```
+
+(If your editor or biome flags the missing `mode` dep, the inline biome-ignore comment above suppresses it — paired with the explanatory comment above.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm -F @modeldoctor/web exec vitest run src/features/prometheus-datasources/DatasourceSheet.test.tsx`
+
+Expected: All tests (existing + the two new ones) PASS.
+
+If TypeScript complains about `Partial<DatasourceInput>` not being exported, export the `DatasourceInput` type or move it above the `DatasourceSheetMode` declaration. (Quick check: `interface DatasourceInput { … }` should sit above the union now.)
+
+- [ ] **Step 6: Run apps/web lint as a regression guard**
+
+Run: `pnpm -F @modeldoctor/web lint`
+
+Expected: PASS — no new biome / native-select / i18n parity failures.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/features/prometheus-datasources/DatasourceSheet.tsx \
+        apps/web/src/features/prometheus-datasources/DatasourceSheet.test.tsx
+git commit -m "feat(web): DatasourceSheet create mode accepts \`initial\` pre-fill (refs #207)"
+```
+
+---
+
+## Task 3: i18n keys for the pill
+
+**Files:**
+- Modify: `apps/web/src/locales/zh-CN/connections.json`
+- Modify: `apps/web/src/locales/en-US/connections.json`
+
+We add these now (not later) because the next task's tests reference the keys via `t()` — i18next falls back to the key string if the value is missing, which produces confusing test failures.
+
+- [ ] **Step 1: Add Chinese keys**
+
+In `apps/web/src/locales/zh-CN/connections.json`, locate the `"discover"` block (around line 101). Inside it, immediately before the closing `"confidence": { … }` block, add:
+
+```json
+      "registerCta": {
+        "headline": "推断到 {{url}}",
+        "body": "尚未注册为数据源",
+        "action": "注册为数据源"
+      },
+```
+
+Don't forget the trailing comma so the `confidence` block still parses.
+
+- [ ] **Step 2: Add English keys**
+
+In `apps/web/src/locales/en-US/connections.json`, find the equivalent `"discover"` block. Add the same key at the same position with English copy:
+
+```json
+      "registerCta": {
+        "headline": "Detected {{url}}",
+        "body": "Not registered as a datasource yet",
+        "action": "Register as datasource"
+      },
+```
+
+- [ ] **Step 3: Verify i18n parity check passes**
+
+Run: `pnpm -F @modeldoctor/web exec node scripts/check-i18n-parity.mjs`
+
+Expected: PASS (no missing keys between zh-CN and en-US). If it fails listing a missing key, double-check both files have the exact same key path.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/locales/zh-CN/connections.json \
+        apps/web/src/locales/en-US/connections.json
+git commit -m "i18n(web): add discover.registerCta strings (refs #207)"
+```
+
+---
+
+## Task 4: ConnectionSheet — track `inferredPrometheusUrl` across Discover
+
+**Files:**
+- Modify: `apps/web/src/features/connections/ConnectionSheet.tsx`
+- Modify: `apps/web/src/features/connections/ConnectionSheet.test.tsx`
+
+This task adds the new state and wires Discover to populate it. The pill itself + register-sheet plumbing come in Task 5. We split because the state plumbing is testable on its own (test 1 from the spec covers "pill appears after Discover").
+
+We add the pill render block IN THIS TASK so test 1 is a real RED→GREEN cycle (test referring to a not-yet-rendered DOM node).
+
+- [ ] **Step 1: Add state + Discover wiring**
+
+In `apps/web/src/features/connections/ConnectionSheet.tsx`, around line 172 where `discoverResult` is declared, add a sibling state hook:
+
+```tsx
+const [inferredPrometheusUrl, setInferredPrometheusUrl] = useState<string | null>(null);
+```
+
+Find the `runDiscover` function (around line 256). Inside the `try` block, RIGHT AFTER the `const res = await discoverMut.mutateAsync(...)` line, add:
+
+```tsx
+      setInferredPrometheusUrl(res.inferred.prometheusUrl.value ?? null);
+```
+
+Find `dismissDiscoverFeedback` (around line 297) and add the new state to its clear list:
+
+```tsx
+const dismissDiscoverFeedback = () => {
+  setDiscoverError(null);
+  setDiscoverResult(null);
+  setInferredPrometheusUrl(null);
+};
+```
+
+Find the `useEffect` that resets state on sheet close (search for `if (!open)` near line 308). Inside its `if (!open)` body, add:
+
+```tsx
+      setInferredPrometheusUrl(null);
+```
+
+- [ ] **Step 2: Compute pill visibility + derive name**
+
+ABOVE the `return (` of the component (search for the JSX root), add:
+
+```tsx
+// Discover → register CTA — see issue #207. Show the pill only when all
+// four conditions hold: an inferred URL exists, it's not already a
+// registered datasource, the user hasn't picked any datasource yet, and
+// the current user is an admin (backend requires admin for create).
+const user = useAuthStore((s) => s.user);
+const isAdmin = (user?.roles ?? []).includes("admin");
+const watchedDsId = form.watch("prometheusDatasourceId");
+const inferredAlreadyRegistered = inferredPrometheusUrl
+  ? (datasources ?? []).some((d) => d.baseUrl === inferredPrometheusUrl)
+  : false;
+const showRegisterCta =
+  showPrometheusDatasourceField &&
+  inferredPrometheusUrl != null &&
+  !inferredAlreadyRegistered &&
+  watchedDsId == null &&
+  isAdmin;
+```
+
+At the TOP of the file, near the other imports, add:
+
+```tsx
+import { useAuthStore } from "@/stores/auth-store";
+import { Sparkles } from "lucide-react";
+```
+
+(`useState` and `useEffect` are already imported.)
+
+- [ ] **Step 3: Write the failing test**
+
+In `apps/web/src/features/connections/ConnectionSheet.test.tsx`, add an admin-store mock at the top alongside the other `vi.mock` calls (after the alerts/notifications mocks, before the `import { ConnectionSheet }` line):
+
+```tsx
+let mockUserRoles: string[] = ["admin"];
+vi.mock("@/stores/auth-store", () => ({
+  useAuthStore: <T,>(selector: (s: { user: { roles: string[] } }) => T) =>
+    selector({ user: { roles: mockUserRoles } }),
+}));
+```
+
+Then add a new `describe("Discover register CTA", () => { … })` block at the end of the file (before any final closing `});` of an outer describe — if the file has no outer describe wrapping all tests, just add it at module scope):
+
+```tsx
+describe("Discover register CTA", () => {
+  beforeEach(() => {
+    mockUserRoles = ["admin"];
+    discoverMutate.mockReset();
+  });
+
+  it("shows the pill on the auto-apply path when inferred URL is unregistered", async () => {
+    const user = userEvent.setup();
+    discoverMutate.mockResolvedValue({
+      inferred: {
+        serverKind: { value: "vllm", confidence: "certain", evidence: [] },
+        models: { values: ["m1"], confidence: "certain", evidence: [] },
+        category: { value: null, confidence: "unknown", evidence: [] },
+        suggestedTags: { values: [], confidence: "unknown", evidence: [] },
+        prometheusUrl: {
+          value: "http://discovered-prom:9090",
+          confidence: "likely",
+          evidence: [],
+        },
+      },
+      health: { ok: true, probesFailed: [] },
+    });
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, { wrapper: Wrapper });
+    await fillBaseFields(user);
+    await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/推断到/)).toBeInTheDocument();
+      expect(screen.getByText(/http:\/\/discovered-prom:9090/)).toBeInTheDocument();
+    });
+  });
+});
+```
+
+(The Discover button label is `🔍 自动发现` in zh-CN. The regex above matches either localization defensively.)
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run: `pnpm -F @modeldoctor/web exec vitest run src/features/connections/ConnectionSheet.test.tsx -t "register CTA"`
+
+Expected: FAIL — `Unable to find element with text /推断到/`. We have the state, but no pill in the JSX yet.
+
+- [ ] **Step 5: Add register-sheet state, imports, and wrap return in a Fragment**
+
+In `ConnectionSheet.tsx`, near the other `useState` declarations in the component body, add:
+
+```tsx
+const [registerSheetOpen, setRegisterSheetOpen] = useState(false);
+```
+
+At the TOP of the file alongside the other feature imports, add:
+
+```tsx
+import { DatasourceSheet } from "@/features/prometheus-datasources/DatasourceSheet";
+import { deriveDatasourceNameFromUrl } from "@/features/prometheus-datasources/derive-name";
+```
+
+The component's current return is a single `<Sheet>` root (around line 450 → 1059). To add a sibling `<DatasourceSheet>`, change:
+
+```tsx
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      …
+    </Sheet>
+  );
+```
+
+to:
+
+```tsx
+  return (
+    <>
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        …
+      </Sheet>
+      <DatasourceSheet
+        open={registerSheetOpen}
+        onOpenChange={setRegisterSheetOpen}
+        mode={{
+          kind: "create",
+          initial: {
+            baseUrl: inferredPrometheusUrl ?? "",
+            name: deriveDatasourceNameFromUrl(inferredPrometheusUrl),
+          },
+        }}
+        onSaved={(ds) => {
+          form.setValue("prometheusDatasourceId", ds.id, { shouldDirty: true });
+          setInferredPrometheusUrl(null);
+          setRegisterSheetOpen(false);
+        }}
+      />
+    </>
+  );
+```
+
+At this point the file compiles (the pill JSX comes next).
+
+- [ ] **Step 6: Render the pill in JSX**
+
+In `ConnectionSheet.tsx`, locate the `prometheusDatasourceId` `FormField` block (around lines 922–965). Find the closing `</FormItem>` that follows the help `<p>` and `<FormMessage />`. INSIDE that `FormItem`, AFTER `<FormMessage />`, insert the pill:
+
+```tsx
+                            {showRegisterCta ? (
+                              <div className="mt-2 flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2 text-sm">
+                                <Sparkles className="h-4 w-4 shrink-0 text-muted-foreground" />
+                                <div className="min-w-0 flex-1">
+                                  <p className="truncate">
+                                    {t("dialog.discover.registerCta.headline", { url: inferredPrometheusUrl })}
+                                  </p>
+                                  <p className="text-xs text-muted-foreground">
+                                    {t("dialog.discover.registerCta.body")}
+                                  </p>
+                                </div>
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => setRegisterSheetOpen(true)}
+                                >
+                                  {t("dialog.discover.registerCta.action")} →
+                                </Button>
+                              </div>
+                            ) : null}
+```
+
+`setRegisterSheetOpen` doesn't exist yet — we add it in the next step so the file still compiles.
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `pnpm -F @modeldoctor/web exec vitest run src/features/connections/ConnectionSheet.test.tsx -t "register CTA"`
+
+Expected: PASS — the pill renders, text matches.
+
+- [ ] **Step 8: Run the full ConnectionSheet test file to ensure no regression**
+
+Run: `pnpm -F @modeldoctor/web exec vitest run src/features/connections/ConnectionSheet.test.tsx`
+
+Expected: All existing tests + the new one pass.
+
+If existing tests fail because `useAuthStore` isn't mocked in their setup, the mock added in Step 3 should cover them (it's module-scoped). If a specific test wants a non-admin user, future tests can set `mockUserRoles = []` in their own `beforeEach`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/web/src/features/connections/ConnectionSheet.tsx \
+        apps/web/src/features/connections/ConnectionSheet.test.tsx
+git commit -m "feat(web): track inferred Prometheus URL + render register CTA pill (refs #207)"
+```
+
+---
+
+## Task 5: ConnectionSheet — pill visibility edge cases + DatasourceSheet wiring tests
+
+**Files:**
+- Modify: `apps/web/src/features/connections/ConnectionSheet.test.tsx`
+
+We've already shipped the JSX in Task 4. This task locks in the visibility rules and the post-save flow via mocking `DatasourceSheet`.
+
+- [ ] **Step 1: Add DatasourceSheet mock that captures props**
+
+In `apps/web/src/features/connections/ConnectionSheet.test.tsx`, at module scope alongside the other mocks, add:
+
+```tsx
+type CapturedDatasourceSheetProps = {
+  open: boolean;
+  mode: { kind: string; initial?: { baseUrl?: string; name?: string } };
+  onSaved?: (ds: { id: string; [k: string]: unknown }) => void;
+};
+let lastDatasourceSheetProps: CapturedDatasourceSheetProps | null = null;
+vi.mock("@/features/prometheus-datasources/DatasourceSheet", () => ({
+  DatasourceSheet: (props: CapturedDatasourceSheetProps) => {
+    lastDatasourceSheetProps = props;
+    // Render nothing — we just want to observe props and let tests call onSaved.
+    return null;
+  },
+}));
+```
+
+Reset in each test's `beforeEach` for the new describe block:
+
+```tsx
+beforeEach(() => {
+  // ... existing resets ...
+  lastDatasourceSheetProps = null;
+});
+```
+
+- [ ] **Step 2: Write the four edge-case tests + the open/save tests**
+
+Inside the `describe("Discover register CTA", …)` block from Task 4, add five tests AFTER the existing "shows the pill" test. Use the same Discover mock shape as the first test (extract a helper if it cleans up the noise):
+
+```tsx
+  function mockDiscoverWithProm(url: string | null) {
+    discoverMutate.mockResolvedValue({
+      inferred: {
+        serverKind: { value: "vllm", confidence: "certain", evidence: [] },
+        models: { values: ["m1"], confidence: "certain", evidence: [] },
+        category: { value: null, confidence: "unknown", evidence: [] },
+        suggestedTags: { values: [], confidence: "unknown", evidence: [] },
+        prometheusUrl: { value: url, confidence: "likely", evidence: [] },
+      },
+      health: { ok: true, probesFailed: [] },
+    });
+  }
+
+  it("hides the pill when the inferred URL is already registered", async () => {
+    const user = userEvent.setup();
+    // Mocked datasources list (top of file) already contains baseUrl
+    // "http://prom:9090" with id "ds-default". Use that exact URL so
+    // dup-check fires.
+    mockDiscoverWithProm("http://prom:9090");
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, { wrapper: Wrapper });
+    await fillBaseFields(user);
+    await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
+    await waitFor(() => {
+      // Discover has run (a result-side effect we can assert; here we
+      // just wait a tick by querying any field the auto-apply touched).
+      expect(discoverMutate).toHaveBeenCalled();
+    });
+    expect(screen.queryByText(/推断到/)).not.toBeInTheDocument();
+  });
+
+  it("hides the pill when a datasource is already bound", async () => {
+    const user = userEvent.setup();
+    mockDiscoverWithProm("http://discovered-prom:9090");
+    const existing: ConnectionPublic = { ...EXISTING, prometheusDatasourceId: "ds-default" };
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "edit", existing }} />, { wrapper: Wrapper });
+    await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
+    await waitFor(() => expect(discoverMutate).toHaveBeenCalled());
+    expect(screen.queryByText(/推断到/)).not.toBeInTheDocument();
+  });
+
+  it("hides the pill for non-admin users", async () => {
+    const user = userEvent.setup();
+    mockUserRoles = []; // viewer
+    mockDiscoverWithProm("http://discovered-prom:9090");
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, { wrapper: Wrapper });
+    await fillBaseFields(user);
+    await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
+    await waitFor(() => expect(discoverMutate).toHaveBeenCalled());
+    expect(screen.queryByText(/推断到/)).not.toBeInTheDocument();
+  });
+
+  it("opens DatasourceSheet pre-populated with the inferred URL + derived name", async () => {
+    const user = userEvent.setup();
+    mockDiscoverWithProm("http://discovered-prom:9090");
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, { wrapper: Wrapper });
+    await fillBaseFields(user);
+    await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
+    await waitFor(() => expect(screen.getByText(/推断到/)).toBeInTheDocument());
+    await user.click(screen.getByRole("button", { name: /注册为数据源|register as datasource/i }));
+    await waitFor(() => {
+      expect(lastDatasourceSheetProps?.open).toBe(true);
+      expect(lastDatasourceSheetProps?.mode.kind).toBe("create");
+      expect(lastDatasourceSheetProps?.mode.initial?.baseUrl).toBe("http://discovered-prom:9090");
+      expect(lastDatasourceSheetProps?.mode.initial?.name).toBe("discovered-prom:9090");
+    });
+  });
+
+  it("onSaved binds the new datasource id and hides the pill", async () => {
+    const user = userEvent.setup();
+    mockDiscoverWithProm("http://discovered-prom:9090");
+    render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, { wrapper: Wrapper });
+    await fillBaseFields(user);
+    await user.click(screen.getByRole("button", { name: /自动发现|auto.?discover|🔍/i }));
+    await waitFor(() => expect(screen.getByText(/推断到/)).toBeInTheDocument());
+    await user.click(screen.getByRole("button", { name: /注册为数据源|register as datasource/i }));
+    await waitFor(() => expect(lastDatasourceSheetProps?.onSaved).toBeDefined());
+    // Simulate the sheet's save callback firing with the new row.
+    lastDatasourceSheetProps?.onSaved?.({
+      id: "ds-new",
+      name: "discovered-prom:9090",
+      baseUrl: "http://discovered-prom:9090",
+    });
+    // Pill goes away because (a) form id is now set and (b) inferred state cleared.
+    await waitFor(() => expect(screen.queryByText(/推断到/)).not.toBeInTheDocument());
+  });
+```
+
+- [ ] **Step 3: Run the new tests**
+
+Run: `pnpm -F @modeldoctor/web exec vitest run src/features/connections/ConnectionSheet.test.tsx -t "register CTA"`
+
+Expected: All five new tests + the original "shows the pill" test PASS (6 total in the new describe).
+
+If any test fails, the most common root cause is:
+- Pill text matcher: confirm the i18n key resolved to `推断到 …`. Hard-code English copy if your environment defaults to en-US.
+- Discover button selector: the existing button label is `🔍 自动发现`. The regex matches by `自动发现` substring.
+
+- [ ] **Step 4: Run the full ConnectionSheet test file + apps/web tests**
+
+Run: `pnpm -F @modeldoctor/web exec vitest run src/features/connections/ConnectionSheet.test.tsx`
+
+Expected: All tests pass (existing + 6 new).
+
+Then run: `pnpm -F @modeldoctor/web test`
+
+Expected: All apps/web tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/features/connections/ConnectionSheet.test.tsx
+git commit -m "test(web): lock in pill visibility + DatasourceSheet wiring (refs #207)"
+```
+
+---
+
+## Task 6: Final verification + lint
+
+- [ ] **Step 1: Type-check apps/web**
+
+Run: `pnpm -F @modeldoctor/web type-check`
+
+Expected: PASS — no TypeScript errors.
+
+- [ ] **Step 2: Lint apps/web**
+
+Run: `pnpm -F @modeldoctor/web lint`
+
+Expected: PASS — biome + no-native-select + no-confirm + no-handcrafted-popover-list + i18n parity all clean.
+
+- [ ] **Step 3: Root-level smoke**
+
+Run: `pnpm lint`
+
+Expected: PASS — all workspaces clean (apps/api lint includes our #209 e2e-env check, which should still report OK).
+
+- [ ] **Step 4: Manual sanity (optional but recommended)**
+
+If a dev server is convenient:
+
+```bash
+pnpm dev
+```
+
+Open the app, log in as admin, open ConnectionSheet for a new model connection, paste a URL whose host serves a Prometheus endpoint (or use a mock fixture), trigger Discover, confirm the pill appears under "Prometheus 数据源", click it, confirm the DatasourceSheet opens with the URL pre-filled, save, confirm the Connection's datasource Select shows the new row selected.
+
+**Kill the dev server before continuing** (cmd-c) — leaving it running between agent sessions has historically wedged the machine.
+
+- [ ] **Step 5: Push + open PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --base main \
+  --title "feat(web): Discover → register-as-datasource CTA (closes #207)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Inline pill below the `prometheusDatasourceId` Select that fires when Discover infers a Prometheus URL that's not already a registered datasource (admin only). Click → `DatasourceSheet` opens pre-filled (URL + name = `new URL(url).host`) → on save, the new datasource id is auto-bound to the Connection form (with `shouldDirty: true` so the Save button lights up).
+- `DatasourceSheet` `create` mode now accepts an optional `initial?: Partial<DatasourceInput>`; existing call sites (`DatasourcesPage`) unaffected.
+- New tiny pure utility `deriveDatasourceNameFromUrl` (URL → host, empty string on parse fail).
+- i18n: 3 new keys under `dialog.discover.registerCta.*` (zh-CN + en-US).
+
+## Visibility rule
+
+The pill renders only when **all four** of these hold:
+1. Discover returned an `inferred.prometheusUrl.value`
+2. No existing datasource matches that `baseUrl`
+3. Connection form's `prometheusDatasourceId` is unset
+4. Current user has `admin` role (backend rejects non-admin with 403)
+
+## Why Direction 2 (inline pill) over Direction 1 (toast action)
+
+Spec rationale: `docs/superpowers/specs/2026-05-20-discover-register-datasource-cta-design.md`. TL;DR — toast TTL is too short for the typical "scan the form for a few seconds" pattern; the pill persists until acted on and lives where the user is already looking.
+
+## Test plan
+
+- [x] `pnpm -F @modeldoctor/web exec vitest run src/features/prometheus-datasources/derive-name.test.ts` → 6/6 pass
+- [x] `pnpm -F @modeldoctor/web exec vitest run src/features/prometheus-datasources/DatasourceSheet.test.tsx` → existing + 2 new (`initial` pre-fill, regression with no `initial`)
+- [x] `pnpm -F @modeldoctor/web exec vitest run src/features/connections/ConnectionSheet.test.tsx` → existing + 6 new (pill render / dup-hide / bound-hide / non-admin-hide / open with initial / onSaved binds + clears)
+- [x] `pnpm -F @modeldoctor/web type-check`
+- [x] `pnpm -F @modeldoctor/web lint` (i18n parity included)
+- [x] Root `pnpm lint`
+- [ ] Manual: admin user, Discover a real Prometheus URL not in datasources, click pill, save → new row appears + Connection auto-bound
+
+Closes #207.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: After CI green + merge — cleanup**
+
+(Standard branch-cleanup flow per project memory: delete local + remote feature branch and worktree once #207 closes.)
+
+---
+
+## Spec ↔ Plan coverage check
+
+- Spec §"Visibility rule" → Task 4 step 2 (the `showRegisterCta` computation).
+- Spec §"Pill placement and visual" → Task 4 step 5 (the JSX block).
+- Spec §"DatasourceSheet extension" → Task 2.
+- Spec §"Name-derivation utility" → Task 1.
+- Spec §"Post-save behavior" → Task 4 step 6 (onSaved handler).
+- Spec §"i18n keys" → Task 3.
+- Spec §"Tests" tests 1-6 → Task 4 step 3 (test 1) + Task 5 step 2 (tests 2-6).
+- Spec §"Tests" tests 7-8 → Task 2 step 1.
+- Spec §"Tests" tests 9-11 → Task 1 step 1.

--- a/docs/superpowers/plans/2026-05-20-discover-register-datasource-cta.md
+++ b/docs/superpowers/plans/2026-05-20-discover-register-datasource-cta.md
@@ -411,17 +411,17 @@ describe("Discover register CTA", () => {
     const user = userEvent.setup();
     discoverMutate.mockResolvedValue({
       inferred: {
-        serverKind: { value: "vllm", confidence: "certain", evidence: [] },
-        models: { values: ["m1"], confidence: "certain", evidence: [] },
-        category: { value: null, confidence: "unknown", evidence: [] },
-        suggestedTags: { values: [], confidence: "unknown", evidence: [] },
+        serverKind: { value: "vllm", confidence: "certain", evidence: "" },
+        models: { values: ["m1"], confidence: "certain", evidence: "" },
+        category: { value: null, confidence: "unknown", evidence: "" },
+        suggestedTags: { values: [], confidence: "unknown", evidence: "" },
         prometheusUrl: {
           value: "http://discovered-prom:9090",
           confidence: "likely",
-          evidence: [],
+          evidence: "",
         },
       },
-      health: { ok: true, probesFailed: [] },
+      health: { durationMs: 50, probesAttempted: 4, probesFailed: [], warnings: [] },
     });
     render(<ConnectionSheet open onOpenChange={() => {}} mode={{ kind: "create" }} />, { wrapper: Wrapper });
     await fillBaseFields(user);
@@ -595,13 +595,13 @@ Inside the `describe("Discover register CTA", …)` block from Task 4, add five 
   function mockDiscoverWithProm(url: string | null) {
     discoverMutate.mockResolvedValue({
       inferred: {
-        serverKind: { value: "vllm", confidence: "certain", evidence: [] },
-        models: { values: ["m1"], confidence: "certain", evidence: [] },
-        category: { value: null, confidence: "unknown", evidence: [] },
-        suggestedTags: { values: [], confidence: "unknown", evidence: [] },
-        prometheusUrl: { value: url, confidence: "likely", evidence: [] },
+        serverKind: { value: "vllm", confidence: "certain", evidence: "" },
+        models: { values: ["m1"], confidence: "certain", evidence: "" },
+        category: { value: null, confidence: "unknown", evidence: "" },
+        suggestedTags: { values: [], confidence: "unknown", evidence: "" },
+        prometheusUrl: { value: url, confidence: "likely", evidence: "" },
       },
-      health: { ok: true, probesFailed: [] },
+      health: { durationMs: 50, probesAttempted: 4, probesFailed: [], warnings: [] },
     });
   }
 

--- a/docs/superpowers/specs/2026-05-20-discover-register-datasource-cta-design.md
+++ b/docs/superpowers/specs/2026-05-20-discover-register-datasource-cta-design.md
@@ -1,0 +1,212 @@
+# Discover → Register-as-Datasource CTA (issue #207)
+
+**Status:** approved · 2026-05-20
+**Scope:** apps/web (ConnectionSheet + DatasourceSheet)
+**Closes:** #207
+
+## Problem
+
+After PR #199, `DiscoverConnectionResponse.inferred.prometheusUrl.value`
+is detected by Connection Discover but there is no UX path from
+"discovered" to "registered as a Prometheus datasource". The user must
+copy the URL, navigate to `/settings/prometheus-datasources`, click
+"+ 新增数据源", and paste — at which point most users give up.
+
+The original issue surveyed three directions and recommended a toast
+action button (Direction 1). On re-read of the auto-apply success path
+in `ConnectionSheet.tsx` we are picking **Direction 2 — an inline pill
+beneath the `prometheusDatasourceId` Select** — because the user is
+contextually right there, the pill persists until acted on, and the
+"toast TTL is too short" failure mode is real for users who scan the
+form for a few seconds.
+
+## Out of scope
+
+- Auto-registration without user confirm (security).
+- Re-running Discover on `edit` open of an existing Connection to
+  populate `inferredPrometheusUrl` without an explicit user gesture.
+- Promoting Alertmanager to a first-class entity (tracked in #210).
+- Any backend changes — `POST /api/prometheus-datasources` already
+  exists and is admin-gated.
+
+## Visibility rule
+
+The pill renders when ALL four conditions hold:
+
+```
+showPill =
+     inferredPrometheusUrl != null                              // (1)
+  && !datasources.some(d => d.baseUrl === inferredPrometheusUrl) // (2)
+  && form.watch("prometheusDatasourceId") == null                // (3)
+  && isAdmin                                                     // (4)
+```
+
+1. **Source of `inferredPrometheusUrl`** — a new
+   `useState<string | null>` in `ConnectionSheet`. `runDiscover`'s
+   success branch sets it from `res.inferred.prometheusUrl.value`
+   regardless of `filled === 0` vs `filled > 0`. The existing
+   `discoverResult` state's semantics are **unchanged**: it is still
+   set only on the `filled === 0` fallback so the
+   `DiscoverResultBanner` mount condition stays identical.
+   - Cleared on **ConnectionSheet** close (alongside `discoverResult` /
+     `discoverError` in the existing reset `useEffect`) and when
+     `onSaved` fires (condition 3 alone would already hide it once the
+     form's id is set, but explicit clear avoids a one-frame flash).
+2. **Dup-check** uses `useDatasources()` which is already loaded in
+   `ConnectionSheet` for the Select options. Compare on `baseUrl`
+   (string equality — the create schema already trims/normalizes).
+3. **Already-bound** — if the user has selected any datasource from
+   the dropdown (including the auto-default), respect that choice and
+   stop nudging.
+4. **Admin gate** — backend rejects non-admin with 403. Use the
+   established pattern `useAuthStore(s => s.user)` +
+   `(user?.roles ?? []).includes("admin")`. Non-admin sees nothing.
+
+## Pill placement and visual
+
+The pill lives inside the existing `<FormField name="prometheusDatasourceId">`
+`FormItem`, after the `<p className="mt-1 text-xs text-muted-foreground">`
+help line and before `<FormMessage />`. Rendering only when
+`showPrometheusDatasourceField` is already true keeps it scoped to the
+right `serverKind`s (model + gateway).
+
+Visual style:
+
+- One row, `rounded-md border bg-muted/40 px-3 py-2 text-sm`.
+- Left half: `<Sparkles className="h-4 w-4 text-muted-foreground" />`
+  + headline `推断到 <code>{url}</code>` + secondary `尚未注册为数据源`.
+- Right side: `<Button size="sm" variant="outline">注册为数据源 →</Button>`.
+
+No emoji. No dismiss button — pill self-dismisses when any of the four
+conditions flips false. The "nag" risk is low because conditions 2 + 3
+naturally clear it after the user takes any action.
+
+## DatasourceSheet extension
+
+`DatasourceSheetMode` gains an optional `initial` on the `create`
+variant:
+
+```ts
+export type DatasourceSheetMode =
+  | { kind: "create"; initial?: Partial<DatasourceInput> }
+  | { kind: "edit"; existing: PrometheusDatasourcePublic };
+```
+
+The form `defaultValues` resolve to `{ ...empty, ...(mode.initial ?? {}) }`
+when `mode.kind === "create"`. `edit` mode is untouched.
+
+`useEffect` that resets the form on `open` / `mode` change must thread
+`mode.initial` through so re-opening the sheet with different initial
+values re-seeds the form (today the equivalent loop seeds from
+`existing`).
+
+Existing call site in `DatasourcesPage.tsx` (which always passes
+`{ kind: "create" }` with no initial) needs no change — `initial` is
+optional.
+
+## Name-derivation utility
+
+```ts
+// apps/web/src/features/prometheus-datasources/derive-name.ts
+export function deriveDatasourceNameFromUrl(url: string | null | undefined): string {
+  if (!url) return "";
+  try {
+    return new URL(url).host;
+  } catch {
+    return "";
+  }
+}
+```
+
+Pure function, exported for unit testing. Used by ConnectionSheet to
+build `initial.name` when opening the register sheet. If it returns
+empty, the user simply types a name in the Sheet — the form is still
+valid because `baseUrl` is pre-filled.
+
+## Post-save behavior
+
+`<DatasourceSheet onSaved={(ds) => …}>` callback fires
+`form.setValue("prometheusDatasourceId", ds.id, { shouldDirty: true })`
+on the Connection form and clears `inferredPrometheusUrl`. The
+`shouldDirty: true` is intentional — this is a user-initiated bind, so
+the Connection's Save button must light up.
+
+`useCreateDatasource` already invalidates the `datasources` query on
+success, so the Select's options re-render with the new row and the
+new `id` resolves cleanly.
+
+## i18n keys
+
+`apps/web/locales/{zh,en}/connections.json`:
+
+```jsonc
+"dialog.discover.registerCta": {
+  "headline": "推断到 {{url}}",     // en: "Detected {{url}}"
+  "body": "尚未注册为数据源",         // en: "Not registered as a datasource yet"
+  "action": "注册为数据源"            // en: "Register as datasource"
+}
+```
+
+## Tests
+
+### ConnectionSheet (vitest + RTL, existing `ConnectionSheet.test.tsx`)
+
+1. **Renders pill on the auto-apply path** — mock `useDatasources` →
+   `[]`, `useAuthStore` user with `roles: ["admin"]`, mock
+   `discoverConnection` returning `inferred.prometheusUrl.value =
+   "http://prom:9090"` plus at least one other inferred field so
+   `countFilledFields > 0` (the toast/auto-apply branch). Trigger
+   Discover via the explicit button. Assert pill visible.
+2. **Hidden by dup** — same as (1) but `useDatasources` returns
+   `[{ baseUrl: "http://prom:9090", … }]`. Assert pill absent.
+3. **Hidden when bound** — same as (1) but the Connection being
+   edited already has `prometheusDatasourceId` set. Assert pill absent.
+4. **Hidden for non-admin** — same as (1) but `roles: []`. Assert
+   pill absent.
+5. **Opens sheet with initial** — click pill, assert
+   `DatasourceSheet` rendered with `mode.kind === "create"` and
+   `mode.initial.baseUrl === "http://prom:9090"` (mock the sheet to
+   capture props rather than render its internals).
+6. **onSaved auto-selects + clears pill** — simulate the captured
+   `onSaved({ id: "new-id" })`. Assert
+   `form.getValues("prometheusDatasourceId") === "new-id"` (via a
+   hidden test probe or by asserting the Select displays the new
+   option label). Assert pill no longer in the DOM.
+
+### DatasourceSheet (extend existing `DatasourceSheet.test.tsx`)
+
+7. **initial pre-fills form** —
+   `mode={{ kind: "create", initial: { baseUrl: "http://x", name: "x" } }}`.
+   Assert the rendered inputs carry those values without user typing.
+8. **Regression: create with no initial** — `mode={{ kind: "create" }}`.
+   Assert empty defaults (same as current behavior).
+
+### derive-name (new tiny unit test)
+
+9. `deriveDatasourceNameFromUrl("http://prom.lab:9090/")` → `"prom.lab:9090"`.
+10. `deriveDatasourceNameFromUrl("not a url")` → `""`.
+11. `deriveDatasourceNameFromUrl(null)` → `""`.
+
+## Files touched
+
+- `apps/web/src/features/connections/ConnectionSheet.tsx` — new
+  `inferredPrometheusUrl` state, `runDiscover` augmentation, pill
+  render block, register-sheet state + `onSaved`.
+- `apps/web/src/features/connections/ConnectionSheet.test.tsx` —
+  tests 1–6.
+- `apps/web/src/features/prometheus-datasources/DatasourceSheet.tsx`
+  — type widening + `defaultValues` resolution.
+- `apps/web/src/features/prometheus-datasources/DatasourceSheet.test.tsx`
+  — tests 7–8.
+- `apps/web/src/features/prometheus-datasources/derive-name.ts`
+  (new) + `derive-name.test.ts` (new) — tests 9–11.
+- `apps/web/locales/zh/connections.json`,
+  `apps/web/locales/en/connections.json` — three i18n keys.
+
+## Acceptance (issue #207)
+
+- [x] After Discover success with `inferred.prometheusUrl.value`
+  present, user sees an actionable affordance — **the pill**.
+- [x] Click → DatasourceSheet opens pre-populated (URL + name from
+  baseUrl host).
+- [x] Test on the auto-apply path asserts the CTA appears (test 1).


### PR DESCRIPTION
## Summary

After Connection Discover infers a Prometheus URL that's not already a registered datasource, the user (if admin) now sees an inline pill below the `prometheusDatasourceId` Select. Click → `DatasourceSheet` opens pre-populated (URL + `name = new URL(url).host`) → on save, the new datasource id is auto-bound to the Connection form with `shouldDirty: true`.

## Direction

Spec picked **Direction 2 (inline pill)** over the issue's recommended Direction 1 (toast action button): the auto-apply toast TTL is ~4-5s, but users typically scan the form for much longer right after Discover fires, so a persistent contextual pill catches them where their eyes already are. Full reasoning in `docs/superpowers/specs/2026-05-20-discover-register-datasource-cta-design.md`.

## Visibility rule

Pill renders only when **all four** conditions hold:
1. Discover returned a `inferred.prometheusUrl.value`
2. No existing datasource matches that `baseUrl`
3. Connection form's `prometheusDatasourceId` is unset
4. Current user has `admin` role (backend rejects non-admin with 403)

## What's in the PR

- **Spec + plan**: `docs/superpowers/specs/2026-05-20-discover-register-datasource-cta-design.md`, `docs/superpowers/plans/2026-05-20-discover-register-datasource-cta.md`.
- **New utility**: `deriveDatasourceNameFromUrl(url)` — pure URL→host, empty on parse fail. 6 unit tests.
- **DatasourceSheet widening**: `create` mode now accepts an optional `initial?: Partial<DatasourceInput>`. `DatasourceInput` is now exported. 2 new tests (pre-fill + no-initial regression).
- **ConnectionSheet changes**: new `inferredPrometheusUrl` state populated on every Discover (both auto-apply and zero-result paths), new `registerSheetOpen` state, `showRegisterCta` visibility computation, pill JSX inside the existing `prometheusDatasourceId` FormItem, sibling `<DatasourceSheet>` with `onSaved` that auto-selects + clears local state. Return wrapped in Fragment to host the sibling Sheet. 6 new tests covering pill visibility (4 edge cases) + sheet wiring (open with initial / onSaved binds).
- **i18n**: `dialog.discover.registerCta.{headline,body,action}` in zh-CN + en-US.
- **Test-only side fix**: DiagnosticsPage's prometheus-datasources mock had to gain the three datasource mutation hooks (DatasourceSheet is now always mounted whenever ConnectionSheet renders); applied the same defensive stub to ConnectionsPage as a follow-up consistency patch.
- **biome auto-fix**: Fragment wrap shifted indentation in ConnectionSheet.tsx — committed as a separate \`chore(web): biome auto-fix\` so reviewers can skip it visually. Whitespace-ignoring diff for that commit is ~37 lines.

## Test plan

- [x] \`pnpm -F @modeldoctor/web exec vitest run src/features/prometheus-datasources/derive-name.test.ts\` — 6/6 pass
- [x] \`pnpm -F @modeldoctor/web exec vitest run src/features/prometheus-datasources/DatasourceSheet.test.tsx\` — existing + 2 new pass
- [x] \`pnpm -F @modeldoctor/web exec vitest run src/features/connections/ConnectionSheet.test.tsx\` — existing + 6 new (1 happy-path + 4 edge-cases + 1 onSaved) pass
- [x] \`pnpm -F @modeldoctor/web test\` → 852/852 pass
- [x] \`pnpm -F @modeldoctor/web type-check\` → clean
- [x] \`pnpm -F @modeldoctor/web lint\` → clean (biome + i18n parity + no-native-select + no-confirm + no-handcrafted-popover-list)
- [ ] Manual: admin user, ConnectionSheet → paste curl with a Prometheus URL not in datasources → pill appears under "Prometheus 数据源" → click → DatasourceSheet opens pre-filled → save → Connection's Prometheus Select shows the new datasource selected

Closes #207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)