### PR TITLE
refactor(api): drop NODE_ENV-conditional branches from env.schema.ts

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,6 +1,9 @@
-# ModelDoctor API — loaded by @nestjs/config in apps/api/src/main.ts.
+# ModelDoctor API — loaded by @nestjs/config (apps/api/src/config/config.module.ts).
 # See the README "Environment variables" section for what each one does.
 # Copy this file to `.env` (gitignored) and fill in the JWT secret.
+#
+# Tests load apps/api/.env.test (tracked in git, all dummy values) instead;
+# env.schema.ts is uniformly required across dev / test / prod since #223.
 
 NODE_ENV=development
 PORT=3001
@@ -13,7 +16,7 @@ CORS_ORIGINS=http://localhost:5173
 # Default worktree uses modeldoctor; this worktree (run-unify) uses modeldoctor_run_unify.
 DATABASE_URL=postgresql://modeldoctor:modeldoctor@localhost:5432/modeldoctor
 
-# Required (except NODE_ENV=test). Minimum 32 characters; generate via:
+# Required. Minimum 32 characters; generate via:
 #   openssl rand -base64 48
 # Rotating this invalidates every outstanding access token on next restart.
 JWT_ACCESS_SECRET=<replace with: openssl rand -base64 48>
@@ -30,7 +33,7 @@ DISABLE_FIRST_USER_ADMIN=false
 
 # --- Benchmark feature -------------------------------------------------
 # K8s is the only execution mode (subprocess driver removed in #101).
-# All RUNNER_IMAGE_* vars below are required outside NODE_ENV=test.
+# All RUNNER_IMAGE_* vars below are required.
 
 # Where the runner pod POSTs lifecycle + metrics back.
 # Local dev (k3d on Docker Desktop): http://host.docker.internal:3001
@@ -104,9 +107,9 @@ PROMETHEUS_FETCH_MAX_BODY_BYTES=5242880
 
 # --- Alertmanager webhook receiver (P0 closed loop) ------------------------
 # Shared secret for the Alertmanager → ModelDoctor webhook
-# (POST /api/alerts/webhook). REQUIRED whenever NODE_ENV != "test" — the
-# api refuses to boot without it. Configure your Alertmanager receiver to
-# send `Authorization: Bearer <this value>` so the webhook handler can
+# (POST /api/alerts/webhook). Required — the api refuses to boot without it.
+# Configure your Alertmanager receiver to send
+# `Authorization: Bearer <this value>` so the webhook handler can
 # authenticate the push. Must be >= 32 chars.
 # Generate with: openssl rand -base64 48
 ALERTMANAGER_WEBHOOK_SECRET=<replace with: openssl rand -base64 48>

--- a/apps/api/.env.test
+++ b/apps/api/.env.test
@@ -1,0 +1,50 @@
+# ModelDoctor API — test-mode env fixture (loaded by ConfigModule when NODE_ENV=test).
+# Tracked in git. NOT secrets — every value here is a stable placeholder so a fresh
+# clone can run the test suite without local setup. See apps/api/src/config/config.module.ts
+# for the envFilePath wiring and apps/api/test/setup/e2e-env-defaults.ts for the
+# TypeScript re-export that spec files import.
+#
+# Closes #223: env.schema.ts is uniformly required across all envs; test isolation
+# moved to the config-loading layer (NestJS sample / Spring profile / Rails environments
+# convention) instead of the schema knowing about NODE_ENV.
+
+# Placeholder DATABASE_URL — vitest configs override this dynamically via
+# pickTestDatabaseUrl() (so a TEST_DATABASE_URL env var or the modeldoctor_test
+# fallback wins). Present here so AppModule boots if a tool loads .env.test
+# directly without setting DATABASE_URL.
+DATABASE_URL=postgresql://modeldoctor:modeldoctor@localhost:5432/modeldoctor_test
+
+# passport-jwt validates secretOrKey at strategy-construction time, so AppModule
+# boot needs a non-empty JWT secret. Length must be >= 32.
+JWT_ACCESS_SECRET=e2e-test-jwt-secret-not-for-production-use-only-32+chars
+
+# 32 zero bytes, base64-encoded — fine for test, MUST NOT be used in prod.
+CONNECTION_API_KEY_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+
+# HmacCallbackGuard validates BENCHMARK_CALLBACK_SECRET at constructor time —
+# same passport-jwt pattern. Length must be >= 32.
+BENCHMARK_CALLBACK_SECRET=e2e-test-callback-secret-not-for-production-use-32+chars
+
+# RunService validates BENCHMARK_CALLBACK_URL at constructor time so a
+# misconfigured deployment fails at boot.
+BENCHMARK_CALLBACK_URL=http://e2e-test-placeholder.invalid/
+
+# AlertsController.verifyAuth compares against this in constant time.
+# alerts.e2e-spec.ts imports E2E_ENV_DEFAULTS.ALERTMANAGER_WEBHOOK_SECRET and
+# sends "Bearer X" with the same value, so they must match exactly.
+ALERTMANAGER_WEBHOOK_SECRET=alertmanager-test-secret-padded-to-32-chars-min
+
+# Per-tool runner images. K8s is the only execution mode (subprocess driver
+# removed in #101); test mode doesn't actually create pods, but the schema
+# validates these at boot so we inject placeholders.
+RUNNER_IMAGE_GUIDELLM=test:guidellm
+RUNNER_IMAGE_VEGETA=test:vegeta
+RUNNER_IMAGE_PREFIX_CACHE_PROBE=test:prefix-cache-probe
+RUNNER_IMAGE_EVALSCOPE=test:evalscope
+RUNNER_IMAGE_AIPERF=test:aiperf
+
+# MCP V1 — both must be set together to enable /mcp. mcp.e2e-spec.ts sends
+# `Bearer ${MCP_BEARER_TOKEN}` and the guard stamps `mcpUserId` from MCP_USER_ID;
+# both must match exactly with what spec files read via E2E_ENV_DEFAULTS.
+MCP_BEARER_TOKEN=test-mcp-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+MCP_USER_ID=e2e-mcp-test-user

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -72,6 +72,7 @@
     "@types/multer": "^2.1.0",
     "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6",
+    "dotenv": "^17.4.1",
     "pino-pretty": "^11",
     "supertest": "^7",
     "testcontainers": "^11.14.0",

--- a/apps/api/src/config/config.module.ts
+++ b/apps/api/src/config/config.module.ts
@@ -8,11 +8,14 @@ import { validateEnv } from "./env.schema.js";
       isGlobal: true,
       cache: true,
       validate: validateEnv,
-      // Default envFilePath resolves to `${cwd}/.env`. When running via
-      // `pnpm -F @modeldoctor/api start:dev` cwd is `apps/api/`, so the
-      // app's own `.env` is loaded — per-app convention, no path-resolve
-      // gymnastics. CI / prod inject env vars directly and the absence of
-      // a .env file is handled silently by @nestjs/config.
+      // Per-environment env file resolution. Matches NestJS sample / Spring
+      // Boot profile / Rails environments convention: test isolation lives
+      // at the loading layer, not in env.schema.ts (which is uniformly
+      // required across envs since #223). cwd is `apps/api/` under
+      // `pnpm -F @modeldoctor/api …` and under vitest workers — no path
+      // resolve gymnastics. CI / prod inject env vars directly and the
+      // absence of a .env file is handled silently by @nestjs/config.
+      envFilePath: process.env.NODE_ENV === "test" ? ".env.test" : ".env",
     }),
   ],
   exports: [NestConfigModule],

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -12,189 +12,119 @@ const envBoolean = z
   })
   .transform((v) => (typeof v === "boolean" ? v : v === "true"));
 
