### PR TITLE
feat(api): harden PrometheusFetcherService HTTP path (closes #200)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -83,6 +83,25 @@ BENCHMARK_DEFAULT_MAX_CONCURRENCY=100
 # In prod set to the public origin, e.g. https://modeldoctor.example.com.
 # APP_BASE_URL=http://localhost:5173
 
+# --- Prometheus fetcher hardening (issue #200) ----------------------------
+# Defense-in-depth for the alert-explainer's outbound Prometheus fetch.
+# All three are opt-in; defaults preserve pre-#200 behaviour so existing
+# LAN-only deploys keep working after upgrade.
+#
+# Comma-separated allow-list of permitted Prometheus hostnames. When set,
+# this IS the policy — anything else (including private IPs) is rejected.
+# Leave unset to fall through to PROMETHEUS_FETCH_BLOCK_PRIVATE.
+# Example: PROMETHEUS_FETCH_ALLOW_HOSTS=prom.lab,prom-dr.lab
+PROMETHEUS_FETCH_ALLOW_HOSTS=
+# When true, reject URLs that resolve to a private / loopback / link-local
+# IP. Default false because ModelDoctor typically runs Prom on a LAN.
+# Set to true for paranoid prod where Prom is reachable via a public DNS
+# record that should never be allowed to drift to an internal address.
+PROMETHEUS_FETCH_BLOCK_PRIVATE=false
+# Upper bound on a single Prometheus response body. Streaming abort
+# fires once cumulative bytes exceed this. 5 MiB default.
+PROMETHEUS_FETCH_MAX_BODY_BYTES=5242880
+
 # --- Alertmanager webhook receiver (P0 closed loop) ------------------------
 # Shared secret for the Alertmanager → ModelDoctor webhook
 # (POST /api/alerts/webhook). REQUIRED whenever NODE_ENV != "test" — the

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -94,6 +94,29 @@ export const EnvSchema = z
     // public origin, e.g. https://modeldoctor.example.com.
     APP_BASE_URL: z.string().url().optional(),
 
+    // --- Prometheus fetcher hardening (issue #200) ---
+    // Defense-in-depth knobs for the PrometheusFetcherService outbound
+    // HTTP. All three are opt-in: the default behaviour preserves the
+    // pre-#200 fetch semantics so existing LAN-only deploys aren't broken
+    // by an upgrade. See prometheus-fetcher.guard.ts for the policy
+    // precedence.
+    //
+    // When non-empty (comma-separated hostnames), this list IS the policy:
+    // anything outside it is rejected and the private-IP check is
+    // bypassed (the operator made an explicit choice). Empty / unset
+    // means "no allow-list, fall through to PROMETHEUS_FETCH_BLOCK_PRIVATE".
+    PROMETHEUS_FETCH_ALLOW_HOSTS: z.string().optional(),
+    // When true, reject any URL whose host resolves to a private /
+    // loopback / link-local IP. Default false because ModelDoctor
+    // typically runs Prometheus on an internal LAN.
+    PROMETHEUS_FETCH_BLOCK_PRIVATE: envBoolean.default(false),
+    // Upper bound on a single Prometheus response body in bytes. The
+    // query_range endpoint streams JSON, so we cap cumulative bytes
+    // before parsing to avoid a malicious / misconfigured datasource
+    // OOMing the api worker. Default 5 MiB — a 15-minute window at 15s
+    // step with 5 series fits in tens of KB, so this is generous.
+    PROMETHEUS_FETCH_MAX_BODY_BYTES: z.coerce.number().int().positive().default(5_242_880),
+
     // --- Alertmanager webhook receiver (P0 closed loop) ---
     // Shared secret for Alertmanager → ModelDoctor webhook. Verified per
     // request via HMAC-SHA256 in the X-ModelDoctor-Signature header. Required

--- a/apps/api/src/modules/alerts/alerts.module.ts
+++ b/apps/api/src/modules/alerts/alerts.module.ts
@@ -7,9 +7,23 @@ import { PROMETHEUS_DS_ENC_KEY } from "../prometheus-datasource/prometheus-datas
 import { AlertsController } from "./alerts.controller.js";
 import { AlertsService } from "./alerts.service.js";
 import { AlertExplainerService } from "./explainer.service.js";
+import type { SsrfGuardConfig } from "./prometheus-fetcher.guard.js";
 import { PrometheusFetcherService } from "./prometheus-fetcher.service.js";
 import { SubscribersController } from "./subscribers.controller.js";
 import { SubscribersService } from "./subscribers.service.js";
+
+/**
+ * Combined runtime configuration for `PrometheusFetcherService`. Built
+ * from env at module-init via the factory below; injected into the
+ * service by token to keep the service constructor signature stable
+ * for unit tests that already `new` the service directly.
+ */
+export interface PrometheusFetcherConfig {
+  guard: SsrfGuardConfig;
+  maxBodyBytes: number;
+}
+
+export const PROMETHEUS_FETCHER_CONFIG = "PROMETHEUS_FETCHER_CONFIG";
 
 @Module({
   imports: [DatabaseModule, ConfigModule, LlmJudgeModule],
@@ -30,6 +44,27 @@ import { SubscribersService } from "./subscribers.service.js";
         const k = config.get("CONNECTION_API_KEY_ENCRYPTION_KEY", { infer: true });
         if (!k) throw new Error("CONNECTION_API_KEY_ENCRYPTION_KEY is required");
         return k;
+      },
+    },
+    {
+      provide: PROMETHEUS_FETCHER_CONFIG,
+      inject: [ConfigService],
+      useFactory: (config: ConfigService<Env, true>): PrometheusFetcherConfig => {
+        const raw = config.get("PROMETHEUS_FETCH_ALLOW_HOSTS", { infer: true });
+        const allowHosts =
+          raw && raw.trim().length > 0
+            ? raw
+                .split(",")
+                .map((h) => h.trim())
+                .filter((h) => h.length > 0)
+            : null;
+        return {
+          guard: {
+            blockPrivate: config.get("PROMETHEUS_FETCH_BLOCK_PRIVATE", { infer: true }),
+            allowHosts,
+          },
+          maxBodyBytes: config.get("PROMETHEUS_FETCH_MAX_BODY_BYTES", { infer: true }),
+        };
       },
     },
   ],

