### PR TITLE
test: 2026-05-20 audit minor follow-up — doc + fix-now (closes #211)

### DIFF
--- a/apps/api/test/e2e/insights.e2e-spec.ts
+++ b/apps/api/test/e2e/insights.e2e-spec.ts
@@ -45,17 +45,21 @@ describe("/api/insights comparison endpoints (e2e)", () => {
     await prisma.connection.deleteMany({ where: { userId } });
   });
 
-  it("baseline-comparison returns empty when no historical data", async () => {
-    const conn = await prisma.connection.create({
+  // Minimal Connection fixture — every test in this file only varies `name`.
+  const makeConn = (name: string) =>
+    prisma.connection.create({
       data: {
         userId,
-        name: "t",
+        name,
         baseUrl: "http://x",
         apiKeyCipher: "v1:a:b:c",
         model: "m",
         category: "chat",
       },
     });
+
+  it("baseline-comparison returns empty when no historical data", async () => {
+    const conn = await makeConn("t");
     const r = await request(ctx.app.getHttpServer())
       .get(`/api/insights/${conn.id}/baseline-comparison?from=${new Date().toISOString()}`)
       .set("Authorization", `Bearer ${token}`)
@@ -64,16 +68,7 @@ describe("/api/insights comparison endpoints (e2e)", () => {
   });
 
   it("fleet-comparison returns empty when only one connection in category", async () => {
-    const conn = await prisma.connection.create({
-      data: {
-        userId,
-        name: "t2",
-        baseUrl: "http://x",
-        apiKeyCipher: "v1:a:b:c",
-        model: "m",
-        category: "chat",
-      },
-    });
+    const conn = await makeConn("t2");
     const r = await request(ctx.app.getHttpServer())
       .get(`/api/insights/${conn.id}/fleet-comparison?from=${new Date().toISOString()}`)
       .set("Authorization", `Bearer ${token}`)
@@ -82,16 +77,7 @@ describe("/api/insights comparison endpoints (e2e)", () => {
   });
 
   it("POST /api/insights/:id/synthesize returns NarrativeFinding[] (mocked LLM)", async () => {
-    const conn = await prisma.connection.create({
-      data: {
-        userId,
-        name: "ai",
-        baseUrl: "http://x",
-        apiKeyCipher: "v1:a:b:c",
-        model: "m",
-        category: "chat",
-      },
-    });
+    const conn = await makeConn("ai");
     // Use the API to create the provider so the apiKey is properly encrypted
     await request(ctx.app.getHttpServer())
       .put("/api/llm-judge/provider")
@@ -109,16 +95,7 @@ describe("/api/insights comparison endpoints (e2e)", () => {
   });
 
   it("synthesize returns 404 when provider not configured", async () => {
-    const conn = await prisma.connection.create({
-      data: {
-        userId,
-        name: "noai",
-        baseUrl: "http://x",
-        apiKeyCipher: "v1:a:b:c",
-        model: "m",
-        category: "chat",
-      },
-    });
+    const conn = await makeConn("noai");
     // Note: beforeEach already wiped llmJudgeProvider; explicitly confirm clean state
     await prisma.llmJudgeProvider.deleteMany();
     await request(ctx.app.getHttpServer())

--- a/apps/api/test/e2e/prometheus-datasource.e2e-spec.ts
+++ b/apps/api/test/e2e/prometheus-datasource.e2e-spec.ts
@@ -40,6 +40,14 @@ describe("PrometheusDatasource e2e", () => {
       .expect(403);
   });
 
+  it("POST :id/set-default requires admin", async () => {
+    // requireAdmin runs before the DB lookup, so we don't need a real id.
+    await request(ctx.app.getHttpServer())
+      .post("/api/prometheus-datasources/ds_nonexistent/set-default")
+      .set("Authorization", `Bearer ${userToken}`)
+      .expect(403);
+  });
+
   it("admin can create + list + set-default + delete", async () => {
     const createRes = await request(ctx.app.getHttpServer())
       .post("/api/prometheus-datasources")
@@ -61,7 +69,8 @@ describe("PrometheusDatasource e2e", () => {
       .expect(200);
     expect(listRes.body.items).toHaveLength(1);
     // bearerToken (plaintext) MUST NOT appear in list responses; only the
-    // create / update / rotate paths echo it once.
+    // create path echoes it once. (PATCH update / rotate paths exist but are
+    // not covered by this e2e suite — see service/controller unit tests.)
     expect(listRes.body.items[0].bearerToken).toBeUndefined();
     expect(listRes.body.items[0].bearerPreview).toContain("...");
 

--- a/apps/web/src/features/benchmarks/__tests__/SetBaselineDialog.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/SetBaselineDialog.test.tsx
@@ -38,7 +38,7 @@ describe("SetBaselineDialog", () => {
     // Submit label is "保存" (zh-CN) / "Save" (en-US); the dialog has exactly
     // one such button (Cancel is the only other one), so anchored name match
     // is unambiguous and resilient to button-order changes.
-    const submit = screen.getByRole("button", { name: /^保存$|^Save$/i });
+    const submit = screen.getByRole("button", { name: /^(保存|Save)$/i });
     expect(submit).toBeDisabled();
     await user.type(screen.getByLabelText(/Name/i), "v1");
     expect(submit).not.toBeDisabled();
@@ -63,7 +63,7 @@ describe("SetBaselineDialog", () => {
     await user.type(screen.getByLabelText(/Name/i), "anchor");
     await user.type(screen.getByLabelText(/Description/i), "desc");
     await user.type(screen.getByLabelText(/Tags/i), "a, b");
-    await user.click(screen.getByRole("button", { name: /^保存$|^Save$/i }));
+    await user.click(screen.getByRole("button", { name: /^(保存|Save)$/i }));
     expect(mockMutate).toHaveBeenCalledWith(
       { benchmarkId: "r_1", name: "anchor", description: "desc", tags: ["a", "b"] },
       expect.any(Object),
@@ -75,7 +75,7 @@ describe("SetBaselineDialog", () => {
     render(<SetBaselineDialog benchmarkId="r_1" open onOpenChange={() => {}} />, {
       wrapper: Wrapper,
     });
-    await user.click(screen.getByRole("button", { name: /^保存$|^Save$/i }));
+    await user.click(screen.getByRole("button", { name: /^(保存|Save)$/i }));
     expect(mockMutate).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/benchmarks/__tests__/SetBaselineDialog.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/SetBaselineDialog.test.tsx
@@ -35,11 +35,10 @@ describe("SetBaselineDialog", () => {
     render(<SetBaselineDialog benchmarkId="b1" open onOpenChange={() => {}} />, {
       wrapper: Wrapper,
     });
-    // The submit label comes from i18n; en-US falls back. Match by being the
-    // form's submit button (disabled by default).
-    const buttons = screen.getAllByRole("button");
-    const submit = buttons.find((b) => (b as HTMLButtonElement).type === "submit");
-    expect(submit).toBeDefined();
+    // Submit label is "保存" (zh-CN) / "Save" (en-US); the dialog has exactly
+    // one such button (Cancel is the only other one), so anchored name match
+    // is unambiguous and resilient to button-order changes.
+    const submit = screen.getByRole("button", { name: /^保存$|^Save$/i });
     expect(submit).toBeDisabled();
     await user.type(screen.getByLabelText(/Name/i), "v1");
     expect(submit).not.toBeDisabled();
@@ -64,10 +63,7 @@ describe("SetBaselineDialog", () => {
     await user.type(screen.getByLabelText(/Name/i), "anchor");
     await user.type(screen.getByLabelText(/Description/i), "desc");
     await user.type(screen.getByLabelText(/Tags/i), "a, b");
-    const submit = screen
-      .getAllByRole("button")
-      .find((b) => (b as HTMLButtonElement).type === "submit") as HTMLButtonElement;
-    await user.click(submit);
+    await user.click(screen.getByRole("button", { name: /^保存$|^Save$/i }));
     expect(mockMutate).toHaveBeenCalledWith(
       { benchmarkId: "r_1", name: "anchor", description: "desc", tags: ["a", "b"] },
       expect.any(Object),
@@ -79,10 +75,7 @@ describe("SetBaselineDialog", () => {
     render(<SetBaselineDialog benchmarkId="r_1" open onOpenChange={() => {}} />, {
       wrapper: Wrapper,
     });
-    const submit = screen
-      .getAllByRole("button")
-      .find((b) => (b as HTMLButtonElement).type === "submit") as HTMLButtonElement;
-    await user.click(submit);
+    await user.click(screen.getByRole("button", { name: /^保存$|^Save$/i }));
     expect(mockMutate).not.toHaveBeenCalled();
   });
 });

--- a/docs/superpowers/audit/2026-05-20-test-minor-followup.md
+++ b/docs/superpowers/audit/2026-05-20-test-minor-followup.md
@@ -1,0 +1,80 @@
+# Test audit (2026-05-20) — minor findings re-enumeration
+
+Follow-up to issue #211. The original 2026-05-19 audit shipped critical
++ important findings in PRs #202 / #203 / #204; the minor tier was
+deferred. This pass re-enumerates the minor items with crisp
+`file:line` references and triages each as fix-now, fix-later, or
+wontfix.
+
+Method: 3 parallel subagent sweeps (apps/api, apps/web, packages)
+constrained to MINOR-tier and the six categories listed in #211. PRs
+#202–#204 territory was excluded by instruction.
+
+**Totals:** 18 findings · 5 fix-now · 13 fix-later · 0 wontfix.
+
+The fix-now subset lands in this same PR. Fix-later items are recorded
+here so future contributors can pick them up without rediscovery; each
+is small enough to fit a single-purpose PR if/when prioritized.
+
+---
+
+## apps/api
+
+### fix-now
+
+- `apps/api/test/e2e/prometheus-datasource.e2e-spec.ts:63-64` — **stale comment** — Says "the create / update / rotate paths echo it once" but neither PATCH (update) nor a rotate path is tested in this file; the claim misleads future authors into thinking the coverage exists. **Fix:** trim the clause to only mention `create`.
+- `apps/api/test/e2e/prometheus-datasource.e2e-spec.ts:35-41` — **single-branch coverage** — Non-admin 403 is asserted for `POST /api/prometheus-datasources` but `POST /:id/set-default` (also admin-gated via `requireAdmin`) has no 403 branch. **Fix:** add a 4-line `it("POST set-default requires admin")` mirroring the existing 403 test.
+- `apps/api/test/e2e/insights.e2e-spec.ts:48-128` — **duplicate fixture setup** — Four consecutive `it` blocks each inline `prisma.connection.create({ data: { userId, name, baseUrl: "http://x", apiKeyCipher: "v1:a:b:c", model: "m", category: "chat" } })` verbatim; only `name` varies. **Fix:** extract a `makeConn(name)` helper at the top of the describe.
+
+### fix-later
+
+- `apps/api/test/e2e/prometheus-datasource.e2e-spec.ts:87-123` — **test isolation** — Duplicate-name/duplicate-baseUrl tests call `prisma.prometheusDatasource.deleteMany()` inline at the top of each `it` rather than in `beforeEach`; under `vitest --shuffle` cross-test contamination is possible.
+- `apps/api/src/modules/connection/connection.service.spec.ts:303` — **single-branch coverage** — `toContractPublic` is tested with a bound datasource; the unbound (`prometheusDatasource: null`) branch is not.
+- `apps/api/test/e2e/{alerts,insights,saved-compares}.e2e-spec.ts` — **cross-file duplicate setup** — Three e2e files seed an `llmJudgeProvider` with the same `deleteMany + create + encrypt` shape; ripe for a `seedLlmJudgeProvider(prisma, key)` helper in `test/helpers/`.
+
+---
+
+## apps/web
+
+### fix-now
+
+- `apps/web/src/features/benchmarks/__tests__/SetBaselineDialog.test.tsx:40-41, 67-69, 82-84` — **fragile selector** — `getAllByRole("button").find(b => b.type === "submit")` selects by DOM attribute rather than accessible name. Three occurrences in the same file. **Fix:** replace each with `getByRole("button", { name: /^保存$|^Save$/i })` (the dialog has only one Save button).
+
+### fix-later
+
+- `apps/web/src/features/playground/image/ImagePage.test.tsx:72` — **fragile selector** — `.at(-1)` on `getAllByRole("button", { name: /^generate$/i })` silently picks the wrong button if a second "generate" appears in the page tree. Add `data-testid="generate-btn"` and switch to `getByTestId`.
+- `apps/web/src/features/quality-gate/__tests__/EvaluationsListPage.test.tsx:76` — **fragile selector** — `getByText("4")` matches a raw digit globally. Replace with `within(row).getByText("4")`.
+- `apps/web/src/features/connections/ConnectionsPage.test.tsx` — **single-branch coverage** — Only populated case tested; no empty-list, no loading, no fetch-error branch. Add at least empty + error cases.
+- `apps/web/src/features/quality-gate/__tests__/RunsListPage.test.tsx` — **single-branch coverage** — Only happy-path; no empty, loading, or error tested.
+- `apps/web/src/features/benchmark-templates/__tests__/{TemplateCreatePage,TemplateEditPage,TemplateListPage}.test.tsx` — **wrapper duplication** — Three near-identical `Wrapper` (QueryClientProvider + MemoryRouter) declarations. Extract a `__tests__/helpers.tsx` with an optional `initialEntries` param.
+- `apps/web/src/features/playground/{image,embeddings,chat,rerank}/*Page.test.tsx` — **mock duplication** — Identical 9-line `vi.mock("@/features/connections/queries", ...)` block + matching `SAMPLE_CONN` fixture across 4+ playground test files. Hoist to a shared playground fixtures module.
+- `apps/web/src/features/playground/chat/{MessageList,MessageComposer}.test.tsx` — **helper duplication** — Two files in the same dir each define an identical `renderWithI18n`. Move to a shared helper.
+
+---
+
+## packages
+
+### fix-now
+
+- `packages/tool-adapters/src/category-defaults.ts:39` — **stale comment** — JSDoc references "`prometheusUrl` presence" but post-#199 the gate is `connection.prometheusDatasource` (an object, not a URL). Comment is in production source but content-only — the runtime check elsewhere already uses the new field. **Fix:** update the comment to reference `prometheusDatasource`.
+
+### fix-later
+
+- `packages/contracts/src/engine-metrics.spec.ts:64` — **uncommented magic index** — `ok.panels[2].thresholds` accesses the third panel by bare numeric index. Add an inline comment explaining why `panels[2]` is the `success_rate` panel.
+- `packages/contracts/src/quality-gate/__tests__/judge-config.spec.ts` — **single-branch coverage** — `contains` and `regex` judge variants only have failure tests; happy-path `.parse(valid)` assertions are missing.
+- `packages/contracts/src/connection.spec.ts:234-270` — **single-branch coverage** — `discoverConnectionResponseSchema` has two happy-path tests but zero failure cases (missing `inferred.serverKind`, invalid `prometheusUrl` format, etc.).
+
+---
+
+## Notes on what isn't here
+
+- The original audit's CRITICAL + IMPORTANT findings — already shipped in PRs #202 / #203 / #204.
+- The `process.env.X = ...` anti-pattern in e2e specs — already locked in by the lint script in PR #214 (closes #209).
+- The MCP_* fixture fold — already shipped in PR #213 (closes #206).
+- The echarts mock pre-existing fragmentation — already deduped by PR #204; this audit verified no regressions.
+
+## Acceptance check vs. issue #211
+
+- [x] Markdown report committed at `docs/superpowers/audit/2026-05-20-test-minor-followup.md` with crisp `file:line` items.
+- [x] Each item triaged: 5 fix-now / 13 fix-later / 0 wontfix.
+- [x] Fix-now subset ships in this same PR.

--- a/packages/tool-adapters/src/category-defaults.ts
+++ b/packages/tool-adapters/src/category-defaults.ts
@@ -36,8 +36,10 @@ export const GUIDELLM_CATEGORY_DEFAULTS = {
 /**
  * prefix-cache-probe targets any chat-compatible vLLM endpoint; the modality
  * category doesn't restrict which connections are compatible. All categories
- * are supported — the only actual gate is `prometheusUrl` presence, which the
- * form checks separately and surfaces as a blocking alert.
+ * are supported — the only actual gate is whether the Connection has a bound
+ * `prometheusDatasource` (post-#199 this is the first-class entity, not the
+ * old `prometheusUrl` field); the form checks that separately and surfaces a
+ * blocking alert when it's absent.
  */
 export const PREFIX_CACHE_PROBE_CATEGORY_DEFAULTS = {
   chat: {},


### PR DESCRIPTION
## Summary

Follow-up to issue #211. The 2026-05-19 full-repo audit shipped its critical + important findings in PRs #202 / #203 / #204; this PR re-enumerates the deferred MINOR tier, ships the unambiguous fix-now subset, and records the rest as fix-later for future single-purpose PRs.

**Approach:** three parallel subagent sweeps (apps/api · apps/web · packages) constrained to MINOR tier + the six categories listed in #211. Findings excluded:
- PRs #202 / #203 / #204 territory (already shipped)
- The `process.env` anti-pattern (locked in by PR #214's lint, closes #209)
- Design-decision territory (prod source changes beyond comment fixes)

**Totals:** 18 findings · 5 fix-now · 13 fix-later · 0 wontfix.

## Audit doc

`docs/superpowers/audit/2026-05-20-test-minor-followup.md` — every finding with crisp `file:line` + triage tag.

## Fix-now subset (in this PR)

**apps/api** — `test(api):` commit:
1. `prometheus-datasource.e2e-spec.ts:63-64` — trim misleading "create / update / rotate" claim down to just "create" (update / rotate aren't exercised by this e2e file).
2. `prometheus-datasource.e2e-spec.ts` — add the missing 403 test for `POST /:id/set-default`; symmetrical with the existing 403 test for `POST /api/prometheus-datasources`.
3. `insights.e2e-spec.ts` — extract a `makeConn(name)` helper; four near-identical fixture blocks differing only in `name` collapse to single-line calls, removing ~32 lines of duplication.

**apps/web + packages** — `test(web)+chore(adapters):` commit:
4. `SetBaselineDialog.test.tsx` (3 occurrences) — replace `getAllByRole("button").find(b => b.type === "submit")` with anchored accessible-name match `getByRole("button", { name: /^保存$|^Save$/i })`.
5. `packages/tool-adapters/src/category-defaults.ts` — JSDoc said the gate is `prometheusUrl` presence; post-#199 it's the first-class `prometheusDatasource` entity. Pure comment correction.

## Test plan

- [x] \`pnpm -F @modeldoctor/api type-check\` → clean
- [x] \`pnpm -F @modeldoctor/api lint\` (incl. PR #214's e2e-env lint) → clean
- [x] \`pnpm -F @modeldoctor/api test\` (unit) → 722/722 pass
- [x] \`pnpm -F @modeldoctor/api exec vitest run --config vitest.e2e.config.mts test/e2e/prometheus-datasource.e2e-spec.ts\` → 6/6 pass (was 5, +1 set-default 403)
- [x] \`pnpm -F @modeldoctor/api exec vitest run --config vitest.e2e.config.mts test/e2e/insights.e2e-spec.ts\` → 4/4 pass with new helper
- [x] \`pnpm -F @modeldoctor/web type-check\` → clean
- [x] \`pnpm -F @modeldoctor/web lint\` → clean
- [x] \`pnpm -F @modeldoctor/web test\` → 863/863 pass
- [x] SetBaselineDialog targeted run → 5/5 pass

## Fix-later items (recorded in audit doc, not in this PR)

13 items deferred — full list in the audit doc. Highlights:
- apps/api: test isolation tweaks (deleteMany in body vs. beforeEach), unbound-datasource branch coverage, `seedLlmJudgeProvider` shared helper
- apps/web: 4 selector / single-branch fragility points (ImagePage, EvaluationsListPage, ConnectionsPage, RunsListPage) + 3 Wrapper / mock duplications across playground + benchmark-templates
- packages/contracts: missing negative-case coverage on `judge-config` + `discoverConnectionResponseSchema`

Closes #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)