### PR TITLE
feat(api): K8s watcher backstop — Phase 1 of watch-based runner status

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -51,6 +51,16 @@ BENCHMARK_CALLBACK_SECRET=<replace with: openssl rand -base64 48>
 # K8s namespace where benchmark Jobs are created.
 BENCHMARK_K8S_NAMESPACE=modeldoctor-benchmarks
 
+# K8s pod watcher mode: off | backstop | primary
+# - off: no watcher (dev default)
+# - backstop: watcher detects pre-start failures + silent runner death
+# - primary: reserved for Phase 2 (do not set yet)
+K8S_WATCHER_MODE=off
+# Grace seconds before FATAL waiting reasons (ImagePullBackOff, ...) → failed.
+WAITING_FATAL_GRACE_SEC=60
+# Grace seconds after pod terminal state before watcher acts (callback wins inside this window).
+TERMINAL_RECONCILE_GRACE_SEC=60
+
 # Per-tool runner images. Rebuild via `./tools/build-runner-images.sh`
 # (uses git short SHA as the tag); the script prints the matching tag to
 # paste here. NOTE: dotenv does NOT expand shell-style ${VAR:-default}

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -53,6 +53,17 @@ export const EnvSchema = z.object({
   // K8s job runner config — subprocess driver removed in #101.
   BENCHMARK_CALLBACK_URL: z.string().url(),
   BENCHMARK_K8S_NAMESPACE: z.string().min(1).default("modeldoctor-benchmarks"),
+  // K8s watcher (Phase 1: backstop only).
+  //   off: informer 不启动（开发本机默认）
+  //   backstop: informer 启动，只做 FATAL waiting / terminal-no-callback 兜底
+  //   primary: Phase 2 之后才用，本 phase 不实施
+  K8S_WATCHER_MODE: z.enum(["off", "backstop", "primary"]).default("off"),
+  // 等待状态进 ImagePullBackOff/CrashLoopBackOff 等 FATAL waiting 多久后翻 failed。
+  // K8s 社区惯例 60s；registry 限速 / 短暂网络抖动通常 < 30s。
+  WAITING_FATAL_GRACE_SEC: z.coerce.number().int().positive().default(60),
+  // pod 进终态后给 callback 多少时间到达；超时则 watcher 接管翻 failed。
+  // 默认 60s，覆盖 /finish 序列化大 stdout/files + 网络往返。
+  TERMINAL_RECONCILE_GRACE_SEC: z.coerce.number().int().positive().default(60),
   // Per-tool runner images (#53 Phase 2 / #78). K8s is the only execution mode.
   RUNNER_IMAGE_GUIDELLM: z.string().min(1),
   RUNNER_IMAGE_VEGETA: z.string().min(1),

--- a/apps/api/src/modules/benchmark/benchmark-charts.service.ts
+++ b/apps/api/src/modules/benchmark/benchmark-charts.service.ts
@@ -1,8 +1,9 @@
 import type { BenchmarkChartsResponse, HistogramBucket } from "@modeldoctor/contracts";
 import { Injectable, Logger } from "@nestjs/common";
+import { TERMINAL_STATES } from "./constants.js";
 
 const HISTOGRAM_BIN_COUNT = 30;
-const TERMINAL_STATES = new Set(["completed", "failed", "canceled"]);
+const TERMINAL_STATES_SET = new Set<string>(TERMINAL_STATES);
 
 interface ExtractInput {
   id: string;
@@ -23,7 +24,7 @@ export class BenchmarkChartsService {
   extract(row: ExtractInput): BenchmarkChartsResponse {
     const empty: BenchmarkChartsResponse = { latencyCdf: null, ttftHistogram: null };
 
-    if (!TERMINAL_STATES.has(row.status)) return empty;
+    if (!TERMINAL_STATES_SET.has(row.status)) return empty;
     const files = (row.rawOutput?.files ?? null) as Record<string, string> | null;
     if (!files) return empty;
 

--- a/apps/api/src/modules/benchmark/benchmark.module.ts
+++ b/apps/api/src/modules/benchmark/benchmark.module.ts
@@ -15,17 +15,9 @@ import { BenchmarkService } from "./benchmark.service.js";
 import { BenchmarkCallbackController } from "./callbacks/benchmark-callback.controller.js";
 import { K8sBenchmarkRunner } from "./k8s/k8s-benchmark-runner.js";
 import { K8sJobWatcherService, type WatcherMode } from "./k8s/k8s-job-watcher.service.js";
+import { DEFAULT_FATAL_WAITING_REASONS } from "./k8s/pod-state-reducer.js";
 import { StartupReconciler } from "./k8s/startup-reconciler.js";
 import { SseHub } from "./sse/sse-hub.service.js";
-
-const FATAL_WAITING_REASONS = [
-  "ImagePullBackOff",
-  "CrashLoopBackOff",
-  "ErrImagePull",
-  "CreateContainerConfigError",
-  "CreateContainerError",
-  "InvalidImageName",
-] as const;
 
 async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeConfig> {
   const k8s = await import("@kubernetes/client-node");
@@ -90,7 +82,7 @@ async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeCon
         }) as number;
 
         const reducerConfig = {
-          fatalWaitingReasons: FATAL_WAITING_REASONS,
+          fatalWaitingReasons: DEFAULT_FATAL_WAITING_REASONS,
           waitingFatalGraceSec,
           terminalReconcileGraceSec,
         };

--- a/apps/api/src/modules/benchmark/benchmark.module.ts
+++ b/apps/api/src/modules/benchmark/benchmark.module.ts
@@ -1,3 +1,4 @@
+import type { CoreV1Api, KubeConfig, V1Pod } from "@kubernetes/client-node";
 import { assertScenariosInvariant } from "@modeldoctor/tool-adapters";
 import { Module, type OnModuleInit } from "@nestjs/common";
 import { ConfigModule, ConfigService } from "@nestjs/config";
@@ -13,7 +14,27 @@ import { BenchmarkRepository } from "./benchmark.repository.js";
 import { BenchmarkService } from "./benchmark.service.js";
 import { BenchmarkCallbackController } from "./callbacks/benchmark-callback.controller.js";
 import { K8sBenchmarkRunner } from "./k8s/k8s-benchmark-runner.js";
+import { K8sJobWatcherService, type WatcherMode } from "./k8s/k8s-job-watcher.service.js";
+import { StartupReconciler } from "./k8s/startup-reconciler.js";
 import { SseHub } from "./sse/sse-hub.service.js";
+
+const FATAL_WAITING_REASONS = [
+  "ImagePullBackOff",
+  "CrashLoopBackOff",
+  "ErrImagePull",
+  "CreateContainerConfigError",
+  "CreateContainerError",
+  "InvalidImageName",
+] as const;
+
+async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeConfig> {
+  const k8s = await import("@kubernetes/client-node");
+  const kc = new k8s.KubeConfig();
+  const explicit = config.get("KUBECONFIG", { infer: true }) as string | undefined;
+  if (explicit) kc.loadFromFile(explicit);
+  else kc.loadFromDefault();
+  return kc;
+}
 
 @Module({
   imports: [
@@ -31,13 +52,7 @@ import { SseHub } from "./sse/sse-hub.service.js";
     BenchmarkChartsService,
     SseHub,
     {
-      // Wire up the runner with a real KubeConfig + apiClients. The
-      // dynamic import keeps `@kubernetes/client-node` (and its native
-      // deps) out of any module-import that doesn't actually create a
-      // Job — notably tests, which use `Test.createTestingModule` +
-      // `overrideProvider(K8sBenchmarkRunner, { useValue: mockRunner })`
-      // to replace this provider entirely (so this useFactory body
-      // never runs in test mode).
+      // K8sBenchmarkRunner — existing wiring (unchanged from before).
       provide: K8sBenchmarkRunner,
       inject: [ConfigService],
       useFactory: async (config: ConfigService<Env, true>): Promise<K8sBenchmarkRunner> => {
@@ -45,18 +60,91 @@ import { SseHub } from "./sse/sse-hub.service.js";
           (config.get("BENCHMARK_K8S_NAMESPACE", { infer: true }) as string | undefined) ??
           "modeldoctor-benchmarks";
         const k8s = await import("@kubernetes/client-node");
-        const kc = new k8s.KubeConfig();
-        const explicitKubeconfig = config.get("KUBECONFIG", { infer: true }) as string | undefined;
-        if (explicitKubeconfig) {
-          kc.loadFromFile(explicitKubeconfig);
-        } else {
-          kc.loadFromDefault();
-        }
+        const kc = await loadKubeConfig(config);
         return new K8sBenchmarkRunner(
           ns,
           kc.makeApiClient(k8s.BatchV1Api),
           kc.makeApiClient(k8s.CoreV1Api),
         );
+      },
+    },
+    {
+      // K8sJobWatcherService — Phase 1 backstop watcher.
+      // useFactory loads KubeConfig + builds Informer factory + StartupReconciler.
+      // Note: WatcherDeps is constructor-injected as a single object (not 6
+      // separate @Inject calls) so the makeInformer factory closure can capture
+      // the KubeConfig + namespace without leaking them into module-level DI.
+      provide: K8sJobWatcherService,
+      inject: [ConfigService, BenchmarkRepository],
+      useFactory: async (
+        config: ConfigService<Env, true>,
+        repo: BenchmarkRepository,
+      ): Promise<K8sJobWatcherService> => {
+        const mode = config.get("K8S_WATCHER_MODE", { infer: true }) as WatcherMode;
+        const namespace = config.get("BENCHMARK_K8S_NAMESPACE", { infer: true }) as string;
+        const waitingFatalGraceSec = config.get("WAITING_FATAL_GRACE_SEC", {
+          infer: true,
+        }) as number;
+        const terminalReconcileGraceSec = config.get("TERMINAL_RECONCILE_GRACE_SEC", {
+          infer: true,
+        }) as number;
+
+        const reducerConfig = {
+          fatalWaitingReasons: FATAL_WAITING_REASONS,
+          waitingFatalGraceSec,
+          terminalReconcileGraceSec,
+        };
+
+        if (mode === "off") {
+          // mode=off: build a service that no-ops on init/destroy. Avoids
+          // loading K8s entirely in dev / CI / unit-test envs.
+          return new K8sJobWatcherService({
+            mode,
+            namespace,
+            reducerConfig,
+            makeInformer: () => {
+              throw new Error("makeInformer called in mode=off");
+            },
+            repo,
+            reconciler: new StartupReconciler({
+              namespace,
+              repo,
+              podCache: { get: () => undefined, list: () => [] },
+            }),
+          });
+        }
+
+        // mode=backstop (or primary, which the service constructor rejects).
+        // Real informer + reconciler with live K8s client.
+        const k8s = await import("@kubernetes/client-node");
+        const kc = await loadKubeConfig(config);
+        const coreV1: CoreV1Api = kc.makeApiClient(k8s.CoreV1Api);
+        const podPath = `/api/v1/namespaces/${namespace}/pods`;
+        const labelSelector = "app.kubernetes.io/name=modeldoctor-run";
+        const listFn = () =>
+          coreV1.listNamespacedPod(
+            namespace,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            labelSelector,
+          );
+        const informer = k8s.makeInformer<V1Pod>(kc, podPath, listFn, labelSelector);
+        const reconciler = new StartupReconciler({
+          namespace,
+          repo,
+          podCache: informer,
+        });
+
+        return new K8sJobWatcherService({
+          mode,
+          namespace,
+          reducerConfig,
+          makeInformer: () => informer,
+          repo,
+          reconciler,
+        });
       },
     },
   ],

--- a/apps/api/src/modules/benchmark/benchmark.repository.spec.ts
+++ b/apps/api/src/modules/benchmark/benchmark.repository.spec.ts
@@ -249,11 +249,10 @@ describe("BenchmarkRepository.updateGuarded", () => {
         status: "running",
       },
     });
-    const updated = await repo.updateGuarded(
-      b.id,
-      ["pending", "submitted", "running"],
-      { status: "failed", statusMessage: "watcher: test" },
-    );
+    const updated = await repo.updateGuarded(b.id, ["pending", "submitted", "running"], {
+      status: "failed",
+      statusMessage: "watcher: test",
+    });
     expect(updated).not.toBeNull();
     expect(updated?.status).toBe("failed");
     expect(updated?.statusMessage).toBe("watcher: test");
@@ -269,11 +268,10 @@ describe("BenchmarkRepository.updateGuarded", () => {
         status: "completed",
       },
     });
-    const updated = await repo.updateGuarded(
-      b.id,
-      ["pending", "submitted", "running"],
-      { status: "failed", statusMessage: "should not apply" },
-    );
+    const updated = await repo.updateGuarded(b.id, ["pending", "submitted", "running"], {
+      status: "failed",
+      statusMessage: "should not apply",
+    });
     expect(updated).toBeNull();
     const reloaded = await prisma.benchmark.findUnique({ where: { id: b.id } });
     expect(reloaded?.status).toBe("completed");
@@ -281,11 +279,9 @@ describe("BenchmarkRepository.updateGuarded", () => {
   });
 
   it("returns null when row does not exist", async () => {
-    const updated = await repo.updateGuarded(
-      "00000000-0000-0000-0000-000000000000",
-      ["running"],
-      { status: "failed" },
-    );
+    const updated = await repo.updateGuarded("00000000-0000-0000-0000-000000000000", ["running"], {
+      status: "failed",
+    });
     expect(updated).toBeNull();
   });
 });

--- a/apps/api/src/modules/benchmark/benchmark.repository.spec.ts
+++ b/apps/api/src/modules/benchmark/benchmark.repository.spec.ts
@@ -4,25 +4,23 @@ import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import { PrismaService } from "../../database/prisma.service.js";
 import { BenchmarkRepository } from "./benchmark.repository.js";
 
+const configServiceMock = {
+  provide: ConfigService,
+  useValue: {
+    get: (key: string) => {
+      if (key === "DATABASE_URL") return process.env.DATABASE_URL;
+      return undefined;
+    },
+  },
+};
+
 describe("BenchmarkRepository", () => {
   let repo: BenchmarkRepository;
   let prisma: PrismaService;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
-      providers: [
-        BenchmarkRepository,
-        PrismaService,
-        {
-          provide: ConfigService,
-          useValue: {
-            get: (key: string) => {
-              if (key === "DATABASE_URL") return process.env.DATABASE_URL;
-              return undefined;
-            },
-          },
-        },
-      ],
+      providers: [BenchmarkRepository, PrismaService, configServiceMock],
     }).compile();
 
     repo = moduleRef.get(BenchmarkRepository);
@@ -219,5 +217,75 @@ describe("BenchmarkRepository", () => {
 
     const n = await repo.countActiveByName(user.id, "shared-name");
     expect(n).toBe(2);
+  });
+});
+
+describe("BenchmarkRepository.updateGuarded", () => {
+  let repo: BenchmarkRepository;
+  let prisma: PrismaService;
+
+  beforeEach(async () => {
+    const mod = await Test.createTestingModule({
+      providers: [BenchmarkRepository, PrismaService, configServiceMock],
+    }).compile();
+    repo = mod.get(BenchmarkRepository);
+    prisma = mod.get(PrismaService);
+    await prisma.baseline.deleteMany();
+    await prisma.benchmark.deleteMany();
+    await prisma.user.deleteMany();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("updates when current status is in allowedStatuses", async () => {
+    const b = await prisma.benchmark.create({
+      data: {
+        name: "t",
+        scenario: "chat",
+        tool: "guidellm",
+        params: {},
+        status: "running",
+      },
+    });
+    const updated = await repo.updateGuarded(
+      b.id,
+      ["pending", "submitted", "running"],
+      { status: "failed", statusMessage: "watcher: test" },
+    );
+    expect(updated).not.toBeNull();
+    expect(updated?.status).toBe("failed");
+    expect(updated?.statusMessage).toBe("watcher: test");
+  });
+
+  it("returns null when current status is NOT in allowedStatuses", async () => {
+    const b = await prisma.benchmark.create({
+      data: {
+        name: "t",
+        scenario: "chat",
+        tool: "guidellm",
+        params: {},
+        status: "completed",
+      },
+    });
+    const updated = await repo.updateGuarded(
+      b.id,
+      ["pending", "submitted", "running"],
+      { status: "failed", statusMessage: "should not apply" },
+    );
+    expect(updated).toBeNull();
+    const reloaded = await prisma.benchmark.findUnique({ where: { id: b.id } });
+    expect(reloaded?.status).toBe("completed");
+    expect(reloaded?.statusMessage).toBeNull();
+  });
+
+  it("returns null when row does not exist", async () => {
+    const updated = await repo.updateGuarded(
+      "00000000-0000-0000-0000-000000000000",
+      ["running"],
+      { status: "failed" },
+    );
+    expect(updated).toBeNull();
   });
 });

--- a/apps/api/src/modules/benchmark/benchmark.repository.ts
+++ b/apps/api/src/modules/benchmark/benchmark.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { Prisma, type Benchmark as PrismaBenchmark } from "@prisma/client";
 import { PrismaService } from "../../database/prisma.service.js";
+import { IN_PROGRESS_STATES } from "./constants.js";
 
 const benchmarkWithRelations = Prisma.validator<Prisma.BenchmarkDefaultArgs>()({
   include: {
@@ -166,7 +167,7 @@ export class BenchmarkRepository {
       where: {
         userId,
         name,
-        status: { in: ["pending", "submitted", "running"] },
+        status: { in: [...IN_PROGRESS_STATES] },
       },
     });
   }

--- a/apps/api/src/modules/benchmark/benchmark.repository.ts
+++ b/apps/api/src/modules/benchmark/benchmark.repository.ts
@@ -151,7 +151,7 @@ export class BenchmarkRepository {
   ): Promise<PrismaBenchmark | null> {
     const result = await this.prisma.benchmark.updateMany({
       where: { id, status: { in: [...allowedStatuses] } },
-      data: input,
+      data: input as Prisma.BenchmarkUpdateInput,
     });
     if (result.count === 0) return null;
     return this.prisma.benchmark.findUnique({ where: { id } });

--- a/apps/api/src/modules/benchmark/benchmark.repository.ts
+++ b/apps/api/src/modules/benchmark/benchmark.repository.ts
@@ -173,6 +173,19 @@ export class BenchmarkRepository {
   }
 
   /**
+   * List benchmarks whose status is in the given set. Used by StartupReconciler
+   * to find IN_PROGRESS benchmarks at boot time and reconcile against cluster
+   * state. Bounded at 500 rows for safety; in practice the IN_PROGRESS set is
+   * tiny (benchmarks finish in minutes, not hours).
+   */
+  async listByStatus(statuses: readonly string[]): Promise<PrismaBenchmark[]> {
+    return this.prisma.benchmark.findMany({
+      where: { status: { in: [...statuses] } },
+      take: 500,
+    });
+  }
+
+  /**
    * Lightweight existence probe used by BenchmarkService to validate
    * `parentBenchmarkId` before issuing a `repo.create` that would otherwise
    * raise a Prisma P2003 FK-constraint error and surface as HTTP 500. Selecting

--- a/apps/api/src/modules/benchmark/benchmark.repository.ts
+++ b/apps/api/src/modules/benchmark/benchmark.repository.ts
@@ -134,6 +134,29 @@ export class BenchmarkRepository {
     });
   }
 
+  /**
+   * Conditional update: only writes when current `status` is in `allowedStatuses`.
+   * Returns the updated row, or `null` if the guard rejected the write (row not
+   * found OR status outside allowed set).
+   *
+   * Implementation uses Prisma's `updateMany` with a `where: { status: { in } }`
+   * filter; if `count === 0` the guard rejected. Followed by a `findUnique` to
+   * return the new row. Two queries instead of one, but cleaner than raw SQL
+   * and the watcher path is low-volume.
+   */
+  async updateGuarded(
+    id: string,
+    allowedStatuses: readonly string[],
+    input: UpdateBenchmarkInput,
+  ): Promise<PrismaBenchmark | null> {
+    const result = await this.prisma.benchmark.updateMany({
+      where: { id, status: { in: [...allowedStatuses] } },
+      data: input,
+    });
+    if (result.count === 0) return null;
+    return this.prisma.benchmark.findUnique({ where: { id } });
+  }
+
   delete(id: string): Promise<PrismaBenchmark> {
     return this.prisma.benchmark.delete({ where: { id } });
   }

--- a/apps/api/src/modules/benchmark/benchmark.service.ts
+++ b/apps/api/src/modules/benchmark/benchmark.service.ts
@@ -28,7 +28,7 @@ import { BenchmarkTemplateRepository } from "../benchmark-template/benchmark-tem
 import { ConnectionService } from "../connection/connection.service.js";
 import { NotifyService } from "../notifications/notify.service.js";
 import { BenchmarkRepository, type BenchmarkWithRelations } from "./benchmark.repository.js";
-import { IN_PROGRESS_STATES, TERMINAL_STATES, isInProgressStatus } from "./constants.js";
+import { IN_PROGRESS_STATES, isInProgressStatus, TERMINAL_STATES } from "./constants.js";
 import { K8sBenchmarkRunner } from "./k8s/k8s-benchmark-runner.js";
 import { imageForTool } from "./k8s/runner-images.js";
 import { readP95LatencyMs } from "./metrics.js";

--- a/apps/api/src/modules/benchmark/benchmark.service.ts
+++ b/apps/api/src/modules/benchmark/benchmark.service.ts
@@ -28,16 +28,10 @@ import { BenchmarkTemplateRepository } from "../benchmark-template/benchmark-tem
 import { ConnectionService } from "../connection/connection.service.js";
 import { NotifyService } from "../notifications/notify.service.js";
 import { BenchmarkRepository, type BenchmarkWithRelations } from "./benchmark.repository.js";
+import { IN_PROGRESS_STATES, TERMINAL_STATES, isInProgressStatus } from "./constants.js";
 import { K8sBenchmarkRunner } from "./k8s/k8s-benchmark-runner.js";
 import { imageForTool } from "./k8s/runner-images.js";
 import { readP95LatencyMs } from "./metrics.js";
-
-const TERMINAL_STATES = ["completed", "failed", "canceled"] as const;
-
-const IN_PROGRESS_STATES = ["pending", "submitted", "running"] as const;
-function isInProgressStatus(status: string): boolean {
-  return (IN_PROGRESS_STATES as readonly string[]).includes(status);
-}
 
 /** Safety cap for the per-user/per-window query the reports endpoint
  * issues. In practice user × 30-day windows are << 1000 rows; this

--- a/apps/api/src/modules/benchmark/constants.ts
+++ b/apps/api/src/modules/benchmark/constants.ts
@@ -1,0 +1,11 @@
+/** Benchmark lifecycle states where the runner has not yet reached a terminal verdict. */
+export const IN_PROGRESS_STATES = ["pending", "submitted", "running"] as const;
+export type InProgressStatus = (typeof IN_PROGRESS_STATES)[number];
+
+export function isInProgressStatus(status: string): boolean {
+  return (IN_PROGRESS_STATES as readonly string[]).includes(status);
+}
+
+/** Terminal states. Once a benchmark reaches one, no further status writes are allowed. */
+export const TERMINAL_STATES = ["completed", "failed", "canceled"] as const;
+export type TerminalStatus = (typeof TERMINAL_STATES)[number];

--- a/apps/api/src/modules/benchmark/k8s/__fixtures__/pod-fixtures.ts
+++ b/apps/api/src/modules/benchmark/k8s/__fixtures__/pod-fixtures.ts
@@ -1,5 +1,7 @@
 import type { V1Pod } from "@kubernetes/client-node";
 
+const FIXED_TIME = new Date("2026-05-25T09:00:00Z");
+
 const RUN_ID = "run-abc";
 
 const BASE: V1Pod = {
@@ -55,7 +57,7 @@ export function podRunning(): V1Pod {
           restartCount: 0,
           image: "x:latest",
           imageID: "x@sha256:abc",
-          state: { running: { startedAt: new Date() } },
+          state: { running: { startedAt: FIXED_TIME } },
         },
       ],
     },
@@ -74,7 +76,7 @@ export function podSucceeded(): V1Pod {
           restartCount: 0,
           image: "x:latest",
           imageID: "x@sha256:abc",
-          state: { terminated: { exitCode: 0, reason: "Completed", finishedAt: new Date() } },
+          state: { terminated: { exitCode: 0, reason: "Completed", finishedAt: FIXED_TIME } },
         },
       ],
     },
@@ -93,7 +95,7 @@ export function podFailed(exitCode = 1, reason = "Error", message = "tool exit 1
           restartCount: 0,
           image: "x:latest",
           imageID: "x@sha256:abc",
-          state: { terminated: { exitCode, reason, message, finishedAt: new Date() } },
+          state: { terminated: { exitCode, reason, message, finishedAt: FIXED_TIME } },
         },
       ],
     },

