### PR TITLE
fix(api): emit JS from nest build after base set noEmit:true

### DIFF
--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -4,7 +4,8 @@
     "declaration": false,
     "sourceMap": true,
     "rootDir": "./src",
-    "paths": {}
+    "paths": {},
+    "noEmit": false
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.e2e-spec.ts", "test"]


### PR DESCRIPTION
## Summary

- `apps/api/tsconfig.build.json` adds `"noEmit": false` to override the base.

## Why

#225 set `noEmit: true` in `tsconfig.base.json` (so package-level type-check is the default) and added `"noEmit": false` overrides to `packages/contracts/tsconfig.build.json` and `packages/tool-adapters/tsconfig.build.json` — but missed `apps/api/tsconfig.build.json`. Result: `nest build` runs `tsc -p tsconfig.build.json`, reports `Found 0 errors`, and emits **zero** JS files. Only the nest-cli asset copy under `dist/integrations/` survives, so `nest start --watch` crashes immediately:

```
Error: Cannot find module '/.../apps/api/dist/main'
  code: 'MODULE_NOT_FOUND'
```

## Test plan

- [x] `pnpm -F @modeldoctor/api exec nest build` emits `apps/api/dist/main.js`
- [x] `pnpm -r build` succeeds workspace-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)