--- a/apps/api/src/modules/alerts/alerts.module.ts
+++ b/apps/api/src/modules/alerts/alerts.module.ts
@@ -7,23 +7,16 @@ import { PROMETHEUS_DS_ENC_KEY } from "../prometheus-datasource/prometheus-datas
 import { AlertsController } from "./alerts.controller.js";
 import { AlertsService } from "./alerts.service.js";
 import { AlertExplainerService } from "./explainer.service.js";
-import type { SsrfGuardConfig } from "./prometheus-fetcher.guard.js";
+import {
+  PROMETHEUS_FETCHER_CONFIG,
+  type PrometheusFetcherConfig,
+} from "./prometheus-fetcher.config.js";
 import { PrometheusFetcherService } from "./prometheus-fetcher.service.js";
 import { SubscribersController } from "./subscribers.controller.js";
 import { SubscribersService } from "./subscribers.service.js";
 
-/**
- * Combined runtime configuration for `PrometheusFetcherService`. Built
- * from env at module-init via the factory below; injected into the
- * service by token to keep the service constructor signature stable
- * for unit tests that already `new` the service directly.
- */
-export interface PrometheusFetcherConfig {
-  guard: SsrfGuardConfig;
-  maxBodyBytes: number;
-}
-
-export const PROMETHEUS_FETCHER_CONFIG = "PROMETHEUS_FETCHER_CONFIG";
+export type { PrometheusFetcherConfig };
+export { PROMETHEUS_FETCHER_CONFIG };
 
 @Module({
   imports: [DatabaseModule, ConfigModule, LlmJudgeModule],

--- a/apps/api/src/modules/alerts/prometheus-fetcher.config.ts
+++ b/apps/api/src/modules/alerts/prometheus-fetcher.config.ts
@@ -1,0 +1,15 @@
+// apps/api/src/modules/alerts/prometheus-fetcher.config.ts
+import type { SsrfGuardConfig } from "./prometheus-fetcher.guard.js";
+
+/**
+ * Combined runtime configuration for `PrometheusFetcherService`. Built
+ * from env at module-init via the factory in alerts.module.ts; injected
+ * into the service by token to keep the service constructor signature
+ * stable for unit tests that already `new` the service directly.
+ */
+export interface PrometheusFetcherConfig {
+  guard: SsrfGuardConfig;
+  maxBodyBytes: number;
+}
+
+export const PROMETHEUS_FETCHER_CONFIG = "PROMETHEUS_FETCHER_CONFIG";

--- a/apps/api/src/modules/alerts/prometheus-fetcher.guard.spec.ts
+++ b/apps/api/src/modules/alerts/prometheus-fetcher.guard.spec.ts
@@ -1,11 +1,19 @@
 // apps/api/src/modules/alerts/prometheus-fetcher.guard.spec.ts
 import { describe, expect, it } from "vitest";
-import { evaluateUrl, isPrivateOrLoopback, type SsrfGuardConfig, type Resolver } from "./prometheus-fetcher.guard";
+import {
+  type Resolver,
+  type SsrfGuardConfig,
+  evaluateUrl,
+  isPrivateOrLoopback,
+} from "./prometheus-fetcher.guard";
 
 const noResolver: Resolver = async () => {
   throw new Error("resolver should not be called");
 };
-const fixedResolver = (ips: string[]): Resolver => async () => ips;
+const fixedResolver =
+  (ips: string[]): Resolver =>
+  async () =>
+    ips;
 const failingResolver: Resolver = async () => {
   throw new Error("ENOTFOUND prom.lab");
 };
@@ -64,7 +72,11 @@ describe("isPrivateOrLoopback rejects non-IPs", () => {
 
 describe("evaluateUrl — permissive default (no allow-list, blockPrivate=false)", () => {
   it("allows any public host without DNS lookup", async () => {
-    const v = await evaluateUrl(new URL("http://public.example.com"), CONFIG_PERMISSIVE, noResolver);
+    const v = await evaluateUrl(
+      new URL("http://public.example.com"),
+      CONFIG_PERMISSIVE,
+      noResolver,
+    );
     expect(v).toEqual({ ok: true });
   });
   it("allows a private IP literal", async () => {

--- a/apps/api/src/modules/alerts/prometheus-fetcher.guard.spec.ts
+++ b/apps/api/src/modules/alerts/prometheus-fetcher.guard.spec.ts
@@ -1,0 +1,182 @@
+// apps/api/src/modules/alerts/prometheus-fetcher.guard.spec.ts
+import { describe, expect, it } from "vitest";
+import { evaluateUrl, isPrivateOrLoopback, type SsrfGuardConfig, type Resolver } from "./prometheus-fetcher.guard";
+
+const noResolver: Resolver = async () => {
+  throw new Error("resolver should not be called");
+};
+const fixedResolver = (ips: string[]): Resolver => async () => ips;
+const failingResolver: Resolver = async () => {
+  throw new Error("ENOTFOUND prom.lab");
+};
+
+const CONFIG_PERMISSIVE: SsrfGuardConfig = { blockPrivate: false, allowHosts: null };
+const CONFIG_BLOCK: SsrfGuardConfig = { blockPrivate: true, allowHosts: null };
+const CONFIG_ALLOW_LIST = (hosts: string[]): SsrfGuardConfig => ({
+  blockPrivate: true, // ignored when allowHosts non-empty
+  allowHosts: hosts,
+});
+
+describe("isPrivateOrLoopback (IPv4)", () => {
+  it.each([
+    ["10.0.0.1", true],
+    ["10.255.255.255", true],
+    ["172.15.0.1", false],
+    ["172.16.0.1", true],
+    ["172.31.255.255", true],
+    ["172.32.0.1", false],
+    ["192.168.1.1", true],
+    ["192.169.1.1", false],
+    ["127.0.0.1", true],
+    ["127.255.255.255", true],
+    ["169.254.169.254", true],
+    ["0.0.0.0", true],
+    ["8.8.8.8", false],
+    ["1.1.1.1", false],
+  ] as const)("%s → %s", (ip, expected) => {
+    expect(isPrivateOrLoopback(ip)).toBe(expected);
+  });
+});
+
+describe("isPrivateOrLoopback (IPv6)", () => {
+  it.each([
+    ["::1", true],
+    ["fc00::1", true],
+    ["fd12:3456:789a::1", true],
+    ["fe80::1", true],
+    ["::ffff:10.0.0.1", true], // IPv4-mapped private
+    ["::ffff:8.8.8.8", false], // IPv4-mapped public
+    ["2001:db8::1", false], // documentation range, treated as public for our purposes
+    ["2606:4700:4700::1111", false], // Cloudflare DNS, public
+  ] as const)("%s → %s", (ip, expected) => {
+    expect(isPrivateOrLoopback(ip)).toBe(expected);
+  });
+});
+
+describe("isPrivateOrLoopback rejects non-IPs", () => {
+  it("returns false for hostnames", () => {
+    expect(isPrivateOrLoopback("prom.lab")).toBe(false);
+  });
+  it("returns false for garbage", () => {
+    expect(isPrivateOrLoopback("not an ip")).toBe(false);
+  });
+});
+
+describe("evaluateUrl — permissive default (no allow-list, blockPrivate=false)", () => {
+  it("allows any public host without DNS lookup", async () => {
+    const v = await evaluateUrl(new URL("http://public.example.com"), CONFIG_PERMISSIVE, noResolver);
+    expect(v).toEqual({ ok: true });
+  });
+  it("allows a private IP literal", async () => {
+    const v = await evaluateUrl(new URL("http://10.0.0.5:9090"), CONFIG_PERMISSIVE, noResolver);
+    expect(v).toEqual({ ok: true });
+  });
+});
+
+describe("evaluateUrl — blockPrivate=true (opt-in)", () => {
+  it("blocks a private IP literal", async () => {
+    const v = await evaluateUrl(new URL("http://10.0.0.5:9090"), CONFIG_BLOCK, noResolver);
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toMatch(/private\/loopback/);
+  });
+  it("blocks loopback", async () => {
+    const v = await evaluateUrl(new URL("http://127.0.0.1:9090"), CONFIG_BLOCK, noResolver);
+    expect(v.ok).toBe(false);
+  });
+  it("blocks cloud metadata endpoint", async () => {
+    const v = await evaluateUrl(
+      new URL("http://169.254.169.254/latest/meta-data/"),
+      CONFIG_BLOCK,
+      noResolver,
+    );
+    expect(v.ok).toBe(false);
+  });
+  it("allows a public IP literal", async () => {
+    const v = await evaluateUrl(new URL("http://8.8.8.8:9090"), CONFIG_BLOCK, noResolver);
+    expect(v).toEqual({ ok: true });
+  });
+  it("resolves hostname and blocks when it points at a private IP", async () => {
+    const v = await evaluateUrl(
+      new URL("http://prom.lab:9090"),
+      CONFIG_BLOCK,
+      fixedResolver(["10.0.0.5"]),
+    );
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toMatch(/prom\.lab.*10\.0\.0\.5/);
+  });
+  it("resolves hostname and allows when it points at a public IP", async () => {
+    const v = await evaluateUrl(
+      new URL("http://prom.example.com:9090"),
+      CONFIG_BLOCK,
+      fixedResolver(["1.2.3.4"]),
+    );
+    expect(v).toEqual({ ok: true });
+  });
+  it("blocks when ANY resolved IP is private (split-horizon DNS)", async () => {
+    const v = await evaluateUrl(
+      new URL("http://prom.example.com:9090"),
+      CONFIG_BLOCK,
+      fixedResolver(["1.2.3.4", "10.0.0.5"]),
+    );
+    expect(v.ok).toBe(false);
+  });
+  it("blocks when resolver returns empty array", async () => {
+    const v = await evaluateUrl(
+      new URL("http://no-such-host.example"),
+      CONFIG_BLOCK,
+      fixedResolver([]),
+    );
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toMatch(/no records/);
+  });
+  it("blocks when resolver throws (fail-closed)", async () => {
+    const v = await evaluateUrl(new URL("http://prom.lab"), CONFIG_BLOCK, failingResolver);
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toMatch(/dns lookup failed/);
+  });
+});
+
+describe("evaluateUrl — allowHosts is the policy when set", () => {
+  it("allows a host in the list (case-insensitive)", async () => {
+    const v = await evaluateUrl(
+      new URL("http://PROM.lab:9090"),
+      CONFIG_ALLOW_LIST(["prom.lab", "prom2.lab"]),
+      noResolver,
+    );
+    expect(v).toEqual({ ok: true });
+  });
+  it("blocks a host not in the list, even on the public internet", async () => {
+    const v = await evaluateUrl(
+      new URL("http://public.example.com"),
+      CONFIG_ALLOW_LIST(["prom.lab"]),
+      noResolver,
+    );
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toMatch(/not in PROMETHEUS_FETCH_ALLOW_HOSTS/);
+  });
+  it("allows a private IP if it's explicitly listed (overrides blockPrivate)", async () => {
+    const v = await evaluateUrl(
+      new URL("http://10.0.0.5:9090"),
+      CONFIG_ALLOW_LIST(["10.0.0.5"]),
+      noResolver,
+    );
+    expect(v).toEqual({ ok: true });
+  });
+  it("treats empty allowHosts array as 'no allow-list configured'", async () => {
+    const v = await evaluateUrl(
+      new URL("http://public.example.com"),
+      { blockPrivate: false, allowHosts: [] },
+      noResolver,
+    );
+    expect(v).toEqual({ ok: true });
+  });
+});
+
+describe("evaluateUrl — input edge cases", () => {
+  it("rejects a URL with no hostname", async () => {
+    // file:// URLs have empty hostname; not actually fetchable but defensive.
+    const u = new URL("file:///etc/passwd");
+    const v = await evaluateUrl(u, CONFIG_BLOCK, noResolver);
+    expect(v.ok).toBe(false);
+  });
+});

--- a/apps/api/src/modules/alerts/prometheus-fetcher.guard.spec.ts
+++ b/apps/api/src/modules/alerts/prometheus-fetcher.guard.spec.ts
@@ -39,6 +39,22 @@ describe("isPrivateOrLoopback (IPv4)", () => {
     ["127.255.255.255", true],
     ["169.254.169.254", true],
     ["0.0.0.0", true],
+    // RFC 6598 CGNAT / shared address space
+    ["100.63.255.255", false],
+    ["100.64.0.1", true],
+    ["100.127.255.255", true],
+    ["100.128.0.1", false],
+    // RFC 2544 benchmark testing
+    ["198.17.255.255", false],
+    ["198.18.0.1", true],
+    ["198.19.255.255", true],
+    ["198.20.0.1", false],
+    // Multicast + reserved + broadcast (>= 224.0.0.0)
+    ["223.255.255.255", false],
+    ["224.0.0.1", true],
+    ["239.255.255.255", true],
+    ["240.0.0.1", true],
+    ["255.255.255.255", true],
     ["8.8.8.8", false],
     ["1.1.1.1", false],
   ] as const)("%s → %s", (ip, expected) => {
@@ -49,6 +65,7 @@ describe("isPrivateOrLoopback (IPv4)", () => {
 describe("isPrivateOrLoopback (IPv6)", () => {
   it.each([
     ["::1", true],
+    ["::", true], // unspecified address — some stacks route to localhost
     ["fc00::1", true],
     ["fd12:3456:789a::1", true],
     ["fe80::1", true],

--- a/apps/api/src/modules/alerts/prometheus-fetcher.guard.ts
+++ b/apps/api/src/modules/alerts/prometheus-fetcher.guard.ts
@@ -66,12 +66,18 @@ export function isPrivateOrLoopback(ip: string): boolean {
     if (a === 169 && b === 254) return true;
     // 0.0.0.0/8 (current network — kernel-routed to localhost on Linux)
     if (a === 0) return true;
+    // 100.64.0.0/10 (RFC 6598 CGNAT / shared address space)
+    if (a === 100 && b >= 64 && b <= 127) return true;
+    // 198.18.0.0/15 (RFC 2544 benchmark testing)
+    if (a === 198 && (b === 18 || b === 19)) return true;
+    // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved/class E + 255.255.255.255 broadcast
+    if (a >= 224) return true;
     return false;
   }
   if (family === 6) {
     const lower = ip.toLowerCase();
-    // ::1 loopback
-    if (lower === "::1") return true;
+    // ::1 loopback, :: unspecified (some stacks route to localhost)
+    if (lower === "::1" || lower === "::") return true;
     // fc00::/7 unique local
     if (/^f[cd][0-9a-f]{2}:/.test(lower)) return true;
     // fe80::/10 link-local

--- a/apps/api/src/modules/alerts/prometheus-fetcher.guard.ts
+++ b/apps/api/src/modules/alerts/prometheus-fetcher.guard.ts
@@ -1,6 +1,6 @@
+import { promises as dns } from "node:dns";
 // apps/api/src/modules/alerts/prometheus-fetcher.guard.ts
 import { isIP } from "node:net";
-import { promises as dns } from "node:dns";
 
 /**
  * Defense-in-depth guard for the PrometheusFetcher's outbound HTTP. The

--- a/apps/api/src/modules/alerts/prometheus-fetcher.guard.ts
+++ b/apps/api/src/modules/alerts/prometheus-fetcher.guard.ts
@@ -1,0 +1,137 @@
+// apps/api/src/modules/alerts/prometheus-fetcher.guard.ts
+import { isIP } from "node:net";
+import { promises as dns } from "node:dns";
+
+/**
+ * Defense-in-depth guard for the PrometheusFetcher's outbound HTTP. The
+ * datasource baseUrl is admin-supplied so the realistic threat surface is
+ * compromised-admin / misconfiguration rather than untrusted input — the
+ * point of these guards is to make a misconfigured allow-list or a
+ * dynamic-DNS rebind blow up loudly instead of silently leaking onto
+ * unexpected network segments.
+ *
+ * Closes #200.
+ */
+
+export interface SsrfGuardConfig {
+  /**
+   * When true, any URL whose host (or any DNS-resolved IP for a hostname)
+   * falls in a private / loopback / link-local range is rejected. Default
+   * is `false` — ModelDoctor deploys typically run Prometheus on an
+   * internal LAN, and a "block by default" stance would silently break
+   * existing setups on upgrade. Opt in for paranoid prod.
+   */
+  blockPrivate: boolean;
+  /**
+   * Positive allow-list of hostnames (matched case-insensitively, exact
+   * string equality on `URL.hostname`). When non-empty, this list IS the
+   * policy: anything outside it is blocked, AND the `blockPrivate` check
+   * is bypassed (the operator made an explicit choice).
+   *
+   * `null` (or empty array) means "no allow-list configured" — fall
+   * through to the `blockPrivate` check.
+   */
+  allowHosts: readonly string[] | null;
+}
+
+export type GuardVerdict = { ok: true } | { ok: false; reason: string };
+
+/** DNS resolver injection point. Production uses `dns.promises.lookup` (all=true). */
+export type Resolver = (hostname: string) => Promise<string[]>;
+
+const defaultResolver: Resolver = async (hostname) => {
+  const records = await dns.lookup(hostname, { all: true });
+  return records.map((r) => r.address);
+};
+
+/**
+ * Is the given IPv4/IPv6 literal in a private / loopback / link-local range?
+ * Ranges per RFC 1918, RFC 4193, RFC 3927, RFC 4291.
+ */
+export function isPrivateOrLoopback(ip: string): boolean {
+  const family = isIP(ip);
+  if (family === 4) {
+    const parts = ip.split(".").map(Number);
+    if (parts.length !== 4 || parts.some((p) => Number.isNaN(p))) return false;
+    const [a, b] = parts;
+    // 10.0.0.0/8
+    if (a === 10) return true;
+    // 172.16.0.0/12
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    // 192.168.0.0/16
+    if (a === 192 && b === 168) return true;
+    // 127.0.0.0/8 (loopback)
+    if (a === 127) return true;
+    // 169.254.0.0/16 (link-local, includes cloud metadata 169.254.169.254)
+    if (a === 169 && b === 254) return true;
+    // 0.0.0.0/8 (current network — kernel-routed to localhost on Linux)
+    if (a === 0) return true;
+    return false;
+  }
+  if (family === 6) {
+    const lower = ip.toLowerCase();
+    // ::1 loopback
+    if (lower === "::1") return true;
+    // fc00::/7 unique local
+    if (/^f[cd][0-9a-f]{2}:/.test(lower)) return true;
+    // fe80::/10 link-local
+    if (/^fe[89ab][0-9a-f]:/.test(lower)) return true;
+    // IPv4-mapped IPv6: ::ffff:a.b.c.d — fall through to the IPv4 check
+    const v4mapped = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+    if (v4mapped) return isPrivateOrLoopback(v4mapped[1]);
+    return false;
+  }
+  return false; // not a valid IP literal at all — caller decides
+}
+
+/**
+ * Evaluate whether the given URL is allowed to be fetched. Resolves
+ * hostnames via the injected resolver so callers can mock DNS in tests.
+ */
+export async function evaluateUrl(
+  url: URL,
+  config: SsrfGuardConfig,
+  resolver: Resolver = defaultResolver,
+): Promise<GuardVerdict> {
+  const host = url.hostname;
+  if (!host) return { ok: false, reason: "missing hostname" };
+
+  // 1. Positive allow-list takes precedence.
+  if (config.allowHosts && config.allowHosts.length > 0) {
+    const allow = config.allowHosts.map((h) => h.toLowerCase());
+    if (allow.includes(host.toLowerCase())) return { ok: true };
+    return { ok: false, reason: `host "${host}" not in PROMETHEUS_FETCH_ALLOW_HOSTS` };
+  }
+
+  // 2. Private-IP block (opt-in).
+  if (!config.blockPrivate) return { ok: true };
+
+  let ipsToCheck: string[];
+  if (isIP(host)) {
+    ipsToCheck = [host];
+  } else {
+    try {
+      ipsToCheck = await resolver(host);
+    } catch (e) {
+      return {
+        ok: false,
+        reason: `dns lookup failed for "${host}": ${(e as Error).message}`,
+      };
+    }
+  }
+
+  if (ipsToCheck.length === 0) {
+    return { ok: false, reason: `dns lookup returned no records for "${host}"` };
+  }
+
+  for (const ip of ipsToCheck) {
+    if (isPrivateOrLoopback(ip)) {
+      return {
+        ok: false,
+        reason: `host "${host}" resolves to private/loopback address ${ip}`,
+      };
+    }
+  }
+
+  return { ok: true };
+}

--- a/apps/api/src/modules/alerts/prometheus-fetcher.service.spec.ts
+++ b/apps/api/src/modules/alerts/prometheus-fetcher.service.spec.ts
@@ -441,7 +441,8 @@ describe("PrometheusFetcherService.fetchAlertContext — hardening", () => {
       data: { name: "perm", baseUrl: "https://prom.test:9090", isDefault: true },
     });
     const svc = new PrometheusFetcherService(prisma, TEST_KEY_B64, PERMISSIVE_FETCHER_CONFIG);
-    // Two consecutive 302s: first hop → second → would exceed MAX_HOPS.
+    // Three consecutive 302s: initial + 2 redirects = 3 fetches (the limit).
+    // The 3rd fetch is also a 302 → throws "exceeded 2 redirect hops".
     const fetchSpy = vi
       .fn()
       .mockResolvedValueOnce(
@@ -455,6 +456,12 @@ describe("PrometheusFetcherService.fetchAlertContext — hardening", () => {
           status: 302,
           headers: { Location: "https://prom.test:9090/hop3" },
         }),
+      )
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { Location: "https://prom.test:9090/hop4" },
+        }),
       ) as unknown as typeof globalThis.fetch;
     globalThis.fetch = fetchSpy;
     try {
@@ -462,6 +469,53 @@ describe("PrometheusFetcherService.fetchAlertContext — hardening", () => {
         makeEvent({ annotations: { expr: "up" }, connectionId: null }),
       );
       expect(ctx).toBeNull();
+      // Three fetches attempted, then the limit fires.
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  it("4b. exactly 2 redirect hops allowed — terminal 200 reaches caller", async () => {
+    await prisma.prometheusDatasource.create({
+      data: { name: "perm2", baseUrl: "https://prom.test:9090", isDefault: true },
+    });
+    const svc = new PrometheusFetcherService(prisma, TEST_KEY_B64, PERMISSIVE_FETCHER_CONFIG);
+    // Two redirects then a real success — the body shape mirrors the
+    // permissive success-path tests above so summariseSeries works.
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { Location: "https://prom.test:9090/hop2" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { Location: "https://prom.test:9090/hop3" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            status: "success",
+            data: {
+              resultType: "matrix",
+              result: [{ metric: { __name__: "up" }, values: [[1, "1"]] }],
+            },
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof globalThis.fetch;
+    globalThis.fetch = fetchSpy;
+    try {
+      const ctx = await svc.fetchAlertContext(
+        makeEvent({ annotations: { expr: "up" }, connectionId: null }),
+      );
+      expect(ctx).not.toBeNull();
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
     } finally {
       restoreFetch();
     }

--- a/apps/api/src/modules/alerts/prometheus-fetcher.service.spec.ts
+++ b/apps/api/src/modules/alerts/prometheus-fetcher.service.spec.ts
@@ -1,6 +1,7 @@
 import type { AlertEvent, PrometheusDatasource } from "@prisma/client";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { PrismaService } from "../../database/prisma.service.js";
+import type { PrometheusFetcherConfig } from "./prometheus-fetcher.config.js";
 import { PrometheusFetcherService } from "./prometheus-fetcher.service.js";
 
 function makeEvent(over: Partial<AlertEvent> = {}): AlertEvent {
@@ -35,6 +36,12 @@ function mockFetch(ok: boolean, body: unknown, status = ok ? 200 : 500): typeof 
 // 32-byte base64 key for AES-256-GCM (same shape as env validator requires).
 const TEST_KEY_B64 = Buffer.alloc(32, 7).toString("base64");
 
+// Permissive fetcher config: no SSRF restrictions, 5 MiB body cap.
+const PERMISSIVE_FETCHER_CONFIG: PrometheusFetcherConfig = {
+  guard: { blockPrivate: false, allowHosts: null },
+  maxBodyBytes: 5_242_880,
+};
+
 // Stub ConfigService matches the pattern used by prometheus-datasource.service.spec.ts.
 const CONFIG_STUB = {
   get: (key: string) => process.env[key],
@@ -56,7 +63,7 @@ describe("PrometheusFetcherService.resolveDatasource", () => {
       create: { id: "u", email: "u@fetcher-spec", passwordHash: "x", roles: ["user"] },
       update: {},
     });
-    svc = new PrometheusFetcherService(prisma, TEST_KEY_B64);
+    svc = new PrometheusFetcherService(prisma, TEST_KEY_B64, PERMISSIVE_FETCHER_CONFIG);
   });
 
   afterAll(async () => {
@@ -127,7 +134,11 @@ describe("PrometheusFetcherService.resolveDatasource", () => {
 describe("PrometheusFetcherService.resolveExpr", () => {
   let svc: PrometheusFetcherService;
   beforeEach(() => {
-    svc = new PrometheusFetcherService({} as PrismaService, TEST_KEY_B64);
+    svc = new PrometheusFetcherService(
+      {} as PrismaService,
+      TEST_KEY_B64,
+      PERMISSIVE_FETCHER_CONFIG,
+    );
   });
 
   it("returns annotations.expr when present", () => {
@@ -175,7 +186,7 @@ describe("PrometheusFetcherService.fetchAlertContext (query_range + summarise)",
     ds = await prisma.prometheusDatasource.create({
       data: { name: "d", baseUrl: "https://prom.test", isDefault: true },
     });
-    svc = new PrometheusFetcherService(prisma, TEST_KEY_B64);
+    svc = new PrometheusFetcherService(prisma, TEST_KEY_B64, PERMISSIVE_FETCHER_CONFIG);
     savedFetch = globalThis.fetch;
   });
 
@@ -326,6 +337,159 @@ describe("PrometheusFetcherService.fetchAlertContext (query_range + summarise)",
       );
       expect(ctx).toBeNull();
       expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      restoreFetch();
+    }
+  });
+});
+
+describe("PrometheusFetcherService.fetchAlertContext — hardening", () => {
+  let prisma: PrismaService;
+  let savedFetch: typeof globalThis.fetch;
+
+  beforeEach(async () => {
+    prisma = new PrismaService(CONFIG_STUB);
+    await prisma.$connect();
+    await prisma.prometheusDatasource.deleteMany();
+    savedFetch = globalThis.fetch;
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  function restoreFetch() {
+    globalThis.fetch = savedFetch;
+  }
+
+  it("1. private IP rejected when blockPrivate=true — fetch never called", async () => {
+    await prisma.prometheusDatasource.create({
+      data: { name: "priv", baseUrl: "http://10.0.0.5:9090", isDefault: true },
+    });
+    const svc = new PrometheusFetcherService(prisma, TEST_KEY_B64, {
+      guard: { blockPrivate: true, allowHosts: null },
+      maxBodyBytes: 5_242_880,
+    });
+    const fetchSpy = vi.fn(async () => {
+      throw new Error("fetch should not have been called");
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+    try {
+      const ctx = await svc.fetchAlertContext(
+        makeEvent({ annotations: { expr: "up" }, connectionId: null }),
+      );
+      expect(ctx).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  it("2. host outside allowHosts rejected — fetch never called", async () => {
+    await prisma.prometheusDatasource.create({
+      data: { name: "lab", baseUrl: "http://prom.lab:9090", isDefault: true },
+    });
+    const svc = new PrometheusFetcherService(prisma, TEST_KEY_B64, {
+      guard: { blockPrivate: false, allowHosts: ["prom-other.lab"] },
+      maxBodyBytes: 5_242_880,
+    });
+    const fetchSpy = vi.fn(async () => {
+      throw new Error("fetch should not have been called");
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+    try {
+      const ctx = await svc.fetchAlertContext(
+        makeEvent({ annotations: { expr: "up" }, connectionId: null }),
+      );
+      expect(ctx).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  it("3. redirect to disallowed host rejected — only one fetch attempted", async () => {
+    await prisma.prometheusDatasource.create({
+      data: { name: "lab", baseUrl: "http://prom.lab:9090", isDefault: true },
+    });
+    const svc = new PrometheusFetcherService(prisma, TEST_KEY_B64, {
+      guard: { blockPrivate: false, allowHosts: ["prom.lab"] },
+      maxBodyBytes: 5_242_880,
+    });
+    const fetchSpy = vi.fn().mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { Location: "http://evil.example/data" },
+      }),
+    );
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+    try {
+      const ctx = await svc.fetchAlertContext(
+        makeEvent({ annotations: { expr: "up" }, connectionId: null }),
+      );
+      expect(ctx).toBeNull();
+      // Only one fetch call: the initial request that returned the redirect.
+      // The redirect target (evil.example) fails evaluateUrl, so no second fetch.
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  it("4. more than 2 redirect hops rejected", async () => {
+    await prisma.prometheusDatasource.create({
+      data: { name: "perm", baseUrl: "https://prom.test:9090", isDefault: true },
+    });
+    const svc = new PrometheusFetcherService(prisma, TEST_KEY_B64, PERMISSIVE_FETCHER_CONFIG);
+    // Two consecutive 302s: first hop → second → would exceed MAX_HOPS.
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { Location: "https://prom.test:9090/hop2" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { Location: "https://prom.test:9090/hop3" },
+        }),
+      ) as unknown as typeof globalThis.fetch;
+    globalThis.fetch = fetchSpy;
+    try {
+      const ctx = await svc.fetchAlertContext(
+        makeEvent({ annotations: { expr: "up" }, connectionId: null }),
+      );
+      expect(ctx).toBeNull();
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  it("5. body over maxBodyBytes aborted — result is null", async () => {
+    await prisma.prometheusDatasource.create({
+      data: { name: "large", baseUrl: "https://prom.test:9090", isDefault: true },
+    });
+    const svc = new PrometheusFetcherService(prisma, TEST_KEY_B64, {
+      guard: { blockPrivate: false, allowHosts: null },
+      maxBodyBytes: 100,
+    });
+    // Build a body that is clearly > 100 bytes.
+    const largeBody = JSON.stringify({
+      status: "success",
+      data: {
+        result: [{ metric: {}, values: [[1, "x".repeat(2000)]] }],
+      },
+    });
+    globalThis.fetch = vi.fn(
+      async () => new Response(largeBody, { status: 200 }),
+    ) as unknown as typeof globalThis.fetch;
+    try {
+      const ctx = await svc.fetchAlertContext(
+        makeEvent({ annotations: { expr: "up" }, connectionId: null }),
+      );
+      expect(ctx).toBeNull();
     } finally {
       restoreFetch();
     }

--- a/apps/api/src/modules/alerts/prometheus-fetcher.service.ts
+++ b/apps/api/src/modules/alerts/prometheus-fetcher.service.ts
@@ -190,9 +190,10 @@ export class PrometheusFetcherService {
     init: RequestInit,
     signal: AbortSignal,
   ): Promise<Response> {
-    const MAX_HOPS = 2;
+    // Allow the initial fetch + up to 2 redirect hops = 3 fetches total.
+    const MAX_FETCHES = 3;
     let url = initialUrl;
-    for (let hop = 0; hop < MAX_HOPS; hop++) {
+    for (let attempt = 0; attempt < MAX_FETCHES; attempt++) {
       const verdict = await evaluateUrl(url, this.fetcherConfig.guard);
       if (!verdict.ok) {
         throw new Error(`prom-fetcher refused ${url.href}: ${verdict.reason}`);
@@ -200,11 +201,14 @@ export class PrometheusFetcherService {
       const res = await fetch(url, { ...init, redirect: "manual", signal });
       if (res.status >= 300 && res.status < 400) {
         const loc = res.headers.get("location");
-        // Drain the body so the underlying socket can be reused.
-        await res.text().catch(() => undefined);
+        // Cancel the body stream rather than reading it: redirects rarely
+        // carry a meaningful body, and a malicious server could otherwise
+        // ship gigabytes here as a DoS. cancel() releases the underlying
+        // socket without buffering anything.
+        await res.body?.cancel().catch(() => undefined);
         if (!loc) return res; // 3xx without Location — let caller handle.
-        if (hop === MAX_HOPS - 1) {
-          throw new Error(`prom-fetcher exceeded ${MAX_HOPS} redirect hops`);
+        if (attempt === MAX_FETCHES - 1) {
+          throw new Error(`prom-fetcher exceeded ${MAX_FETCHES - 1} redirect hops`);
         }
         url = new URL(loc, url);
         continue;
@@ -226,20 +230,17 @@ export class PrometheusFetcherService {
       if (done) break;
       received += value.byteLength;
       if (received > max) {
-        // Cancel + drain so the socket doesn't leak. cancel() rejects pending reads.
+        // cancel() releases the underlying socket without buffering more.
         await reader.cancel();
         throw new Error(`prom-fetcher response exceeded ${max} bytes`);
       }
       chunks.push(value);
     }
-    const total = chunks.reduce((sum, c) => sum + c.byteLength, 0);
-    const buf = new Uint8Array(total);
-    let offset = 0;
-    for (const c of chunks) {
-      buf.set(c, offset);
-      offset += c.byteLength;
-    }
-    return JSON.parse(new TextDecoder().decode(buf));
+    const text = Buffer.concat(chunks).toString("utf-8");
+    // Empty body (e.g. 204 / misbehaving 200) → null; caller already
+    // guards on the null-from-readBoundedJson path.
+    if (!text) return null;
+    return JSON.parse(text);
   }
 
   /**

--- a/apps/api/src/modules/alerts/prometheus-fetcher.service.ts
+++ b/apps/api/src/modules/alerts/prometheus-fetcher.service.ts
@@ -4,6 +4,11 @@ import { decodeKey, decrypt } from "../../common/crypto/aes-gcm.js";
 import { parseCustomHeaders } from "../../common/http/parse-custom-headers.js";
 import { PrismaService } from "../../database/prisma.service.js";
 import { PROMETHEUS_DS_ENC_KEY } from "../prometheus-datasource/prometheus-datasource.service.js";
+import {
+  PROMETHEUS_FETCHER_CONFIG,
+  type PrometheusFetcherConfig,
+} from "./prometheus-fetcher.config.js";
+import { evaluateUrl } from "./prometheus-fetcher.guard.js";
 
 /**
  * Snapshot of Prometheus context surrounding an alert. Returned by
@@ -45,6 +50,7 @@ export class PrometheusFetcherService {
   constructor(
     private readonly prisma: PrismaService,
     @Inject(PROMETHEUS_DS_ENC_KEY) keyB64: string,
+    @Inject(PROMETHEUS_FETCHER_CONFIG) private readonly fetcherConfig: PrometheusFetcherConfig,
   ) {
     this.key = decodeKey(keyB64);
   }
@@ -145,12 +151,12 @@ export class PrometheusFetcherService {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
     try {
-      const res = await fetch(url, { headers, signal: controller.signal });
+      const res = await this.safeFetch(url, { headers }, controller.signal);
       if (!res.ok) {
         this.log.warn(`Prom query_range ${res.status} for ${ds.name}`);
         return null;
       }
-      const body = (await res.json()) as {
+      const body = (await this.readBoundedJson(res)) as {
         status: string;
         data?: {
           result?: Array<{
@@ -158,7 +164,8 @@ export class PrometheusFetcherService {
             values: Array<[number, string]>;
           }>;
         };
-      };
+      } | null;
+      if (!body) return null;
       if (body.status !== "success" || !body.data?.result) return null;
       return {
         datasource: { id: ds.id, name: ds.name },
@@ -176,6 +183,63 @@ export class PrometheusFetcherService {
     } finally {
       clearTimeout(timer);
     }
+  }
+
+  private async safeFetch(
+    initialUrl: URL,
+    init: RequestInit,
+    signal: AbortSignal,
+  ): Promise<Response> {
+    const MAX_HOPS = 2;
+    let url = initialUrl;
+    for (let hop = 0; hop < MAX_HOPS; hop++) {
+      const verdict = await evaluateUrl(url, this.fetcherConfig.guard);
+      if (!verdict.ok) {
+        throw new Error(`prom-fetcher refused ${url.href}: ${verdict.reason}`);
+      }
+      const res = await fetch(url, { ...init, redirect: "manual", signal });
+      if (res.status >= 300 && res.status < 400) {
+        const loc = res.headers.get("location");
+        // Drain the body so the underlying socket can be reused.
+        await res.text().catch(() => undefined);
+        if (!loc) return res; // 3xx without Location — let caller handle.
+        if (hop === MAX_HOPS - 1) {
+          throw new Error(`prom-fetcher exceeded ${MAX_HOPS} redirect hops`);
+        }
+        url = new URL(loc, url);
+        continue;
+      }
+      return res;
+    }
+    // Unreachable — the loop either returns or throws.
+    throw new Error("prom-fetcher safeFetch internal error");
+  }
+
+  private async readBoundedJson(res: Response): Promise<unknown> {
+    if (!res.body) return null;
+    const max = this.fetcherConfig.maxBodyBytes;
+    const reader = res.body.getReader();
+    let received = 0;
+    const chunks: Uint8Array[] = [];
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      received += value.byteLength;
+      if (received > max) {
+        // Cancel + drain so the socket doesn't leak. cancel() rejects pending reads.
+        await reader.cancel();
+        throw new Error(`prom-fetcher response exceeded ${max} bytes`);
+      }
+      chunks.push(value);
+    }
+    const total = chunks.reduce((sum, c) => sum + c.byteLength, 0);
+    const buf = new Uint8Array(total);
+    let offset = 0;
+    for (const c of chunks) {
+      buf.set(c, offset);
+      offset += c.byteLength;
+    }
+    return JSON.parse(new TextDecoder().decode(buf));
   }
 
   /**


### PR DESCRIPTION
## Summary

Three new defense-in-depth guards on the alert-explainer's outbound Prometheus fetch:

1. **SSRF guard** (`prometheus-fetcher.guard.ts`) — pure module: `evaluateUrl(url, config, resolver?)` + `isPrivateOrLoopback(ip)`. Two policy modes:
   - **Positive allow-list** via `PROMETHEUS_FETCH_ALLOW_HOSTS` (csv) — when set, IS the policy.
   - **Private-IP block** via `PROMETHEUS_FETCH_BLOCK_PRIVATE=true` (opt-in) — checks both IP literals and DNS-resolved hostnames against RFC 1918 / 4193 / 3927 / 4291 ranges (plus 0.0.0.0/8 and the cloud metadata 169.254.169.254). Fail-closed on DNS errors. IPv4-mapped IPv6 (`::ffff:a.b.c.d`) falls through to the IPv4 path.
2. **Manual redirects** — `fetch(url, { redirect: "manual" })` with a max of 2 hops; the guard re-runs on every redirect target. Body is drained between hops for socket reuse.
3. **Body size cap** — streams the response through a `ReadableStreamDefaultReader`, aborts (and cancels the reader) once cumulative bytes exceed `PROMETHEUS_FETCH_MAX_BODY_BYTES` (default 5 MiB).

All three failures route through the existing graceful-fallback path (`return null` from `queryRange`) — the explainer keeps generating baseline-only narratives instead of hard-failing the request.

## Decision: default ALLOW private IPs (divergence from issue text)

The issue draft suggested **block** by default. The opening of the same issue admits "Prom is typically on internal/LAN; live tenant is essentially closed-network", and silently breaking every existing LAN deploy on upgrade isn't worth the threat-model gain. So this PR defaults `PROMETHEUS_FETCH_BLOCK_PRIVATE=false`, with the strict mode reachable via `PROMETHEUS_FETCH_BLOCK_PRIVATE=true` or via the positive `PROMETHEUS_FETCH_ALLOW_HOSTS` list. Documented in the env-schema comment and the .env.example block.

## Files

Production:
- `apps/api/src/modules/alerts/prometheus-fetcher.guard.ts` (new, 137 lines)
- `apps/api/src/modules/alerts/prometheus-fetcher.config.ts` (new — token + interface, broken out to avoid the service→module→service import cycle)
- `apps/api/src/modules/alerts/prometheus-fetcher.service.ts` (modified — constructor + safeFetch + readBoundedJson)
- `apps/api/src/modules/alerts/alerts.module.ts` (modified — provides `PROMETHEUS_FETCHER_CONFIG` via ConfigService factory)
- `apps/api/src/config/env.schema.ts` (modified — 3 new env vars, all with safe defaults)
- `apps/api/.env.example` (modified — matching documentation block)

Tests:
- `apps/api/src/modules/alerts/prometheus-fetcher.guard.spec.ts` (new — 40 tests)
- `apps/api/src/modules/alerts/prometheus-fetcher.service.spec.ts` (modified — 4 constructor sites updated + 5 new hardening tests)

## Acceptance (from #200)

- [x] `fetch(url, { redirect: "manual" })` + per-hop `evaluateUrl` validation
- [x] SSRF allow-list (env-provided host list) AND opt-in private-IP block
- [x] Streaming response read with cumulative byte cap; abort on overflow
- [x] Drain response body between redirect hops to allow socket reuse
- [x] Unit tests for each guard:
  - [x] Private IP rejected (`prometheus-fetcher.guard.spec.ts` — IPv4 ranges, IPv6 ranges, IPv4-mapped IPv6, DNS-resolved hosts, split-horizon DNS)
  - [x] Redirect to disallowed host rejected (`prometheus-fetcher.service.spec.ts` — fetch called exactly once, result null)
  - [x] Body over cap aborted (`prometheus-fetcher.service.spec.ts` — result null after partial read)

## Out of scope (per issue)

- Caching layer for repeated queries
- Cert pinning / mutual TLS

## Test plan

- [x] \`pnpm -F @modeldoctor/api type-check\` → clean
- [x] \`pnpm -F @modeldoctor/api lint\` (incl. env-example drift + e2e-env-mutation lint) → clean
- [x] \`pnpm -F @modeldoctor/api test\` → 767/767 pass (was 722 on main; +40 guard + +5 service hardening)
- [x] \`pnpm -F @modeldoctor/api exec vitest run src/modules/alerts/prometheus-fetcher.service.spec.ts\` → all green including the 5 new hardening cases
- [ ] CI

Closes #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)