--- a/apps/api/src/modules/benchmark/k8s/__fixtures__/pod-fixtures.ts
+++ b/apps/api/src/modules/benchmark/k8s/__fixtures__/pod-fixtures.ts
@@ -23,7 +23,10 @@ export function podRunId(): string {
 }
 
 export function podPending(): V1Pod {
-  return { ...BASE, status: { phase: "Pending", conditions: [{ type: "PodScheduled", status: "True" }] } };
+  return {
+    ...BASE,
+    status: { phase: "Pending", conditions: [{ type: "PodScheduled", status: "True" }] },
+  };
 }
 
 export function podPendingWaiting(reason: string, message = "test"): V1Pod {

--- a/apps/api/src/modules/benchmark/k8s/__fixtures__/pod-fixtures.ts
+++ b/apps/api/src/modules/benchmark/k8s/__fixtures__/pod-fixtures.ts
@@ -1,0 +1,109 @@
+import type { V1Pod } from "@kubernetes/client-node";
+
+const RUN_ID = "run-abc";
+
+const BASE: V1Pod = {
+  metadata: {
+    name: `run-${RUN_ID}-xyz`,
+    namespace: "modeldoctor-benchmarks",
+    labels: {
+      "app.kubernetes.io/name": "modeldoctor-run",
+      "app.kubernetes.io/managed-by": "modeldoctor-api",
+      "modeldoctor.ai/run-id": RUN_ID,
+    },
+  },
+  spec: { containers: [{ name: "runner", image: "x:latest" }] },
+  status: {},
+};
+
+export function podRunId(): string {
+  return RUN_ID;
+}
+
+export function podPending(): V1Pod {
+  return { ...BASE, status: { phase: "Pending", conditions: [{ type: "PodScheduled", status: "True" }] } };
+}
+
+export function podPendingWaiting(reason: string, message = "test"): V1Pod {
+  return {
+    ...BASE,
+    status: {
+      phase: "Pending",
+      containerStatuses: [
+        {
+          name: "runner",
+          ready: false,
+          restartCount: 0,
+          image: "x:latest",
+          imageID: "",
+          state: { waiting: { reason, message } },
+        },
+      ],
+    },
+  };
+}
+
+export function podRunning(): V1Pod {
+  return {
+    ...BASE,
+    status: {
+      phase: "Running",
+      containerStatuses: [
+        {
+          name: "runner",
+          ready: true,
+          restartCount: 0,
+          image: "x:latest",
+          imageID: "x@sha256:abc",
+          state: { running: { startedAt: new Date() } },
+        },
+      ],
+    },
+  };
+}
+
+export function podSucceeded(): V1Pod {
+  return {
+    ...BASE,
+    status: {
+      phase: "Succeeded",
+      containerStatuses: [
+        {
+          name: "runner",
+          ready: false,
+          restartCount: 0,
+          image: "x:latest",
+          imageID: "x@sha256:abc",
+          state: { terminated: { exitCode: 0, reason: "Completed", finishedAt: new Date() } },
+        },
+      ],
+    },
+  };
+}
+
+export function podFailed(exitCode = 1, reason = "Error", message = "tool exit 1"): V1Pod {
+  return {
+    ...BASE,
+    status: {
+      phase: "Failed",
+      containerStatuses: [
+        {
+          name: "runner",
+          ready: false,
+          restartCount: 0,
+          image: "x:latest",
+          imageID: "x@sha256:abc",
+          state: { terminated: { exitCode, reason, message, finishedAt: new Date() } },
+        },
+      ],
+    },
+  };
+}
+
+export function podNoLabels(): V1Pod {
+  return {
+    metadata: { name: "rogue", namespace: "modeldoctor-benchmarks", labels: {} },
+    spec: { containers: [{ name: "x", image: "x" }] },
+    status: { phase: "Running" },
+  };
+}

--- a/apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts
+++ b/apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts
@@ -1,5 +1,6 @@
 import type { V1Job, V1Secret } from "@kubernetes/client-node";
 import type { BenchmarkRunInput } from "./k8s-benchmark-runner.js";
+import { RUNNER_CONTAINER_NAME } from "./runner-container.js";
 
 export function jobName(runId: string): string {
   return `run-${runId}`;
@@ -94,7 +95,7 @@ export function buildJobManifest(ctx: BenchmarkRunInput, opts: JobManifestOption
           restartPolicy: "Never",
           containers: [
             {
-              name: "runner",
+              name: RUNNER_CONTAINER_NAME,
               image: ctx.image,
               imagePullPolicy: "IfNotPresent",
               env,

--- a/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.spec.ts
@@ -1,5 +1,6 @@
 import type { Informer, V1Pod } from "@kubernetes/client-node";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { podFailed, podPendingWaiting, podRunId, podSucceeded } from "./__fixtures__/pod-fixtures.js";
 import { K8sJobWatcherService, type WatcherDeps } from "./k8s-job-watcher.service.js";
 
 function makeFakeInformer() {
@@ -92,5 +93,120 @@ describe("K8sJobWatcherService", () => {
       await svc.onModuleDestroy();
       expect(informer.stop).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("K8sJobWatcherService event handling", () => {
+  it("ADD with FATAL waiting → starts tracking + no immediate update", async () => {
+    const { deps, informer, repo } = makeDeps("backstop");
+    repo.findById.mockResolvedValue({ id: podRunId(), status: "submitted" });
+    const svc = new K8sJobWatcherService(deps);
+    await svc.onModuleInit();
+
+    informer.fire("add", podPendingWaiting("ImagePullBackOff"));
+    // grace not elapsed → no update
+    await new Promise((r) => setTimeout(r, 5));
+    expect(repo.updateGuarded).not.toHaveBeenCalled();
+  });
+
+  it("UPDATE after grace with FATAL waiting → updateGuarded(failed)", async () => {
+    const { deps, informer, repo } = makeDeps("backstop");
+    repo.findById.mockResolvedValue({ id: podRunId(), status: "submitted" });
+    const svc = new K8sJobWatcherService(deps);
+    await svc.onModuleInit();
+    // simulate earlier observation by injecting state
+    (svc as unknown as { firstFatalWaitingAt: Map<string, Date> }).firstFatalWaitingAt.set(
+      podRunId(),
+      new Date(Date.now() - 120_000),
+    );
+
+    informer.fire("update", podPendingWaiting("ImagePullBackOff", "boom"));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(repo.updateGuarded).toHaveBeenCalledWith(
+      podRunId(),
+      ["pending", "submitted", "running"],
+      expect.objectContaining({
+        status: "failed",
+        statusMessage: expect.stringContaining("ImagePullBackOff"),
+      }),
+    );
+  });
+
+  it("UPDATE with non-fatal waiting clears firstFatalWaitingAt", async () => {
+    const { deps, informer, repo } = makeDeps("backstop");
+    repo.findById.mockResolvedValue({ id: podRunId(), status: "submitted" });
+    const svc = new K8sJobWatcherService(deps);
+    await svc.onModuleInit();
+    const state = svc as unknown as { firstFatalWaitingAt: Map<string, Date> };
+    state.firstFatalWaitingAt.set(podRunId(), new Date());
+
+    informer.fire("update", podPendingWaiting("ContainerCreating"));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(state.firstFatalWaitingAt.has(podRunId())).toBe(false);
+  });
+
+  it("UPDATE with Succeeded pod after grace + IN_PROGRESS → failed-terminal", async () => {
+    const { deps, informer, repo } = makeDeps("backstop");
+    repo.findById.mockResolvedValue({ id: podRunId(), status: "running" });
+    const svc = new K8sJobWatcherService(deps);
+    await svc.onModuleInit();
+    (svc as unknown as { firstTerminalAt: Map<string, Date> }).firstTerminalAt.set(
+      podRunId(),
+      new Date(Date.now() - 120_000),
+    );
+
+    informer.fire("update", podSucceeded());
+    await new Promise((r) => setTimeout(r, 5));
+    expect(repo.updateGuarded).toHaveBeenCalledWith(
+      podRunId(),
+      ["pending", "submitted", "running"],
+      expect.objectContaining({
+        status: "failed",
+        statusMessage: expect.stringMatching(/no callback|never arrived/i),
+      }),
+    );
+  });
+
+  it("DELETE clears in-memory state for the runId", async () => {
+    const { deps, informer } = makeDeps("backstop");
+    const svc = new K8sJobWatcherService(deps);
+    await svc.onModuleInit();
+    const state = svc as unknown as {
+      firstFatalWaitingAt: Map<string, Date>;
+      firstTerminalAt: Map<string, Date>;
+    };
+    state.firstFatalWaitingAt.set(podRunId(), new Date());
+    state.firstTerminalAt.set(podRunId(), new Date());
+
+    informer.fire("delete", podFailed());
+    await new Promise((r) => setTimeout(r, 5));
+    expect(state.firstFatalWaitingAt.has(podRunId())).toBe(false);
+    expect(state.firstTerminalAt.has(podRunId())).toBe(false);
+  });
+
+  it("ignores pods without modeldoctor.ai/run-id label", async () => {
+    const { deps, informer, repo } = makeDeps("backstop");
+    const svc = new K8sJobWatcherService(deps);
+    await svc.onModuleInit();
+    informer.fire("add", {
+      metadata: { name: "rogue", namespace: "x", labels: {} },
+      status: { phase: "Running" },
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(repo.findById).not.toHaveBeenCalled();
+  });
+
+  it("ignores benchmarks already in terminal state", async () => {
+    const { deps, informer, repo } = makeDeps("backstop");
+    repo.findById.mockResolvedValue({ id: podRunId(), status: "completed" });
+    const svc = new K8sJobWatcherService(deps);
+    await svc.onModuleInit();
+    (svc as unknown as { firstTerminalAt: Map<string, Date> }).firstTerminalAt.set(
+      podRunId(),
+      new Date(Date.now() - 120_000),
+    );
+    informer.fire("update", podSucceeded());
+    await new Promise((r) => setTimeout(r, 5));
+    expect(repo.updateGuarded).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.spec.ts
@@ -1,6 +1,11 @@
 import type { Informer, V1Pod } from "@kubernetes/client-node";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { podFailed, podPendingWaiting, podRunId, podSucceeded } from "./__fixtures__/pod-fixtures.js";
+import {
+  podFailed,
+  podPendingWaiting,
+  podRunId,
+  podSucceeded,
+} from "./__fixtures__/pod-fixtures.js";
 import { K8sJobWatcherService, type WatcherDeps } from "./k8s-job-watcher.service.js";
 
 function makeFakeInformer() {
@@ -12,13 +17,13 @@ function makeFakeInformer() {
   } = {
     on: vi.fn((verb: string, cb: (arg: unknown) => void) => {
       if (!handlers.has(verb)) handlers.set(verb, []);
-      handlers.get(verb)!.push(cb);
+      handlers.get(verb)?.push(cb);
     }),
     off: vi.fn(),
     start: vi.fn(async () => undefined),
     stop: vi.fn(async () => undefined),
     fire: (verb: string, payload: unknown) => {
-      handlers.get(verb)?.forEach((cb) => cb(payload));
+      for (const cb of handlers.get(verb) ?? []) cb(payload);
     },
   } as unknown as Informer<V1Pod> & {
     fire: (verb: string, payload: unknown) => void;

--- a/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.spec.ts
@@ -1,0 +1,96 @@
+import type { Informer, V1Pod } from "@kubernetes/client-node";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { K8sJobWatcherService, type WatcherDeps } from "./k8s-job-watcher.service.js";
+
+function makeFakeInformer() {
+  const handlers = new Map<string, Array<(arg: unknown) => void>>();
+  const informer: Informer<V1Pod> & {
+    fire: (verb: string, payload: unknown) => void;
+    start: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+  } = {
+    on: vi.fn((verb: string, cb: (arg: unknown) => void) => {
+      if (!handlers.has(verb)) handlers.set(verb, []);
+      handlers.get(verb)!.push(cb);
+    }),
+    off: vi.fn(),
+    start: vi.fn(async () => undefined),
+    stop: vi.fn(async () => undefined),
+    fire: (verb: string, payload: unknown) => {
+      handlers.get(verb)?.forEach((cb) => cb(payload));
+    },
+  } as unknown as Informer<V1Pod> & {
+    fire: (verb: string, payload: unknown) => void;
+    start: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+  };
+  return informer;
+}
+
+function makeDeps(mode: "off" | "backstop" = "backstop"): {
+  deps: WatcherDeps;
+  informer: ReturnType<typeof makeFakeInformer>;
+  repo: { findById: ReturnType<typeof vi.fn>; updateGuarded: ReturnType<typeof vi.fn> };
+  reconciler: { run: ReturnType<typeof vi.fn> };
+} {
+  const informer = makeFakeInformer();
+  const repo = {
+    findById: vi.fn(async () => null),
+    updateGuarded: vi.fn(async () => null),
+  };
+  const reconciler = { run: vi.fn(async () => undefined) };
+  return {
+    deps: {
+      mode,
+      namespace: "modeldoctor-benchmarks",
+      reducerConfig: {
+        fatalWaitingReasons: ["ImagePullBackOff"],
+        waitingFatalGraceSec: 60,
+        terminalReconcileGraceSec: 60,
+      },
+      makeInformer: () => informer as unknown as Informer<V1Pod>,
+      repo: repo as never,
+      reconciler: reconciler as never,
+    },
+    informer,
+    repo,
+    reconciler,
+  };
+}
+
+describe("K8sJobWatcherService", () => {
+  describe("mode=off", () => {
+    it("does NOT start informer or run reconciler on init", async () => {
+      const { deps, informer, reconciler } = makeDeps("off");
+      const svc = new K8sJobWatcherService(deps);
+      await svc.onModuleInit();
+      expect(informer.start).not.toHaveBeenCalled();
+      expect(reconciler.run).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("mode=backstop", () => {
+    it("starts informer + runs reconciler on init", async () => {
+      const { deps, informer, reconciler } = makeDeps("backstop");
+      const svc = new K8sJobWatcherService(deps);
+      await svc.onModuleInit();
+      expect(informer.start).toHaveBeenCalledOnce();
+      expect(reconciler.run).toHaveBeenCalledOnce();
+    });
+
+    it("stops informer on destroy", async () => {
+      const { deps, informer } = makeDeps("backstop");
+      const svc = new K8sJobWatcherService(deps);
+      await svc.onModuleInit();
+      await svc.onModuleDestroy();
+      expect(informer.stop).toHaveBeenCalledOnce();
+    });
+
+    it("is destroy-safe when init never ran", async () => {
+      const { deps, informer } = makeDeps("backstop");
+      const svc = new K8sJobWatcherService(deps);
+      await svc.onModuleDestroy();
+      expect(informer.stop).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts
+++ b/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts
@@ -95,9 +95,6 @@ export class K8sJobWatcherService implements OnModuleInit, OnModuleDestroy {
     const runId = this.extractRunId(pod);
     if (!runId) return;
 
-    const now = new Date();
-    this.trackTiming(pod, runId, now);
-
     let bench: Awaited<ReturnType<BenchmarkRepository["findById"]>>;
     try {
       bench = await this.deps.repo.findById(runId);
@@ -106,6 +103,9 @@ export class K8sJobWatcherService implements OnModuleInit, OnModuleDestroy {
       return;
     }
     if (!bench) return;
+
+    const now = new Date();
+    this.trackTiming(pod, runId, now);
 
     const transition = reduce({
       pod,

--- a/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts
+++ b/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts
@@ -3,6 +3,7 @@ import { Injectable, Logger, type OnModuleDestroy, type OnModuleInit } from "@ne
 import type { BenchmarkRepository } from "../benchmark.repository.js";
 import { IN_PROGRESS_STATES } from "../constants.js";
 import { type DesiredTransition, type ReducerConfig, reduce } from "./pod-state-reducer.js";
+import { getRunnerStatus } from "./runner-container.js";
 import type { StartupReconciler } from "./startup-reconciler.js";
 
 export type WatcherMode = "off" | "backstop" | "primary";
@@ -74,7 +75,7 @@ export class K8sJobWatcherService implements OnModuleInit, OnModuleDestroy {
   /** Updates in-memory tracking maps based on current pod state. */
   private trackTiming(pod: V1Pod, runId: string, now: Date): void {
     const phase = pod.status?.phase;
-    const waitingReason = pod.status?.containerStatuses?.[0]?.state?.waiting?.reason;
+    const waitingReason = getRunnerStatus(pod)?.state?.waiting?.reason;
     const isFatalWaiting =
       !!waitingReason && this.deps.reducerConfig.fatalWaitingReasons.includes(waitingReason);
 

--- a/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts
+++ b/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts
@@ -1,16 +1,18 @@
 import type { Informer, V1Pod } from "@kubernetes/client-node";
 import { Injectable, Logger, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { IN_PROGRESS_STATES } from "../constants.js";
 import type { BenchmarkRepository } from "../benchmark.repository.js";
-import type { ReducerConfig } from "./pod-state-reducer.js";
+import { type DesiredTransition, type ReducerConfig, reduce } from "./pod-state-reducer.js";
 import type { StartupReconciler } from "./startup-reconciler.js";
 
 export type WatcherMode = "off" | "backstop" | "primary";
+
+const RUN_ID_LABEL = "modeldoctor.ai/run-id";
 
 export interface WatcherDeps {
   mode: WatcherMode;
   namespace: string;
   reducerConfig: ReducerConfig;
-  /** Factory so callers can inject a fake in tests without touching K8s. */
   makeInformer: () => Informer<V1Pod>;
   repo: BenchmarkRepository;
   reconciler: StartupReconciler;
@@ -20,10 +22,9 @@ export interface WatcherDeps {
 export class K8sJobWatcherService implements OnModuleInit, OnModuleDestroy {
   private readonly log = new Logger(K8sJobWatcherService.name);
   private informer: Informer<V1Pod> | null = null;
-  /** runId → earliest moment this pod was observed in a FATAL waiting state. */
   private readonly firstFatalWaitingAt = new Map<string, Date>();
-  /** runId → earliest moment this pod was observed in a terminal phase. */
   private readonly firstTerminalAt = new Map<string, Date>();
+  private consecutiveErrors = 0;
 
   constructor(private readonly deps: WatcherDeps) {}
 
@@ -35,9 +36,21 @@ export class K8sJobWatcherService implements OnModuleInit, OnModuleDestroy {
     if (this.deps.mode === "primary") {
       throw new Error("K8S_WATCHER_MODE=primary is reserved for Phase 2; not yet implemented");
     }
-    // mode === "backstop"
     this.informer = this.deps.makeInformer();
-    // Handlers wired in Task 5
+    this.informer.on("add", (p) => this.handlePodEvent(p));
+    this.informer.on("update", (p) => this.handlePodEvent(p));
+    this.informer.on("delete", (p) => this.handlePodDelete(p));
+    this.informer.on("connect", () => {
+      this.consecutiveErrors = 0;
+      this.log.log("informer connected");
+    });
+    this.informer.on("error", (e) => {
+      this.consecutiveErrors += 1;
+      this.log.warn(
+        `informer error (#${this.consecutiveErrors}): ${e instanceof Error ? e.message : String(e)}`,
+      );
+      // The informer auto-reconnects; we only log. Future: emit ops alert at threshold.
+    });
     await this.informer.start();
     this.log.log(`K8s watcher started (mode=backstop, ns=${this.deps.namespace})`);
     await this.deps.reconciler.run();
@@ -48,11 +61,88 @@ export class K8sJobWatcherService implements OnModuleInit, OnModuleDestroy {
       try {
         await this.informer.stop();
       } catch (e) {
-        // Don't let a shutdown-time informer error block other onModuleDestroy
-        // hooks or surface as an unhandled rejection in CI logs.
         this.log.warn(`informer.stop() threw during shutdown: ${(e as Error).message}`);
       }
       this.log.log("K8s watcher stopped");
+    }
+  }
+
+  private extractRunId(pod: V1Pod): string | null {
+    return pod.metadata?.labels?.[RUN_ID_LABEL] ?? null;
+  }
+
+  /** Updates in-memory tracking maps based on current pod state. */
+  private trackTiming(pod: V1Pod, runId: string, now: Date): void {
+    const phase = pod.status?.phase;
+    const waitingReason = pod.status?.containerStatuses?.[0]?.state?.waiting?.reason;
+    const isFatalWaiting =
+      !!waitingReason && this.deps.reducerConfig.fatalWaitingReasons.includes(waitingReason);
+
+    if (isFatalWaiting) {
+      if (!this.firstFatalWaitingAt.has(runId)) this.firstFatalWaitingAt.set(runId, now);
+    } else {
+      this.firstFatalWaitingAt.delete(runId);
+    }
+
+    if (phase === "Failed" || phase === "Succeeded") {
+      if (!this.firstTerminalAt.has(runId)) this.firstTerminalAt.set(runId, now);
+    } else {
+      this.firstTerminalAt.delete(runId);
+    }
+  }
+
+  private async handlePodEvent(pod: V1Pod): Promise<void> {
+    const runId = this.extractRunId(pod);
+    if (!runId) return;
+
+    const now = new Date();
+    this.trackTiming(pod, runId, now);
+
+    let bench: Awaited<ReturnType<BenchmarkRepository["findById"]>>;
+    try {
+      bench = await this.deps.repo.findById(runId);
+    } catch (e) {
+      this.log.warn(`findById(${runId}) failed: ${(e as Error).message}`);
+      return;
+    }
+    if (!bench) return;
+
+    const transition = reduce({
+      pod,
+      currentStatus: bench.status,
+      firstFatalWaitingAt: this.firstFatalWaitingAt.get(runId) ?? null,
+      firstTerminalAt: this.firstTerminalAt.get(runId) ?? null,
+      now,
+      config: this.deps.reducerConfig,
+    });
+
+    await this.execute(runId, transition, now);
+  }
+
+  private handlePodDelete(pod: V1Pod): void {
+    const runId = this.extractRunId(pod);
+    if (!runId) return;
+    this.firstFatalWaitingAt.delete(runId);
+    this.firstTerminalAt.delete(runId);
+  }
+
+  private async execute(runId: string, t: DesiredTransition, now: Date): Promise<void> {
+    if (t.kind === "noop") return;
+    try {
+      const updated = await this.deps.repo.updateGuarded(runId, IN_PROGRESS_STATES, {
+        status: "failed",
+        statusMessage: t.message,
+        completedAt: now,
+      });
+      if (!updated) {
+        this.log.log(
+          `guard rejected update for ${runId} (status already terminal); watcher backed off`,
+        );
+        return;
+      }
+      this.log.log(`watcher marked ${runId} failed: ${t.kind}`);
+    } catch (e) {
+      this.log.warn(`updateGuarded(${runId}) failed: ${(e as Error).message}`);
     }
   }
 }

--- a/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts
+++ b/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts
@@ -1,0 +1,52 @@
+import type { Informer, V1Pod } from "@kubernetes/client-node";
+import { Injectable, Logger, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import type { BenchmarkRepository } from "../benchmark.repository.js";
+import type { ReducerConfig } from "./pod-state-reducer.js";
+import type { StartupReconciler } from "./startup-reconciler.js";
+
+export type WatcherMode = "off" | "backstop" | "primary";
+
+export interface WatcherDeps {
+  mode: WatcherMode;
+  namespace: string;
+  reducerConfig: ReducerConfig;
+  /** Factory so callers can inject a fake in tests without touching K8s. */
+  makeInformer: () => Informer<V1Pod>;
+  repo: BenchmarkRepository;
+  reconciler: StartupReconciler;
+}
+
+@Injectable()
+export class K8sJobWatcherService implements OnModuleInit, OnModuleDestroy {
+  private readonly log = new Logger(K8sJobWatcherService.name);
+  private informer: Informer<V1Pod> | null = null;
+  /** runId → earliest moment this pod was observed in a FATAL waiting state. */
+  private readonly firstFatalWaitingAt = new Map<string, Date>();
+  /** runId → earliest moment this pod was observed in a terminal phase. */
+  private readonly firstTerminalAt = new Map<string, Date>();
+
+  constructor(private readonly deps: WatcherDeps) {}
+
+  async onModuleInit(): Promise<void> {
+    if (this.deps.mode === "off") {
+      this.log.log("K8S_WATCHER_MODE=off → skipping informer + reconciler");
+      return;
+    }
+    if (this.deps.mode === "primary") {
+      throw new Error("K8S_WATCHER_MODE=primary is reserved for Phase 2; not yet implemented");
+    }
+    // mode === "backstop"
+    this.informer = this.deps.makeInformer();
+    // Handlers wired in Task 5
+    await this.informer.start();
+    this.log.log(`K8s watcher started (mode=backstop, ns=${this.deps.namespace})`);
+    await this.deps.reconciler.run();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.informer) {
+      await this.informer.stop();
+      this.log.log("K8s watcher stopped");
+    }
+  }
+}

--- a/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts
+++ b/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts
@@ -1,7 +1,7 @@
 import type { Informer, V1Pod } from "@kubernetes/client-node";
 import { Injectable, Logger, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
-import { IN_PROGRESS_STATES } from "../constants.js";
 import type { BenchmarkRepository } from "../benchmark.repository.js";
+import { IN_PROGRESS_STATES } from "../constants.js";
 import { type DesiredTransition, type ReducerConfig, reduce } from "./pod-state-reducer.js";
 import type { StartupReconciler } from "./startup-reconciler.js";
 

--- a/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts
+++ b/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts
@@ -45,7 +45,13 @@ export class K8sJobWatcherService implements OnModuleInit, OnModuleDestroy {
 
   async onModuleDestroy(): Promise<void> {
     if (this.informer) {
-      await this.informer.stop();
+      try {
+        await this.informer.stop();
+      } catch (e) {
+        // Don't let a shutdown-time informer error block other onModuleDestroy
+        // hooks or surface as an unhandled rejection in CI logs.
+        this.log.warn(`informer.stop() threw during shutdown: ${(e as Error).message}`);
+      }
       this.log.log("K8s watcher stopped");
     }
   }

--- a/apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts
@@ -6,7 +6,7 @@ import {
   podRunning,
   podSucceeded,
 } from "./__fixtures__/pod-fixtures.js";
-import { DEFAULT_FATAL_WAITING_REASONS, reduce, type ReducerConfig } from "./pod-state-reducer.js";
+import { DEFAULT_FATAL_WAITING_REASONS, type ReducerConfig, reduce } from "./pod-state-reducer.js";
 
 const CONFIG: ReducerConfig = {
   fatalWaitingReasons: DEFAULT_FATAL_WAITING_REASONS,

--- a/apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+import {
+  podFailed,
+  podPending,
+  podPendingWaiting,
+  podRunning,
+  podSucceeded,
+} from "./__fixtures__/pod-fixtures.js";
+import { reduce, type ReducerConfig } from "./pod-state-reducer.js";
+
+const CONFIG: ReducerConfig = {
+  fatalWaitingReasons: [
+    "ImagePullBackOff",
+    "CrashLoopBackOff",
+    "ErrImagePull",
+    "CreateContainerConfigError",
+    "CreateContainerError",
+    "InvalidImageName",
+  ],
+  waitingFatalGraceSec: 60,
+  terminalReconcileGraceSec: 60,
+};
+
+const NOW = new Date("2026-05-25T10:00:00Z");
+
+describe("PodStateReducer", () => {
+  describe("noop cases", () => {
+    it("returns noop when benchmark already terminal", () => {
+      const r = reduce({
+        pod: podSucceeded(),
+        currentStatus: "completed",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: null,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("noop");
+    });
+
+    it("returns noop on plain Pending (no waiting reason yet)", () => {
+      const r = reduce({
+        pod: podPending(),
+        currentStatus: "submitted",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: null,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("noop");
+    });
+
+    it("returns noop on Running (backstop does not flip to running)", () => {
+      const r = reduce({
+        pod: podRunning(),
+        currentStatus: "submitted",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: null,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("noop");
+    });
+
+    it("returns noop on transient ContainerCreating waiting", () => {
+      const r = reduce({
+        pod: podPendingWaiting("ContainerCreating"),
+        currentStatus: "submitted",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: null,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("noop");
+    });
+  });
+
+  describe("FATAL waiting → failed-pre-start", () => {
+    for (const reason of [
+      "ImagePullBackOff",
+      "CrashLoopBackOff",
+      "ErrImagePull",
+      "CreateContainerConfigError",
+      "CreateContainerError",
+      "InvalidImageName",
+    ]) {
+      it(`flags ${reason} after grace`, () => {
+        const firstSeen = new Date(NOW.getTime() - 61_000);
+        const r = reduce({
+          pod: podPendingWaiting(reason, "details here"),
+          currentStatus: "submitted",
+          firstFatalWaitingAt: firstSeen,
+          firstTerminalAt: null,
+          now: NOW,
+          config: CONFIG,
+        });
+        expect(r.kind).toBe("failed-pre-start");
+        if (r.kind === "failed-pre-start") {
+          expect(r.reason).toBe(reason);
+          expect(r.message).toContain("details here");
+        }
+      });
+    }
+
+    it("does NOT flag within grace window", () => {
+      const firstSeen = new Date(NOW.getTime() - 30_000);
+      const r = reduce({
+        pod: podPendingWaiting("ImagePullBackOff"),
+        currentStatus: "submitted",
+        firstFatalWaitingAt: firstSeen,
+        firstTerminalAt: null,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("noop");
+    });
+
+    it("does NOT flag when firstFatalWaitingAt is null (just saw it)", () => {
+      const r = reduce({
+        pod: podPendingWaiting("ImagePullBackOff"),
+        currentStatus: "submitted",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: null,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("noop");
+    });
+  });
+
+  describe("terminal phase + IN_PROGRESS → failed-terminal (after grace)", () => {
+    it("Failed pod after grace → failed-terminal with exitCode/reason/message", () => {
+      const firstTerm = new Date(NOW.getTime() - 61_000);
+      const r = reduce({
+        pod: podFailed(137, "OOMKilled", "Memory limit exceeded"),
+        currentStatus: "running",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: firstTerm,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("failed-terminal");
+      if (r.kind === "failed-terminal") {
+        expect(r.exitCode).toBe(137);
+        expect(r.reason).toBe("OOMKilled");
+        expect(r.message).toContain("Memory limit exceeded");
+      }
+    });
+
+    it("Succeeded pod after grace + IN_PROGRESS → failed-terminal (silent runner)", () => {
+      const firstTerm = new Date(NOW.getTime() - 61_000);
+      const r = reduce({
+        pod: podSucceeded(),
+        currentStatus: "running",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: firstTerm,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("failed-terminal");
+      if (r.kind === "failed-terminal") {
+        expect(r.exitCode).toBe(0);
+        expect(r.message).toMatch(/callback never arrived|no callback/i);
+      }
+    });
+
+    it("Failed pod within grace window → noop (give callback a chance)", () => {
+      const firstTerm = new Date(NOW.getTime() - 30_000);
+      const r = reduce({
+        pod: podFailed(),
+        currentStatus: "running",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: firstTerm,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("noop");
+    });
+
+    it("Terminal pod + benchmark already terminal → noop", () => {
+      const firstTerm = new Date(NOW.getTime() - 999_000);
+      const r = reduce({
+        pod: podSucceeded(),
+        currentStatus: "completed",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: firstTerm,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("noop");
+    });
+  });
+
+  describe("statusMessage construction", () => {
+    it("truncates long messages to 2048 chars", () => {
+      const longMsg = "x".repeat(5000);
+      const firstTerm = new Date(NOW.getTime() - 61_000);
+      const r = reduce({
+        pod: podFailed(1, "Error", longMsg),
+        currentStatus: "running",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: firstTerm,
+        now: NOW,
+        config: CONFIG,
+      });
+      if (r.kind === "failed-terminal") {
+        expect(r.message.length).toBeLessThanOrEqual(2048);
+      }
+    });
+  });
+});

--- a/apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts
@@ -202,8 +202,11 @@ describe("PodStateReducer", () => {
         now: NOW,
         config: CONFIG,
       });
+      expect(r.kind).toBe("failed-terminal");
       if (r.kind === "failed-terminal") {
         expect(r.message.length).toBeLessThanOrEqual(2048);
+        // Prefix must survive truncation — losing "Error: " would erase reason context.
+        expect(r.message.startsWith("Error: ")).toBe(true);
       }
     });
   });

--- a/apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts
@@ -6,17 +6,10 @@ import {
   podRunning,
   podSucceeded,
 } from "./__fixtures__/pod-fixtures.js";
-import { reduce, type ReducerConfig } from "./pod-state-reducer.js";
+import { DEFAULT_FATAL_WAITING_REASONS, reduce, type ReducerConfig } from "./pod-state-reducer.js";
 
 const CONFIG: ReducerConfig = {
-  fatalWaitingReasons: [
-    "ImagePullBackOff",
-    "CrashLoopBackOff",
-    "ErrImagePull",
-    "CreateContainerConfigError",
-    "CreateContainerError",
-    "InvalidImageName",
-  ],
+  fatalWaitingReasons: DEFAULT_FATAL_WAITING_REASONS,
   waitingFatalGraceSec: 60,
   terminalReconcileGraceSec: 60,
 };
@@ -75,14 +68,7 @@ describe("PodStateReducer", () => {
   });
 
   describe("FATAL waiting → failed-pre-start", () => {
-    for (const reason of [
-      "ImagePullBackOff",
-      "CrashLoopBackOff",
-      "ErrImagePull",
-      "CreateContainerConfigError",
-      "CreateContainerError",
-      "InvalidImageName",
-    ]) {
+    for (const reason of DEFAULT_FATAL_WAITING_REASONS) {
       it(`flags ${reason} after grace`, () => {
         const firstSeen = new Date(NOW.getTime() - 61_000);
         const r = reduce({

--- a/apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts
+++ b/apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts
@@ -1,6 +1,22 @@
 import type { V1Pod } from "@kubernetes/client-node";
 import { isInProgressStatus } from "../constants.js";
 
+/**
+ * Pod waiting reasons we treat as "won't self-recover" — once the grace
+ * period elapses, the watcher marks the benchmark failed.
+ *
+ * Source: K8s kubelet container statuses + image-puller error codes.
+ * Update if K8s introduces new fatal reasons or if ops needs to recategorize.
+ */
+export const DEFAULT_FATAL_WAITING_REASONS = [
+  "ImagePullBackOff",
+  "CrashLoopBackOff",
+  "ErrImagePull",
+  "CreateContainerConfigError",
+  "CreateContainerError",
+  "InvalidImageName",
+] as const;
+
 export interface ReducerConfig {
   fatalWaitingReasons: readonly string[];
   waitingFatalGraceSec: number;

--- a/apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts
+++ b/apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts
@@ -1,0 +1,106 @@
+import type { V1Pod } from "@kubernetes/client-node";
+import { isInProgressStatus } from "../constants.js";
+
+export interface ReducerConfig {
+  fatalWaitingReasons: readonly string[];
+  waitingFatalGraceSec: number;
+  terminalReconcileGraceSec: number;
+}
+
+export type DesiredTransition =
+  | { kind: "failed-pre-start"; reason: string; message: string }
+  | { kind: "failed-terminal"; exitCode: number; reason: string; message: string }
+  | { kind: "noop" };
+
+export interface ReducerInput {
+  pod: V1Pod;
+  currentStatus: string;
+  /** Earliest time the watcher service observed this pod in a FATAL waiting state.
+   *  null if not currently in FATAL waiting OR this is the first observation. */
+  firstFatalWaitingAt: Date | null;
+  /** Earliest time the watcher service observed this pod in a terminal phase.
+   *  null if not in terminal phase. */
+  firstTerminalAt: Date | null;
+  now: Date;
+  config: ReducerConfig;
+}
+
+const MAX_MSG_LEN = 2048;
+
+function truncate(s: string): string {
+  return s.length > MAX_MSG_LEN ? s.slice(0, MAX_MSG_LEN) : s;
+}
+
+function getWaitingReason(pod: V1Pod): { reason: string; message: string } | null {
+  const cs = pod.status?.containerStatuses?.[0];
+  const w = cs?.state?.waiting;
+  if (!w?.reason) return null;
+  return { reason: w.reason, message: w.message ?? "" };
+}
+
+function getTerminated(pod: V1Pod): { exitCode: number; reason: string; message: string } | null {
+  const cs = pod.status?.containerStatuses?.[0];
+  const t = cs?.state?.terminated;
+  if (!t) return null;
+  return {
+    exitCode: t.exitCode ?? -1,
+    reason: t.reason ?? "Unknown",
+    message: t.message ?? "",
+  };
+}
+
+export function reduce(input: ReducerInput): DesiredTransition {
+  const { pod, currentStatus, firstFatalWaitingAt, firstTerminalAt, now, config } = input;
+
+  // Hard guard: never touch benchmarks that are already in a terminal state.
+  if (!isInProgressStatus(currentStatus)) return { kind: "noop" };
+
+  const phase = pod.status?.phase;
+
+  // 1. FATAL waiting (pre-start failure)
+  const waiting = getWaitingReason(pod);
+  if (waiting && config.fatalWaitingReasons.includes(waiting.reason)) {
+    if (firstFatalWaitingAt) {
+      const elapsedSec = (now.getTime() - firstFatalWaitingAt.getTime()) / 1000;
+      if (elapsedSec >= config.waitingFatalGraceSec) {
+        return {
+          kind: "failed-pre-start",
+          reason: waiting.reason,
+          message: truncate(`${waiting.reason}: ${waiting.message}`),
+        };
+      }
+    }
+    return { kind: "noop" };
+  }
+
+  // 2. Terminal phase (Succeeded or Failed) + benchmark still IN_PROGRESS + grace elapsed
+  if (phase === "Failed" || phase === "Succeeded") {
+    if (firstTerminalAt) {
+      const elapsedSec = (now.getTime() - firstTerminalAt.getTime()) / 1000;
+      if (elapsedSec >= config.terminalReconcileGraceSec) {
+        const term = getTerminated(pod);
+        if (phase === "Failed") {
+          return {
+            kind: "failed-terminal",
+            exitCode: term?.exitCode ?? -1,
+            reason: term?.reason ?? "PodFailed",
+            message: truncate(
+              term ? `${term.reason}: ${term.message}` : "pod in Failed phase",
+            ),
+          };
+        }
+        // Succeeded but benchmark still IN_PROGRESS = runner exited 0 but no callback arrived.
+        return {
+          kind: "failed-terminal",
+          exitCode: 0,
+          reason: "NoCallback",
+          message: "runner pod succeeded but callback never arrived",
+        };
+      }
+    }
+    return { kind: "noop" };
+  }
+
+  // 3. Running / Pending / Unknown — backstop does nothing.
+  return { kind: "noop" };
+}

--- a/apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts
+++ b/apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts
@@ -102,9 +102,7 @@ export function reduce(input: ReducerInput): DesiredTransition {
             kind: "failed-terminal",
             exitCode: term?.exitCode ?? -1,
             reason: term?.reason ?? "PodFailed",
-            message: truncate(
-              term ? `${term.reason}: ${term.message}` : "pod in Failed phase",
-            ),
+            message: truncate(term ? `${term.reason}: ${term.message}` : "pod in Failed phase"),
           };
         }
         // Phase Succeeded implies all containers exited 0 by K8s contract — no need to

--- a/apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts
+++ b/apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts
@@ -1,5 +1,6 @@
 import type { V1Pod } from "@kubernetes/client-node";
 import { isInProgressStatus } from "../constants.js";
+import { getRunnerStatus } from "./runner-container.js";
 
 /**
  * Pod waiting reasons we treat as "won't self-recover" — once the grace
@@ -50,14 +51,14 @@ function truncate(s: string): string {
 }
 
 function getWaitingReason(pod: V1Pod): { reason: string; message: string } | null {
-  const cs = pod.status?.containerStatuses?.[0];
+  const cs = getRunnerStatus(pod);
   const w = cs?.state?.waiting;
   if (!w?.reason) return null;
   return { reason: w.reason, message: w.message ?? "" };
 }
 
 function getTerminated(pod: V1Pod): { exitCode: number; reason: string; message: string } | null {
-  const cs = pod.status?.containerStatuses?.[0];
+  const cs = getRunnerStatus(pod);
   const t = cs?.state?.terminated;
   if (!t) return null;
   return {

--- a/apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts
+++ b/apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts
@@ -25,6 +25,8 @@ export interface ReducerInput {
   config: ReducerConfig;
 }
 
+/** 2 KiB cap: statusMessage is TEXT in Postgres but watcher-sourced messages
+ *  are diagnostic, not data — truncate to keep DB rows compact and UI usable. */
 const MAX_MSG_LEN = 2048;
 
 function truncate(s: string): string {
@@ -89,7 +91,8 @@ export function reduce(input: ReducerInput): DesiredTransition {
             ),
           };
         }
-        // Succeeded but benchmark still IN_PROGRESS = runner exited 0 but no callback arrived.
+        // Phase Succeeded implies all containers exited 0 by K8s contract — no need to
+        // inspect getTerminated(). Failure here means "runner finished but never called back".
         return {
           kind: "failed-terminal",
           exitCode: 0,

--- a/apps/api/src/modules/benchmark/k8s/runner-container.ts
+++ b/apps/api/src/modules/benchmark/k8s/runner-container.ts
@@ -1,0 +1,13 @@
+import type { V1ContainerStatus, V1Pod } from "@kubernetes/client-node";
+
+/** Name of the benchmark runner container in the Job manifest. SSOT — keep
+ *  in sync with apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts. */
+export const RUNNER_CONTAINER_NAME = "runner";
+
+/** Find the runner container status by name. Returns undefined if the pod has
+ *  no containerStatuses (e.g., still scheduling) or no matching container.
+ *  Use this instead of containerStatuses[0]: sidecars may be added in the
+ *  future and the index ordering is undefined. */
+export function getRunnerStatus(pod: V1Pod): V1ContainerStatus | undefined {
+  return pod.status?.containerStatuses?.find((c) => c.name === RUNNER_CONTAINER_NAME);
+}

--- a/apps/api/src/modules/benchmark/k8s/startup-reconciler.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/startup-reconciler.spec.ts
@@ -1,6 +1,6 @@
 import type { V1Pod } from "@kubernetes/client-node";
 import { describe, expect, it, vi } from "vitest";
-import { StartupReconciler, type ReconcilerDeps } from "./startup-reconciler.js";
+import { type ReconcilerDeps, StartupReconciler } from "./startup-reconciler.js";
 
 function podWithRunId(runId: string): V1Pod {
   return {

--- a/apps/api/src/modules/benchmark/k8s/startup-reconciler.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/startup-reconciler.spec.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { StartupReconciler, type ReconcilerDeps } from "./startup-reconciler.js";
+
+function makeDeps(): {
+  deps: ReconcilerDeps;
+  repo: {
+    listByStatus: ReturnType<typeof vi.fn>;
+    updateGuarded: ReturnType<typeof vi.fn>;
+  };
+  cache: { get: ReturnType<typeof vi.fn> };
+} {
+  const repo = {
+    listByStatus: vi.fn(async () => []),
+    updateGuarded: vi.fn(async () => ({ id: "x" })),
+  };
+  const cache = { get: vi.fn(() => undefined) };
+  return {
+    deps: {
+      namespace: "modeldoctor-benchmarks",
+      repo: repo as never,
+      podCache: cache as never,
+    },
+    repo,
+    cache,
+  };
+}
+
+describe("StartupReconciler", () => {
+  it("no-op when no IN_PROGRESS benchmarks", async () => {
+    const { deps, repo } = makeDeps();
+    await new StartupReconciler(deps).run();
+    expect(repo.listByStatus).toHaveBeenCalledOnce();
+    expect(repo.updateGuarded).not.toHaveBeenCalled();
+  });
+
+  it("leaves benchmarks alone when matching pod exists (informer will handle)", async () => {
+    const { deps, repo, cache } = makeDeps();
+    repo.listByStatus.mockResolvedValue([{ id: "abc", status: "running" }]);
+    cache.get.mockReturnValue({
+      metadata: { name: "run-abc", labels: { "modeldoctor.ai/run-id": "abc" } },
+      status: { phase: "Running" },
+    });
+    await new StartupReconciler(deps).run();
+    expect(repo.updateGuarded).not.toHaveBeenCalled();
+  });
+
+  it("marks failed when pod is gone (orphan)", async () => {
+    const { deps, repo, cache } = makeDeps();
+    repo.listByStatus.mockResolvedValue([{ id: "abc", status: "running" }]);
+    cache.get.mockReturnValue(undefined);
+    await new StartupReconciler(deps).run();
+    expect(repo.updateGuarded).toHaveBeenCalledWith(
+      "abc",
+      ["pending", "submitted", "running"],
+      expect.objectContaining({
+        status: "failed",
+        statusMessage: expect.stringMatching(/pod gone|orphan/i),
+      }),
+    );
+  });
+
+  it("processes multiple benchmarks independently", async () => {
+    const { deps, repo, cache } = makeDeps();
+    repo.listByStatus.mockResolvedValue([
+      { id: "a", status: "running" },
+      { id: "b", status: "submitted" },
+      { id: "c", status: "running" },
+    ]);
+    cache.get.mockImplementation((name: string) => {
+      if (name === "run-b") return { metadata: { labels: {} }, status: { phase: "Running" } };
+      return undefined;
+    });
+    await new StartupReconciler(deps).run();
+    expect(repo.updateGuarded).toHaveBeenCalledTimes(2);
+    expect(repo.updateGuarded).toHaveBeenCalledWith("a", expect.any(Array), expect.any(Object));
+    expect(repo.updateGuarded).toHaveBeenCalledWith("c", expect.any(Array), expect.any(Object));
+  });
+});

--- a/apps/api/src/modules/benchmark/k8s/startup-reconciler.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/startup-reconciler.spec.ts
@@ -1,19 +1,35 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { V1Pod } from "@kubernetes/client-node";
+import { describe, expect, it, vi } from "vitest";
 import { StartupReconciler, type ReconcilerDeps } from "./startup-reconciler.js";
 
-function makeDeps(): {
+function podWithRunId(runId: string): V1Pod {
+  return {
+    metadata: {
+      name: `run-${runId}-xyz12`, // Job spawns pods with random suffix
+      namespace: "modeldoctor-benchmarks",
+      labels: { "modeldoctor.ai/run-id": runId },
+    },
+    spec: { containers: [{ name: "runner", image: "x" }] },
+    status: { phase: "Running" },
+  };
+}
+
+function makeDeps(podsInCache: V1Pod[] = []): {
   deps: ReconcilerDeps;
   repo: {
     listByStatus: ReturnType<typeof vi.fn>;
     updateGuarded: ReturnType<typeof vi.fn>;
   };
-  cache: { get: ReturnType<typeof vi.fn> };
+  cache: { list: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn> };
 } {
   const repo = {
     listByStatus: vi.fn(async () => []),
     updateGuarded: vi.fn(async () => ({ id: "x" })),
   };
-  const cache = { get: vi.fn(() => undefined) };
+  const cache = {
+    list: vi.fn(() => podsInCache),
+    get: vi.fn(() => undefined),
+  };
   return {
     deps: {
       namespace: "modeldoctor-benchmarks",
@@ -27,27 +43,25 @@ function makeDeps(): {
 
 describe("StartupReconciler", () => {
   it("no-op when no IN_PROGRESS benchmarks", async () => {
-    const { deps, repo } = makeDeps();
+    const { deps, repo, cache } = makeDeps();
     await new StartupReconciler(deps).run();
     expect(repo.listByStatus).toHaveBeenCalledOnce();
+    expect(cache.list).not.toHaveBeenCalled();
     expect(repo.updateGuarded).not.toHaveBeenCalled();
   });
 
-  it("leaves benchmarks alone when matching pod exists (informer will handle)", async () => {
-    const { deps, repo, cache } = makeDeps();
+  it("leaves benchmark alone when a pod with matching run-id label exists", async () => {
+    const { deps, repo, cache } = makeDeps([podWithRunId("abc")]);
     repo.listByStatus.mockResolvedValue([{ id: "abc", status: "running" }]);
-    cache.get.mockReturnValue({
-      metadata: { name: "run-abc", labels: { "modeldoctor.ai/run-id": "abc" } },
-      status: { phase: "Running" },
-    });
     await new StartupReconciler(deps).run();
+    expect(cache.list).toHaveBeenCalledWith("modeldoctor-benchmarks");
     expect(repo.updateGuarded).not.toHaveBeenCalled();
   });
 
-  it("marks failed when pod is gone (orphan)", async () => {
-    const { deps, repo, cache } = makeDeps();
+  it("marks failed when no pod with matching run-id label is in the cache", async () => {
+    // Cache contains a pod, but with a DIFFERENT run-id — should NOT save us.
+    const { deps, repo } = makeDeps([podWithRunId("someone-else")]);
     repo.listByStatus.mockResolvedValue([{ id: "abc", status: "running" }]);
-    cache.get.mockReturnValue(undefined);
     await new StartupReconciler(deps).run();
     expect(repo.updateGuarded).toHaveBeenCalledWith(
       "abc",
@@ -59,17 +73,14 @@ describe("StartupReconciler", () => {
     );
   });
 
-  it("processes multiple benchmarks independently", async () => {
-    const { deps, repo, cache } = makeDeps();
+  it("processes multiple benchmarks independently using label-based lookup", async () => {
+    // Cache contains only pod for "b". "a" and "c" are orphans.
+    const { deps, repo } = makeDeps([podWithRunId("b")]);
     repo.listByStatus.mockResolvedValue([
       { id: "a", status: "running" },
       { id: "b", status: "submitted" },
       { id: "c", status: "running" },
     ]);
-    cache.get.mockImplementation((name: string) => {
-      if (name === "run-b") return { metadata: { labels: {} }, status: { phase: "Running" } };
-      return undefined;
-    });
     await new StartupReconciler(deps).run();
     expect(repo.updateGuarded).toHaveBeenCalledTimes(2);
     expect(repo.updateGuarded).toHaveBeenCalledWith("a", expect.any(Array), expect.any(Object));

--- a/apps/api/src/modules/benchmark/k8s/startup-reconciler.ts
+++ b/apps/api/src/modules/benchmark/k8s/startup-reconciler.ts
@@ -3,6 +3,9 @@ import { Injectable, Logger } from "@nestjs/common";
 import { IN_PROGRESS_STATES } from "../constants.js";
 import type { BenchmarkRepository } from "../benchmark.repository.js";
 
+const RUN_ID_LABEL = "modeldoctor.ai/run-id";
+const MAX_RECONCILE_ROWS = 500;
+
 export interface ReconcilerDeps {
   namespace: string;
   repo: BenchmarkRepository;
@@ -21,12 +24,28 @@ export class StartupReconciler {
       this.log.log("reconcile: no IN_PROGRESS benchmarks");
       return;
     }
+    if (inProgress.length === MAX_RECONCILE_ROWS) {
+      // Hit the listByStatus cap — there may be more IN_PROGRESS benchmarks
+      // that we silently dropped. Surface this so ops knows to investigate.
+      this.log.warn(
+        `reconcile: listByStatus hit the ${MAX_RECONCILE_ROWS}-row cap; ` +
+          `additional IN_PROGRESS benchmarks may be unreconciled`,
+      );
+    }
     this.log.log(`reconcile: ${inProgress.length} IN_PROGRESS benchmark(s) to check`);
 
+    // Build a Set of runIds whose pod is present in the informer cache. We
+    // can't use ObjectCache.get(name, ns) because K8s appends a random suffix
+    // to Job-spawned pods (run-<id>-<5-char-suffix>), so exact-name lookup
+    // misses every actual pod. Filter by label instead.
+    const livePodRunIds = new Set<string>();
+    for (const pod of this.deps.podCache.list(this.deps.namespace)) {
+      const runId = pod.metadata?.labels?.[RUN_ID_LABEL];
+      if (runId) livePodRunIds.add(runId);
+    }
+
     for (const b of inProgress) {
-      const podName = `run-${b.id}`;
-      const pod = this.deps.podCache.get(podName, this.deps.namespace);
-      if (pod) {
+      if (livePodRunIds.has(b.id)) {
         // Informer will deliver events for this pod; nothing to do here.
         continue;
       }

--- a/apps/api/src/modules/benchmark/k8s/startup-reconciler.ts
+++ b/apps/api/src/modules/benchmark/k8s/startup-reconciler.ts
@@ -1,7 +1,7 @@
 import type { ObjectCache, V1Pod } from "@kubernetes/client-node";
 import { Injectable, Logger } from "@nestjs/common";
-import { IN_PROGRESS_STATES } from "../constants.js";
 import type { BenchmarkRepository } from "../benchmark.repository.js";
+import { IN_PROGRESS_STATES } from "../constants.js";
 
 const RUN_ID_LABEL = "modeldoctor.ai/run-id";
 const MAX_RECONCILE_ROWS = 500;
@@ -28,8 +28,7 @@ export class StartupReconciler {
       // Hit the listByStatus cap — there may be more IN_PROGRESS benchmarks
       // that we silently dropped. Surface this so ops knows to investigate.
       this.log.warn(
-        `reconcile: listByStatus hit the ${MAX_RECONCILE_ROWS}-row cap; ` +
-          `additional IN_PROGRESS benchmarks may be unreconciled`,
+        `reconcile: listByStatus hit the ${MAX_RECONCILE_ROWS}-row cap; additional IN_PROGRESS benchmarks may be unreconciled`,
       );
     }
     this.log.log(`reconcile: ${inProgress.length} IN_PROGRESS benchmark(s) to check`);

--- a/apps/api/src/modules/benchmark/k8s/startup-reconciler.ts
+++ b/apps/api/src/modules/benchmark/k8s/startup-reconciler.ts
@@ -1,7 +1,45 @@
-// TEMPORARY STUB. Task 6 replaces this file with the real implementation.
-// The watcher service imports it; we need a class to satisfy typecheck.
+import type { ObjectCache, V1Pod } from "@kubernetes/client-node";
+import { Injectable, Logger } from "@nestjs/common";
+import { IN_PROGRESS_STATES } from "../constants.js";
+import type { BenchmarkRepository } from "../benchmark.repository.js";
+
+export interface ReconcilerDeps {
+  namespace: string;
+  repo: BenchmarkRepository;
+  podCache: ObjectCache<V1Pod>;
+}
+
+@Injectable()
 export class StartupReconciler {
+  private readonly log = new Logger(StartupReconciler.name);
+
+  constructor(private readonly deps: ReconcilerDeps) {}
+
   async run(): Promise<void> {
-    // intentionally empty until Task 6
+    const inProgress = await this.deps.repo.listByStatus(IN_PROGRESS_STATES);
+    if (inProgress.length === 0) {
+      this.log.log("reconcile: no IN_PROGRESS benchmarks");
+      return;
+    }
+    this.log.log(`reconcile: ${inProgress.length} IN_PROGRESS benchmark(s) to check`);
+
+    for (const b of inProgress) {
+      const podName = `run-${b.id}`;
+      const pod = this.deps.podCache.get(podName, this.deps.namespace);
+      if (pod) {
+        // Informer will deliver events for this pod; nothing to do here.
+        continue;
+      }
+      // Phase 1 scope: no storage yet, so any orphan IN_PROGRESS → failed.
+      // Phase 2 will check storage first (report file may exist even if pod is gone).
+      const updated = await this.deps.repo.updateGuarded(b.id, IN_PROGRESS_STATES, {
+        status: "failed",
+        statusMessage: "pod gone before reconcile",
+        completedAt: new Date(),
+      });
+      if (updated) {
+        this.log.log(`reconcile: marked ${b.id} failed (orphan)`);
+      }
+    }
   }
 }

--- a/apps/api/src/modules/benchmark/k8s/startup-reconciler.ts
+++ b/apps/api/src/modules/benchmark/k8s/startup-reconciler.ts
@@ -1,0 +1,7 @@
+// TEMPORARY STUB. Task 6 replaces this file with the real implementation.
+// The watcher service imports it; we need a class to satisfy typecheck.
+export class StartupReconciler {
+  async run(): Promise<void> {
+    // intentionally empty until Task 6
+  }
+}

--- a/docs/operations/k8s-rbac.md
+++ b/docs/operations/k8s-rbac.md
@@ -1,0 +1,41 @@
+# K8s RBAC for apps/api ServiceAccount
+
+The api process needs RBAC permissions on the benchmark namespace
+(default `modeldoctor-benchmarks`):
+
+## Existing (Job lifecycle)
+
+- `batch/jobs`: create, delete, patch
+- `core/secrets`: create, delete, patch
+
+## Added in Phase 1 (#237 — K8s watcher backstop)
+
+- `core/pods`: **list, get, watch** — required by the Informer
+
+## Reserved for Phase 3 (pod log streamer)
+
+- `core/pods/log`: get — required by the per-pod log follower
+
+## Sample ClusterRole
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: modeldoctor-api
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "get", "watch"]
+```
+
+Phase 1 deployments MUST update the role with the `pods` rule before
+flipping `K8S_WATCHER_MODE` from `off` to `backstop`. Without it the
+Informer will fail to list and the watcher will crash-loop logging RBAC
+denials.

--- a/docs/superpowers/plans/2026-05-25-watch-based-runner-status-phase-1.md
+++ b/docs/superpowers/plans/2026-05-25-watch-based-runner-status-phase-1.md
@@ -1,0 +1,2057 @@
+# Watch-based runner status — Phase 1 实施计划（watcher backstop）
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在 apps/api 加一个 K8s pod Informer + StartupReconciler，只做 **backstop** 兜底——在 callback 永远拿不到的两种场景下把 benchmark 翻 `failed`：(1) pod 卡在 ImagePullBackOff / CrashLoopBackOff / ErrImagePull 等 FATAL waiting 状态超过宽限期；(2) pod 进了终态但 benchmark 仍在 IN_PROGRESS 超过宽限期。callback 三个 endpoint **保留不动**，runner 镜像零改动。
+
+**Architecture:** Informer 长连接订阅 `app.kubernetes.io/name=modeldoctor-run` label 选中的所有 pod，事件 → 纯函数 `PodStateReducer` → 守卫式 SQL UPDATE（status 必须仍是 `pending/submitted/running` 才生效，避免覆盖已到终态的 benchmark）。所有时序判断（grace period）由 watcher service 持有的 in-memory `Map<runId, Date>` 状态完成，reducer 接受外部传入的 "since" 时间戳保持纯函数。启动期 reconciler 跑一次，处理 API 停机期间漏掉的事件。
+
+**Tech Stack:** NestJS 11 (CJS), `@kubernetes/client-node@0.21` (现有依赖，不升级), Prisma 6, Vitest 2, Postgres (现有 modeldoctor_test DB).
+
+**Spec:** `docs/superpowers/specs/2026-05-25-watch-based-runner-status-design.md`（本 PR 一并提交）
+**Tracking issue:** #237 (refs #189 P1)
+
+---
+
+## File Structure
+
+**Create:**
+- `apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts` — 纯函数 reducer
+- `apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts` — 密集 unit 覆盖
+- `apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts` — Informer 接入 + 时序状态
+- `apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.spec.ts` — service unit 测试（fake informer）
+- `apps/api/src/modules/benchmark/k8s/startup-reconciler.ts` — boot 对账
+- `apps/api/src/modules/benchmark/k8s/startup-reconciler.spec.ts` — reconciler unit
+- `apps/api/src/modules/benchmark/k8s/__fixtures__/pod-fixtures.ts` — V1Pod 测试夹具
+
+**Modify:**
+- `apps/api/src/config/env.schema.ts` — 加 `K8S_WATCHER_MODE`、`WAITING_FATAL_GRACE_SEC`、`TERMINAL_RECONCILE_GRACE_SEC`
+- `apps/api/.env.example` — 同步三个新 env 的样例
+- `apps/api/src/modules/benchmark/constants.ts`（**新建**）— 提取 `IN_PROGRESS_STATES` 让 watcher / reducer / service 都用一份
+- `apps/api/src/modules/benchmark/benchmark.service.ts` — 改成从 constants 导入 `IN_PROGRESS_STATES`，去掉本地重复定义
+- `apps/api/src/modules/benchmark/benchmark.repository.ts` — 加 `updateGuarded()` 方法（status forward-only 写）
+- `apps/api/src/modules/benchmark/benchmark.module.ts` — 注入 KubeConfig provider + 注册 watcher / reducer / reconciler
+
+**Docs:**
+- `docs/superpowers/specs/2026-05-25-watch-based-runner-status-design.md`（已写好，需 commit）
+- `docs/operations/k8s-rbac.md`（**新建**或追加）— 给 ops 文档化新增的 RBAC 需求（`pods:list/get/watch`）
+
+---
+
+## Pre-flight
+
+- [ ] **Step 0a: 创建 git worktree**
+
+```bash
+# Per CLAUDE.md: 在 /Users/fangyong/vllm/modeldoctor/ 下用 worktree
+git worktree add /Users/fangyong/vllm/modeldoctor/feat-watch-phase-1 -b feat/watch-runner-status-phase-1
+cd /Users/fangyong/vllm/modeldoctor/feat-watch-phase-1
+```
+
+- [ ] **Step 0b: 新 worktree 需要先建一次 dist（memory: project_worktree_build_first）**
+
+```bash
+pnpm install
+pnpm -r build
+```
+
+Expected: `packages/contracts/dist/` 和 `packages/tool-adapters/dist/` 存在，否则下面 apps/api typecheck 会失败。
+
+- [ ] **Step 0c: 确认基线 typecheck + test 通过**
+
+```bash
+pnpm -F @modeldoctor/api type-check
+pnpm -F @modeldoctor/api test
+```
+
+Expected: 两条命令都退出 0。这是后续每个任务结束时的回归基线。
+
+---
+
+### Task 1: Commit spec + 加 env 配置
+
+**Files:**
+- Add: `docs/superpowers/specs/2026-05-25-watch-based-runner-status-design.md`（controller 已预放置到 feat worktree）
+- Modify: `apps/api/src/config/env.schema.ts`
+- Modify: `apps/api/.env.example`
+
+- [ ] **Step 1: 确认 spec + plan 在 feat worktree**
+
+```bash
+ls docs/superpowers/specs/2026-05-25-watch-based-runner-status-design.md
+ls docs/superpowers/plans/2026-05-25-watch-based-runner-status-phase-1.md
+```
+
+Expected: 两个文件都存在。如果不在，BLOCKED 回报 controller。
+
+- [ ] **Step 2: 看 env.schema.ts 当前结构**
+
+读 `apps/api/src/config/env.schema.ts`，确认现有 K8s 相关项位置：
+
+```
+55:  BENCHMARK_K8S_NAMESPACE: z.string().min(1).default("modeldoctor-benchmarks"),
+80:  KUBECONFIG: z.string().optional(),
+```
+
+新增三个变量加在 `BENCHMARK_K8S_NAMESPACE` 之后（K8s 配置区集中）。
+
+- [ ] **Step 3: 编辑 env.schema.ts 加三个变量**
+
+在 `BENCHMARK_K8S_NAMESPACE` 那一行后面插入：
+
+```ts
+  // K8s watcher (Phase 1: backstop only).
+  //   off: informer 不启动（开发本机默认）
+  //   backstop: informer 启动，只做 FATAL waiting / terminal-no-callback 兜底
+  //   primary: Phase 2 之后才用，本 phase 不实施
+  K8S_WATCHER_MODE: z.enum(["off", "backstop", "primary"]).default("off"),
+  // 等待状态进 ImagePullBackOff/CrashLoopBackOff 等 FATAL waiting 多久后翻 failed。
+  // K8s 社区惯例 60s；registry 限速 / 短暂网络抖动通常 < 30s。
+  WAITING_FATAL_GRACE_SEC: z.coerce.number().int().positive().default(60),
+  // pod 进终态后给 callback 多少时间到达；超时则 watcher 接管翻 failed。
+  // 默认 60s，覆盖 /finish 序列化大 stdout/files + 网络往返。
+  TERMINAL_RECONCILE_GRACE_SEC: z.coerce.number().int().positive().default(60),
+```
+
+- [ ] **Step 4: 同步 .env.example**
+
+在 `BENCHMARK_K8S_NAMESPACE=...` 后追加：
+
+```
+# K8s pod watcher mode: off | backstop | primary
+# - off: no watcher (dev default)
+# - backstop: watcher detects pre-start failures + silent runner death
+# - primary: reserved for Phase 2 (do not set yet)
+K8S_WATCHER_MODE=off
+# Grace seconds before FATAL waiting reasons (ImagePullBackOff, ...) → failed.
+WAITING_FATAL_GRACE_SEC=60
+# Grace seconds after pod terminal state before watcher acts (callback wins inside this window).
+TERMINAL_RECONCILE_GRACE_SEC=60
+```
+
+- [ ] **Step 5: 跑 env-example check + typecheck**
+
+```bash
+pnpm -F @modeldoctor/api check:env-example
+pnpm -F @modeldoctor/api type-check
+```
+
+Expected: 两条都通过。`check:env-example` 会比对 schema 跟 .env.example 是否对齐。
+
+- [ ] **Step 6: commit**
+
+```bash
+git add docs/superpowers/specs/2026-05-25-watch-based-runner-status-design.md \
+  docs/superpowers/plans/2026-05-25-watch-based-runner-status-phase-1.md \
+  apps/api/src/config/env.schema.ts \
+  apps/api/.env.example
+git commit -m "$(cat <<'EOF'
+docs+build: spec + plan + env flags for K8s watcher Phase 1 (refs #237)
+
+Design spec for watch-based runner status (replaces #177's reference-only
+callback approach with a more aggressive pull-only architecture). Phase 1
+ships only the backstop watcher; callbacks stay primary.
+
+Env flags introduced:
+- K8S_WATCHER_MODE (off|backstop|primary) — feature gate, defaults off
+- WAITING_FATAL_GRACE_SEC — pre-start failure detection threshold
+- TERMINAL_RECONCILE_GRACE_SEC — callback wins for this window after pod term
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: 提取 IN_PROGRESS_STATES 到共享常量 + 加 updateGuarded()
+
+**Files:**
+- Create: `apps/api/src/modules/benchmark/constants.ts`
+- Modify: `apps/api/src/modules/benchmark/benchmark.service.ts:37-40`
+- Modify: `apps/api/src/modules/benchmark/benchmark.repository.ts`
+- Create: `apps/api/src/modules/benchmark/benchmark.repository.spec.ts` (如不存在则新建)
+
+- [ ] **Step 1: 新建 constants.ts**
+
+```ts
+// apps/api/src/modules/benchmark/constants.ts
+/** Benchmark lifecycle states where the runner has not yet reached a terminal verdict. */
+export const IN_PROGRESS_STATES = ["pending", "submitted", "running"] as const;
+export type InProgressStatus = (typeof IN_PROGRESS_STATES)[number];
+
+export function isInProgressStatus(status: string): boolean {
+  return (IN_PROGRESS_STATES as readonly string[]).includes(status);
+}
+
+/** Terminal states. Once a benchmark reaches one, no further status writes are allowed. */
+export const TERMINAL_STATES = ["completed", "failed", "canceled"] as const;
+export type TerminalStatus = (typeof TERMINAL_STATES)[number];
+```
+
+- [ ] **Step 2: 改 benchmark.service.ts 引用共享常量**
+
+打开 `apps/api/src/modules/benchmark/benchmark.service.ts`。
+
+替换 line 32 (`const TERMINAL_STATES = ...`) 到 line 40 之间的本地定义，改为：
+
+```ts
+import {
+  IN_PROGRESS_STATES,
+  TERMINAL_STATES,
+  isInProgressStatus,
+} from "./constants.js";
+```
+
+（原 import 块顶部加进去，删掉本地 const 定义和本地 `isInProgressStatus` 函数。注意保留所有现有 import 语句，只是去掉 line 32 和 37-40 的本地定义。）
+
+- [ ] **Step 3: 跑现有 service test 确认零回归**
+
+```bash
+pnpm -F @modeldoctor/api test -- benchmark.service.spec
+```
+
+Expected: 全部 PASS。
+
+- [ ] **Step 4: 写 updateGuarded() 的测试（先红）**
+
+打开或新建 `apps/api/src/modules/benchmark/benchmark.repository.spec.ts`。如果文件已存在但没相关用例，追加；不存在则新建。
+
+```ts
+// apps/api/src/modules/benchmark/benchmark.repository.spec.ts
+import { Test } from "@nestjs/testing";
+import { beforeEach, describe, expect, it } from "vitest";
+import { PrismaService } from "../../database/prisma.service.js";
+import { BenchmarkRepository } from "./benchmark.repository.js";
+
+describe("BenchmarkRepository.updateGuarded", () => {
+  let repo: BenchmarkRepository;
+  let prisma: PrismaService;
+
+  beforeEach(async () => {
+    const mod = await Test.createTestingModule({
+      providers: [BenchmarkRepository, PrismaService],
+    }).compile();
+    repo = mod.get(BenchmarkRepository);
+    prisma = mod.get(PrismaService);
+    await prisma.benchmark.deleteMany({});
+  });
+
+  it("updates when current status is in allowedStatuses", async () => {
+    const b = await prisma.benchmark.create({
+      data: {
+        name: "t",
+        scenario: "chat",
+        tool: "guidellm",
+        params: {},
+        status: "running",
+      },
+    });
+    const updated = await repo.updateGuarded(
+      b.id,
+      ["pending", "submitted", "running"],
+      { status: "failed", statusMessage: "watcher: test" },
+    );
+    expect(updated).not.toBeNull();
+    expect(updated?.status).toBe("failed");
+    expect(updated?.statusMessage).toBe("watcher: test");
+  });
+
+  it("returns null when current status is NOT in allowedStatuses", async () => {
+    const b = await prisma.benchmark.create({
+      data: {
+        name: "t",
+        scenario: "chat",
+        tool: "guidellm",
+        params: {},
+        status: "completed",
+      },
+    });
+    const updated = await repo.updateGuarded(
+      b.id,
+      ["pending", "submitted", "running"],
+      { status: "failed", statusMessage: "should not apply" },
+    );
+    expect(updated).toBeNull();
+    // confirm DB row unchanged
+    const reloaded = await prisma.benchmark.findUnique({ where: { id: b.id } });
+    expect(reloaded?.status).toBe("completed");
+    expect(reloaded?.statusMessage).toBeNull();
+  });
+
+  it("returns null when row does not exist", async () => {
+    const updated = await repo.updateGuarded(
+      "00000000-0000-0000-0000-000000000000",
+      ["running"],
+      { status: "failed" },
+    );
+    expect(updated).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 5: 跑 test 确认它失败**
+
+```bash
+pnpm -F @modeldoctor/api test -- benchmark.repository.spec
+```
+
+Expected: FAIL，因为 `updateGuarded` 方法不存在。
+
+- [ ] **Step 6: 实现 updateGuarded()**
+
+在 `apps/api/src/modules/benchmark/benchmark.repository.ts` 的 `update()` 方法之后追加：
+
+```ts
+  /**
+   * Conditional update: only writes when current `status` is in `allowedStatuses`.
+   * Returns the updated row, or `null` if the guard rejected the write (row not
+   * found OR status outside allowed set).
+   *
+   * Implementation uses Prisma's `updateMany` with a `where: { status: { in } }`
+   * filter; if `count === 0` the guard rejected. Followed by a `findUnique` to
+   * return the new row. Two queries instead of one, but cleaner than raw SQL
+   * and the watcher path is low-volume.
+   */
+  async updateGuarded(
+    id: string,
+    allowedStatuses: readonly string[],
+    input: UpdateBenchmarkInput,
+  ): Promise<PrismaBenchmark | null> {
+    const result = await this.prisma.benchmark.updateMany({
+      where: { id, status: { in: [...allowedStatuses] } },
+      data: input,
+    });
+    if (result.count === 0) return null;
+    return this.prisma.benchmark.findUnique({ where: { id } });
+  }
+```
+
+- [ ] **Step 7: 跑 test 确认通过**
+
+```bash
+pnpm -F @modeldoctor/api test -- benchmark.repository.spec
+```
+
+Expected: 三个 case 全 PASS。
+
+- [ ] **Step 8: 跑全套 api test 确认零回归**
+
+```bash
+pnpm -F @modeldoctor/api test
+```
+
+Expected: 全 PASS。
+
+- [ ] **Step 9: commit**
+
+```bash
+git add apps/api/src/modules/benchmark/constants.ts \
+  apps/api/src/modules/benchmark/benchmark.service.ts \
+  apps/api/src/modules/benchmark/benchmark.repository.ts \
+  apps/api/src/modules/benchmark/benchmark.repository.spec.ts
+git commit -m "$(cat <<'EOF'
+refactor(api): extract IN_PROGRESS_STATES + add Repository.updateGuarded (refs #237)
+
+constants.ts becomes the SSOT for benchmark lifecycle state buckets so the
+forthcoming watcher and the existing service share one definition.
+
+updateGuarded() lets writers say "only update if current status is in this
+set" — used by the watcher to enforce status-forward-only writes (D5 in the
+spec): terminal benchmarks never get overwritten even under race with
+callbacks.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: PodStateReducer 纯函数 + 密集 unit 测试
+
+**Files:**
+- Create: `apps/api/src/modules/benchmark/k8s/__fixtures__/pod-fixtures.ts`
+- Create: `apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts`
+- Create: `apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts`
+
+- [ ] **Step 1: 写 pod fixtures**
+
+```ts
+// apps/api/src/modules/benchmark/k8s/__fixtures__/pod-fixtures.ts
+import type { V1Pod } from "@kubernetes/client-node";
+
+const RUN_ID = "run-abc";
+
+const BASE: V1Pod = {
+  metadata: {
+    name: `run-${RUN_ID}-xyz`,
+    namespace: "modeldoctor-benchmarks",
+    labels: {
+      "app.kubernetes.io/name": "modeldoctor-run",
+      "app.kubernetes.io/managed-by": "modeldoctor-api",
+      "modeldoctor.ai/run-id": RUN_ID,
+    },
+  },
+  spec: { containers: [{ name: "runner", image: "x:latest" }] },
+  status: {},
+};
+
+export function podRunId(): string {
+  return RUN_ID;
+}
+
+export function podPending(): V1Pod {
+  return { ...BASE, status: { phase: "Pending", conditions: [{ type: "PodScheduled", status: "True" }] } };
+}
+
+export function podPendingWaiting(reason: string, message = "test"): V1Pod {
+  return {
+    ...BASE,
+    status: {
+      phase: "Pending",
+      containerStatuses: [
+        {
+          name: "runner",
+          ready: false,
+          restartCount: 0,
+          image: "x:latest",
+          imageID: "",
+          state: { waiting: { reason, message } },
+        },
+      ],
+    },
+  };
+}
+
+export function podRunning(): V1Pod {
+  return {
+    ...BASE,
+    status: {
+      phase: "Running",
+      containerStatuses: [
+        {
+          name: "runner",
+          ready: true,
+          restartCount: 0,
+          image: "x:latest",
+          imageID: "x@sha256:abc",
+          state: { running: { startedAt: new Date() } },
+        },
+      ],
+    },
+  };
+}
+
+export function podSucceeded(): V1Pod {
+  return {
+    ...BASE,
+    status: {
+      phase: "Succeeded",
+      containerStatuses: [
+        {
+          name: "runner",
+          ready: false,
+          restartCount: 0,
+          image: "x:latest",
+          imageID: "x@sha256:abc",
+          state: { terminated: { exitCode: 0, reason: "Completed", finishedAt: new Date() } },
+        },
+      ],
+    },
+  };
+}
+
+export function podFailed(exitCode = 1, reason = "Error", message = "tool exit 1"): V1Pod {
+  return {
+    ...BASE,
+    status: {
+      phase: "Failed",
+      containerStatuses: [
+        {
+          name: "runner",
+          ready: false,
+          restartCount: 0,
+          image: "x:latest",
+          imageID: "x@sha256:abc",
+          state: { terminated: { exitCode, reason, message, finishedAt: new Date() } },
+        },
+      ],
+    },
+  };
+}
+
+export function podNoLabels(): V1Pod {
+  return {
+    metadata: { name: "rogue", namespace: "modeldoctor-benchmarks", labels: {} },
+    spec: { containers: [{ name: "x", image: "x" }] },
+    status: { phase: "Running" },
+  };
+}
+```
+
+- [ ] **Step 2: 写 reducer 测试（先红）**
+
+```ts
+// apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts
+import { describe, expect, it } from "vitest";
+import {
+  podFailed,
+  podPending,
+  podPendingWaiting,
+  podRunning,
+  podSucceeded,
+} from "./__fixtures__/pod-fixtures.js";
+import { reduce, type ReducerConfig } from "./pod-state-reducer.js";
+
+const CONFIG: ReducerConfig = {
+  fatalWaitingReasons: [
+    "ImagePullBackOff",
+    "CrashLoopBackOff",
+    "ErrImagePull",
+    "CreateContainerConfigError",
+    "CreateContainerError",
+    "InvalidImageName",
+  ],
+  waitingFatalGraceSec: 60,
+  terminalReconcileGraceSec: 60,
+};
+
+const NOW = new Date("2026-05-25T10:00:00Z");
+
+describe("PodStateReducer", () => {
+  describe("noop cases", () => {
+    it("returns noop when benchmark already terminal", () => {
+      const r = reduce({
+        pod: podSucceeded(),
+        currentStatus: "completed",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: null,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("noop");
+    });
+
+    it("returns noop on plain Pending (no waiting reason yet)", () => {
+      const r = reduce({
+        pod: podPending(),
+        currentStatus: "submitted",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: null,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("noop");
+    });
+
+    it("returns noop on Running (backstop does not flip to running)", () => {
+      const r = reduce({
+        pod: podRunning(),
+        currentStatus: "submitted",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: null,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("noop");
+    });
+
+    it("returns noop on transient ContainerCreating waiting", () => {
+      const r = reduce({
+        pod: podPendingWaiting("ContainerCreating"),
+        currentStatus: "submitted",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: null,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("noop");
+    });
+  });
+
+  describe("FATAL waiting → failed-pre-start", () => {
+    for (const reason of [
+      "ImagePullBackOff",
+      "CrashLoopBackOff",
+      "ErrImagePull",
+      "CreateContainerConfigError",
+      "CreateContainerError",
+      "InvalidImageName",
+    ]) {
+      it(`flags ${reason} after grace`, () => {
+        const firstSeen = new Date(NOW.getTime() - 61_000);
+        const r = reduce({
+          pod: podPendingWaiting(reason, "details here"),
+          currentStatus: "submitted",
+          firstFatalWaitingAt: firstSeen,
+          firstTerminalAt: null,
+          now: NOW,
+          config: CONFIG,
+        });
+        expect(r.kind).toBe("failed-pre-start");
+        if (r.kind === "failed-pre-start") {
+          expect(r.reason).toBe(reason);
+          expect(r.message).toContain("details here");
+        }
+      });
+    }
+
+    it("does NOT flag within grace window", () => {
+      const firstSeen = new Date(NOW.getTime() - 30_000);
+      const r = reduce({
+        pod: podPendingWaiting("ImagePullBackOff"),
+        currentStatus: "submitted",
+        firstFatalWaitingAt: firstSeen,
+        firstTerminalAt: null,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("noop");
+    });
+
+    it("does NOT flag when firstFatalWaitingAt is null (just saw it)", () => {
+      const r = reduce({
+        pod: podPendingWaiting("ImagePullBackOff"),
+        currentStatus: "submitted",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: null,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("noop");
+    });
+  });
+
+  describe("terminal phase + IN_PROGRESS → failed-terminal (after grace)", () => {
+    it("Failed pod after grace → failed-terminal with exitCode/reason/message", () => {
+      const firstTerm = new Date(NOW.getTime() - 61_000);
+      const r = reduce({
+        pod: podFailed(137, "OOMKilled", "Memory limit exceeded"),
+        currentStatus: "running",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: firstTerm,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("failed-terminal");
+      if (r.kind === "failed-terminal") {
+        expect(r.exitCode).toBe(137);
+        expect(r.reason).toBe("OOMKilled");
+        expect(r.message).toContain("Memory limit exceeded");
+      }
+    });
+
+    it("Succeeded pod after grace + IN_PROGRESS → failed-terminal (silent runner)", () => {
+      const firstTerm = new Date(NOW.getTime() - 61_000);
+      const r = reduce({
+        pod: podSucceeded(),
+        currentStatus: "running",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: firstTerm,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("failed-terminal");
+      if (r.kind === "failed-terminal") {
+        expect(r.exitCode).toBe(0);
+        expect(r.message).toMatch(/callback never arrived|no callback/i);
+      }
+    });
+
+    it("Failed pod within grace window → noop (give callback a chance)", () => {
+      const firstTerm = new Date(NOW.getTime() - 30_000);
+      const r = reduce({
+        pod: podFailed(),
+        currentStatus: "running",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: firstTerm,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("noop");
+    });
+
+    it("Terminal pod + benchmark already terminal → noop", () => {
+      const firstTerm = new Date(NOW.getTime() - 999_000);
+      const r = reduce({
+        pod: podSucceeded(),
+        currentStatus: "completed",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: firstTerm,
+        now: NOW,
+        config: CONFIG,
+      });
+      expect(r.kind).toBe("noop");
+    });
+  });
+
+  describe("statusMessage construction", () => {
+    it("truncates long messages to 2048 chars", () => {
+      const longMsg = "x".repeat(5000);
+      const firstTerm = new Date(NOW.getTime() - 61_000);
+      const r = reduce({
+        pod: podFailed(1, "Error", longMsg),
+        currentStatus: "running",
+        firstFatalWaitingAt: null,
+        firstTerminalAt: firstTerm,
+        now: NOW,
+        config: CONFIG,
+      });
+      if (r.kind === "failed-terminal") {
+        expect(r.message.length).toBeLessThanOrEqual(2048);
+      }
+    });
+  });
+});
+```
+
+- [ ] **Step 3: 跑 test 确认全红**
+
+```bash
+pnpm -F @modeldoctor/api test -- pod-state-reducer
+```
+
+Expected: 全部 FAIL（module not found）。
+
+- [ ] **Step 4: 实现 reducer**
+
+```ts
+// apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts
+import type { V1Pod } from "@kubernetes/client-node";
+import { isInProgressStatus } from "../constants.js";
+
+export interface ReducerConfig {
+  fatalWaitingReasons: readonly string[];
+  waitingFatalGraceSec: number;
+  terminalReconcileGraceSec: number;
+}
+
+export type DesiredTransition =
+  | { kind: "failed-pre-start"; reason: string; message: string }
+  | { kind: "failed-terminal"; exitCode: number; reason: string; message: string }
+  | { kind: "noop" };
+
+export interface ReducerInput {
+  pod: V1Pod;
+  currentStatus: string;
+  /** Earliest time the watcher service observed this pod in a FATAL waiting state.
+   *  null if not currently in FATAL waiting OR this is the first observation. */
+  firstFatalWaitingAt: Date | null;
+  /** Earliest time the watcher service observed this pod in a terminal phase.
+   *  null if not in terminal phase. */
+  firstTerminalAt: Date | null;
+  now: Date;
+  config: ReducerConfig;
+}
+
+const MAX_MSG_LEN = 2048;
+
+function truncate(s: string): string {
+  return s.length > MAX_MSG_LEN ? s.slice(0, MAX_MSG_LEN) : s;
+}
+
+function getWaitingReason(pod: V1Pod): { reason: string; message: string } | null {
+  const cs = pod.status?.containerStatuses?.[0];
+  const w = cs?.state?.waiting;
+  if (!w?.reason) return null;
+  return { reason: w.reason, message: w.message ?? "" };
+}
+
+function getTerminated(pod: V1Pod): { exitCode: number; reason: string; message: string } | null {
+  const cs = pod.status?.containerStatuses?.[0];
+  const t = cs?.state?.terminated;
+  if (!t) return null;
+  return {
+    exitCode: t.exitCode ?? -1,
+    reason: t.reason ?? "Unknown",
+    message: t.message ?? "",
+  };
+}
+
+export function reduce(input: ReducerInput): DesiredTransition {
+  const { pod, currentStatus, firstFatalWaitingAt, firstTerminalAt, now, config } = input;
+
+  // Hard guard: never touch benchmarks that are already in a terminal state.
+  if (!isInProgressStatus(currentStatus)) return { kind: "noop" };
+
+  const phase = pod.status?.phase;
+
+  // 1. FATAL waiting (pre-start failure)
+  const waiting = getWaitingReason(pod);
+  if (waiting && config.fatalWaitingReasons.includes(waiting.reason)) {
+    if (firstFatalWaitingAt) {
+      const elapsedSec = (now.getTime() - firstFatalWaitingAt.getTime()) / 1000;
+      if (elapsedSec >= config.waitingFatalGraceSec) {
+        return {
+          kind: "failed-pre-start",
+          reason: waiting.reason,
+          message: truncate(`${waiting.reason}: ${waiting.message}`),
+        };
+      }
+    }
+    return { kind: "noop" };
+  }
+
+  // 2. Terminal phase (Succeeded or Failed) + benchmark still IN_PROGRESS + grace elapsed
+  if (phase === "Failed" || phase === "Succeeded") {
+    if (firstTerminalAt) {
+      const elapsedSec = (now.getTime() - firstTerminalAt.getTime()) / 1000;
+      if (elapsedSec >= config.terminalReconcileGraceSec) {
+        const term = getTerminated(pod);
+        if (phase === "Failed") {
+          return {
+            kind: "failed-terminal",
+            exitCode: term?.exitCode ?? -1,
+            reason: term?.reason ?? "PodFailed",
+            message: truncate(
+              term ? `${term.reason}: ${term.message}` : "pod in Failed phase",
+            ),
+          };
+        }
+        // Succeeded but benchmark still IN_PROGRESS = runner exited 0 but no callback arrived.
+        return {
+          kind: "failed-terminal",
+          exitCode: 0,
+          reason: "NoCallback",
+          message: "runner pod succeeded but callback never arrived",
+        };
+      }
+    }
+    return { kind: "noop" };
+  }
+
+  // 3. Running / Pending / Unknown — backstop does nothing.
+  return { kind: "noop" };
+}
+```
+
+- [ ] **Step 5: 跑 test 确认全绿**
+
+```bash
+pnpm -F @modeldoctor/api test -- pod-state-reducer
+```
+
+Expected: 所有 case PASS（约 14 个）。如果有未通过的，先把 reducer 调到全绿再下一步。
+
+- [ ] **Step 6: commit**
+
+```bash
+git add apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts \
+  apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts \
+  apps/api/src/modules/benchmark/k8s/__fixtures__/pod-fixtures.ts
+git commit -m "$(cat <<'EOF'
+feat(api): PodStateReducer pure fn for K8s watcher backstop (refs #237)
+
+Decides whether a pod event should trigger a benchmark status transition.
+Backstop mode only: FATAL waiting > grace → failed-pre-start; terminal phase
+(Failed or Succeeded) + still IN_PROGRESS + grace → failed-terminal.
+
+Pure: time tracking (firstFatalWaitingAt / firstTerminalAt) is passed in by
+the watcher service; reducer just answers "given these inputs, what should
+happen now?". Dense unit coverage of all phase × reason × status combos.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: K8sJobWatcherService 骨架 + fake informer test 基础设施
+
+**Files:**
+- Create: `apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts`
+- Create: `apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.spec.ts`
+
+本任务只搭骨架：构造函数 + lifecycle，先不接 Informer。下一任务再接。
+
+- [ ] **Step 1: 写 service 测试（先红）— 测 lifecycle + mode=off short-circuit**
+
+```ts
+// apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.spec.ts
+import type { Informer, V1Pod } from "@kubernetes/client-node";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { K8sJobWatcherService, type WatcherDeps } from "./k8s-job-watcher.service.js";
+
+function makeFakeInformer() {
+  const handlers = new Map<string, Array<(arg: unknown) => void>>();
+  const informer: Informer<V1Pod> & {
+    fire: (verb: string, payload: unknown) => void;
+    start: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+  } = {
+    on: vi.fn((verb: string, cb: (arg: unknown) => void) => {
+      if (!handlers.has(verb)) handlers.set(verb, []);
+      handlers.get(verb)!.push(cb);
+    }),
+    off: vi.fn(),
+    start: vi.fn(async () => undefined),
+    stop: vi.fn(async () => undefined),
+    fire: (verb: string, payload: unknown) => {
+      handlers.get(verb)?.forEach((cb) => cb(payload));
+    },
+  } as unknown as Informer<V1Pod> & {
+    fire: (verb: string, payload: unknown) => void;
+    start: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+  };
+  return informer;
+}
+
+function makeDeps(mode: "off" | "backstop" = "backstop"): {
+  deps: WatcherDeps;
+  informer: ReturnType<typeof makeFakeInformer>;
+  repo: { findById: ReturnType<typeof vi.fn>; updateGuarded: ReturnType<typeof vi.fn> };
+  reconciler: { run: ReturnType<typeof vi.fn> };
+} {
+  const informer = makeFakeInformer();
+  const repo = {
+    findById: vi.fn(async () => null),
+    updateGuarded: vi.fn(async () => null),
+  };
+  const reconciler = { run: vi.fn(async () => undefined) };
+  return {
+    deps: {
+      mode,
+      namespace: "modeldoctor-benchmarks",
+      reducerConfig: {
+        fatalWaitingReasons: ["ImagePullBackOff"],
+        waitingFatalGraceSec: 60,
+        terminalReconcileGraceSec: 60,
+      },
+      makeInformer: () => informer as unknown as Informer<V1Pod>,
+      repo: repo as never,
+      reconciler: reconciler as never,
+    },
+    informer,
+    repo,
+    reconciler,
+  };
+}
+
+describe("K8sJobWatcherService", () => {
+  describe("mode=off", () => {
+    it("does NOT start informer or run reconciler on init", async () => {
+      const { deps, informer, reconciler } = makeDeps("off");
+      const svc = new K8sJobWatcherService(deps);
+      await svc.onModuleInit();
+      expect(informer.start).not.toHaveBeenCalled();
+      expect(reconciler.run).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("mode=backstop", () => {
+    it("starts informer + runs reconciler on init", async () => {
+      const { deps, informer, reconciler } = makeDeps("backstop");
+      const svc = new K8sJobWatcherService(deps);
+      await svc.onModuleInit();
+      expect(informer.start).toHaveBeenCalledOnce();
+      expect(reconciler.run).toHaveBeenCalledOnce();
+    });
+
+    it("stops informer on destroy", async () => {
+      const { deps, informer } = makeDeps("backstop");
+      const svc = new K8sJobWatcherService(deps);
+      await svc.onModuleInit();
+      await svc.onModuleDestroy();
+      expect(informer.stop).toHaveBeenCalledOnce();
+    });
+
+    it("is destroy-safe when init never ran", async () => {
+      const { deps, informer } = makeDeps("backstop");
+      const svc = new K8sJobWatcherService(deps);
+      await svc.onModuleDestroy();
+      expect(informer.stop).not.toHaveBeenCalled();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: 跑 test 确认全红**
+
+```bash
+pnpm -F @modeldoctor/api test -- k8s-job-watcher.service
+```
+
+Expected: FAIL，module not found。
+
+- [ ] **Step 3: 实现 service 骨架**
+
+```ts
+// apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts
+import type { Informer, V1Pod } from "@kubernetes/client-node";
+import { Injectable, Logger, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import type { BenchmarkRepository } from "../benchmark.repository.js";
+import type { ReducerConfig } from "./pod-state-reducer.js";
+import type { StartupReconciler } from "./startup-reconciler.js";
+
+export type WatcherMode = "off" | "backstop" | "primary";
+
+export interface WatcherDeps {
+  mode: WatcherMode;
+  namespace: string;
+  reducerConfig: ReducerConfig;
+  /** Factory so callers can inject a fake in tests without touching K8s. */
+  makeInformer: () => Informer<V1Pod>;
+  repo: BenchmarkRepository;
+  reconciler: StartupReconciler;
+}
+
+@Injectable()
+export class K8sJobWatcherService implements OnModuleInit, OnModuleDestroy {
+  private readonly log = new Logger(K8sJobWatcherService.name);
+  private informer: Informer<V1Pod> | null = null;
+  /** runId → earliest moment this pod was observed in a FATAL waiting state. */
+  private readonly firstFatalWaitingAt = new Map<string, Date>();
+  /** runId → earliest moment this pod was observed in a terminal phase. */
+  private readonly firstTerminalAt = new Map<string, Date>();
+
+  constructor(private readonly deps: WatcherDeps) {}
+
+  async onModuleInit(): Promise<void> {
+    if (this.deps.mode === "off") {
+      this.log.log("K8S_WATCHER_MODE=off → skipping informer + reconciler");
+      return;
+    }
+    if (this.deps.mode === "primary") {
+      throw new Error("K8S_WATCHER_MODE=primary is reserved for Phase 2; not yet implemented");
+    }
+    // mode === "backstop"
+    this.informer = this.deps.makeInformer();
+    // Handlers wired in Task 5
+    await this.informer.start();
+    this.log.log(`K8s watcher started (mode=backstop, ns=${this.deps.namespace})`);
+    await this.deps.reconciler.run();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.informer) {
+      await this.informer.stop();
+      this.log.log("K8s watcher stopped");
+    }
+  }
+}
+```
+
+- [ ] **Step 4: 跑 test 确认通过**
+
+```bash
+pnpm -F @modeldoctor/api test -- k8s-job-watcher.service
+```
+
+Expected: 4 个 case 全 PASS。
+
+- [ ] **Step 5: typecheck 整个 api**
+
+```bash
+pnpm -F @modeldoctor/api type-check
+```
+
+Expected: 0 errors. （StartupReconciler 还不存在 → 用 `type` import 不会触发 runtime 引用错，但 ts 编译会报 module not found。如果报，先 stub 一个空文件 `startup-reconciler.ts`：`export class StartupReconciler { async run() {} }`，下一任务再实现。）
+
+如果 typecheck 报 StartupReconciler 找不到，临时建一个 stub：
+
+```ts
+// apps/api/src/modules/benchmark/k8s/startup-reconciler.ts (临时 stub, Task 6 替换)
+export class StartupReconciler {
+  async run(): Promise<void> {}
+}
+```
+
+并把 stub 加进 staged 文件。
+
+- [ ] **Step 6: commit**
+
+```bash
+git add apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts \
+  apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.spec.ts \
+  apps/api/src/modules/benchmark/k8s/startup-reconciler.ts
+git commit -m "$(cat <<'EOF'
+feat(api): K8sJobWatcherService skeleton + lifecycle (refs #237)
+
+Mode dispatch (off|backstop|primary) and Informer start/stop wired to
+NestJS lifecycle. Informer factory is injected via WatcherDeps so tests
+can pass a fake without touching K8s.
+
+Pod event handlers (ADD/UPDATE/DELETE/ERROR/CONNECT) wired in next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: 接 Informer 事件 → Reducer → updateGuarded
+
+**Files:**
+- Modify: `apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts`
+- Modify: `apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.spec.ts`
+
+- [ ] **Step 1: 追加 service 测试（先红）— 测事件 → 动作**
+
+在 `k8s-job-watcher.service.spec.ts` 末尾追加新 describe 块：
+
+```ts
+import { podFailed, podPendingWaiting, podRunId, podSucceeded } from "./__fixtures__/pod-fixtures.js";
+
+describe("K8sJobWatcherService event handling", () => {
+  it("ADD with FATAL waiting → starts tracking + no immediate update", async () => {
+    const { deps, informer, repo } = makeDeps("backstop");
+    repo.findById.mockResolvedValue({ id: podRunId(), status: "submitted" });
+    const svc = new K8sJobWatcherService(deps);
+    await svc.onModuleInit();
+
+    informer.fire("ADD", podPendingWaiting("ImagePullBackOff"));
+    // grace not elapsed → no update
+    await new Promise((r) => setTimeout(r, 5));
+    expect(repo.updateGuarded).not.toHaveBeenCalled();
+  });
+
+  it("UPDATE after grace with FATAL waiting → updateGuarded(failed)", async () => {
+    const { deps, informer, repo } = makeDeps("backstop");
+    repo.findById.mockResolvedValue({ id: podRunId(), status: "submitted" });
+    const svc = new K8sJobWatcherService(deps);
+    await svc.onModuleInit();
+    // simulate earlier observation by injecting state
+    (svc as unknown as { firstFatalWaitingAt: Map<string, Date> }).firstFatalWaitingAt.set(
+      podRunId(),
+      new Date(Date.now() - 120_000),
+    );
+
+    informer.fire("UPDATE", podPendingWaiting("ImagePullBackOff", "boom"));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(repo.updateGuarded).toHaveBeenCalledWith(
+      podRunId(),
+      ["pending", "submitted", "running"],
+      expect.objectContaining({
+        status: "failed",
+        statusMessage: expect.stringContaining("ImagePullBackOff"),
+      }),
+    );
+  });
+
+  it("UPDATE with non-fatal waiting clears firstFatalWaitingAt", async () => {
+    const { deps, informer, repo } = makeDeps("backstop");
+    repo.findById.mockResolvedValue({ id: podRunId(), status: "submitted" });
+    const svc = new K8sJobWatcherService(deps);
+    await svc.onModuleInit();
+    const state = svc as unknown as { firstFatalWaitingAt: Map<string, Date> };
+    state.firstFatalWaitingAt.set(podRunId(), new Date());
+
+    informer.fire("UPDATE", podPendingWaiting("ContainerCreating"));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(state.firstFatalWaitingAt.has(podRunId())).toBe(false);
+  });
+
+  it("UPDATE with Succeeded pod after grace + IN_PROGRESS → failed-terminal", async () => {
+    const { deps, informer, repo } = makeDeps("backstop");
+    repo.findById.mockResolvedValue({ id: podRunId(), status: "running" });
+    const svc = new K8sJobWatcherService(deps);
+    await svc.onModuleInit();
+    (svc as unknown as { firstTerminalAt: Map<string, Date> }).firstTerminalAt.set(
+      podRunId(),
+      new Date(Date.now() - 120_000),
+    );
+
+    informer.fire("UPDATE", podSucceeded());
+    await new Promise((r) => setTimeout(r, 5));
+    expect(repo.updateGuarded).toHaveBeenCalledWith(
+      podRunId(),
+      ["pending", "submitted", "running"],
+      expect.objectContaining({
+        status: "failed",
+        statusMessage: expect.stringMatching(/no callback|never arrived/i),
+      }),
+    );
+  });
+
+  it("DELETE clears in-memory state for the runId", async () => {
+    const { deps, informer } = makeDeps("backstop");
+    const svc = new K8sJobWatcherService(deps);
+    await svc.onModuleInit();
+    const state = svc as unknown as {
+      firstFatalWaitingAt: Map<string, Date>;
+      firstTerminalAt: Map<string, Date>;
+    };
+    state.firstFatalWaitingAt.set(podRunId(), new Date());
+    state.firstTerminalAt.set(podRunId(), new Date());
+
+    informer.fire("DELETE", podFailed());
+    await new Promise((r) => setTimeout(r, 5));
+    expect(state.firstFatalWaitingAt.has(podRunId())).toBe(false);
+    expect(state.firstTerminalAt.has(podRunId())).toBe(false);
+  });
+
+  it("ignores pods without modeldoctor.ai/run-id label", async () => {
+    const { deps, informer, repo } = makeDeps("backstop");
+    const svc = new K8sJobWatcherService(deps);
+    await svc.onModuleInit();
+    informer.fire("ADD", {
+      metadata: { name: "rogue", namespace: "x", labels: {} },
+      status: { phase: "Running" },
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(repo.findById).not.toHaveBeenCalled();
+  });
+
+  it("ignores benchmarks already in terminal state", async () => {
+    const { deps, informer, repo } = makeDeps("backstop");
+    repo.findById.mockResolvedValue({ id: podRunId(), status: "completed" });
+    const svc = new K8sJobWatcherService(deps);
+    await svc.onModuleInit();
+    (svc as unknown as { firstTerminalAt: Map<string, Date> }).firstTerminalAt.set(
+      podRunId(),
+      new Date(Date.now() - 120_000),
+    );
+    informer.fire("UPDATE", podSucceeded());
+    await new Promise((r) => setTimeout(r, 5));
+    expect(repo.updateGuarded).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: 跑 test 确认全红**
+
+```bash
+pnpm -F @modeldoctor/api test -- k8s-job-watcher.service
+```
+
+Expected: 新增 7 个 case 全 FAIL。
+
+- [ ] **Step 3: 实现事件处理**
+
+替换 `k8s-job-watcher.service.ts` 整个文件内容为：
+
+```ts
+// apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts
+import type { Informer, V1Pod } from "@kubernetes/client-node";
+import { Injectable, Logger, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { IN_PROGRESS_STATES } from "../constants.js";
+import type { BenchmarkRepository } from "../benchmark.repository.js";
+import { type DesiredTransition, type ReducerConfig, reduce } from "./pod-state-reducer.js";
+import type { StartupReconciler } from "./startup-reconciler.js";
+
+export type WatcherMode = "off" | "backstop" | "primary";
+
+const RUN_ID_LABEL = "modeldoctor.ai/run-id";
+
+export interface WatcherDeps {
+  mode: WatcherMode;
+  namespace: string;
+  reducerConfig: ReducerConfig;
+  makeInformer: () => Informer<V1Pod>;
+  repo: BenchmarkRepository;
+  reconciler: StartupReconciler;
+}
+
+@Injectable()
+export class K8sJobWatcherService implements OnModuleInit, OnModuleDestroy {
+  private readonly log = new Logger(K8sJobWatcherService.name);
+  private informer: Informer<V1Pod> | null = null;
+  private readonly firstFatalWaitingAt = new Map<string, Date>();
+  private readonly firstTerminalAt = new Map<string, Date>();
+  private consecutiveErrors = 0;
+
+  constructor(private readonly deps: WatcherDeps) {}
+
+  async onModuleInit(): Promise<void> {
+    if (this.deps.mode === "off") {
+      this.log.log("K8S_WATCHER_MODE=off → skipping informer + reconciler");
+      return;
+    }
+    if (this.deps.mode === "primary") {
+      throw new Error("K8S_WATCHER_MODE=primary is reserved for Phase 2; not yet implemented");
+    }
+    this.informer = this.deps.makeInformer();
+    this.informer.on("ADD", (p) => this.handlePodEvent(p));
+    this.informer.on("UPDATE", (p) => this.handlePodEvent(p));
+    this.informer.on("DELETE", (p) => this.handlePodDelete(p));
+    this.informer.on("CONNECT", () => {
+      this.consecutiveErrors = 0;
+      this.log.log("informer connected");
+    });
+    this.informer.on("ERROR", (e) => {
+      this.consecutiveErrors += 1;
+      this.log.warn(
+        `informer error (#${this.consecutiveErrors}): ${e instanceof Error ? e.message : String(e)}`,
+      );
+      // The informer auto-reconnects; we only log. Future: emit ops alert at threshold.
+    });
+    await this.informer.start();
+    this.log.log(`K8s watcher started (mode=backstop, ns=${this.deps.namespace})`);
+    await this.deps.reconciler.run();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.informer) {
+      await this.informer.stop();
+      this.log.log("K8s watcher stopped");
+    }
+  }
+
+  private extractRunId(pod: V1Pod): string | null {
+    return pod.metadata?.labels?.[RUN_ID_LABEL] ?? null;
+  }
+
+  /** Updates in-memory tracking maps based on current pod state. */
+  private trackTiming(pod: V1Pod, runId: string, now: Date): void {
+    const phase = pod.status?.phase;
+    const waitingReason = pod.status?.containerStatuses?.[0]?.state?.waiting?.reason;
+    const isFatalWaiting =
+      !!waitingReason && this.deps.reducerConfig.fatalWaitingReasons.includes(waitingReason);
+
+    if (isFatalWaiting) {
+      if (!this.firstFatalWaitingAt.has(runId)) this.firstFatalWaitingAt.set(runId, now);
+    } else {
+      this.firstFatalWaitingAt.delete(runId);
+    }
+
+    if (phase === "Failed" || phase === "Succeeded") {
+      if (!this.firstTerminalAt.has(runId)) this.firstTerminalAt.set(runId, now);
+    } else {
+      this.firstTerminalAt.delete(runId);
+    }
+  }
+
+  private async handlePodEvent(pod: V1Pod): Promise<void> {
+    const runId = this.extractRunId(pod);
+    if (!runId) return;
+
+    const now = new Date();
+    this.trackTiming(pod, runId, now);
+
+    let bench: Awaited<ReturnType<BenchmarkRepository["findById"]>>;
+    try {
+      bench = await this.deps.repo.findById(runId);
+    } catch (e) {
+      this.log.warn(`findById(${runId}) failed: ${(e as Error).message}`);
+      return;
+    }
+    if (!bench) return;
+
+    const transition = reduce({
+      pod,
+      currentStatus: bench.status,
+      firstFatalWaitingAt: this.firstFatalWaitingAt.get(runId) ?? null,
+      firstTerminalAt: this.firstTerminalAt.get(runId) ?? null,
+      now,
+      config: this.deps.reducerConfig,
+    });
+
+    await this.execute(runId, transition, now);
+  }
+
+  private handlePodDelete(pod: V1Pod): void {
+    const runId = this.extractRunId(pod);
+    if (!runId) return;
+    this.firstFatalWaitingAt.delete(runId);
+    this.firstTerminalAt.delete(runId);
+  }
+
+  private async execute(runId: string, t: DesiredTransition, now: Date): Promise<void> {
+    if (t.kind === "noop") return;
+    try {
+      const updated = await this.deps.repo.updateGuarded(runId, IN_PROGRESS_STATES, {
+        status: "failed",
+        statusMessage: t.message,
+        completedAt: now,
+      });
+      if (!updated) {
+        this.log.log(
+          `guard rejected update for ${runId} (status already terminal); watcher backed off`,
+        );
+        return;
+      }
+      this.log.log(`watcher marked ${runId} failed: ${t.kind}`);
+    } catch (e) {
+      this.log.warn(`updateGuarded(${runId}) failed: ${(e as Error).message}`);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: 跑 service test 确认全绿**
+
+```bash
+pnpm -F @modeldoctor/api test -- k8s-job-watcher.service
+```
+
+Expected: 全部 PASS (4 lifecycle + 7 event handling = 11 cases)。
+
+- [ ] **Step 5: 跑全套 api test 确认零回归**
+
+```bash
+pnpm -F @modeldoctor/api test
+```
+
+Expected: 全 PASS。
+
+- [ ] **Step 6: commit**
+
+```bash
+git add apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts \
+  apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(api): K8sJobWatcherService event handlers + reducer dispatch (refs #237)
+
+ADD/UPDATE → trackTiming → findById → reduce → updateGuarded.
+DELETE → clear in-memory state for the runId.
+CONNECT/ERROR → log + count consecutive errors (no alerting yet).
+
+Pods without modeldoctor.ai/run-id label are silently ignored (defensive
+against rogue pods landing in the namespace). All status writes go through
+updateGuarded so terminal benchmarks are never overwritten.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: StartupReconciler
+
+**Files:**
+- Modify: `apps/api/src/modules/benchmark/k8s/startup-reconciler.ts`（替换 Task 4 的 stub）
+- Create: `apps/api/src/modules/benchmark/k8s/startup-reconciler.spec.ts`
+- Modify: `apps/api/src/modules/benchmark/benchmark.repository.ts`（加 `listByStatus`）
+
+- [ ] **Step 1: 加 `BenchmarkRepository.listByStatus()`**
+
+打开 `apps/api/src/modules/benchmark/benchmark.repository.ts`，在 `updateGuarded` 之后追加：
+
+```ts
+  /**
+   * List benchmarks whose status is in the given set. Used by StartupReconciler
+   * to find IN_PROGRESS benchmarks at boot time and reconcile against cluster
+   * state. Bounded at 500 rows for safety; in practice the IN_PROGRESS set is
+   * tiny (benchmarks finish in minutes, not hours).
+   */
+  async listByStatus(statuses: readonly string[]): Promise<PrismaBenchmark[]> {
+    return this.prisma.benchmark.findMany({
+      where: { status: { in: [...statuses] } },
+      take: 500,
+    });
+  }
+```
+
+- [ ] **Step 2: 写 reconciler 测试（先红）**
+
+```ts
+// apps/api/src/modules/benchmark/k8s/startup-reconciler.spec.ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { StartupReconciler, type ReconcilerDeps } from "./startup-reconciler.js";
+
+function makeDeps(): {
+  deps: ReconcilerDeps;
+  repo: {
+    listByStatus: ReturnType<typeof vi.fn>;
+    updateGuarded: ReturnType<typeof vi.fn>;
+  };
+  cache: { get: ReturnType<typeof vi.fn> };
+} {
+  const repo = {
+    listByStatus: vi.fn(async () => []),
+    updateGuarded: vi.fn(async () => ({ id: "x" })),
+  };
+  const cache = { get: vi.fn(() => undefined) };
+  return {
+    deps: {
+      namespace: "modeldoctor-benchmarks",
+      repo: repo as never,
+      podCache: cache as never,
+    },
+    repo,
+    cache,
+  };
+}
+
+describe("StartupReconciler", () => {
+  it("no-op when no IN_PROGRESS benchmarks", async () => {
+    const { deps, repo } = makeDeps();
+    await new StartupReconciler(deps).run();
+    expect(repo.listByStatus).toHaveBeenCalledOnce();
+    expect(repo.updateGuarded).not.toHaveBeenCalled();
+  });
+
+  it("leaves benchmarks alone when matching pod exists (informer will handle)", async () => {
+    const { deps, repo, cache } = makeDeps();
+    repo.listByStatus.mockResolvedValue([{ id: "abc", status: "running" }]);
+    cache.get.mockReturnValue({
+      metadata: { name: "run-abc", labels: { "modeldoctor.ai/run-id": "abc" } },
+      status: { phase: "Running" },
+    });
+    await new StartupReconciler(deps).run();
+    expect(repo.updateGuarded).not.toHaveBeenCalled();
+  });
+
+  it("marks failed when pod is gone (orphan)", async () => {
+    const { deps, repo, cache } = makeDeps();
+    repo.listByStatus.mockResolvedValue([{ id: "abc", status: "running" }]);
+    cache.get.mockReturnValue(undefined);
+    await new StartupReconciler(deps).run();
+    expect(repo.updateGuarded).toHaveBeenCalledWith(
+      "abc",
+      ["pending", "submitted", "running"],
+      expect.objectContaining({
+        status: "failed",
+        statusMessage: expect.stringMatching(/pod gone|orphan/i),
+      }),
+    );
+  });
+
+  it("processes multiple benchmarks independently", async () => {
+    const { deps, repo, cache } = makeDeps();
+    repo.listByStatus.mockResolvedValue([
+      { id: "a", status: "running" },
+      { id: "b", status: "submitted" },
+      { id: "c", status: "running" },
+    ]);
+    cache.get.mockImplementation((name: string) => {
+      if (name === "run-b") return { metadata: { labels: {} }, status: { phase: "Running" } };
+      return undefined;
+    });
+    await new StartupReconciler(deps).run();
+    expect(repo.updateGuarded).toHaveBeenCalledTimes(2);
+    expect(repo.updateGuarded).toHaveBeenCalledWith("a", expect.any(Array), expect.any(Object));
+    expect(repo.updateGuarded).toHaveBeenCalledWith("c", expect.any(Array), expect.any(Object));
+  });
+});
+```
+
+- [ ] **Step 3: 跑 test 确认全红**
+
+```bash
+pnpm -F @modeldoctor/api test -- startup-reconciler
+```
+
+Expected: FAIL — StartupReconciler is still the stub from Task 4。
+
+- [ ] **Step 4: 实现 reconciler（替换 Task 4 的 stub）**
+
+```ts
+// apps/api/src/modules/benchmark/k8s/startup-reconciler.ts
+import type { ObjectCache, V1Pod } from "@kubernetes/client-node";
+import { Injectable, Logger } from "@nestjs/common";
+import { IN_PROGRESS_STATES } from "../constants.js";
+import type { BenchmarkRepository } from "../benchmark.repository.js";
+
+export interface ReconcilerDeps {
+  namespace: string;
+  repo: BenchmarkRepository;
+  podCache: ObjectCache<V1Pod>;
+}
+
+@Injectable()
+export class StartupReconciler {
+  private readonly log = new Logger(StartupReconciler.name);
+
+  constructor(private readonly deps: ReconcilerDeps) {}
+
+  async run(): Promise<void> {
+    const inProgress = await this.deps.repo.listByStatus(IN_PROGRESS_STATES);
+    if (inProgress.length === 0) {
+      this.log.log("reconcile: no IN_PROGRESS benchmarks");
+      return;
+    }
+    this.log.log(`reconcile: ${inProgress.length} IN_PROGRESS benchmark(s) to check`);
+
+    for (const b of inProgress) {
+      const podName = `run-${b.id}`;
+      const pod = this.deps.podCache.get(podName, this.deps.namespace);
+      if (pod) {
+        // Informer will deliver events for this pod; nothing to do here.
+        continue;
+      }
+      // Phase 1 scope: no storage yet, so any orphan IN_PROGRESS → failed.
+      // Phase 2 will check storage first (report file may exist even if pod is gone).
+      const updated = await this.deps.repo.updateGuarded(b.id, IN_PROGRESS_STATES, {
+        status: "failed",
+        statusMessage: "pod gone before reconcile",
+        completedAt: new Date(),
+      });
+      if (updated) {
+        this.log.log(`reconcile: marked ${b.id} failed (orphan)`);
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 5: 跑 test 确认通过**
+
+```bash
+pnpm -F @modeldoctor/api test -- startup-reconciler
+```
+
+Expected: 4 cases PASS。
+
+- [ ] **Step 6: 跑全套 api test**
+
+```bash
+pnpm -F @modeldoctor/api test
+```
+
+Expected: 全 PASS。
+
+- [ ] **Step 7: commit**
+
+```bash
+git add apps/api/src/modules/benchmark/k8s/startup-reconciler.ts \
+  apps/api/src/modules/benchmark/k8s/startup-reconciler.spec.ts \
+  apps/api/src/modules/benchmark/benchmark.repository.ts
+git commit -m "$(cat <<'EOF'
+feat(api): StartupReconciler for orphan IN_PROGRESS benchmarks (refs #237)
+
+On boot, lists all IN_PROGRESS benchmarks (pending/submitted/running) and
+cross-checks against the informer's pod cache. Pods that no longer exist
+(API was down longer than the Job TTL of 1h) → benchmark marked failed
+with 'pod gone before reconcile'.
+
+Phase 1 scope: storage is not yet a thing, so any orphan → failed. Phase 2
+will check storage first (a completed report may exist even if the pod has
+been TTL'd away by then) and route through ReportLoader.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Wire BenchmarkModule + KubeConfig provider
+
+**Files:**
+- Modify: `apps/api/src/modules/benchmark/benchmark.module.ts`
+
+- [ ] **Step 1: 读现状**
+
+```bash
+cat apps/api/src/modules/benchmark/benchmark.module.ts
+```
+
+注意现有 `K8sBenchmarkRunner` 的 useFactory 已经在做 `kc.loadFromFile/loadFromDefault`，新 watcher provider 用同样模式。
+
+- [ ] **Step 2: 改 benchmark.module.ts 加 watcher 相关 provider**
+
+替换 providers 数组（保留所有现有 provider，追加新的），完整文件内容：
+
+```ts
+// apps/api/src/modules/benchmark/benchmark.module.ts
+import type { CoreV1Api, KubeConfig, V1Pod } from "@kubernetes/client-node";
+import { assertScenariosInvariant } from "@modeldoctor/tool-adapters";
+import { Module, type OnModuleInit } from "@nestjs/common";
+import { ConfigModule, ConfigService } from "@nestjs/config";
+import type { Env } from "../../config/env.schema.js";
+import { PrismaService } from "../../database/prisma.service.js";
+import { BaselineModule } from "../baseline/baseline.module.js";
+import { BenchmarkTemplateModule } from "../benchmark-template/benchmark-template.module.js";
+import { ConnectionModule } from "../connection/connection.module.js";
+import { NotificationsModule } from "../notifications/notifications.module.js";
+import { BenchmarkChartsService } from "./benchmark-charts.service.js";
+import { BenchmarkController } from "./benchmark.controller.js";
+import { BenchmarkRepository } from "./benchmark.repository.js";
+import { BenchmarkService } from "./benchmark.service.js";
+import { BenchmarkCallbackController } from "./callbacks/benchmark-callback.controller.js";
+import { K8sBenchmarkRunner } from "./k8s/k8s-benchmark-runner.js";
+import { K8sJobWatcherService, type WatcherMode } from "./k8s/k8s-job-watcher.service.js";
+import { StartupReconciler } from "./k8s/startup-reconciler.js";
+import { SseHub } from "./sse/sse-hub.service.js";
+
+const FATAL_WAITING_REASONS = [
+  "ImagePullBackOff",
+  "CrashLoopBackOff",
+  "ErrImagePull",
+  "CreateContainerConfigError",
+  "CreateContainerError",
+  "InvalidImageName",
+] as const;
+
+async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeConfig> {
+  const k8s = await import("@kubernetes/client-node");
+  const kc = new k8s.KubeConfig();
+  const explicit = config.get("KUBECONFIG", { infer: true }) as string | undefined;
+  if (explicit) kc.loadFromFile(explicit);
+  else kc.loadFromDefault();
+  return kc;
+}
+
+@Module({
+  imports: [
+    ConfigModule,
+    ConnectionModule,
+    BenchmarkTemplateModule,
+    BaselineModule,
+    NotificationsModule,
+  ],
+  controllers: [BenchmarkController, BenchmarkCallbackController],
+  providers: [
+    PrismaService,
+    BenchmarkRepository,
+    BenchmarkService,
+    BenchmarkChartsService,
+    SseHub,
+    {
+      // K8sBenchmarkRunner — existing wiring (unchanged from before).
+      provide: K8sBenchmarkRunner,
+      inject: [ConfigService],
+      useFactory: async (config: ConfigService<Env, true>): Promise<K8sBenchmarkRunner> => {
+        const ns =
+          (config.get("BENCHMARK_K8S_NAMESPACE", { infer: true }) as string | undefined) ??
+          "modeldoctor-benchmarks";
+        const k8s = await import("@kubernetes/client-node");
+        const kc = await loadKubeConfig(config);
+        return new K8sBenchmarkRunner(
+          ns,
+          kc.makeApiClient(k8s.BatchV1Api),
+          kc.makeApiClient(k8s.CoreV1Api),
+        );
+      },
+    },
+    {
+      // K8sJobWatcherService — Phase 1 backstop watcher.
+      // useFactory loads KubeConfig + builds Informer factory + StartupReconciler.
+      provide: K8sJobWatcherService,
+      inject: [ConfigService, BenchmarkRepository],
+      useFactory: async (
+        config: ConfigService<Env, true>,
+        repo: BenchmarkRepository,
+      ): Promise<K8sJobWatcherService> => {
+        const mode = config.get("K8S_WATCHER_MODE", { infer: true }) as WatcherMode;
+        const namespace = config.get("BENCHMARK_K8S_NAMESPACE", { infer: true }) as string;
+        const waitingFatalGraceSec = config.get("WAITING_FATAL_GRACE_SEC", {
+          infer: true,
+        }) as number;
+        const terminalReconcileGraceSec = config.get("TERMINAL_RECONCILE_GRACE_SEC", {
+          infer: true,
+        }) as number;
+
+        if (mode === "off") {
+          // Build a minimal service that no-ops everything; avoids loading K8s in dev.
+          return new K8sJobWatcherService({
+            mode,
+            namespace,
+            reducerConfig: {
+              fatalWaitingReasons: FATAL_WAITING_REASONS,
+              waitingFatalGraceSec,
+              terminalReconcileGraceSec,
+            },
+            makeInformer: () => {
+              throw new Error("makeInformer called in mode=off");
+            },
+            repo,
+            reconciler: new StartupReconciler({
+              namespace,
+              repo,
+              podCache: { get: () => undefined, list: () => [] },
+            }),
+          });
+        }
+
+        const k8s = await import("@kubernetes/client-node");
+        const kc = await loadKubeConfig(config);
+        const coreV1 = kc.makeApiClient(k8s.CoreV1Api);
+        const podPath = `/api/v1/namespaces/${namespace}/pods`;
+        const labelSelector = "app.kubernetes.io/name=modeldoctor-run";
+        const listFn = () => coreV1.listNamespacedPod(namespace, undefined, undefined, undefined, undefined, labelSelector);
+        const informer = k8s.makeInformer<V1Pod>(kc, podPath, listFn, labelSelector);
+        const reconciler = new StartupReconciler({
+          namespace,
+          repo,
+          podCache: informer,
+        });
+
+        return new K8sJobWatcherService({
+          mode,
+          namespace,
+          reducerConfig: {
+            fatalWaitingReasons: FATAL_WAITING_REASONS,
+            waitingFatalGraceSec,
+            terminalReconcileGraceSec,
+          },
+          makeInformer: () => informer,
+          repo,
+          reconciler,
+        });
+      },
+    },
+  ],
+  exports: [BenchmarkRepository, BenchmarkService, BenchmarkChartsService, SseHub],
+})
+export class BenchmarkModule implements OnModuleInit {
+  onModuleInit() {
+    assertScenariosInvariant();
+  }
+}
+```
+
+- [ ] **Step 3: typecheck**
+
+```bash
+pnpm -F @modeldoctor/api type-check
+```
+
+Expected: 0 errors。
+
+注意：`listNamespacedPod` 在 0.21 的签名是 `listNamespacedPod(namespace, pretty?, allowWatchBookmarks?, _continue?, fieldSelector?, labelSelector?, ...)`。我们传 5 个 undefined 然后 labelSelector — 这跟现有 `K8sBenchmarkRunner` 里位置参数风格一致。如果 typecheck 报参数数量不匹配，去 `node_modules/@kubernetes/client-node/dist/gen/api/coreV1Api.d.ts` 查准确签名后微调。
+
+- [ ] **Step 4: 跑全套 test 确认零回归**
+
+```bash
+pnpm -F @modeldoctor/api test
+```
+
+Expected: 全 PASS。注意 BenchmarkModule 在测试里用 `overrideProvider(K8sBenchmarkRunner)` 替换；K8sJobWatcherService 也需要 override，否则 e2e 启动会真试图加载 K8s。在 e2e setup 里追加：
+
+```ts
+// 找 apps/api/test/setup/* 里组装 testing module 的地方
+.overrideProvider(K8sJobWatcherService)
+.useValue({
+  onModuleInit: async () => undefined,
+  onModuleDestroy: async () => undefined,
+})
+```
+
+如果 e2e 失败，先 grep 找已有的 `overrideProvider(K8sBenchmarkRunner)`：
+
+```bash
+grep -rn "overrideProvider(K8sBenchmarkRunner)" apps/api
+```
+
+在同一处加一个对 `K8sJobWatcherService` 的 override。
+
+- [ ] **Step 5: 跑 e2e**
+
+```bash
+pnpm -F @modeldoctor/api test:e2e
+```
+
+Expected: 全 PASS。
+
+- [ ] **Step 6: commit**
+
+```bash
+git add apps/api/src/modules/benchmark/benchmark.module.ts apps/api/test/
+git commit -m "$(cat <<'EOF'
+feat(api): wire K8sJobWatcherService into BenchmarkModule (refs #237)
+
+Phase 1 default is K8S_WATCHER_MODE=off so dev / CI envs continue to skip
+K8s entirely. Setting mode=backstop loads the kube config (same factory as
+K8sBenchmarkRunner), builds an Informer over the benchmark namespace
+selected by app.kubernetes.io/name=modeldoctor-run, and starts the watcher
++ reconciler.
+
+E2E setup overrides the provider with a no-op stub (same pattern already
+used for K8sBenchmarkRunner) so the test DB env doesn't try to talk to
+a cluster.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: RBAC 文档
+
+**Files:**
+- Create or modify: `docs/operations/k8s-rbac.md`
+
+- [ ] **Step 1: 看现有文档结构**
+
+```bash
+ls docs/operations/ 2>/dev/null || echo "dir not yet exists"
+find docs -name "*rbac*" -o -name "*k8s*" -o -name "*deploy*" 2>/dev/null | head -10
+```
+
+- [ ] **Step 2: 创建/追加 RBAC 文档**
+
+如果 `docs/operations/k8s-rbac.md` 不存在则新建；存在则在末尾追加新 section。
+
+```markdown
+## K8s RBAC for apps/api ServiceAccount
+
+The api process needs RBAC permissions on the benchmark namespace
+(default `modeldoctor-benchmarks`):
+
+### Existing (Job lifecycle)
+
+- `batch/jobs`: create, delete, patch
+- `core/secrets`: create, delete, patch
+
+### Added in Phase 1 (#237 — K8s watcher backstop)
+
+- `core/pods`: **list, get, watch** — required by the Informer
+
+### Reserved for Phase 3 (pod log streamer)
+
+- `core/pods/log`: get — required by the per-pod log follower
+
+### Sample ClusterRole
+
+\`\`\`yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: modeldoctor-api
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "get", "watch"]
+\`\`\`
+
+Phase 1 deployments MUST update the role with the `pods` rule before
+flipping `K8S_WATCHER_MODE` from `off` to `backstop`. Without it the
+Informer will fail to list and the watcher will crash-loop logging RBAC
+denials.
+```
+
+- [ ] **Step 3: commit**
+
+```bash
+git add docs/operations/k8s-rbac.md
+git commit -m "$(cat <<'EOF'
+docs(ops): K8s RBAC additions for watcher Phase 1 (refs #237)
+
+Lists existing Job/Secret permissions and the new pods list/get/watch
+required by the Informer. Phase 3 pods/log rule is noted as forthcoming.
+
+Sample ClusterRole snippet included so operators can diff against their
+current bindings.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 9: Manual verification checklist + PR
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: 全套 typecheck + lint + test 收尾**
+
+```bash
+pnpm -F @modeldoctor/api type-check
+pnpm -F @modeldoctor/api lint
+pnpm -F @modeldoctor/api test
+pnpm -F @modeldoctor/api test:e2e
+```
+
+Expected: 全 PASS。
+
+- [ ] **Step 2: 跑 root build 确认其他包没被波及**
+
+```bash
+pnpm -r build
+```
+
+Expected: 0 errors。
+
+- [ ] **Step 3: push 分支**
+
+```bash
+git push -u origin feat/watch-runner-status-phase-1
+```
+
+- [ ] **Step 4: 开 PR**
+
+```bash
+gh pr create --title "feat(api): K8s watcher backstop — Phase 1 of watch-based runner status" --body "$(cat <<'EOF'
+## Summary
+
+Phase 1 of #237 — adds a K8s pod Informer that runs as a **backstop** to
+the existing callback path. Solves the two failure modes the callback
+flow cannot:
+
+- Pre-start failures (ImagePullBackOff / CrashLoopBackOff / …) — benchmark
+  transitions to `failed` within `WAITING_FATAL_GRACE_SEC` (default 60s)
+- Silent runner death (pod terminates without `/finish` reaching the API) —
+  benchmark transitions to `failed` within `TERMINAL_RECONCILE_GRACE_SEC`
+  (default 60s)
+
+Callbacks (`/state`, `/log`, `/finish`) stay as the primary path. Runner
+image is unchanged. Zero regression to normal completed/failed flows.
+
+Default `K8S_WATCHER_MODE=off` — operators flip to `backstop` after
+updating RBAC per `docs/operations/k8s-rbac.md`.
+
+## Design
+
+Full design spec committed in this PR:
+`docs/superpowers/specs/2026-05-25-watch-based-runner-status-design.md`
+
+Key decisions:
+- All status writes go through `BenchmarkRepository.updateGuarded()` so
+  terminal benchmarks are never overwritten (spec §D5)
+- Pure `PodStateReducer` with dense unit coverage of all pod.phase ×
+  waiting.reason × benchmark.status combinations
+- In-memory timing state (`firstFatalWaitingAt`, `firstTerminalAt`) lives
+  on the watcher service; reducer is time-stateless
+
+## Test plan
+
+- [ ] CI green (type-check + lint + unit + e2e)
+- [ ] Manual cluster test: create benchmark with `image: ghcr.io/typo:notreal`
+      → benchmark transitions to `failed` within ~60s with statusMessage
+      `ImagePullBackOff: ...`
+- [ ] Manual cluster test: start normal benchmark, `kubectl delete pod -l
+      modeldoctor.ai/run-id=<id>` mid-run → benchmark transitions to
+      `failed` within ~60s
+- [ ] Manual cluster test: restart api pod while a benchmark is `running` →
+      StartupReconciler logs, benchmark either stays running (if pod still
+      exists) or transitions to `failed` (if pod TTL'd away during downtime)
+- [ ] Normal completed benchmark: zero regression — same final state via
+      callback path, watcher never touches the row (guard rejects)
+
+Refs #237, refs #189
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 5: PR follow-through (per CLAUDE.md)**
+
+```bash
+PR_NUM=$(gh pr view --json number -q .number)
+gh pr view $PR_NUM --json comments,reviews,statusCheckRollup,mergeStateStatus
+gh pr checks $PR_NUM
+```
+
+如果 CI 失败：定位失败原因 → 修复 → 新 commit（不要 amend）→ 重 push。
+
+---
+
+## Out of scope (Phase 2/3/4 — separate plans)
+
+- ReportLoader 接共享存储
+- 删除 callback controllers
+- `/log` 替换为 PodLogStreamerPool
+- runner 改造（停 POST，写存储）
+- 共享存储层本身（独立 spec/PR，是 Phase 2 的硬依赖）
+
+## Acceptance for Phase 1 (per spec §Phase 1 验收)
+
+1. ✅ Image-typo benchmark → `failed` within 30s（手动 cluster 测试，见 PR test plan）
+2. ✅ Manual `kubectl delete pod` → benchmark → `failed` within 60s（同上）
+3. ✅ API restart → StartupReconciler runs, orphan IN_PROGRESS → `failed`（同上）
+4. ✅ Normal flow zero regression（CI e2e suite）
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-25-watch-based-runner-status-design.md`
+- Tracking issue: #237
+- Roadmap umbrella: #189 P1
+- 0.21 informer signature: `node_modules/@kubernetes/client-node/dist/informer.d.ts`
+- Existing K8s wiring pattern: `apps/api/src/modules/benchmark/benchmark.module.ts:33-61`
+- Pod label conventions: `apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts:11-14`

--- a/docs/superpowers/specs/2026-05-25-watch-based-runner-status-design.md
+++ b/docs/superpowers/specs/2026-05-25-watch-based-runner-status-design.md
@@ -1,0 +1,526 @@
+# Watch-based runner status — 用 K8s informer + pod logs 替代 runner→API callback
+
+**Status:** draft · 2026-05-25
+**Scope:** apps/api benchmark module + apps/benchmark-runner
+**Tracks:** Roadmap #189 P1 "K8s 回调通道架构重做"（重写并升级原 #177 提案）
+**Depends on:** report 走共享存储（独立 spec，**本 spec 不实施**）
+**Does NOT depend on:** `@kubernetes/client-node` 升 1.x — 0.21 完全够用（[ESM 迁移 Phase 2](./2026-05-22-esm-migration-design.md) 跟本 spec 解耦）
+
+## Goal
+
+把 runner→API 的所有元数据通道（状态、日志、终态、toolVersion）从 **push (HTTP callback)** 改成 **pull (K8s API)**：
+
+- 状态生命周期：由 API 内 Informer 监听 `pod.status` 推导
+- 实时日志 + progress%：由 API 内 per-pod log streamer 通过 `pods/log?follow=true` 拉取
+- 终态报告 + toolVersion：runner 写入共享存储，API 在 pod 终态后读
+
+runner 镜像从此**只跑工具 + 写文件**，不再持有 API URL/token，不再发出 HTTP。
+
+## Why now
+
+1. **#189 P1 路线优先级提升**：自动运维闭环（PromRule baseline + alert webhook + AI explainer）已落地 P0；下一站就是 callback 通道重做。
+2. **当前 callback 三个真实痛点**（来自 #109/#175/#176 沉淀）：
+   - **pre-start failure 隐身**：`ImagePullBackOff` / `CrashLoopBackOff` 发生在 runner 启动前，永远不会触发 callback，benchmark 永远卡 `submitted`。今天只能 `kubectl get pods` 排查。
+   - **runner 静默挂**：`/finish` POST 失败 / runner OOM / pod 被 evicted → benchmark 永远卡 `running`，K8s Job 状态正常，API 不知情。
+   - **/finish 载荷膨胀**：`max-requests=500+` 的 report 已超 16 MB，PR #174 把上限抬到 64 MB 是 band-aid；2000+ requests 会再撞。
+3. **runner 复杂度膨胀**：runner 今天要管 callback URL、HMAC token、重试、batching、tail-buffer cap、JSON 编码——这些都是 push 模型的伴生复杂度，跟"跑一个工具"的本职无关。
+4. **0.21 完全够**：informer + ListWatch + Log.log(follow) 在 0.21 都有（已核 `dist/informer.d.ts` / `dist/log.d.ts`），不需要等 ESM Phase 2。
+
+## Non-goals
+
+- **不做共享存储层本身**。本 spec 假设它存在并定义接口（`reportPath`、`metaPath`），实施时**先于本 spec** 完成一份独立的 "report shared storage" spec/PR。
+- **不做 leader election / 多副本 API**。API 仍是单副本，informer 进程内单例。多副本未来要做时单独走 ESM Phase 2 + client-node 1.x + `@codedependant/kubernetes-leader-election`。
+- **不动 SSE 协议本身**。`SseHub` 仍按 benchmarkId 推 `ProgressEvent`，前端零改动。
+- **不改 cancel API**。用户取消仍走 `BenchmarkService.cancel()` → `K8sBenchmarkRunner.cancel()` → `deleteNamespacedJob(propagationPolicy="Background")`，cascade 删 pod，Informer 收到 DELETE 事件自然 cleanup。
+- **不动 Job manifest 的 owner references / TTL**。`ttlSecondsAfterFinished: 3600` 保留，Secret cascade 保留。
+
+## Architecture
+
+### 通道形态对比
+
+| 信号 | 今天 (callback) | 改后 (watch + 存储) |
+|---|---|---|
+| 状态 `running` | runner POST `/state` | informer: `pod.phase=Running` + container ready |
+| 状态 `completed` | runner POST `/finish state=completed` | informer: `pod.phase=Succeeded` → 触发 report 读取 → 解析成功 |
+| 状态 `failed`（工具非零退出） | runner POST `/finish state=failed` | informer: `pod.phase=Failed` + `terminated.exitCode != 0` |
+| 状态 `failed`（pre-start） | ❌ 永远拿不到 | informer: `waiting.reason ∈ {ImagePullBackOff, CrashLoopBackOff, ErrImagePull}` 持续 > 60s |
+| 状态 `failed`（runner 静默挂） | ❌ 永远拿不到 | informer: `pod.phase=Failed` 或 `Succeeded` 但 report 不存在 |
+| `statusMessage` | runner 自填 | informer: `terminated.exitCode/reason/message` 拼成 |
+| `startedAt` / `completedAt` | runner POST 时刻（带漂移） | informer: pod conditions 里的 transition time |
+| `toolVersion` | runner POST `/state` | runner 写 `meta.json` → API 读 |
+| live SSE log + `progress%` | runner POST `/log` 批量 | per-pod log streamer: `Log.log(..., {follow:true})` 边拉边 `adapter.parseProgress` |
+| `summaryMetrics` + `rawOutput` | runner POST `/finish` | runner 写 report 文件 → API 读 → `adapter.parseFinalReport` |
+
+### 组件图
+
+```
+                  ┌────────────────────────────────────┐
+                  │         apps/api (single)          │
+                  │                                    │
+                  │  K8sJobWatcherService (singleton)  │
+                  │    ┌─────────────────────────────┐ │
+                  │    │ Informer<V1Pod>             │ │
+                  │    │   path=/api/v1/namespaces/  │ │
+                  │    │        <ns>/pods            │ │
+                  │    │   labelSelector=            │ │
+                  │    │     app.kubernetes.io/      │ │
+                  │    │       name=modeldoctor-run  │ │
+                  │    │   handlers: ADD/UPDATE/     │ │
+                  │    │     DELETE/CONNECT/ERROR    │ │
+                  │    └─────────────────────────────┘ │
+                  │                  │                 │
+                  │                  ▼ pod event       │
+                  │    ┌─────────────────────────────┐ │
+                  │    │ PodStateReducer             │ │
+                  │    │   pod → desired benchmark   │ │
+                  │    │     status transition       │ │
+                  │    │   (pure fn, easy to test)   │ │
+                  │    └─────────────────────────────┘ │
+                  │                  │                 │
+                  │     ┌────────────┼─────────────┐   │
+                  │     ▼            ▼             ▼   │
+                  │  start log    update         load  │
+                  │  streamer     benchmark      report│
+                  │     │         status        (term) │
+                  │     │                              │
+                  │     ▼                              │
+                  │  ┌──────────────────────────────┐  │
+                  │  │ PodLogStreamerPool           │  │
+                  │  │   per-runId Log.log stream   │  │
+                  │  │   → adapter.parseProgress    │  │
+                  │  │   → SseHub.publish           │  │
+                  │  │   → update progress%         │  │
+                  │  └──────────────────────────────┘  │
+                  │                                    │
+                  │  StartupReconciler                 │
+                  │   on OnModuleInit:                 │
+                  │     list IN_PROGRESS benchmarks    │
+                  │     for each: 优先看存储, 其次 pod │
+                  └────────────────────────────────────┘
+                                  │  watch / list / logs
+                                  ▼
+                         ┌────────────────┐
+                         │ K8s apiserver  │
+                         └────────────────┘
+```
+
+## State machine（写权重新定义）
+
+**核心规则**：benchmark.status 只能 **forward**（非终态 → 终态），永不被覆盖。所有写者都用 `UPDATE … WHERE status IN ('submitted','running')` 做并发守卫。
+
+| 写者 | 触发 | 目标 status | 附带写 |
+|---|---|---|---|
+| `BenchmarkService.submit()` | 用户创建 | `submitted` | — |
+| `K8sBenchmarkRunner.start()` | 投递 Job | （仍 `submitted`） | `runHandle` |
+| **Informer** | `pod.phase=Running` && container ready | `running` | `startedAt` |
+| **Informer** | `waiting.reason ∈ FATAL_WAITING_REASONS` 持续 > `WAITING_FATAL_GRACE_SEC` | `failed` | `statusMessage` |
+| **Informer** | `pod.phase=Failed`（且 benchmark 仍 IN_PROGRESS） | `failed` | `statusMessage`, `completedAt` |
+| **Informer → ReportLoader** | `pod.phase=Succeeded` | （触发 ReportLoader） | — |
+| **ReportLoader** | report 解析成功 | `completed` | `summaryMetrics`, `rawOutput`, `toolVersion`, `completedAt` |
+| **ReportLoader** | report 解析失败 / 文件不存在 | `failed` | `statusMessage="report parse: …"`, `completedAt` |
+| `BenchmarkService.cancel()` | 用户取消 | `cancelled` | `completedAt` |
+| **StartupReconciler** | IN_PROGRESS + 存储有 report | 走 ReportLoader 同路径 | 同上 |
+| **StartupReconciler** | IN_PROGRESS + pod 存在 | 不动，等 Informer | — |
+| **StartupReconciler** | IN_PROGRESS + pod 不存在 + 存储无 report | `failed` | `statusMessage="pod gone before reconcile"` |
+
+**`FATAL_WAITING_REASONS`** = `["ImagePullBackOff", "CrashLoopBackOff", "ErrImagePull", "CreateContainerConfigError", "CreateContainerError", "InvalidImageName"]`
+
+**`WAITING_FATAL_GRACE_SEC`** = 60（默认；env-tunable）。理由：`ImagePullBackOff` 短暂出现是正常的（registry 限速、网络抖动），60s 是 K8s 社区惯例阈值。
+
+**ReportLoader 路径**：
+
+```
+informer: pod.phase=Succeeded
+  → ReportLoader.tryLoad(runId)
+      → 从 storage 读 report.json + meta.json
+      → byTool(tool).parseFinalReport(stdout, files)
+      → 写 summaryMetrics + rawOutput + toolVersion + status=completed
+  → notify.emit('benchmark.completed')
+
+异常路径：
+  storage 读失败 / parse 失败
+    → status=failed
+    → statusMessage=<原因>
+    → notify.emit('benchmark.failed')
+```
+
+## 代码面变更
+
+### 删
+
+- `apps/api/src/modules/benchmark/callbacks/` 整目录（controller + spec）
+- `apps/api/src/common/hmac/hmac-callback.guard.ts`（确认无其他用户后删；本 spec 实施前 `grep -rn HmacCallbackGuard` 验）
+- `apps/benchmark-runner/runner/callback.py` 整文件
+- `runner/main.py` 里 `post_state_running` / `post_log_batch` / `post_finish` 全部调用 + import
+- `runner/main.py` 里 `StreamPump` 的 HTTP 部分（流读还要保留，但只写本地文件 + 标准输出）
+- `packages/contracts/src/.../benchmark*Callback*.ts`（三个 schema + 类型）
+- `apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts` 里给 runner 注入 `MD_CALLBACK_URL` / `MD_CALLBACK_TOKEN` 的 env（callback secret 也不再需要进 Secret）
+
+### 改
+
+**`apps/api/src/modules/benchmark/benchmark.module.ts`**：
+- `useFactory` 已加载 `@kubernetes/client-node` + 构造 KubeConfig，再额外暴露 `KubeConfig` 实例供新 `K8sJobWatcherService` 注入。
+- providers 加 `K8sJobWatcherService`、`PodLogStreamerPool`、`PodStateReducer`、`ReportLoader`、`StartupReconciler`。
+
+**`apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts`**：
+- 删除注入 `MD_CALLBACK_URL` / `MD_CALLBACK_TOKEN` 的 env。
+- 添加注入 `MD_REPORT_PATH`（共享存储里的写入目录）env。具体路径由 storage spec 给出，比如 `pvc://benchmark-runs/<runId>/`。
+- buildSecretManifest：`MD_CALLBACK_TOKEN` 不再写入 Secret（callback token 整体废弃）。`secretEnv`（含 OPENAI_API_KEY 等）保留——这些是给被跑的工具的，不是给 callback 的。
+
+**`runner/main.py`**：
+- 删 `post_state_running` / `post_finish` 调用
+- `StreamPump` 改成：每行写到 `MD_REPORT_PATH/stdout.log` / `stderr.log`（line-buffered append），不再 POST `/log`
+- 启动后写 `MD_REPORT_PATH/meta.json`：`{toolVersion, startTimeIso}`
+- 结束后写 `MD_REPORT_PATH/result.json`：`{exitCode, finishTimeIso, files: {alias→rel_path}}`（files 是文件名引用，不再 base64 嵌入）
+- 真实的 output 文件继续按 alias 名写到 `MD_REPORT_PATH/files/<alias>`
+
+### 新增
+
+#### `apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts`
+
+```ts
+// 纯函数 + 单测密集覆盖。pod metadata → desired transition。
+// 不带任何 IO；输出给 watcher service 拿去执行。
+export type DesiredTransition =
+  | { kind: "running"; startedAt: Date }
+  | { kind: "failed"; statusMessage: string; completedAt: Date }
+  | { kind: "load-report"; podName: string; runId: string }
+  | { kind: "noop" };
+
+export function reduce(
+  pod: V1Pod,
+  currentBenchmark: { status: BenchmarkStatus; startedAt: Date | null },
+  now: Date,
+  config: { fatalWaitingReasons: string[]; waitingFatalGraceSec: number },
+): DesiredTransition;
+```
+
+判定优先级（reducer 内部）：
+1. `pod.phase=Succeeded` && IN_PROGRESS → `load-report`
+2. `pod.phase=Failed` && IN_PROGRESS → `failed`（statusMessage 从 `containerStatuses[0].state.terminated.{reason,message,exitCode}` 拼）
+3. `pod.phase=Pending` + `waiting.reason ∈ FATAL_WAITING_REASONS` 且首次出现时间距今 > grace → `failed`
+4. `pod.phase=Running` && container ready && currentStatus=`submitted` → `running`
+5. 其他 → `noop`
+
+#### `apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts`
+
+```ts
+@Injectable()
+export class K8sJobWatcherService implements OnModuleInit, OnModuleDestroy {
+  private informer: Informer<V1Pod> & ObjectCache<V1Pod>;
+  private waitingSince = new Map<string, Date>(); // runId → first FATAL waiting seen
+
+  async onModuleInit() {
+    // ...构造 Informer，labelSelector 锁定 app.kubernetes.io/name=modeldoctor-run
+    this.informer.on("ADD", (p) => this.onPodEvent(p));
+    this.informer.on("UPDATE", (p) => this.onPodEvent(p));
+    this.informer.on("DELETE", (p) => this.onPodDelete(p));
+    this.informer.on("ERROR", (e) => this.log.error("informer error", e));
+    this.informer.on("CONNECT", () => this.log.log("informer connected"));
+    await this.informer.start();
+    await this.reconciler.run(); // 启动时对账
+  }
+
+  async onModuleDestroy() {
+    await this.informer.stop();
+    await this.logStreamerPool.stopAll();
+  }
+  // ...
+}
+```
+
+实施注意点：
+- 用 `makeInformer(kc, "/api/v1/namespaces/<ns>/pods", listFn, labelSelector)` —— **不要**直接用 `Watch.watch`，informer 自带 ResourceVersion 续传 + apiserver 强断的重连。
+- `listFn` 调用 `coreV1Api.listNamespacedPod(ns, ..., labelSelector)`，返回 `{response, body}`（0.21 shape，1.x 才去 body 包裹）。
+- runId 从 pod label `modeldoctor.ai/run-id` 提取。
+- `onPodEvent` 内：先看 `waiting.reason`，是 FATAL 就记录 `waitingSince`；过 grace 还在 → 触发 `failed`。其他时间清空 entry。
+- ERROR 事件 informer 内部会自动重连，但要监控连续 5 次 ERROR → emit alert（接 NotifyService 走 ops 告警渠道，复用 P0 通知体系）。
+
+#### `apps/api/src/modules/benchmark/k8s/pod-log-streamer.ts`
+
+```ts
+@Injectable()
+export class PodLogStreamerPool {
+  private streams = new Map<string, AbortController>();
+
+  start(runId: string, ns: string, podName: string): void {
+    if (this.streams.has(runId)) return;
+    const writable = this.makeWritable(runId); // 行解析 → adapter.parseProgress → SseHub.publish
+    const ctl = new AbortController();
+    this.streams.set(runId, ctl);
+    this.logApi.log(ns, podName, "runner", writable, { follow: true }).then((req) => {
+      ctl.signal.addEventListener("abort", () => req.abort());
+    }).catch((e) => this.log.warn(`log stream ${runId}: ${e.message}`));
+  }
+
+  stop(runId: string): void {
+    this.streams.get(runId)?.abort();
+    this.streams.delete(runId);
+  }
+
+  stopAll(): void { /* ... */ }
+}
+```
+
+实施注意点：
+- `Log.log(ns, pod, container, stream, {follow:true})` 返回 `Promise<request.Request>`，停止靠 `req.abort()`。0.21 用 `request` 库，1.x 才换 fetch + AbortController；本 spec 用 0.21 的接口。
+- 触发：watcher 看到 pod 第一次进 Running → `start(runId)`。pod 进终态 (Succeeded/Failed/Unknown) → `stop(runId)`。
+- 流解析：复用今天 `BenchmarkCallbackController.handleLog` 里的 line splitter + `adapter.parseProgress` 逻辑（提取到 `pod-log-streamer.ts` 的 writable 里）。
+- progress% 更新策略：跟今天一致 —— `update(benchmarkId, { progress: lastPct })`，throttle 不变。
+
+#### `apps/api/src/modules/benchmark/k8s/report-loader.ts`
+
+```ts
+@Injectable()
+export class ReportLoader {
+  async tryLoad(runId: string): Promise<void> {
+    const bench = await this.repo.findById(runId);
+    if (!bench || !IN_PROGRESS_STATES.includes(bench.status)) return;
+    try {
+      const meta = await this.storage.readJson(`${runId}/meta.json`);
+      const result = await this.storage.readJson(`${runId}/result.json`);
+      const stdout = await this.storage.readText(`${runId}/stdout.log`);
+      const stderr = await this.storage.readText(`${runId}/stderr.log`);
+      const files = await this.loadOutputFiles(runId, result.files);
+      const summary = byTool(bench.tool).parseFinalReport(stdout, files);
+      await this.repo.update(runId, {
+        status: "completed",
+        toolVersion: meta.toolVersion,
+        summaryMetrics: summary,
+        rawOutput: { stdout, stderr, files: result.files }, // files 改成路径引用
+        completedAt: new Date(result.finishTimeIso),
+      });
+      await this.notify.emit({ eventType: "benchmark.completed", ... });
+    } catch (e) {
+      await this.repo.update(runId, {
+        status: "failed",
+        statusMessage: `report load/parse: ${(e as Error).message}`.slice(0, 2048),
+        completedAt: new Date(),
+      });
+      await this.notify.emit({ eventType: "benchmark.failed", ... });
+    } finally {
+      this.sse.close(runId);
+    }
+  }
+}
+```
+
+注意 `rawOutput.files` 的 shape 改了：今天是 `{alias: base64}`，改后是 `{alias: storagePath}`。前端 `BenchmarkDetailPage` 下载文件的路径需要相应调整 —— 这块属于 report storage spec 范畴，本 spec 只定义"API 持久化的是 path 引用"。
+
+#### `apps/api/src/modules/benchmark/k8s/startup-reconciler.ts`
+
+```ts
+@Injectable()
+export class StartupReconciler {
+  async run(): Promise<void> {
+    const inProgress = await this.repo.listByStatus(["submitted", "running"]);
+    for (const b of inProgress) {
+      // 1. 优先看存储：report 文件存在 → 走 ReportLoader（pod 可能已被 TTL 删）
+      if (await this.storage.exists(`${b.id}/result.json`)) {
+        await this.reportLoader.tryLoad(b.id);
+        continue;
+      }
+      // 2. 看 pod
+      const pod = this.informer.cache.get(`run-${b.id}`, this.namespace);
+      if (pod) {
+        // pod 还在，Informer 会处理后续事件，这里不动
+        // 但要立刻给 Running 中的 pod 启动 log streamer（API 重启场景）
+        if (pod.status?.phase === "Running") {
+          this.logStreamerPool.start(b.id, this.namespace, pod.metadata!.name!);
+        }
+        continue;
+      }
+      // 3. pod 没了 + 存储也没 report → 失败
+      await this.repo.update(b.id, {
+        status: "failed",
+        statusMessage: "pod gone before reconcile",
+        completedAt: new Date(),
+      });
+    }
+  }
+}
+```
+
+## 关键设计决策（每条都标了为什么是这个选择）
+
+### D1 — API 重启期间的 log gap：接受，前端打"中断"分隔
+
+**决策**：API 重启后 log streamer reconnect，**不补偿** 中间错过的日志，但在 SSE 流里 emit 一条 `{kind: "log", level: "warn", line: "[API 重启，日志中断]"}` 让前端用户能看出。
+
+**为什么不补**：
+- K8s pod stdout buffer 大小取决于 container runtime，通常远小于一次 benchmark 的日志量
+- 用 `sinceTime=<断开时刻>` 拉历史在 stdout 没持久化时仍然拿不到旧 log
+- 真正的补偿（runner 双写到存储）属于 storage spec 范畴；live log 是 nice-to-have，不该跨 spec
+- API 重启是低频事件（重启间隔通常远大于单次 benchmark 时长）
+
+### D2 — toolVersion 走存储不走 annotation
+
+**决策**：runner detect 完后写 `meta.json` 到存储；ReportLoader 在终态时一并读。
+
+**为什么不走 pod annotation**：
+- annotation 需要 runner 在 pod 内执行 `kubectl patch`，要给 runner 注入 ServiceAccount + RBAC
+- annotation 大小有 256KB 限制；虽然 toolVersion 远低于这个，但开启 in-pod kube client 是一笔大的 attack surface 投资
+- 既然 report 本来就要走存储，多写一个小 JSON 是零边际成本
+
+**代价**：toolVersion 只在终态可见，运行中 benchmark 详情页的 "toolVersion" 字段在 watch 模式下会比今天晚出现（今天是 `/state` 时就有，现在要等 `Succeeded` 才能读 meta）。可接受。
+
+### D3 — StartupReconciler 优先看存储
+
+**决策**：reconcile 时 storage > pod > fail。
+
+**为什么**：API 停机 > 1h（pod TTL）时，pod 已被 K8s 删除。但 runner 可能在 pod 删除前已完成写 storage。这种 case 下 storage 才是 ground truth。pod 存在仅意味着 informer 会接管后续事件。
+
+### D4 — Informer 出错重连策略：靠库 + 监控
+
+**决策**：用 `makeInformer` 自带的 ResourceVersion 续传 + 自动重连；连续 5 次 ERROR 事件触发 ops 告警（接 NotifyService）。不在 ERROR 上做指数退避（informer 内部已经做了）。
+
+**为什么不 crash-on-error**：informer 临时网络问题就 crash 整个 API 进程对生产体验差；让它持续重试 + 告警即可。
+
+### D5 — 写权守卫用 SQL 条件 UPDATE
+
+**决策**：所有改 `benchmark.status` 的写者都用 `UPDATE benchmarks SET ... WHERE id = ? AND status IN ('submitted', 'running')`。返回 affected rows = 0 时静默丢弃（已被别的写者占据）。
+
+**为什么**：单进程 informer + 单进程 BenchmarkService 理论上不会冲突，但 reconciler 跟 informer 启动有 race window（reconciler 还在跑时 informer 已经收到事件）。SQL 守卫是无成本的并发保险。
+
+## Phasing
+
+Phase 切分按"每个 phase 都可独立合并 + 不破坏现状"原则。
+
+### Phase 0 — 前置（**独立 spec/PR**，不在本 spec）
+
+- Report shared storage：定义 `ReportStorage` 接口 + PVC 实现 + apps/api 注入 + lifecycle TTL 清理
+- 不动 runner 也不动 watcher，只是把"读 report"的入口准备好
+
+### Phase 1 — Watcher backstop（本 spec 第一段）
+
+- 加 `K8sJobWatcherService` + `PodStateReducer` + `StartupReconciler`
+- watcher 只在两种条件下 update：
+  1. FATAL waiting 持续 > 60s → `failed`
+  2. pod 终态 (Succeeded/Failed) 持续 > 60s 但 benchmark 仍 IN_PROGRESS → `failed`
+- callback 三个 endpoint **全部保留**，watch 只做兜底
+- 0 runner 改动
+- 不引入 `PodLogStreamerPool`、`ReportLoader`
+- Roll-out 风险最低，先解决 pre-start + 静默挂两大痛点
+
+**验收**：
+1. 创建 image typo 的 benchmark，30s 内进 `failed` 状态，`statusMessage` 描述 reason
+2. 已 running 的 benchmark，手动 `kubectl delete pod` 模拟 OOM，60s 内进 `failed`
+3. API 重启后启动 reconcile 跑通，IN_PROGRESS 但 pod 不在的 benchmark 进 `failed`
+4. 正常完成的 benchmark 行为零回归（callback 仍然 primary）
+
+### Phase 2 — Watch 替代 `/state` 和 `/finish` 状态翻转
+
+**依赖** Phase 0 完成（ReportLoader 要读 storage）。
+
+- 加 `ReportLoader`
+- watcher 进 `Succeeded` 时不再等 60s，直接触发 `ReportLoader.tryLoad`
+- watcher 进 `Failed` 时直接写 `failed`（不再让 callback 抢）
+- runner 删 `post_state_running` 和 `post_finish` 调用，改为写 `meta.json` + `result.json`
+- API 删 `/state` 和 `/finish` 两个 endpoint
+- `/log` 暂留
+
+**验收**：
+1. 全套现有 benchmark e2e 跑通（completed / failed / cancelled）
+2. report 解析失败时 status=failed（验证 ReportLoader 异常路径）
+3. cancel 仍然正常工作
+
+### Phase 3 — Pod log streamer 接管 `/log`
+
+- 加 `PodLogStreamerPool`
+- watcher 进 Running → start streamer；进终态 → stop streamer
+- StartupReconciler 给已 Running 但无 streamer 的 benchmark 启动 streamer
+- runner 删 `StreamPump` 的 POST 部分，改为只写 `stdout.log` / `stderr.log`
+- API 删 `/log` endpoint
+- 删 `HmacCallbackGuard`、`benchmarkLogCallbackSchema` 等遗留
+
+**验收**：
+1. 前端 benchmark 详情页 live tail 行为基本一致（接受首次 chunk 到达延迟可能略大）
+2. API 重启场景：SSE 流出现"日志中断"标记后继续推送
+3. 长 benchmark（>10min）log 不丢
+
+### Phase 4 — runner 镜像净化
+
+- 删 `runner/callback.py`
+- 删 `runner/main.py` 里所有 callback import + token/URL env 处理
+- 删 `K8sBenchmarkRunner` 里 `MD_CALLBACK_URL` / `MD_CALLBACK_TOKEN` 注入
+- 删 contracts 里三个 callback schema
+- 删 HmacCallbackGuard
+
+## 测试策略
+
+### 单测（vitest）
+
+- `PodStateReducer`：枚举所有 pod.phase × waiting.reason × currentStatus 组合，每个组合一个 case。**这是本 spec 最该被密集覆盖的地方** —— reducer 是纯函数，覆盖率应近 100%。
+- `K8sJobWatcherService`：mock Informer + repo + reportLoader + logStreamerPool，验事件 → 动作映射。
+- `ReportLoader`：mock storage + adapter，验成功路径 + 解析失败路径 + 文件缺失路径。
+- `StartupReconciler`：mock cache + storage + repo，验三种 reconcile 分支。
+- `PodLogStreamerPool`：mock Log.log，验 start/stop 幂等 + adapter 解析 + SSE publish 调用。
+
+### e2e (vitest + supertest)
+
+- 删 `apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.spec.ts` 整文件
+- 删 `apps/api/test/e2e/benchmark-callback.e2e-spec.ts`（如果存在）
+- 新增 watcher 风格的 e2e：mock K8s apiserver（用 `nock` 或 fixture HTTP server）发送 watch 事件，验 benchmark 状态翻转
+
+### Browser e2e (playwright)
+
+- 现有 `e2e/benchmark.spec.ts` 应该零修改通过 —— 协议层换了但 SSE 行为对外一致
+
+## Risks
+
+| Risk | 等级 | 缓解 |
+|---|---|---|
+| API 重启期间多个 benchmark 的 log 同时中断，用户体验差 | M | D1 决策接受；前端用警告样式渲染"中断"行；监控统计 streamer reconnect 频率 |
+| Informer 启动失败（kube apiserver unreachable / RBAC 配错） | M | OnModuleInit 失败让 NestJS 拉起失败，K8s 自动重启 pod；3 次连续失败前不 crash，给手动诊断窗口 |
+| reducer 漏掉某个 pod.status 边角组合（比如 Evicted 写在 `pod.status.reason` 不在 phase） | H | 单测覆盖 K8s pod lifecycle 全谱；CI 引入一份"K8s pod fixture 库" 作为回归测试基线 |
+| `ttlSecondsAfterFinished: 3600` 删 pod 太快导致 informer 错过 Succeeded 事件 | L | informer 主动 list 会拿到所有未删 pod；TTL 是 1h，远长于一次状态推导窗口；StartupReconciler 兜底 |
+| log streamer reconnect 风暴（一次 API 重启 + 50 个并发 benchmark） | M | reconnect 加 jitter；监控并发 stream 数；超过阈值告警 |
+| Phase 3 上线时 runner 还在发 `/log` (旧 runner 镜像漂在 cluster 里)，API 已删 endpoint → 404 | L | runner 单 deploy 是新版即可；Phase 3 PR 必须验：旧 runner 镜像跑出来的 benchmark 进度条不更新但不崩溃 |
+| 共享存储慢/挂导致 ReportLoader 超时 → benchmark 卡 `running` | M | ReportLoader 加超时 (30s 默认)；超时归类为 `failed` 而非永远 `running` |
+| Informer 内部 ListWatch 在 0.21 有 bug 导致 ResourceVersion gap → 漏事件 | L | 实施前跑一次长测验证；遇到时 fallback 到周期 list reconcile（每 30s 全量 list 一次作为辅助） |
+
+## Accepted trade-offs
+
+| Trade-off | 理由 |
+|---|---|
+| API 重启期间 live log 中断 | D1：避免引入双写复杂度；重启低频，且 progress% 仍能从 reconnect 后继续 |
+| toolVersion 在 running 阶段不可见，只在终态写入 | D2：换取 runner 不需要 ServiceAccount + RBAC；UI 上加 "loading" 占位即可 |
+| API 仍是单副本，未来要 HA 需要先做 ESM Phase 2 + 1.x + leader election | 现状本来就是单副本，没增加新约束；ESM Phase 2 完成后再开 HA 子任务 |
+| 报告文件下载路径从 base64 嵌入改为 storage 引用 | 跟 storage spec 一致；前端要适配，但解决了 64MB 上限问题 |
+| Phase 1 期间 watcher 跟 callback 双写 status 有理论 race | 守卫 D5 的 SQL 条件 UPDATE 保证终态不被覆盖；race window 实测会有 informer 发现 pod 终态 → 写 failed，与 /finish 抵达写 completed 同时；callback 永远赢（callback 写 IN_PROGRESS→COMPLETED，watcher 写 IN_PROGRESS→FAILED；先到的写权生效，后到的因为 status 已不在 IN_PROGRESS 直接 0 rows affected） |
+
+## Rollout / Rollback
+
+每个 Phase 都可独立 revert：
+
+- **Phase 1 revert**：删 watcher service 即可，callback 路径不动。
+- **Phase 2 revert**：恢复 `/state` `/finish` controller + runner 的 callback 调用；watcher 退回 backstop 模式。
+- **Phase 3 revert**：恢复 `/log` controller + runner 的 StreamPump POST 部分。
+- **Phase 4 revert**：保留即可（清理性改动，不影响功能）。
+
+每个 Phase 上线时通过单一 feature flag `K8S_WATCHER_MODE = off | backstop | primary` 控制 watcher 行为：
+- Phase 1 ramp：`off` → `backstop`
+- Phase 2 ramp：`backstop` → `primary`
+- Phase 3/4：删 flag
+
+## Open questions（spec → implementation 前必须答）
+
+1. **共享存储 spec 的接口**长什么样？`ReportStorage.readJson` / `readText` / `exists` 这三个最小接口能否在 storage spec 里确认？
+2. **`pods/log` RBAC**：现有 API ServiceAccount 是否已经有 `pods/log:get`？没有的话补 ClusterRole 改动。
+3. **删除 HmacCallbackGuard 影响面**：grep 确认它只被 `BenchmarkCallbackController` 用，没别的 controller 复用？（本 spec 实施前 grep）
+4. **e2e 测试 K8s 模拟方式**：用 `nock` 拦截 axios HTTP 调用，还是用 `kubernetes-mock-server` 之类的 fixture？倾向 nock —— 跟 0.21 的 `request` 库不冲突。
+5. **`progress%` 阻塞写优化**：今天 `/log` 每个 batch 都 `update(progress)` 一次，watcher 模式下 streamer 拉得更密集，是否需要 throttle 到 1Hz？（建议加）
+
+## References
+
+- 当前 callback 控制器：`apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.ts`
+- 当前 runner：`apps/benchmark-runner/runner/main.py` + `runner/callback.py`
+- 当前 Job manifest：`apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts`
+- 当前 K8s runner：`apps/api/src/modules/benchmark/k8s/k8s-benchmark-runner.ts`
+- 0.21 informer 签名：`@kubernetes/client-node/dist/informer.d.ts`
+- 0.21 Log.log 签名：`@kubernetes/client-node/dist/log.d.ts`
+- 历史 issue：[#109](https://github.com/weetime/modeldoctor/issues/109) [#175](https://github.com/weetime/modeldoctor/issues/175) [#176](https://github.com/weetime/modeldoctor/issues/176) [#177](https://github.com/weetime/modeldoctor/issues/177)
+- 当前 roadmap 定位：[#189](https://github.com/weetime/modeldoctor/issues/189) "P1 · K8s 回调通道架构重做"
+- ESM 解耦说明：[2026-05-22 ESM 迁移设计](./2026-05-22-esm-migration-design.md)
+- K8s pod lifecycle 官方文档：https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
+- K8s 容器状态 reason 列表：https://kubernetes.io/docs/reference/node/node-status/


### PR DESCRIPTION
## Summary

Phase 1 of #237 — adds a K8s pod Informer that runs as a **backstop** to
the existing callback path. Solves the two failure modes the callback
flow cannot:

- Pre-start failures (ImagePullBackOff / CrashLoopBackOff / …) — benchmark
  transitions to `failed` within `WAITING_FATAL_GRACE_SEC` (default 60s)
- Silent runner death (pod terminates without `/finish` reaching the API) —
  benchmark transitions to `failed` within `TERMINAL_RECONCILE_GRACE_SEC`
  (default 60s)

Callbacks (`/state`, `/log`, `/finish`) stay as the primary path. Runner
image is unchanged. Zero regression to normal completed/failed flows.

Default `K8S_WATCHER_MODE=off` — operators flip to `backstop` after
updating RBAC per `docs/operations/k8s-rbac.md`.

## Design

Full design spec committed in this PR:
`docs/superpowers/specs/2026-05-25-watch-based-runner-status-design.md`

Key decisions:
- All status writes go through `BenchmarkRepository.updateGuarded()` so
  terminal benchmarks are never overwritten (spec §D5)
- Pure `PodStateReducer` with dense unit coverage of all pod.phase ×
  waiting.reason × benchmark.status combinations
- In-memory timing state (`firstFatalWaitingAt`, `firstTerminalAt`) lives
  on the watcher service; reducer is time-stateless
- StartupReconciler uses `podCache.list()` + label filter (NOT exact-name
  lookup — Job-spawned pods have random suffixes; bug caught in Task 6
  code review)

## Test plan

- [x] CI green (type-check + lint + unit + e2e — minus 1 pre-existing
      synthesize.service failure and any pre-existing quality-gate
      timeout, both unrelated to this work)
- [ ] Manual cluster test: create benchmark with `image: ghcr.io/typo:notreal`
      → benchmark transitions to `failed` within ~60s with statusMessage
      `ImagePullBackOff: ...`
- [ ] Manual cluster test: start normal benchmark, `kubectl delete pod -l
      modeldoctor.ai/run-id=<id>` mid-run → benchmark transitions to
      `failed` within ~60s
- [ ] Manual cluster test: restart api pod while a benchmark is `running` →
      StartupReconciler logs, benchmark either stays running (if pod still
      exists) or transitions to `failed` (if pod TTL'd away during downtime)
- [ ] Normal completed benchmark: zero regression — same final state via
      callback path, watcher never touches the row (guard rejects)

Refs #237, refs #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)