-export const EnvSchema = z
-  .object({
-    NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
-    PORT: z.coerce.number().int().positive().default(3001),
-    LOG_LEVEL: z
-      .enum(["trace", "debug", "info", "warn", "error", "fatal", "silent"])
-      .default("info"),
+// Schema is uniformly required across all envs since #223. Test isolation
+// lives at the loading layer (apps/api/.env.test, loaded by AppConfigModule
+// when NODE_ENV=test) — matches NestJS sample / Spring Boot profile / Rails
+// environments convention. Truly optional fields (BENCHMARK_PROCESSOR,
+// KUBECONFIG, MCP_*, APP_BASE_URL, prometheus fetcher knobs) stay .optional().
+export const EnvSchema = z.object({
+  NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+  PORT: z.coerce.number().int().positive().default(3001),
+  LOG_LEVEL: z.enum(["trace", "debug", "info", "warn", "error", "fatal", "silent"]).default("info"),
 
-    // CORS in non-production — comma-separated origin list
-    CORS_ORIGINS: z
-      .string()
-      .default("http://localhost:5173")
-      .transform((s) =>
-        s
-          .split(",")
-          .map((o) => o.trim())
-          .filter(Boolean),
-      ),
+  // CORS in non-production — comma-separated origin list
+  CORS_ORIGINS: z
+    .string()
+    .default("http://localhost:5173")
+    .transform((s) =>
+      s
+        .split(",")
+        .map((o) => o.trim())
+        .filter(Boolean),
+    ),
 
-    // Required when NODE_ENV !== "test"; optional in test mode so non-DB e2e specs
-    // can load AppModule without a live database.
-    DATABASE_URL: z.string().url().optional(),
-    JWT_ACCESS_SECRET: z.string().min(32).optional(),
-    JWT_ACCESS_EXPIRES_IN: z.string().default("15m"),
-    JWT_REFRESH_EXPIRES_DAYS: z.coerce.number().int().positive().default(7),
-    // 32-byte base64-encoded AES-256 key used to encrypt user-supplied API
-    // keys at rest. Optional in dev/test; required in production once the
-    // run callback path persists encrypted connection rows.
-    CONNECTION_API_KEY_ENCRYPTION_KEY: z
-      .string()
-      .optional()
-      .refine(
-        (v) => {
-          if (v === undefined) return true;
-          // Reject obviously non-base64 input. Buffer.from is permissive (it
-          // silently drops invalid chars) so we lint with a regex first.
-          if (!/^[A-Za-z0-9+/=]+$/.test(v)) return false;
-          return Buffer.from(v, "base64").length === 32;
-        },
-        { message: "must be a base64 string that decodes to exactly 32 bytes" },
-      ),
-    // Secret used to derive per-run HMAC callback tokens. Phase 3 enforces;
-    // Phase 1 only validates length when present.
-    BENCHMARK_CALLBACK_SECRET: z.string().min(32).optional(),
-    // K8s job runner config — subprocess driver removed in #101.
-    BENCHMARK_CALLBACK_URL: z.string().url().optional(),
-    BENCHMARK_K8S_NAMESPACE: z.string().min(1).default("modeldoctor-benchmarks"),
-    // Per-tool runner images (#53 Phase 2 / #78). Required when
-    // NODE_ENV !== "test" (k8s is the only execution mode).
-    RUNNER_IMAGE_GUIDELLM: z.string().min(1).optional(),
-    RUNNER_IMAGE_VEGETA: z.string().min(1).optional(),
-    RUNNER_IMAGE_PREFIX_CACHE_PROBE: z.string().min(1).optional(),
-    RUNNER_IMAGE_EVALSCOPE: z.string().min(1).optional(),
-    RUNNER_IMAGE_AIPERF: z.string().min(1).optional(),
-    BENCHMARK_DEFAULT_MAX_DURATION_SECONDS: z.coerce.number().int().positive().default(1800),
-    // Optional HuggingFace tokenizer id for guidellm synthetic prompt token
-    // counting (passed as --processor). Set this when the target gateway
-    // exposes a local model name (e.g. "gen-studio_…") that doesn't resolve
-    // on HF — the tokenizer needs to come from somewhere. Example:
-    // BENCHMARK_PROCESSOR=Qwen/Qwen2.5-0.5B-Instruct
-    BENCHMARK_PROCESSOR: z.string().optional(),
-    // Max concurrent in-flight requests for throughput-mode runs.
-    // guidellm 0.5.x ThroughputProfile requires this; constant/poisson rate
-    // modes ignore it. 100 is a sensible default for medium-tier targets;
-    // tune up for high-RPS clusters or down for fragile ones.
-    BENCHMARK_DEFAULT_MAX_CONCURRENCY: z.coerce.number().int().positive().default(100),
-    // Optional override for the kubeconfig file used by the K8s driver.
-    // Out-of-cluster local dev: set this to a specific kubeconfig (e.g. an
-    // isolated k3d config) so the driver doesn't pick up your default
-    // ~/.kube/config (which may point at a real cluster).
-    // In-cluster production: leave unset; @kubernetes/client-node falls back
-    // to the in-cluster ServiceAccount automatically.
-    KUBECONFIG: z.string().optional(),
-    DISABLE_FIRST_USER_ADMIN: envBoolean.default(false),
+  DATABASE_URL: z.string().url(),
+  JWT_ACCESS_SECRET: z.string().min(32),
+  JWT_ACCESS_EXPIRES_IN: z.string().default("15m"),
+  JWT_REFRESH_EXPIRES_DAYS: z.coerce.number().int().positive().default(7),
+  // 32-byte base64-encoded AES-256 key used to encrypt user-supplied API
+  // keys at rest. The run callback path persists encrypted connection rows.
+  CONNECTION_API_KEY_ENCRYPTION_KEY: z.string().refine(
+    (v) => {
+      // Reject obviously non-base64 input. Buffer.from is permissive (it
+      // silently drops invalid chars) so we lint with a regex first.
+      if (!/^[A-Za-z0-9+/=]+$/.test(v)) return false;
+      return Buffer.from(v, "base64").length === 32;
+    },
+    { message: "must be a base64 string that decodes to exactly 32 bytes" },
+  ),
+  // Secret used to derive per-run HMAC callback tokens.
+  BENCHMARK_CALLBACK_SECRET: z.string().min(32),
+  // K8s job runner config — subprocess driver removed in #101.
+  BENCHMARK_CALLBACK_URL: z.string().url(),
+  BENCHMARK_K8S_NAMESPACE: z.string().min(1).default("modeldoctor-benchmarks"),
+  // Per-tool runner images (#53 Phase 2 / #78). K8s is the only execution mode.
+  RUNNER_IMAGE_GUIDELLM: z.string().min(1),
+  RUNNER_IMAGE_VEGETA: z.string().min(1),
+  RUNNER_IMAGE_PREFIX_CACHE_PROBE: z.string().min(1),
+  RUNNER_IMAGE_EVALSCOPE: z.string().min(1),
+  RUNNER_IMAGE_AIPERF: z.string().min(1),
+  BENCHMARK_DEFAULT_MAX_DURATION_SECONDS: z.coerce.number().int().positive().default(1800),
+  // Optional HuggingFace tokenizer id for guidellm synthetic prompt token
+  // counting (passed as --processor). Set this when the target gateway
+  // exposes a local model name (e.g. "gen-studio_…") that doesn't resolve
+  // on HF — the tokenizer needs to come from somewhere. Example:
+  // BENCHMARK_PROCESSOR=Qwen/Qwen2.5-0.5B-Instruct
+  BENCHMARK_PROCESSOR: z.string().optional(),
+  // Max concurrent in-flight requests for throughput-mode runs.
+  // guidellm 0.5.x ThroughputProfile requires this; constant/poisson rate
+  // modes ignore it. 100 is a sensible default for medium-tier targets;
+  // tune up for high-RPS clusters or down for fragile ones.
+  BENCHMARK_DEFAULT_MAX_CONCURRENCY: z.coerce.number().int().positive().default(100),
+  // Optional override for the kubeconfig file used by the K8s driver.
+  // Out-of-cluster local dev: set this to a specific kubeconfig (e.g. an
+  // isolated k3d config) so the driver doesn't pick up your default
+  // ~/.kube/config (which may point at a real cluster).
+  // In-cluster production: leave unset; @kubernetes/client-node falls back
+  // to the in-cluster ServiceAccount automatically.
+  KUBECONFIG: z.string().optional(),
+  DISABLE_FIRST_USER_ADMIN: envBoolean.default(false),
 
-    // Optional web-app base URL used in outbound notification templates
-    // (e.g. the "查看详情" link in dingtalk alert markdown). Leave unset in
-    // dev to suppress the link entirely — message body still renders, it
-    // just doesn't carry a clickable detail link. In prod, set to the
-    // public origin, e.g. https://modeldoctor.example.com.
-    APP_BASE_URL: z.string().url().optional(),
+  // Optional web-app base URL used in outbound notification templates
+  // (e.g. the "查看详情" link in dingtalk alert markdown). Leave unset in
+  // dev to suppress the link entirely — message body still renders, it
+  // just doesn't carry a clickable detail link. In prod, set to the
+  // public origin, e.g. https://modeldoctor.example.com.
+  APP_BASE_URL: z.string().url().optional(),
 
-    // --- Prometheus fetcher hardening (issue #200) ---
-    // Defense-in-depth knobs for the PrometheusFetcherService outbound
-    // HTTP. All three are opt-in: the default behaviour preserves the
-    // pre-#200 fetch semantics so existing LAN-only deploys aren't broken
-    // by an upgrade. See prometheus-fetcher.guard.ts for the policy
-    // precedence.
-    //
-    // When non-empty (comma-separated hostnames), this list IS the policy:
-    // anything outside it is rejected and the private-IP check is
-    // bypassed (the operator made an explicit choice). Empty / unset
-    // means "no allow-list, fall through to PROMETHEUS_FETCH_BLOCK_PRIVATE".
-    PROMETHEUS_FETCH_ALLOW_HOSTS: z.string().optional(),
-    // When true, reject any URL whose host resolves to a private /
-    // loopback / link-local IP. Default false because ModelDoctor
-    // typically runs Prometheus on an internal LAN.
-    PROMETHEUS_FETCH_BLOCK_PRIVATE: envBoolean.default(false),
-    // Upper bound on a single Prometheus response body in bytes. The
-    // query_range endpoint streams JSON, so we cap cumulative bytes
-    // before parsing to avoid a malicious / misconfigured datasource
-    // OOMing the api worker. Default 5 MiB — a 15-minute window at 15s
-    // step with 5 series fits in tens of KB, so this is generous.
-    PROMETHEUS_FETCH_MAX_BODY_BYTES: z.coerce.number().int().positive().default(5_242_880),
+  // --- Prometheus fetcher hardening (issue #200) ---
+  // Defense-in-depth knobs for the PrometheusFetcherService outbound
+  // HTTP. All three are opt-in: the default behaviour preserves the
+  // pre-#200 fetch semantics so existing LAN-only deploys aren't broken
+  // by an upgrade. See prometheus-fetcher.guard.ts for the policy
+  // precedence.
+  //
+  // When non-empty (comma-separated hostnames), this list IS the policy:
+  // anything outside it is rejected and the private-IP check is
+  // bypassed (the operator made an explicit choice). Empty / unset
+  // means "no allow-list, fall through to PROMETHEUS_FETCH_BLOCK_PRIVATE".
+  PROMETHEUS_FETCH_ALLOW_HOSTS: z.string().optional(),
+  // When true, reject any URL whose host resolves to a private /
+  // loopback / link-local IP. Default false because ModelDoctor
+  // typically runs Prometheus on an internal LAN.
+  PROMETHEUS_FETCH_BLOCK_PRIVATE: envBoolean.default(false),
+  // Upper bound on a single Prometheus response body in bytes. The
+  // query_range endpoint streams JSON, so we cap cumulative bytes
+  // before parsing to avoid a malicious / misconfigured datasource
+  // OOMing the api worker. Default 5 MiB — a 15-minute window at 15s
+  // step with 5 series fits in tens of KB, so this is generous.
+  PROMETHEUS_FETCH_MAX_BODY_BYTES: z.coerce.number().int().positive().default(5_242_880),
 
-    // --- Alertmanager webhook receiver (P0 closed loop) ---
-    // Shared secret for Alertmanager → ModelDoctor webhook. Verified per
-    // request via HMAC-SHA256 in the X-ModelDoctor-Signature header. Required
-    // in non-test environments — the webhook endpoint hard-fails open
-    // requests in production. Length matches BENCHMARK_CALLBACK_SECRET.
-    ALERTMANAGER_WEBHOOK_SECRET: z.string().min(32).optional(),
+  // --- Alertmanager webhook receiver (P0 closed loop) ---
+  // Shared secret for Alertmanager → ModelDoctor webhook. Verified per
+  // request via HMAC-SHA256 in the X-ModelDoctor-Signature header.
+  // Length matches BENCHMARK_CALLBACK_SECRET.
+  ALERTMANAGER_WEBHOOK_SECRET: z.string().min(32),
 
-    // --- MCP server (V1) ---
-    // Both must be set together to enable /mcp. When either is unset the
-    // MCP route returns 503 ("not configured"). See apps/api/.env.example
-    // and apps/api/src/modules/mcp/README.md for bootstrap instructions.
-    MCP_BEARER_TOKEN: z.string().min(32).optional(),
-    // User ids are Prisma cuid()s, not UUIDs — just require a non-empty
-    // string and let the first tool call surface a 404 if it doesn't match.
-    MCP_USER_ID: z.string().min(1).optional(),
-  })
-  .superRefine((env, ctx) => {
-    if (env.NODE_ENV !== "test" && !env.DATABASE_URL) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["DATABASE_URL"],
-        message: "DATABASE_URL is required when NODE_ENV is not 'test'",
-      });
-    }
-    if (env.NODE_ENV !== "test" && !env.JWT_ACCESS_SECRET) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["JWT_ACCESS_SECRET"],
-        message: "JWT_ACCESS_SECRET is required when NODE_ENV is not 'test'",
-      });
-    }
-    if (env.NODE_ENV !== "test" && !env.CONNECTION_API_KEY_ENCRYPTION_KEY) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["CONNECTION_API_KEY_ENCRYPTION_KEY"],
-        message: "CONNECTION_API_KEY_ENCRYPTION_KEY is required when NODE_ENV is not 'test'",
-      });
-    }
-    if (env.NODE_ENV !== "test" && !env.BENCHMARK_CALLBACK_SECRET) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["BENCHMARK_CALLBACK_SECRET"],
-        message: "BENCHMARK_CALLBACK_SECRET is required when NODE_ENV is not 'test'",
-      });
-    }
-    if (env.NODE_ENV !== "test" && !env.ALERTMANAGER_WEBHOOK_SECRET) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["ALERTMANAGER_WEBHOOK_SECRET"],
-        message: "ALERTMANAGER_WEBHOOK_SECRET is required when NODE_ENV is not 'test'",
-      });
-    }
-    if (env.NODE_ENV !== "test" && !env.BENCHMARK_CALLBACK_URL) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["BENCHMARK_CALLBACK_URL"],
-        message: "BENCHMARK_CALLBACK_URL is required when NODE_ENV is not 'test'",
-      });
-    }
-    if (env.NODE_ENV !== "test") {
-      const perToolImages = [
-        "RUNNER_IMAGE_GUIDELLM",
-        "RUNNER_IMAGE_VEGETA",
-        "RUNNER_IMAGE_PREFIX_CACHE_PROBE",
-        "RUNNER_IMAGE_EVALSCOPE",
-        "RUNNER_IMAGE_AIPERF",
-      ] as const;
-      for (const key of perToolImages) {
-        if (!env[key]) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: [key],
-            message: `${key} is required when NODE_ENV is not 'test' (k8s is the only runner)`,
-          });
-        }
-      }
-    }
-  });
+  // --- MCP server (V1) ---
+  // Both must be set together to enable /mcp. When either is unset the
+  // MCP route returns 503 ("not configured"). See apps/api/.env.example
+  // and apps/api/src/modules/mcp/README.md for bootstrap instructions.
+  MCP_BEARER_TOKEN: z.string().min(32).optional(),
+  // User ids are Prisma cuid()s, not UUIDs — just require a non-empty
+  // string and let the first tool call surface a 404 if it doesn't match.
+  MCP_USER_ID: z.string().min(1).optional(),
+});
 
 export type Env = z.infer<typeof EnvSchema>;
 

--- a/apps/api/src/config/env.spec.ts
+++ b/apps/api/src/config/env.spec.ts
@@ -1,120 +1,143 @@
 import { describe, expect, it } from "vitest";
 import { validateEnv } from "./env.schema.js";
 
+// Single fixture: a fully-valid env that every spec starts from and mutates
+// to assert a single failure mode. Mirrors the dummy values in
+// apps/api/.env.test (the SSOT consumed at runtime when NODE_ENV=test). After
+// #223 the schema is uniformly required across all envs — test isolation
+// lives at the loading layer, not the schema.
+const validEnv = () => ({
+  NODE_ENV: "test" as const,
+  DATABASE_URL: "postgresql://u:p@h:5432/d",
+  JWT_ACCESS_SECRET: "x".repeat(48),
+  CONNECTION_API_KEY_ENCRYPTION_KEY: Buffer.alloc(32, 1).toString("base64"),
+  BENCHMARK_CALLBACK_SECRET: "y".repeat(48),
+  BENCHMARK_CALLBACK_URL: "http://localhost:3001",
+  ALERTMANAGER_WEBHOOK_SECRET: "z".repeat(48),
+  RUNNER_IMAGE_GUIDELLM: "md-runner-guidellm:test",
+  RUNNER_IMAGE_VEGETA: "md-runner-vegeta:test",
+  RUNNER_IMAGE_PREFIX_CACHE_PROBE: "md-runner-prefix-cache-probe:test",
+  RUNNER_IMAGE_EVALSCOPE: "md-runner-evalscope:test",
+  RUNNER_IMAGE_AIPERF: "md-runner-aiperf:test",
+});
+
 describe("validateEnv", () => {
-  it("accepts minimal env in test mode", () => {
-    const env = validateEnv({ NODE_ENV: "test" });
+  it("accepts a fully-populated env in test mode", () => {
+    const env = validateEnv(validEnv());
     expect(env.NODE_ENV).toBe("test");
     expect(env.PORT).toBe(3001);
     expect(env.LOG_LEVEL).toBe("info");
     expect(env.CORS_ORIGINS).toEqual(["http://localhost:5173"]);
+    expect(env.BENCHMARK_K8S_NAMESPACE).toBe("modeldoctor-benchmarks");
+    expect(env.BENCHMARK_DEFAULT_MAX_DURATION_SECONDS).toBe(1800);
+  });
+
+  it("accepts the same env in production", () => {
+    const env = validateEnv({ ...validEnv(), NODE_ENV: "production" });
+    expect(env.NODE_ENV).toBe("production");
+    expect(env.JWT_ACCESS_SECRET).toBe("x".repeat(48));
   });
 
   it("coerces PORT string to number", () => {
-    const env = validateEnv({ NODE_ENV: "test", PORT: "8080" });
+    const env = validateEnv({ ...validEnv(), PORT: "8080" });
     expect(env.PORT).toBe(8080);
   });
 
   it("rejects bad LOG_LEVEL", () => {
-    expect(() => validateEnv({ NODE_ENV: "test", LOG_LEVEL: "chatty" })).toThrow(/LOG_LEVEL/);
+    expect(() => validateEnv({ ...validEnv(), LOG_LEVEL: "chatty" })).toThrow(/LOG_LEVEL/);
   });
 
   it("splits CORS_ORIGINS on comma", () => {
-    const env = validateEnv({ NODE_ENV: "test", CORS_ORIGINS: "http://a,http://b" });
+    const env = validateEnv({ ...validEnv(), CORS_ORIGINS: "http://a,http://b" });
     expect(env.CORS_ORIGINS).toEqual(["http://a", "http://b"]);
   });
 
-  it("rejects JWT_ACCESS_SECRET shorter than 32 chars when provided", () => {
-    expect(() => validateEnv({ NODE_ENV: "test", JWT_ACCESS_SECRET: "short" })).toThrow(
+  // Uniformly-required fields — schema rejects missing values in EVERY env,
+  // including test mode (#223). Each spec omits one required key and asserts
+  // the corresponding ZodIssue path is reported.
+  describe("uniformly required fields", () => {
+    const requiredKeys = [
+      "DATABASE_URL",
+      "JWT_ACCESS_SECRET",
+      "CONNECTION_API_KEY_ENCRYPTION_KEY",
+      "BENCHMARK_CALLBACK_SECRET",
+      "BENCHMARK_CALLBACK_URL",
+      "ALERTMANAGER_WEBHOOK_SECRET",
+      "RUNNER_IMAGE_GUIDELLM",
+      "RUNNER_IMAGE_VEGETA",
+      "RUNNER_IMAGE_PREFIX_CACHE_PROBE",
+      "RUNNER_IMAGE_EVALSCOPE",
+      "RUNNER_IMAGE_AIPERF",
+    ] as const;
+
+    for (const key of requiredKeys) {
+      it(`rejects when ${key} is missing in test mode`, () => {
+        const { [key]: _omitted, ...rest } = validEnv();
+        expect(() => validateEnv(rest)).toThrow(new RegExp(key));
+      });
+
+      it(`rejects when ${key} is missing in production`, () => {
+        const { [key]: _omitted, ...rest } = validEnv();
+        expect(() => validateEnv({ ...rest, NODE_ENV: "production" })).toThrow(new RegExp(key));
+      });
+    }
+  });
+
+  // Per-field shape constraints (length, format) — these guarded the same
+  // mistakes pre-#223 and still apply.
+  it("rejects JWT_ACCESS_SECRET shorter than 32 chars", () => {
+    expect(() => validateEnv({ ...validEnv(), JWT_ACCESS_SECRET: "short" })).toThrow(
       /JWT_ACCESS_SECRET/,
     );
   });
 
-  // DATABASE_URL enforcement tests
-  it("throws when NODE_ENV=development and DATABASE_URL is missing", () => {
-    expect(() => validateEnv({})).toThrow(/DATABASE_URL/);
+  it("rejects non-URL DATABASE_URL", () => {
+    expect(() => validateEnv({ ...validEnv(), DATABASE_URL: "not-a-url" })).toThrow(/DATABASE_URL/);
   });
 
-  it("throws when NODE_ENV=production and DATABASE_URL is missing", () => {
-    expect(() => validateEnv({ NODE_ENV: "production" })).toThrow(/DATABASE_URL/);
-  });
-
-  it("accepts NODE_ENV=production with a valid DATABASE_URL", () => {
-    const env = validateEnv({
-      NODE_ENV: "production",
-      DATABASE_URL: "postgresql://u:p@h:5432/d",
-      JWT_ACCESS_SECRET: "a".repeat(32),
-      CONNECTION_API_KEY_ENCRYPTION_KEY: Buffer.alloc(32, 1).toString("base64"),
-      BENCHMARK_CALLBACK_SECRET: "y".repeat(48),
-      BENCHMARK_CALLBACK_URL: "http://localhost:3001",
-      ALERTMANAGER_WEBHOOK_SECRET: "z".repeat(48),
-      RUNNER_IMAGE_GUIDELLM: "md-runner-guidellm:test",
-      RUNNER_IMAGE_VEGETA: "md-runner-vegeta:test",
-      RUNNER_IMAGE_PREFIX_CACHE_PROBE: "md-runner-prefix-cache-probe:test",
-      RUNNER_IMAGE_EVALSCOPE: "md-runner-evalscope:test",
-      RUNNER_IMAGE_AIPERF: "md-runner-aiperf:test",
-    });
-    expect(env.DATABASE_URL).toBe("postgresql://u:p@h:5432/d");
-  });
-
-  it("rejects non-URL DATABASE_URL in production", () => {
-    expect(() => validateEnv({ NODE_ENV: "production", DATABASE_URL: "not-a-url" })).toThrow(
-      /DATABASE_URL/,
+  it("rejects BENCHMARK_CALLBACK_SECRET shorter than 32 chars", () => {
+    expect(() => validateEnv({ ...validEnv(), BENCHMARK_CALLBACK_SECRET: "x".repeat(31) })).toThrow(
+      /BENCHMARK_CALLBACK_SECRET/,
     );
   });
 
-  // JWT_ACCESS_SECRET enforcement tests
-  it("throws when NODE_ENV=development and JWT_ACCESS_SECRET is missing", () => {
-    expect(() => validateEnv({})).toThrow(/JWT_ACCESS_SECRET/);
-  });
-
-  it("throws when NODE_ENV=production and JWT_ACCESS_SECRET is missing", () => {
+  it("rejects CONNECTION_API_KEY_ENCRYPTION_KEY that decodes to ≠ 32 bytes", () => {
+    const tooShort = Buffer.alloc(16, 0x42).toString("base64");
     expect(() =>
-      validateEnv({ NODE_ENV: "production", DATABASE_URL: "postgresql://u:p@h:5432/d" }),
-    ).toThrow(/JWT_ACCESS_SECRET/);
+      validateEnv({ ...validEnv(), CONNECTION_API_KEY_ENCRYPTION_KEY: tooShort }),
+    ).toThrow(/CONNECTION_API_KEY_ENCRYPTION_KEY/);
   });
 
-  it("accepts NODE_ENV=production with a valid JWT_ACCESS_SECRET and valid DATABASE_URL", () => {
-    const env = validateEnv({
-      NODE_ENV: "production",
-      DATABASE_URL: "postgresql://u:p@h:5432/d",
-      JWT_ACCESS_SECRET: "a".repeat(32),
-      CONNECTION_API_KEY_ENCRYPTION_KEY: Buffer.alloc(32, 1).toString("base64"),
-      BENCHMARK_CALLBACK_SECRET: "y".repeat(48),
-      BENCHMARK_CALLBACK_URL: "http://localhost:3001",
-      ALERTMANAGER_WEBHOOK_SECRET: "z".repeat(48),
-      RUNNER_IMAGE_GUIDELLM: "md-runner-guidellm:test",
-      RUNNER_IMAGE_VEGETA: "md-runner-vegeta:test",
-      RUNNER_IMAGE_PREFIX_CACHE_PROBE: "md-runner-prefix-cache-probe:test",
-      RUNNER_IMAGE_EVALSCOPE: "md-runner-evalscope:test",
-      RUNNER_IMAGE_AIPERF: "md-runner-aiperf:test",
-    });
-    expect(env.JWT_ACCESS_SECRET).toBe("a".repeat(32));
+  it("rejects CONNECTION_API_KEY_ENCRYPTION_KEY with non-base64 input", () => {
+    expect(() =>
+      validateEnv({ ...validEnv(), CONNECTION_API_KEY_ENCRYPTION_KEY: "not!base64!@#$" }),
+    ).toThrow(/CONNECTION_API_KEY_ENCRYPTION_KEY/);
   });
 
-  // DISABLE_FIRST_USER_ADMIN string-to-boolean coercion (safe-by-default semantics).
-  // Regression guard: z.coerce.boolean() treated string "false" as truthy.
+  // DISABLE_FIRST_USER_ADMIN string-to-boolean coercion (safe-by-default
+  // semantics). Regression guard: z.coerce.boolean() treated string "false"
+  // as truthy.
   it("DISABLE_FIRST_USER_ADMIN defaults to false when unset", () => {
-    const env = validateEnv({ NODE_ENV: "test" });
+    const env = validateEnv(validEnv());
     expect(env.DISABLE_FIRST_USER_ADMIN).toBe(false);
   });
 
   it('DISABLE_FIRST_USER_ADMIN reads string "false" as boolean false', () => {
-    const env = validateEnv({ NODE_ENV: "test", DISABLE_FIRST_USER_ADMIN: "false" });
+    const env = validateEnv({ ...validEnv(), DISABLE_FIRST_USER_ADMIN: "false" });
     expect(env.DISABLE_FIRST_USER_ADMIN).toBe(false);
   });
 
   it('DISABLE_FIRST_USER_ADMIN reads string "true" as boolean true', () => {
-    const env = validateEnv({ NODE_ENV: "test", DISABLE_FIRST_USER_ADMIN: "true" });
+    const env = validateEnv({ ...validEnv(), DISABLE_FIRST_USER_ADMIN: "true" });
     expect(env.DISABLE_FIRST_USER_ADMIN).toBe(true);
   });
 
   it("DISABLE_FIRST_USER_ADMIN accepts native booleans", () => {
     expect(
-      validateEnv({ NODE_ENV: "test", DISABLE_FIRST_USER_ADMIN: true }).DISABLE_FIRST_USER_ADMIN,
+      validateEnv({ ...validEnv(), DISABLE_FIRST_USER_ADMIN: true }).DISABLE_FIRST_USER_ADMIN,
     ).toBe(true);
     expect(
-      validateEnv({ NODE_ENV: "test", DISABLE_FIRST_USER_ADMIN: false }).DISABLE_FIRST_USER_ADMIN,
+      validateEnv({ ...validEnv(), DISABLE_FIRST_USER_ADMIN: false }).DISABLE_FIRST_USER_ADMIN,
     ).toBe(false);
   });
 
@@ -124,135 +147,9 @@ describe("validateEnv", () => {
     // "TRUE" must crash boot rather than silently resolve to false (the prior
     // bug behavior with z.coerce.boolean() was the symmetric mistake).
     for (const v of ["", "0", "no", "off", "TRUE", "yes", "1", "ture", "False"]) {
-      expect(() => validateEnv({ NODE_ENV: "test", DISABLE_FIRST_USER_ADMIN: v })).toThrow(
+      expect(() => validateEnv({ ...validEnv(), DISABLE_FIRST_USER_ADMIN: v })).toThrow(
         /DISABLE_FIRST_USER_ADMIN/,
       );
     }
-  });
-
-  // CONNECTION_API_KEY_ENCRYPTION_KEY: optional, but if provided must be a
-  // base64 string that decodes to exactly 32 bytes (AES-256 key length).
-  it("CONNECTION_API_KEY_ENCRYPTION_KEY is optional", () => {
-    const env = validateEnv({ NODE_ENV: "test" });
-    expect(env.CONNECTION_API_KEY_ENCRYPTION_KEY).toBeUndefined();
-  });
-
-  it("CONNECTION_API_KEY_ENCRYPTION_KEY accepts a 32-byte base64 key", () => {
-    const key = Buffer.alloc(32, 0x42).toString("base64");
-    const env = validateEnv({ NODE_ENV: "test", CONNECTION_API_KEY_ENCRYPTION_KEY: key });
-    expect(env.CONNECTION_API_KEY_ENCRYPTION_KEY).toBe(key);
-  });
-
-  it("CONNECTION_API_KEY_ENCRYPTION_KEY rejects a key that decodes to ≠ 32 bytes", () => {
-    const tooShort = Buffer.alloc(16, 0x42).toString("base64");
-    expect(() =>
-      validateEnv({ NODE_ENV: "test", CONNECTION_API_KEY_ENCRYPTION_KEY: tooShort }),
-    ).toThrow(/CONNECTION_API_KEY_ENCRYPTION_KEY/);
-  });
-
-  it("CONNECTION_API_KEY_ENCRYPTION_KEY rejects non-base64 input", () => {
-    expect(() =>
-      validateEnv({ NODE_ENV: "test", CONNECTION_API_KEY_ENCRYPTION_KEY: "not!base64!@#$" }),
-    ).toThrow(/CONNECTION_API_KEY_ENCRYPTION_KEY/);
-  });
-
-  // BENCHMARK_CALLBACK_SECRET: optional, but if provided must be ≥ 32 chars.
-  it("BENCHMARK_CALLBACK_SECRET is optional", () => {
-    const env = validateEnv({ NODE_ENV: "test" });
-    expect(env.BENCHMARK_CALLBACK_SECRET).toBeUndefined();
-  });
-
-  it("BENCHMARK_CALLBACK_SECRET accepts a 32-char string", () => {
-    const env = validateEnv({ NODE_ENV: "test", BENCHMARK_CALLBACK_SECRET: "x".repeat(32) });
-    expect(env.BENCHMARK_CALLBACK_SECRET).toBe("x".repeat(32));
-  });
-
-  it("BENCHMARK_CALLBACK_SECRET rejects a string shorter than 32 chars", () => {
-    expect(() =>
-      validateEnv({ NODE_ENV: "test", BENCHMARK_CALLBACK_SECRET: "x".repeat(31) }),
-    ).toThrow(/BENCHMARK_CALLBACK_SECRET/);
-  });
-
-  describe("Phase 3 benchmark env", () => {
-    const baseTest = {
-      NODE_ENV: "test" as const,
-    };
-    const baseDev = {
-      NODE_ENV: "development" as const,
-      DATABASE_URL: "postgres://localhost:5432/db",
-      JWT_ACCESS_SECRET: "x".repeat(32),
-      CONNECTION_API_KEY_ENCRYPTION_KEY: Buffer.alloc(32, 1).toString("base64"),
-      BENCHMARK_CALLBACK_SECRET: "y".repeat(48),
-      BENCHMARK_CALLBACK_URL: "http://localhost:3001",
-      ALERTMANAGER_WEBHOOK_SECRET: "z".repeat(48),
-      RUNNER_IMAGE_GUIDELLM: "md-runner-guidellm:test",
-      RUNNER_IMAGE_VEGETA: "md-runner-vegeta:test",
-      RUNNER_IMAGE_PREFIX_CACHE_PROBE: "md-runner-prefix-cache-probe:test",
-      RUNNER_IMAGE_EVALSCOPE: "md-runner-evalscope:test",
-      RUNNER_IMAGE_AIPERF: "md-runner-aiperf:test",
-    };
-
-    it("requires RUNNER_IMAGE_GUIDELLM outside test mode", () => {
-      const { RUNNER_IMAGE_GUIDELLM: _omitted, ...rest } = baseDev;
-      expect(() => validateEnv(rest)).toThrow(/RUNNER_IMAGE_GUIDELLM/);
-    });
-
-    it("requires RUNNER_IMAGE_VEGETA outside test mode", () => {
-      const { RUNNER_IMAGE_VEGETA: _omitted, ...rest } = baseDev;
-      expect(() => validateEnv(rest)).toThrow(/RUNNER_IMAGE_VEGETA/);
-    });
-
-    it("accepts a fully-configured dev env with all RUNNER_IMAGE_* set", () => {
-      const env = validateEnv(baseDev);
-      expect(env.BENCHMARK_K8S_NAMESPACE).toBe("modeldoctor-benchmarks");
-      expect(env.RUNNER_IMAGE_GUIDELLM).toBe("md-runner-guidellm:test");
-      expect(env.RUNNER_IMAGE_VEGETA).toBe("md-runner-vegeta:test");
-      expect(env.RUNNER_IMAGE_PREFIX_CACHE_PROBE).toBe("md-runner-prefix-cache-probe:test");
-      expect(env.RUNNER_IMAGE_EVALSCOPE).toBe("md-runner-evalscope:test");
-      expect(env.RUNNER_IMAGE_AIPERF).toBe("md-runner-aiperf:test");
-    });
-
-    it("requires RUNNER_IMAGE_PREFIX_CACHE_PROBE outside test mode", () => {
-      const { RUNNER_IMAGE_PREFIX_CACHE_PROBE: _omitted, ...rest } = baseDev;
-      expect(() => validateEnv(rest)).toThrow(/RUNNER_IMAGE_PREFIX_CACHE_PROBE/);
-    });
-
-    it("requires RUNNER_IMAGE_EVALSCOPE outside test mode", () => {
-      const { RUNNER_IMAGE_EVALSCOPE: _omitted, ...rest } = baseDev;
-      expect(() => validateEnv(rest)).toThrow(/RUNNER_IMAGE_EVALSCOPE/);
-    });
-
-    it("requires RUNNER_IMAGE_AIPERF outside test mode", () => {
-      const { RUNNER_IMAGE_AIPERF: _omitted, ...rest } = baseDev;
-      expect(() => validateEnv(rest)).toThrow(/RUNNER_IMAGE_AIPERF/);
-    });
-
-    it("defaults BENCHMARK_DEFAULT_MAX_DURATION_SECONDS to 1800", () => {
-      const env = validateEnv(baseDev);
-      expect(env.BENCHMARK_DEFAULT_MAX_DURATION_SECONDS).toBe(1800);
-    });
-
-    it("requires CONNECTION_API_KEY_ENCRYPTION_KEY outside test mode", () => {
-      const noKey = { ...baseDev, CONNECTION_API_KEY_ENCRYPTION_KEY: undefined };
-      expect(() => validateEnv(noKey)).toThrow(/CONNECTION_API_KEY_ENCRYPTION_KEY/);
-    });
-
-    it("requires BENCHMARK_CALLBACK_SECRET outside test mode", () => {
-      const noSecret = { ...baseDev, BENCHMARK_CALLBACK_SECRET: undefined };
-      expect(() => validateEnv(noSecret)).toThrow(/BENCHMARK_CALLBACK_SECRET/);
-    });
-
-    it("requires BENCHMARK_CALLBACK_URL outside test mode", () => {
-      const noUrl = { ...baseDev, BENCHMARK_CALLBACK_URL: undefined };
-      expect(() => validateEnv(noUrl)).toThrow(/BENCHMARK_CALLBACK_URL/);
-    });
-
-    it("does not require benchmark vars in test mode", () => {
-      // Sanity: minimal `baseTest` still validates without RUNNER_IMAGE_*
-      // (they're only required when NODE_ENV !== "test").
-      const env = validateEnv(baseTest);
-      expect(env.NODE_ENV).toBe("test");
-      expect(env.RUNNER_IMAGE_GUIDELLM).toBeUndefined();
-    });
   });
 });

--- a/apps/api/test/setup/e2e-env-defaults.ts
+++ b/apps/api/test/setup/e2e-env-defaults.ts
@@ -1,52 +1,62 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 /**
- * Pre-injected env defaults for ALL e2e tests. Spread into vitest.e2e.config.mts
- * `env:` block so they land in process.env BEFORE NestJS's ConfigModule.forRoot
- * runs (which happens at AppModule file-import time, before any beforeAll).
+ * Test-mode env fixture, parsed from apps/api/.env.test.
  *
- * Why these live here and not inline in vitest.e2e.config.mts:
- * - e2e spec files often need to send the SAME secret as the Bearer in their
- *   HTTP requests. Importing E2E_ENV_DEFAULTS.X gives a single source of truth —
- *   if vitest pre-injects X and the spec sends Bearer X, they MUST stay in sync.
- * - Setting `process.env.X = ...` in a spec's `beforeAll` is a known anti-pattern
- *   here: forRoot has already locked the value from .env, so the late mutation
- *   has no effect on ConfigService.get. Use this file instead. The lint at
- *   apps/api/scripts/check-e2e-no-env-mutation.mjs (wired into `pnpm lint`) fails
- *   CI if a new spec re-introduces the pattern — see issue #209.
+ * apps/api/.env.test is the single source of truth: AppConfigModule loads it
+ * automatically when NODE_ENV=test (see apps/api/src/config/config.module.ts).
+ * Spec files that need to send a Bearer header matching what ConfigService
+ * sees re-import E2E_ENV_DEFAULTS.X to stay in sync.
+ *
+ * Parsed at module-load time (synchronous read) so spec files can use the
+ * const at top level. The path is resolved relative to this file so the
+ * resolution doesn't depend on vitest worker cwd.
+ *
+ * Setting `process.env.X = ...` in a spec's `beforeAll` is a known anti-pattern
+ * here: forRoot has already locked the value from .env.test, so the late
+ * mutation has no effect on ConfigService.get. Use this fixture instead. The
+ * lint at apps/api/scripts/check-e2e-no-env-mutation.mjs (wired into
+ * `pnpm lint`) fails CI if a new spec re-introduces the pattern — see #209.
  *
  * NOT included by design:
- * - DATABASE_URL — computed dynamically by pickTestDatabaseUrl()
+ * - DATABASE_URL — vitest configs override it dynamically via pickTestDatabaseUrl().
  */
+const ENV_TEST_PATH = resolve(fileURLToPath(import.meta.url), "..", "..", "..", ".env.test");
+
+// Minimal KEY=VALUE parser. Handles `#` line comments, blank lines, and
+// values without quoting. We control the file (apps/api/.env.test), so we
+// don't need the full dotenv spec (no quoted values, no escape sequences,
+// no $-expansion). If you reach for those, switch to the dotenv lib instead.
+function parseEnvFile(contents: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rawLine of contents.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq < 1) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    out[key] = value;
+  }
+  return out;
+}
+
+const parsed = parseEnvFile(readFileSync(ENV_TEST_PATH, "utf8"));
+
+function required(key: string): string {
+  const v = parsed[key];
+  if (!v) throw new Error(`apps/api/.env.test missing required key: ${key}`);
+  return v;
+}
+
 export const E2E_ENV_DEFAULTS = {
-  // passport-jwt validates secretOrKey at strategy-construction time, so
-  // AppModule boot needs a non-empty JWT secret even in test mode.
-  JWT_ACCESS_SECRET: "e2e-test-jwt-secret-not-for-production-use-only-32+chars",
-  // HmacCallbackGuard validates BENCHMARK_CALLBACK_SECRET at constructor time
-  // (same pattern as passport-jwt), so AppModule boot needs a non-empty value
-  // even when no benchmark e2e test cares about it. env.schema.ts treats it as
-  // optional under NODE_ENV=test; this injects a placeholder so the guard
-  // doesn't throw on construction.
-  BENCHMARK_CALLBACK_SECRET: "e2e-test-callback-secret-not-for-production-use-32+chars",
-  // RunService validates BENCHMARK_CALLBACK_URL at constructor time so a
-  // misconfigured deployment fails at boot instead of crashing with TypeError
-  // on the first run. env.schema.ts treats it as optional under NODE_ENV=test;
-  // inject a placeholder so the service can boot for AppModule e2e.
-  BENCHMARK_CALLBACK_URL: "http://e2e-test-placeholder.invalid/",
-  // BenchmarkService.constructor → decodeKey() runs at module init time, same
-  // constructor-validation pattern. env.schema.ts treats this as optional in
-  // test mode; inject a 32-byte base64 placeholder so the service can boot.
-  // (32 zero bytes; never used to encrypt real data.)
-  CONNECTION_API_KEY_ENCRYPTION_KEY: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-  // AlertsController.verifyAuth compares against this in constant time. .env
-  // defines a real dev value, so without pre-injection ConfigService.get would
-  // return that dev value (validatedConfig caches it at forRoot time) and the
-  // spec's "Bearer X" wouldn't match.
-  ALERTMANAGER_WEBHOOK_SECRET: "alertmanager-test-secret-padded-to-32-chars-min",
-  // McpAuthGuard.canActivate() reads both MCP_BEARER_TOKEN and MCP_USER_ID via
-  // ConfigService. mcp.e2e-spec.ts sends `Bearer ${MCP_BEARER_TOKEN}` and
-  // expects mcpUserId to be stamped from MCP_USER_ID; both must match exactly,
-  // so they live here for a single source of truth. The "missing secret → 503"
-  // branch is unit-covered by mcp.guard.spec.ts, so the fixture safely defines
-  // real values here without losing coverage.
-  MCP_BEARER_TOKEN: "test-mcp-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-  MCP_USER_ID: "e2e-mcp-test-user",
+  JWT_ACCESS_SECRET: required("JWT_ACCESS_SECRET"),
+  BENCHMARK_CALLBACK_SECRET: required("BENCHMARK_CALLBACK_SECRET"),
+  BENCHMARK_CALLBACK_URL: required("BENCHMARK_CALLBACK_URL"),
+  CONNECTION_API_KEY_ENCRYPTION_KEY: required("CONNECTION_API_KEY_ENCRYPTION_KEY"),
+  ALERTMANAGER_WEBHOOK_SECRET: required("ALERTMANAGER_WEBHOOK_SECRET"),
+  MCP_BEARER_TOKEN: required("MCP_BEARER_TOKEN"),
+  MCP_USER_ID: required("MCP_USER_ID"),
 } as const;

--- a/apps/api/test/setup/e2e-env-defaults.ts
+++ b/apps/api/test/setup/e2e-env-defaults.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { parse as parseDotenv } from "dotenv";
 
 /**
  * Test-mode env fixture, parsed from apps/api/.env.test.
@@ -10,9 +11,11 @@ import { fileURLToPath } from "node:url";
  * Spec files that need to send a Bearer header matching what ConfigService
  * sees re-import E2E_ENV_DEFAULTS.X to stay in sync.
  *
- * Parsed at module-load time (synchronous read) so spec files can use the
- * const at top level. The path is resolved relative to this file so the
- * resolution doesn't depend on vitest worker cwd.
+ * Parsed via the same `dotenv` library that `@nestjs/config` uses internally,
+ * so the TypeScript const and the ConfigService.get(...) values can never
+ * diverge on quoted strings, inline comments, or other dotenv-spec edge
+ * cases. The path is resolved relative to this file so it doesn't depend on
+ * the vitest worker cwd.
  *
  * Setting `process.env.X = ...` in a spec's `beforeAll` is a known anti-pattern
  * here: forRoot has already locked the value from .env.test, so the late
@@ -24,26 +27,7 @@ import { fileURLToPath } from "node:url";
  * - DATABASE_URL — vitest configs override it dynamically via pickTestDatabaseUrl().
  */
 const ENV_TEST_PATH = resolve(fileURLToPath(import.meta.url), "..", "..", "..", ".env.test");
-
-// Minimal KEY=VALUE parser. Handles `#` line comments, blank lines, and
-// values without quoting. We control the file (apps/api/.env.test), so we
-// don't need the full dotenv spec (no quoted values, no escape sequences,
-// no $-expansion). If you reach for those, switch to the dotenv lib instead.
-function parseEnvFile(contents: string): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const rawLine of contents.split("\n")) {
-    const line = rawLine.trim();
-    if (!line || line.startsWith("#")) continue;
-    const eq = line.indexOf("=");
-    if (eq < 1) continue;
-    const key = line.slice(0, eq).trim();
-    const value = line.slice(eq + 1).trim();
-    out[key] = value;
-  }
-  return out;
-}
-
-const parsed = parseEnvFile(readFileSync(ENV_TEST_PATH, "utf8"));
+const parsed = parseDotenv(readFileSync(ENV_TEST_PATH));
 
 function required(key: string): string {
   const v = parsed[key];

--- a/apps/api/vitest.e2e.config.mts
+++ b/apps/api/vitest.e2e.config.mts
@@ -1,7 +1,6 @@
 import swc from "unplugin-swc";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
-import { E2E_ENV_DEFAULTS } from "./test/setup/e2e-env-defaults.js";
 import { pickTestDatabaseUrl } from "./test/setup/pick-test-db-url.js";
 
 // Same test DB resolution as vitest.config.mts. See that file for rationale.
@@ -29,11 +28,13 @@ export default defineConfig({
     globalSetup: ["./test/setup/global-setup.mts"],
     setupFiles: ["./test/setup/db-guard.ts"],
     env: {
+      // DATABASE_URL is the only env we inject dynamically — pickTestDatabaseUrl
+      // honours TEST_DATABASE_URL overrides and refuses to pass a non-`_test`
+      // URL through. All other test-mode values (JWT secret, callback URL,
+      // encryption key, ALERTMANAGER / MCP / RUNNER_IMAGE_* …) live in
+      // apps/api/.env.test and are auto-loaded by AppConfigModule when
+      // NODE_ENV=test (vitest sets NODE_ENV=test by default).
       DATABASE_URL: TEST_DATABASE_URL,
-      // Shared fixture so spec files can import the same constants they
-      // expect ConfigService to see. See test/setup/e2e-env-defaults.ts for
-      // per-key rationale.
-      ...E2E_ENV_DEFAULTS,
     },
   },
 });

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -58,19 +58,17 @@ export default defineConfig({
       timeout: 120_000,
       reuseExistingServer: !process.env.CI,
       env: {
-        // NODE_ENV=test makes most env vars optional in env.schema.ts; we still
-        // set the JWT/encryption secrets explicitly because auth + connection
-        // services hash/sign with them and would silently use "" defaults.
+        // NODE_ENV=test triggers AppConfigModule to load apps/api/.env.test —
+        // that file is the single source of truth for JWT/encryption/callback
+        // secrets and runner image tags. We only inline the server-shape config
+        // here (port, DB URL pointing at the e2e DB, CORS origin matching the
+        // playwright web server, log level).
         NODE_ENV: "test",
         PORT: String(E2E_API_PORT),
         DATABASE_URL: TEST_DATABASE_URL,
         CORS_ORIGINS: `http://localhost:${E2E_WEB_PORT}`,
-        JWT_ACCESS_SECRET: "e2e-jwt-access-secret-not-for-prod-not-for-prod",
-        JWT_ACCESS_EXPIRES_IN: "1h",
-        JWT_REFRESH_EXPIRES_DAYS: "7",
-        // 32 zero bytes, base64 — fine for test, MUST NOT be used in prod.
-        CONNECTION_API_KEY_ENCRYPTION_KEY: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-        BENCHMARK_CALLBACK_SECRET: "e2e-callback-secret-not-for-prod-not-for-prod",
+        // Override .env.test's placeholder callback URL with the real e2e API
+        // origin so HMAC-signed callbacks actually reach the test server.
         BENCHMARK_CALLBACK_URL: `http://localhost:${E2E_API_PORT}/api/runs/callback`,
         // Quiet logs during e2e — pino logs at info+ by default.
         LOG_LEVEL: "warn",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       '@types/supertest':
         specifier: ^6
         version: 6.0.3
+      dotenv:
+        specifier: ^17.4.1
+        version: 17.4.1
       pino-pretty:
         specifier: ^11
         version: 11.3.0


### PR DESCRIPTION
## Summary

Closes #223. `env.schema.ts` is now uniformly required across dev / test / prod — the 7 `superRefine` branches that made real prod secrets optional under `NODE_ENV=test` are gone. Schema should describe prod knobs, not be aware of the test runtime.

Test isolation moves to the loading layer (matches NestJS sample / Spring Boot profile / Rails environments convention):

- New `apps/api/.env.test` (tracked in git, all dummy placeholders) is the single source of truth for test-mode values.
- `AppConfigModule` picks `envFilePath` based on `NODE_ENV` — `.env.test` for `test`, `.env` otherwise. Vitest auto-sets `NODE_ENV=test`; Playwright's API child process sets it inline.
- `E2E_ENV_DEFAULTS` no longer hard-codes values — it parses `.env.test` at module-load and re-exports the const, so the TS symbol and the file stay in lockstep.
- `vitest.e2e.config.mts` drops the `E2E_ENV_DEFAULTS` spread from `env` (ConfigModule loads `.env.test` itself); only `DATABASE_URL` (dynamic via `pickTestDatabaseUrl`) stays inline.
- `e2e/playwright.config.ts` drops the inline JWT / encryption / callback secrets; the API child process picks them up from `.env.test`. Keeps `NODE_ENV=test`, port + DB URL overrides, and `BENCHMARK_CALLBACK_URL` (overrides the fixture placeholder with the real e2e API origin so HMAC callbacks land).
- `apps/api/.env.example` drops "(except NODE_ENV=test)" annotations.

Schema fields now uniformly required: `DATABASE_URL`, `JWT_ACCESS_SECRET`, `CONNECTION_API_KEY_ENCRYPTION_KEY`, `BENCHMARK_CALLBACK_SECRET`, `BENCHMARK_CALLBACK_URL`, `ALERTMANAGER_WEBHOOK_SECRET`, `RUNNER_IMAGE_*` (×5). `MCP_BEARER_TOKEN` / `MCP_USER_ID` stay `.optional()` since they're genuinely prod-optional (route returns 503 when unset).

## Test plan

- [x] `pnpm -F @modeldoctor/api type-check` — clean.
- [x] `pnpm -F @modeldoctor/api lint` — 0 errors (11 pre-existing `noExplicitAny` warnings in unrelated insights code).
- [x] `pnpm -F @modeldoctor/api test` — 788/789 pass; the one failure (`synthesize.service.spec.ts`) is pre-existing on `main` and unrelated to this change.
- [x] `pnpm test:e2e:api` — 89/89 pass.
- [x] `env.spec.ts` rewritten around a single `validEnv()` fixture; every required key is asserted to fail in BOTH `test` and `production` modes.
- [ ] CI green (workflows pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)