### PR TITLE
feat: Phase 0+2 — report shared storage + watcher primary mode

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -52,14 +52,26 @@ BENCHMARK_CALLBACK_SECRET=<replace with: openssl rand -base64 48>
 BENCHMARK_K8S_NAMESPACE=modeldoctor-benchmarks
 
 # K8s pod watcher mode: off | backstop | primary
-# - off: no watcher (dev default)
-# - backstop: watcher detects pre-start failures + silent runner death
-# - primary: reserved for Phase 2 (do not set yet)
-K8S_WATCHER_MODE=off
+# - off: no watcher (local dev / unit tests)
+# - backstop: watcher tries to detect pre-start failures + silent runner death; callback still primary
+# - primary: watcher owns status flip; runner writes report to S3 (Phase 2, default since #237)
+K8S_WATCHER_MODE=primary
 # Grace seconds before FATAL waiting reasons (ImagePullBackOff, ...) → failed.
 WAITING_FATAL_GRACE_SEC=60
-# Grace seconds after pod terminal state before watcher acts (callback wins inside this window).
+# Grace seconds after pod terminal state before watcher acts (backstop mode only).
 TERMINAL_RECONCILE_GRACE_SEC=60
+
+# S3-compatible report storage. Required when K8S_WATCHER_MODE!=off.
+# Runner writes meta/result/files/stdout/stderr under <runId>/...;
+# API ReportLoader reads them when pod reaches terminal phase.
+# Same Secret md-benchmark-storage is mounted into runner Job env via
+# apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts (envFrom).
+# Dev: existing MinIO at http://10.100.121.67:31871, bucket "weetime".
+S3_ENDPOINT=http://10.100.121.67:31871
+S3_ACCESS_KEY=
+S3_SECRET_KEY=
+S3_BUCKET=weetime
+S3_REGION=us-east-1
 
 # Per-tool runner images. Rebuild via `./tools/build-runner-images.sh`
 # (uses git short SHA as the tag); the script prints the matching tag to

--- a/apps/api/.env.test
+++ b/apps/api/.env.test
@@ -48,3 +48,16 @@ RUNNER_IMAGE_AIPERF=test:aiperf
 # both must match exactly with what spec files read via E2E_ENV_DEFAULTS.
 MCP_BEARER_TOKEN=test-mcp-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 MCP_USER_ID=e2e-mcp-test-user
+
+# K8s watcher mode — override default "primary" for tests; informers must not
+# spin up during unit/e2e tests (no real K8s API server available).
+K8S_WATCHER_MODE=off
+
+# S3-compatible object storage — placeholder values so env validation passes.
+# Tests that exercise S3ReportStorage mock the AWS SDK client directly and do
+# not need a real endpoint.
+S3_ENDPOINT=http://localhost:9999
+S3_ACCESS_KEY=test-access-key
+S3_SECRET_KEY=test-secret-key
+S3_BUCKET=test-bucket
+S3_REGION=us-east-1

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -30,6 +30,7 @@
     "test:e2e": "vitest run --config vitest.e2e.config.mts"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1053.0",
     "@kubernetes/client-node": "^0.21",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@modeldoctor/contracts": "workspace:*",
@@ -72,6 +73,7 @@
     "@types/multer": "^2.1.0",
     "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6",
+    "aws-sdk-client-mock": "^4.1.0",
     "dotenv": "^17.4.1",
     "pino-pretty": "^11",
     "supertest": "^7",

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -53,11 +53,20 @@ export const EnvSchema = z.object({
   // K8s job runner config — subprocess driver removed in #101.
   BENCHMARK_CALLBACK_URL: z.string().url(),
   BENCHMARK_K8S_NAMESPACE: z.string().min(1).default("modeldoctor-benchmarks"),
-  // K8s watcher (Phase 1: backstop only).
+  // K8s watcher mode.
   //   off: informer 不启动（开发本机默认）
   //   backstop: informer 启动，只做 FATAL waiting / terminal-no-callback 兜底
-  //   primary: Phase 2 之后才用，本 phase 不实施
-  K8S_WATCHER_MODE: z.enum(["off", "backstop", "primary"]).default("off"),
+  //   primary: Phase 2 — watcher 是状态机主驱动，callback 降为兜底
+  K8S_WATCHER_MODE: z.enum(["off", "backstop", "primary"]).default("primary"),
+  // S3-compatible object storage — used by S3ReportStorage to persist run
+  // artifacts (stdout, files) so the watcher can read them after pod exit.
+  // S3_REGION defaults to us-east-1: MinIO ignores it but AWS SDK requires a
+  // non-empty region string.
+  S3_ENDPOINT: z.string().url(),
+  S3_ACCESS_KEY: z.string().min(1),
+  S3_SECRET_KEY: z.string().min(1),
+  S3_BUCKET: z.string().min(1),
+  S3_REGION: z.string().default("us-east-1"),
   // 等待状态进 ImagePullBackOff/CrashLoopBackOff 等 FATAL waiting 多久后翻 failed。
   // K8s 社区惯例 60s；registry 限速 / 短暂网络抖动通常 < 30s。
   WAITING_FATAL_GRACE_SEC: z.coerce.number().int().positive().default(60),

--- a/apps/api/src/config/env.spec.ts
+++ b/apps/api/src/config/env.spec.ts
@@ -19,6 +19,11 @@ const validEnv = () => ({
   RUNNER_IMAGE_PREFIX_CACHE_PROBE: "md-runner-prefix-cache-probe:test",
   RUNNER_IMAGE_EVALSCOPE: "md-runner-evalscope:test",
   RUNNER_IMAGE_AIPERF: "md-runner-aiperf:test",
+  // S3-compatible object storage (required since Phase 2).
+  S3_ENDPOINT: "http://localhost:9999",
+  S3_ACCESS_KEY: "test-access-key",
+  S3_SECRET_KEY: "test-secret-key",
+  S3_BUCKET: "test-bucket",
 });
 
 describe("validateEnv", () => {
@@ -68,6 +73,11 @@ describe("validateEnv", () => {
       "RUNNER_IMAGE_PREFIX_CACHE_PROBE",
       "RUNNER_IMAGE_EVALSCOPE",
       "RUNNER_IMAGE_AIPERF",
+      // S3 (required since Phase 2 — S3_REGION has a default so excluded)
+      "S3_ENDPOINT",
+      "S3_ACCESS_KEY",
+      "S3_SECRET_KEY",
+      "S3_BUCKET",
     ] as const;
 
     for (const key of requiredKeys) {

--- a/apps/api/src/modules/benchmark/benchmark-files.controller.spec.ts
+++ b/apps/api/src/modules/benchmark/benchmark-files.controller.spec.ts
@@ -1,3 +1,4 @@
+import { Readable } from "node:stream";
 import { ForbiddenException, NotFoundException, StreamableFile } from "@nestjs/common";
 import { describe, expect, it, vi } from "vitest";
 import { BenchmarkFilesController } from "./benchmark-files.controller.js";
@@ -17,6 +18,7 @@ function makeCtrl(opts: { bench?: Bench | null; fileBytes?: Buffer }) {
     readBytes: vi.fn(async () => opts.fileBytes ?? Buffer.from("data")),
     readJson: vi.fn(),
     readText: vi.fn(),
+    readStream: vi.fn(async () => Readable.from([opts.fileBytes ?? Buffer.from("data")])),
   };
   return {
     ctrl: new BenchmarkFilesController(repo as never, storage as never),
@@ -64,7 +66,7 @@ describe("BenchmarkFilesController", () => {
     });
     const out = await ctrl.getFile(userAdmin as never, "r1", "report.json");
     expect(out).toBeInstanceOf(StreamableFile);
-    expect(storage.readBytes).toHaveBeenCalledWith("r1/files/report.json");
+    expect(storage.readStream).toHaveBeenCalledWith("r1/files/report.json");
   });
 
   it("404 when alias not in rawOutput.files", async () => {
@@ -95,6 +97,6 @@ describe("BenchmarkFilesController", () => {
     });
     const out = await ctrl.getFile(userU1 as never, "r1", "report.json");
     expect(out).toBeInstanceOf(StreamableFile);
-    expect(storage.readBytes).toHaveBeenCalledWith("r1/files/report.json");
+    expect(storage.readStream).toHaveBeenCalledWith("r1/files/report.json");
   });
 });

--- a/apps/api/src/modules/benchmark/benchmark-files.controller.spec.ts
+++ b/apps/api/src/modules/benchmark/benchmark-files.controller.spec.ts
@@ -1,0 +1,65 @@
+import { ForbiddenException, NotFoundException, StreamableFile } from "@nestjs/common";
+import { describe, expect, it, vi } from "vitest";
+import { BenchmarkFilesController } from "./benchmark-files.controller.js";
+
+interface Bench {
+  id: string; userId: string | null; tool: string; status: string;
+  rawOutput: { files?: Record<string, string> } | null;
+}
+
+function makeCtrl(opts: {
+  bench?: Bench | null;
+  fileBytes?: Buffer;
+}) {
+  const repo = { findById: vi.fn(async () => opts.bench ?? null) };
+  const storage = {
+    exists: vi.fn(async () => true),
+    readBytes: vi.fn(async () => opts.fileBytes ?? Buffer.from("data")),
+    readJson: vi.fn(),
+    readText: vi.fn(),
+  };
+  return {
+    ctrl: new BenchmarkFilesController(repo as never, storage as never),
+    repo, storage,
+  };
+}
+
+const userU1 = { sub: "u1", roles: [], email: "x@y" };
+const userAdmin = { sub: "admin1", roles: ["admin"], email: "a@y" };
+
+describe("BenchmarkFilesController", () => {
+  it("404 when benchmark not found", async () => {
+    const { ctrl } = makeCtrl({ bench: null });
+    await expect(ctrl.getFile(userU1 as never, "r1", "report.json")).rejects.toThrow(NotFoundException);
+  });
+
+  it("403 when userId mismatch and not admin", async () => {
+    const { ctrl } = makeCtrl({ bench: { id: "r1", userId: "other-user", tool: "guidellm", status: "completed", rawOutput: { files: { "report.json": "files/report.json" } } } });
+    await expect(ctrl.getFile(userU1 as never, "r1", "report.json")).rejects.toThrow(ForbiddenException);
+  });
+
+  it("admin can access any user's files", async () => {
+    const { ctrl, storage } = makeCtrl({
+      bench: { id: "r1", userId: "other-user", tool: "guidellm", status: "completed", rawOutput: { files: { "report.json": "files/report.json" } } },
+      fileBytes: Buffer.from("admin-can-see"),
+    });
+    const out = await ctrl.getFile(userAdmin as never, "r1", "report.json");
+    expect(out).toBeInstanceOf(StreamableFile);
+    expect(storage.readBytes).toHaveBeenCalledWith("r1/files/report.json");
+  });
+
+  it("404 when alias not in rawOutput.files", async () => {
+    const { ctrl } = makeCtrl({ bench: { id: "r1", userId: "u1", tool: "guidellm", status: "completed", rawOutput: { files: {} } } });
+    await expect(ctrl.getFile(userU1 as never, "r1", "missing.json")).rejects.toThrow(NotFoundException);
+  });
+
+  it("returns StreamableFile with content for valid request", async () => {
+    const { ctrl, storage } = makeCtrl({
+      bench: { id: "r1", userId: "u1", tool: "guidellm", status: "completed", rawOutput: { files: { "report.json": "files/report.json" } } },
+      fileBytes: Buffer.from('{"ok":true}'),
+    });
+    const out = await ctrl.getFile(userU1 as never, "r1", "report.json");
+    expect(out).toBeInstanceOf(StreamableFile);
+    expect(storage.readBytes).toHaveBeenCalledWith("r1/files/report.json");
+  });
+});

--- a/apps/api/src/modules/benchmark/benchmark-files.controller.spec.ts
+++ b/apps/api/src/modules/benchmark/benchmark-files.controller.spec.ts
@@ -3,14 +3,14 @@ import { describe, expect, it, vi } from "vitest";
 import { BenchmarkFilesController } from "./benchmark-files.controller.js";
 
 interface Bench {
-  id: string; userId: string | null; tool: string; status: string;
+  id: string;
+  userId: string | null;
+  tool: string;
+  status: string;
   rawOutput: { files?: Record<string, string> } | null;
 }
 
-function makeCtrl(opts: {
-  bench?: Bench | null;
-  fileBytes?: Buffer;
-}) {
+function makeCtrl(opts: { bench?: Bench | null; fileBytes?: Buffer }) {
   const repo = { findById: vi.fn(async () => opts.bench ?? null) };
   const storage = {
     exists: vi.fn(async () => true),
@@ -20,7 +20,8 @@ function makeCtrl(opts: {
   };
   return {
     ctrl: new BenchmarkFilesController(repo as never, storage as never),
-    repo, storage,
+    repo,
+    storage,
   };
 }
 
@@ -30,17 +31,35 @@ const userAdmin = { sub: "admin1", roles: ["admin"], email: "a@y" };
 describe("BenchmarkFilesController", () => {
   it("404 when benchmark not found", async () => {
     const { ctrl } = makeCtrl({ bench: null });
-    await expect(ctrl.getFile(userU1 as never, "r1", "report.json")).rejects.toThrow(NotFoundException);
+    await expect(ctrl.getFile(userU1 as never, "r1", "report.json")).rejects.toThrow(
+      NotFoundException,
+    );
   });
 
   it("403 when userId mismatch and not admin", async () => {
-    const { ctrl } = makeCtrl({ bench: { id: "r1", userId: "other-user", tool: "guidellm", status: "completed", rawOutput: { files: { "report.json": "files/report.json" } } } });
-    await expect(ctrl.getFile(userU1 as never, "r1", "report.json")).rejects.toThrow(ForbiddenException);
+    const { ctrl } = makeCtrl({
+      bench: {
+        id: "r1",
+        userId: "other-user",
+        tool: "guidellm",
+        status: "completed",
+        rawOutput: { files: { "report.json": "files/report.json" } },
+      },
+    });
+    await expect(ctrl.getFile(userU1 as never, "r1", "report.json")).rejects.toThrow(
+      ForbiddenException,
+    );
   });
 
   it("admin can access any user's files", async () => {
     const { ctrl, storage } = makeCtrl({
-      bench: { id: "r1", userId: "other-user", tool: "guidellm", status: "completed", rawOutput: { files: { "report.json": "files/report.json" } } },
+      bench: {
+        id: "r1",
+        userId: "other-user",
+        tool: "guidellm",
+        status: "completed",
+        rawOutput: { files: { "report.json": "files/report.json" } },
+      },
       fileBytes: Buffer.from("admin-can-see"),
     });
     const out = await ctrl.getFile(userAdmin as never, "r1", "report.json");
@@ -49,13 +68,29 @@ describe("BenchmarkFilesController", () => {
   });
 
   it("404 when alias not in rawOutput.files", async () => {
-    const { ctrl } = makeCtrl({ bench: { id: "r1", userId: "u1", tool: "guidellm", status: "completed", rawOutput: { files: {} } } });
-    await expect(ctrl.getFile(userU1 as never, "r1", "missing.json")).rejects.toThrow(NotFoundException);
+    const { ctrl } = makeCtrl({
+      bench: {
+        id: "r1",
+        userId: "u1",
+        tool: "guidellm",
+        status: "completed",
+        rawOutput: { files: {} },
+      },
+    });
+    await expect(ctrl.getFile(userU1 as never, "r1", "missing.json")).rejects.toThrow(
+      NotFoundException,
+    );
   });
 
   it("returns StreamableFile with content for valid request", async () => {
     const { ctrl, storage } = makeCtrl({
-      bench: { id: "r1", userId: "u1", tool: "guidellm", status: "completed", rawOutput: { files: { "report.json": "files/report.json" } } },
+      bench: {
+        id: "r1",
+        userId: "u1",
+        tool: "guidellm",
+        status: "completed",
+        rawOutput: { files: { "report.json": "files/report.json" } },
+      },
       fileBytes: Buffer.from('{"ok":true}'),
     });
     const out = await ctrl.getFile(userU1 as never, "r1", "report.json");

--- a/apps/api/src/modules/benchmark/benchmark-files.controller.ts
+++ b/apps/api/src/modules/benchmark/benchmark-files.controller.ts
@@ -45,7 +45,7 @@ export class BenchmarkFilesController {
     if (!relPath) throw new NotFoundException(`alias ${alias} not in this benchmark's files`);
 
     const key = `${id}/${relPath}`;
-    const bytes = await this.storage.readBytes(key);
-    return new StreamableFile(bytes, { disposition: `attachment; filename="${alias}"` });
+    const stream = await this.storage.readStream(key);
+    return new StreamableFile(stream, { disposition: `attachment; filename="${alias}"` });
   }
 }

--- a/apps/api/src/modules/benchmark/benchmark-files.controller.ts
+++ b/apps/api/src/modules/benchmark/benchmark-files.controller.ts
@@ -1,0 +1,41 @@
+import { Controller, ForbiddenException, Get, Inject, NotFoundException, Param, StreamableFile, UseGuards } from "@nestjs/common";
+import { ApiOperation, ApiTags } from "@nestjs/swagger";
+import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
+import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
+import type { JwtPayload } from "../auth/jwt.strategy.js";
+import { BenchmarkRepository } from "./benchmark.repository.js";
+import { REPORT_STORAGE, type ReportStorage } from "./storage/report-storage.js";
+
+@ApiTags("benchmarks")
+@Controller("benchmarks/:id/files")
+@UseGuards(JwtAuthGuard)
+export class BenchmarkFilesController {
+  constructor(
+    private readonly repo: BenchmarkRepository,
+    @Inject(REPORT_STORAGE) private readonly storage: ReportStorage,
+  ) {}
+
+  @Get(":alias")
+  @ApiOperation({ summary: "Stream an output file from the benchmark's S3 report" })
+  async getFile(
+    @CurrentUser() user: JwtPayload,
+    @Param("id") id: string,
+    @Param("alias") alias: string,
+  ): Promise<StreamableFile> {
+    const bench = await this.repo.findById(id);
+    if (!bench) throw new NotFoundException(`benchmark ${id} not found`);
+
+    const isAdmin = user.roles.includes("admin");
+    if (!isAdmin && bench.userId && bench.userId !== user.sub) {
+      throw new ForbiddenException();
+    }
+
+    const files = ((bench.rawOutput as { files?: Record<string, string> } | null) ?? {}).files ?? {};
+    const relPath = files[alias];
+    if (!relPath) throw new NotFoundException(`alias ${alias} not in this benchmark's files`);
+
+    const key = `${id}/${relPath}`;
+    const bytes = await this.storage.readBytes(key);
+    return new StreamableFile(bytes, { disposition: `attachment; filename="${alias}"` });
+  }
+}

--- a/apps/api/src/modules/benchmark/benchmark-files.controller.ts
+++ b/apps/api/src/modules/benchmark/benchmark-files.controller.ts
@@ -1,8 +1,17 @@
-import { Controller, ForbiddenException, Get, Inject, NotFoundException, Param, StreamableFile, UseGuards } from "@nestjs/common";
+import {
+  Controller,
+  ForbiddenException,
+  Get,
+  Inject,
+  NotFoundException,
+  Param,
+  StreamableFile,
+  UseGuards,
+} from "@nestjs/common";
 import { ApiOperation, ApiTags } from "@nestjs/swagger";
 import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
-import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
 import type { JwtPayload } from "../auth/jwt.strategy.js";
+import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
 import { BenchmarkRepository } from "./benchmark.repository.js";
 import { REPORT_STORAGE, type ReportStorage } from "./storage/report-storage.js";
 
@@ -30,7 +39,8 @@ export class BenchmarkFilesController {
       throw new ForbiddenException();
     }
 
-    const files = ((bench.rawOutput as { files?: Record<string, string> } | null) ?? {}).files ?? {};
+    const files =
+      ((bench.rawOutput as { files?: Record<string, string> } | null) ?? {}).files ?? {};
     const relPath = files[alias];
     if (!relPath) throw new NotFoundException(`alias ${alias} not in this benchmark's files`);
 

--- a/apps/api/src/modules/benchmark/benchmark.module.ts
+++ b/apps/api/src/modules/benchmark/benchmark.module.ts
@@ -88,15 +88,21 @@ async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeCon
           terminalReconcileGraceSec,
         };
 
-        // Stub reportLoader — replaced in T12 when S3ReportStorage + ReportLoader
-        // are wired as proper NestJS providers. Until then this satisfies the
-        // WatcherDeps type and prevents type-check failures.
+        // Stub reportLoader + reportStorage — replaced in T12 when S3ReportStorage
+        // + ReportLoader are wired as proper NestJS providers. Until then these
+        // satisfy the ReconcilerDeps / WatcherDeps types and prevent type-check failures.
         const reportLoaderStub: ReportLoader = {
           tryLoad: async (runId: string) => {
             // TODO(T12): replace with injected ReportLoader
             void runId;
           },
         } as unknown as ReportLoader;
+        const reportStorageStub = {
+          exists: async (_key: string) => false,
+          readJson: async (_key: string) => { throw new Error("not implemented"); },
+          readText: async (_key: string) => { throw new Error("not implemented"); },
+          readBytes: async (_key: string) => { throw new Error("not implemented"); },
+        };
 
         if (mode === "off") {
           // mode=off: build a service that no-ops on init/destroy. Avoids
@@ -113,6 +119,8 @@ async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeCon
               namespace,
               repo,
               podCache: { get: () => undefined, list: () => [] },
+              storage: reportStorageStub,
+              reportLoader: reportLoaderStub,
             }),
             reportLoader: reportLoaderStub,
           });
@@ -139,6 +147,8 @@ async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeCon
           namespace,
           repo,
           podCache: informer,
+          storage: reportStorageStub,
+          reportLoader: reportLoaderStub,
         });
 
         return new K8sJobWatcherService({

--- a/apps/api/src/modules/benchmark/benchmark.module.ts
+++ b/apps/api/src/modules/benchmark/benchmark.module.ts
@@ -17,6 +17,7 @@ import { K8sBenchmarkRunner } from "./k8s/k8s-benchmark-runner.js";
 import { K8sJobWatcherService, type WatcherMode } from "./k8s/k8s-job-watcher.service.js";
 import { DEFAULT_FATAL_WAITING_REASONS } from "./k8s/pod-state-reducer.js";
 import { StartupReconciler } from "./k8s/startup-reconciler.js";
+import type { ReportLoader } from "./storage/report-loader.js";
 import { SseHub } from "./sse/sse-hub.service.js";
 
 async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeConfig> {
@@ -87,6 +88,16 @@ async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeCon
           terminalReconcileGraceSec,
         };
 
+        // Stub reportLoader — replaced in T12 when S3ReportStorage + ReportLoader
+        // are wired as proper NestJS providers. Until then this satisfies the
+        // WatcherDeps type and prevents type-check failures.
+        const reportLoaderStub: ReportLoader = {
+          tryLoad: async (runId: string) => {
+            // TODO(T12): replace with injected ReportLoader
+            void runId;
+          },
+        } as unknown as ReportLoader;
+
         if (mode === "off") {
           // mode=off: build a service that no-ops on init/destroy. Avoids
           // loading K8s entirely in dev / CI / unit-test envs.
@@ -103,6 +114,7 @@ async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeCon
               repo,
               podCache: { get: () => undefined, list: () => [] },
             }),
+            reportLoader: reportLoaderStub,
           });
         }
 
@@ -136,6 +148,7 @@ async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeCon
           makeInformer: () => informer,
           repo,
           reconciler,
+          reportLoader: reportLoaderStub,
         });
       },
     },

--- a/apps/api/src/modules/benchmark/benchmark.module.ts
+++ b/apps/api/src/modules/benchmark/benchmark.module.ts
@@ -13,16 +13,16 @@ import { BenchmarkController } from "./benchmark.controller.js";
 import { BenchmarkRepository } from "./benchmark.repository.js";
 import { BenchmarkService } from "./benchmark.service.js";
 import { BenchmarkChartsService } from "./benchmark-charts.service.js";
-import { BenchmarkCallbackController } from "./callbacks/benchmark-callback.controller.js";
 import { BenchmarkFilesController } from "./benchmark-files.controller.js";
+import { BenchmarkCallbackController } from "./callbacks/benchmark-callback.controller.js";
 import { K8sBenchmarkRunner } from "./k8s/k8s-benchmark-runner.js";
 import { K8sJobWatcherService, type WatcherMode } from "./k8s/k8s-job-watcher.service.js";
 import { DEFAULT_FATAL_WAITING_REASONS } from "./k8s/pod-state-reducer.js";
 import { StartupReconciler } from "./k8s/startup-reconciler.js";
+import { SseHub } from "./sse/sse-hub.service.js";
 import { ReportLoader } from "./storage/report-loader.js";
 import { REPORT_STORAGE, type ReportStorage } from "./storage/report-storage.js";
 import { S3ReportStorage } from "./storage/s3-report-storage.js";
-import { SseHub } from "./sse/sse-hub.service.js";
 
 async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeConfig> {
   const k8s = await import("@kubernetes/client-node");

--- a/apps/api/src/modules/benchmark/benchmark.module.ts
+++ b/apps/api/src/modules/benchmark/benchmark.module.ts
@@ -8,16 +8,20 @@ import { BaselineModule } from "../baseline/baseline.module.js";
 import { BenchmarkTemplateModule } from "../benchmark-template/benchmark-template.module.js";
 import { ConnectionModule } from "../connection/connection.module.js";
 import { NotificationsModule } from "../notifications/notifications.module.js";
+import { NotifyService } from "../notifications/notify.service.js";
 import { BenchmarkController } from "./benchmark.controller.js";
 import { BenchmarkRepository } from "./benchmark.repository.js";
 import { BenchmarkService } from "./benchmark.service.js";
 import { BenchmarkChartsService } from "./benchmark-charts.service.js";
 import { BenchmarkCallbackController } from "./callbacks/benchmark-callback.controller.js";
+import { BenchmarkFilesController } from "./benchmark-files.controller.js";
 import { K8sBenchmarkRunner } from "./k8s/k8s-benchmark-runner.js";
 import { K8sJobWatcherService, type WatcherMode } from "./k8s/k8s-job-watcher.service.js";
 import { DEFAULT_FATAL_WAITING_REASONS } from "./k8s/pod-state-reducer.js";
 import { StartupReconciler } from "./k8s/startup-reconciler.js";
-import type { ReportLoader } from "./storage/report-loader.js";
+import { ReportLoader } from "./storage/report-loader.js";
+import { REPORT_STORAGE, type ReportStorage } from "./storage/report-storage.js";
+import { S3ReportStorage } from "./storage/s3-report-storage.js";
 import { SseHub } from "./sse/sse-hub.service.js";
 
 async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeConfig> {
@@ -37,7 +41,7 @@ async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeCon
     BaselineModule,
     NotificationsModule,
   ],
-  controllers: [BenchmarkController, BenchmarkCallbackController],
+  controllers: [BenchmarkController, BenchmarkCallbackController, BenchmarkFilesController],
   providers: [
     PrismaService,
     BenchmarkRepository,
@@ -62,16 +66,41 @@ async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeCon
       },
     },
     {
-      // K8sJobWatcherService — Phase 1 backstop watcher.
+      provide: REPORT_STORAGE,
+      inject: [ConfigService],
+      useFactory: (config: ConfigService<Env, true>): ReportStorage => {
+        return new S3ReportStorage({
+          endpoint: config.get("S3_ENDPOINT", { infer: true }) as string,
+          region: config.get("S3_REGION", { infer: true }) as string,
+          accessKeyId: config.get("S3_ACCESS_KEY", { infer: true }) as string,
+          secretAccessKey: config.get("S3_SECRET_KEY", { infer: true }) as string,
+          bucket: config.get("S3_BUCKET", { infer: true }) as string,
+        });
+      },
+    },
+    {
+      provide: ReportLoader,
+      inject: [REPORT_STORAGE, BenchmarkRepository, NotifyService, SseHub],
+      useFactory: (
+        storage: ReportStorage,
+        repo: BenchmarkRepository,
+        notify: NotifyService,
+        sse: SseHub,
+      ): ReportLoader => new ReportLoader({ storage, repo, notify, sse }),
+    },
+    {
+      // K8sJobWatcherService — Phase 2 primary watcher.
       // useFactory loads KubeConfig + builds Informer factory + StartupReconciler.
       // Note: WatcherDeps is constructor-injected as a single object (not 6
       // separate @Inject calls) so the makeInformer factory closure can capture
       // the KubeConfig + namespace without leaking them into module-level DI.
       provide: K8sJobWatcherService,
-      inject: [ConfigService, BenchmarkRepository],
+      inject: [ConfigService, BenchmarkRepository, ReportLoader, REPORT_STORAGE],
       useFactory: async (
         config: ConfigService<Env, true>,
         repo: BenchmarkRepository,
+        reportLoader: ReportLoader,
+        storage: ReportStorage,
       ): Promise<K8sJobWatcherService> => {
         const mode = config.get("K8S_WATCHER_MODE", { infer: true }) as WatcherMode;
         const namespace = config.get("BENCHMARK_K8S_NAMESPACE", { infer: true }) as string;
@@ -86,22 +115,6 @@ async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeCon
           fatalWaitingReasons: DEFAULT_FATAL_WAITING_REASONS,
           waitingFatalGraceSec,
           terminalReconcileGraceSec,
-        };
-
-        // Stub reportLoader + reportStorage — replaced in T12 when S3ReportStorage
-        // + ReportLoader are wired as proper NestJS providers. Until then these
-        // satisfy the ReconcilerDeps / WatcherDeps types and prevent type-check failures.
-        const reportLoaderStub: ReportLoader = {
-          tryLoad: async (runId: string) => {
-            // TODO(T12): replace with injected ReportLoader
-            void runId;
-          },
-        } as unknown as ReportLoader;
-        const reportStorageStub = {
-          exists: async (_key: string) => false,
-          readJson: async (_key: string) => { throw new Error("not implemented"); },
-          readText: async (_key: string) => { throw new Error("not implemented"); },
-          readBytes: async (_key: string) => { throw new Error("not implemented"); },
         };
 
         if (mode === "off") {
@@ -119,15 +132,14 @@ async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeCon
               namespace,
               repo,
               podCache: { get: () => undefined, list: () => [] },
-              storage: reportStorageStub,
-              reportLoader: reportLoaderStub,
+              storage,
+              reportLoader,
             }),
-            reportLoader: reportLoaderStub,
+            reportLoader,
           });
         }
 
-        // mode=backstop (or primary, which the service constructor rejects).
-        // Real informer + reconciler with live K8s client.
+        // mode=backstop or primary — real informer + reconciler
         const k8s = await import("@kubernetes/client-node");
         const kc = await loadKubeConfig(config);
         const coreV1: CoreV1Api = kc.makeApiClient(k8s.CoreV1Api);
@@ -147,8 +159,8 @@ async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeCon
           namespace,
           repo,
           podCache: informer,
-          storage: reportStorageStub,
-          reportLoader: reportLoaderStub,
+          storage,
+          reportLoader,
         });
 
         return new K8sJobWatcherService({
@@ -158,7 +170,7 @@ async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeCon
           makeInformer: () => informer,
           repo,
           reconciler,
-          reportLoader: reportLoaderStub,
+          reportLoader,
         });
       },
     },

--- a/apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.spec.ts
+++ b/apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.spec.ts
@@ -1,4 +1,3 @@
-import * as toolAdapters from "@modeldoctor/tool-adapters";
 import type { Benchmark as PrismaBenchmark } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SseHub } from "../sse/sse-hub.service.js";
@@ -39,10 +38,6 @@ vi.mock("@modeldoctor/tool-adapters", async (orig) => {
         line.startsWith("PROGRESS:")
           ? { kind: "progress", pct: Number.parseFloat(line.slice("PROGRESS:".length)) }
           : { kind: "log", level: "info", line },
-      parseFinalReport: (stdout: string) => {
-        if (stdout === "BAD") throw new Error("simulated parse failure");
-        return { tool: "guidellm", data: { ttft: { mean: 1, p50: 1, p90: 1, p95: 1, p99: 1 } } };
-      },
     }),
   };
 });
@@ -56,65 +51,7 @@ describe("BenchmarkCallbackController", () => {
     vi.restoreAllMocks();
     repo = new MockBenchmarkRepo();
     sse = new SseHub();
-    ctrl = new BenchmarkCallbackController(repo as never, sse, { emit: vi.fn() } as never);
-  });
-
-  it("/state running marks the row as running", async () => {
-    repo.setup("r1", { id: "r1", tool: "guidellm", status: "submitted" });
-    await ctrl.handleState("r1", { state: "running" });
-    const row = await repo.findById("r1");
-    expect(row?.status).toBe("running");
-  });
-
-  it("/state running with toolVersion sets both status and toolVersion on a pending row", async () => {
-    repo.setup("r1", { id: "r1", tool: "guidellm", status: "submitted", toolVersion: null });
-    await ctrl.handleState("r1", { state: "running", toolVersion: "guidellm 0.5.2" });
-    const row = await repo.findById("r1");
-    expect(row?.status).toBe("running");
-    expect(row?.toolVersion).toBe("guidellm 0.5.2");
-  });
-
-  it("/state running without toolVersion preserves null toolVersion on a pending row", async () => {
-    repo.setup("r1", { id: "r1", tool: "guidellm", status: "submitted", toolVersion: null });
-    await ctrl.handleState("r1", { state: "running" });
-    const row = await repo.findById("r1");
-    expect(row?.status).toBe("running");
-    expect(row?.toolVersion).toBeNull();
-    // Verify the update patch did not include toolVersion (i.e. did not
-    // overwrite an existing value with null).
-    const lastPatch = repo.updateCalls.at(-1)?.patch;
-    expect(lastPatch).toBeDefined();
-    expect(Object.hasOwn(lastPatch as object, "toolVersion")).toBe(false);
-  });
-
-  it("/state with only toolVersion updates toolVersion on an already-running row", async () => {
-    repo.setup("r1", {
-      id: "r1",
-      tool: "guidellm",
-      status: "running",
-      toolVersion: "guidellm 0.5.2",
-    });
-    await ctrl.handleState("r1", { toolVersion: "guidellm 0.5.3" } as never);
-    const row = await repo.findById("r1");
-    expect(row?.status).toBe("running");
-    expect(row?.toolVersion).toBe("guidellm 0.5.3");
-    const lastPatch = repo.updateCalls.at(-1)?.patch;
-    expect(lastPatch).toEqual({ toolVersion: "guidellm 0.5.3" });
-  });
-
-  it("/state with identical toolVersion is a no-op (no extra update call)", async () => {
-    repo.setup("r1", {
-      id: "r1",
-      tool: "guidellm",
-      status: "running",
-      toolVersion: "guidellm 0.5.2",
-    });
-    const before = repo.updateCalls.length;
-    await ctrl.handleState("r1", { toolVersion: "guidellm 0.5.2" } as never);
-    expect(repo.updateCalls.length).toBe(before);
-    const row = await repo.findById("r1");
-    expect(row?.toolVersion).toBe("guidellm 0.5.2");
-    expect(row?.status).toBe("running");
+    ctrl = new BenchmarkCallbackController(repo as never, sse);
   });
 
   it("/log invokes adapter.parseProgress and publishes ProgressEvent", async () => {
@@ -125,75 +62,5 @@ describe("BenchmarkCallbackController", () => {
     expect(evts).toHaveLength(2);
     expect((evts[0] as { kind: string }).kind).toBe("progress");
     expect((evts[1] as { kind: string }).kind).toBe("log");
-  });
-
-  it("/finish parses report and writes summaryMetrics + rawOutput on success", async () => {
-    repo.setup("r1", { id: "r1", tool: "guidellm", status: "running" });
-    await ctrl.handleFinish("r1", {
-      state: "completed",
-      exitCode: 0,
-      stdout: "ok",
-      stderr: "",
-      files: { report: Buffer.from('{"ok":true}', "utf8").toString("base64") },
-    });
-    const row = await repo.findById("r1");
-    expect(row?.status).toBe("completed");
-    expect((row?.summaryMetrics as { tool?: string })?.tool).toBe("guidellm");
-    expect(row?.rawOutput).toEqual({
-      stdout: "ok",
-      stderr: "",
-      files: { report: Buffer.from('{"ok":true}', "utf8").toString("base64") },
-    });
-  });
-
-  it("/finish forces failed when adapter.parseFinalReport throws", async () => {
-    repo.setup("r1", { id: "r1", tool: "guidellm", status: "running" });
-    await ctrl.handleFinish("r1", {
-      state: "completed", // runner reports completed but parser fails
-      exitCode: 0,
-      stdout: "BAD",
-      stderr: "",
-      files: {},
-    });
-    const row = await repo.findById("r1");
-    expect(row?.status).toBe("failed");
-    expect((row?.statusMessage as string | undefined) ?? "").toMatch(/report parse/);
-    expect(row?.summaryMetrics).toBeNull();
-  });
-
-  it("/finish state=failed preserves runner message and does NOT call parseFinalReport", async () => {
-    const parseFinalReport = vi.fn(() => {
-      throw new Error("should not be called when state=failed");
-    });
-    vi.spyOn(toolAdapters, "byTool").mockReturnValueOnce({
-      name: "guidellm",
-      scenarios: ["inference"],
-      paramsSchema: { parse: (x: unknown) => x } as never,
-      reportSchema: { parse: (x: unknown) => x } as never,
-      paramDefaults: {},
-      buildCommand: () => ({ argv: [], env: {}, secretEnv: {}, outputFiles: {} }),
-      parseProgress: () => null,
-      parseFinalReport,
-      getMaxDurationSeconds: () => 60,
-      readMetric: () => null,
-    });
-
-    repo.setup("benchmark-1", { id: "benchmark-1", tool: "guidellm", status: "running" });
-    await ctrl.handleFinish("benchmark-1", {
-      state: "failed",
-      exitCode: 137,
-      message: "tool exited with code 137",
-      stdout: "",
-      stderr: "OSError: perf_analyzer not found",
-      files: {},
-    } as never);
-
-    expect(parseFinalReport).not.toHaveBeenCalled();
-    const row = await repo.findById("benchmark-1");
-    expect(row).toMatchObject({
-      status: "failed",
-      statusMessage: "tool exited with code 137",
-      summaryMetrics: null,
-    });
   });
 });

--- a/apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.ts
+++ b/apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.ts
@@ -1,28 +1,10 @@
-import {
-  type BenchmarkFinishCallback,
-  type BenchmarkLogCallback,
-  type BenchmarkStateCallback,
-  benchmarkFinishCallbackSchema,
-  benchmarkLogCallbackSchema,
-  benchmarkStateCallbackSchema,
-} from "@modeldoctor/contracts";
+import { type BenchmarkLogCallback, benchmarkLogCallbackSchema } from "@modeldoctor/contracts";
 import { byTool, type ProgressEvent, type ToolName } from "@modeldoctor/tool-adapters";
-import {
-  Body,
-  Controller,
-  HttpCode,
-  HttpStatus,
-  Logger,
-  Param,
-  Post,
-  UseGuards,
-} from "@nestjs/common";
+import { Body, Controller, HttpCode, HttpStatus, Param, Post, UseGuards } from "@nestjs/common";
 import { ApiOperation, ApiTags } from "@nestjs/swagger";
-import type { Prisma } from "@prisma/client";
 import { Public } from "../../../common/decorators/public.decorator.js";
 import { HmacCallbackGuard } from "../../../common/hmac/hmac-callback.guard.js";
 import { ZodValidationPipe } from "../../../common/pipes/zod-validation.pipe.js";
-import { NotifyService } from "../../notifications/notify.service.js";
 import { BenchmarkRepository } from "../benchmark.repository.js";
 import { SseHub } from "../sse/sse-hub.service.js";
 
@@ -30,46 +12,10 @@ import { SseHub } from "../sse/sse-hub.service.js";
 @UseGuards(HmacCallbackGuard)
 @Controller("internal/benchmarks/:id")
 export class BenchmarkCallbackController {
-  private readonly log = new Logger(BenchmarkCallbackController.name);
-
   constructor(
     private readonly benchmarks: BenchmarkRepository,
     private readonly sse: SseHub,
-    private readonly notify: NotifyService,
   ) {}
-
-  @Post("state")
-  @Public()
-  @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: "v2 callback: state transition" })
-  async handleState(
-    @Param("id") id: string,
-    @Body(new ZodValidationPipe(benchmarkStateCallbackSchema)) body: BenchmarkStateCallback,
-  ): Promise<void> {
-    const row = await this.benchmarks.findById(id);
-    if (!row) {
-      this.log.warn(`/state callback for unknown benchmark ${id}; ignoring`);
-      return;
-    }
-    // Assumption: the runner emits a single, idempotent toolVersion value
-    // per benchmark, captured once during runner-startup version detection.
-    // The read-modify-write below (findById → compare in memory → update)
-    // is therefore not atomic — two concurrent /state callbacks landing in
-    // the same millisecond could both decide an update is needed — but
-    // since the runner serializes the version-detection step, no real
-    // contention is expected. If a future runner change makes /state
-    // emission concurrent, swap this for a conditional UPDATE in SQL.
-    if (body.state === "running" && row.status !== "running") {
-      await this.benchmarks.update(id, {
-        status: "running",
-        startedAt: row.startedAt ?? new Date(),
-        ...(body.toolVersion ? { toolVersion: body.toolVersion } : {}),
-      });
-    } else if (body.toolVersion && row.toolVersion !== body.toolVersion) {
-      // record toolVersion even if we already transitioned to running
-      await this.benchmarks.update(id, { toolVersion: body.toolVersion });
-    }
-  }
 
   @Post("log")
   @Public()
@@ -96,70 +42,6 @@ export class BenchmarkCallbackController {
     }
     if (lastProgress !== null) {
       await this.benchmarks.update(id, { progress: lastProgress });
-    }
-  }
-
-  @Post("finish")
-  @Public()
-  @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: "v2 callback: terminal state + final report" })
-  async handleFinish(
-    @Param("id") id: string,
-    @Body(new ZodValidationPipe(benchmarkFinishCallbackSchema)) body: BenchmarkFinishCallback,
-  ): Promise<void> {
-    const row = await this.benchmarks.findById(id);
-    if (!row) {
-      this.log.warn(`/finish callback for unknown benchmark ${id}; ignoring`);
-      return;
-    }
-    const adapter = byTool(row.tool as ToolName);
-    let finalState: "completed" | "failed" = body.state;
-    let message = body.message;
-    let summary: unknown = null;
-
-    if (body.state === "completed") {
-      try {
-        const fileBuffers: Record<string, Buffer> = Object.fromEntries(
-          Object.entries(body.files).map(([k, v]) => [k, Buffer.from(v, "base64")]),
-        );
-        summary = adapter.parseFinalReport(body.stdout, fileBuffers);
-      } catch (e) {
-        finalState = "failed";
-        message = `report parse: ${(e as Error).message}`.slice(0, 2048);
-        summary = null;
-      }
-    }
-    // state==="failed": preserve runner-supplied message + body.stderr/stdout into rawOutput below.
-
-    await this.benchmarks.update(id, {
-      status: finalState,
-      completedAt: new Date(),
-      statusMessage: message ?? null,
-      summaryMetrics: (summary ?? null) as Prisma.InputJsonValue,
-      rawOutput: {
-        stdout: body.stdout,
-        stderr: body.stderr,
-        files: body.files,
-      } as Prisma.InputJsonValue,
-    });
-    this.sse.close(id);
-
-    if (row.userId) {
-      await this.notify.emit({
-        eventType: finalState === "completed" ? "benchmark.completed" : "benchmark.failed",
-        userId: row.userId,
-        connectionId: row.connectionId ?? undefined,
-        payload: {
-          benchmarkId: row.id,
-          name: row.name,
-          status: finalState,
-          scenario: row.scenario,
-          tool: row.tool,
-          connectionId: row.connectionId,
-          summaryMetrics: summary,
-          message,
-        },
-      });
     }
   }
 }

--- a/apps/api/src/modules/benchmark/k8s/k8s-job-manifest.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/k8s-job-manifest.spec.ts
@@ -32,12 +32,23 @@ describe("buildSecretManifest", () => {
 });
 
 describe("buildJobManifest", () => {
-  it("references the per-run Secret via envFrom", () => {
+  it("references the per-run Secret and storage Secret via envFrom", () => {
     const j = buildJobManifest(ctx, { namespace: "ns" });
     expect(j.metadata?.name).toBe("run-abc123");
     const c = j.spec?.template.spec?.containers[0];
     expect(c?.image).toBe("ghcr.io/example/runner:latest");
-    expect(c?.envFrom).toContainEqual({ secretRef: { name: "run-abc123" } });
+    expect(c?.envFrom).toEqual([
+      { secretRef: { name: "run-abc123" } },
+      { secretRef: { name: "md-benchmark-storage" } },
+    ]);
+  });
+
+  it("envFrom includes md-benchmark-storage Secret", () => {
+    const j = buildJobManifest(ctx, { namespace: "ns" });
+    const c = j.spec?.template.spec?.containers[0];
+    expect(c?.envFrom).toContainEqual(
+      expect.objectContaining({ secretRef: expect.objectContaining({ name: "md-benchmark-storage" }) }),
+    );
   });
 
   it("ships non-secret env values directly + MD_* control vars", () => {

--- a/apps/api/src/modules/benchmark/k8s/k8s-job-manifest.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/k8s-job-manifest.spec.ts
@@ -47,7 +47,9 @@ describe("buildJobManifest", () => {
     const j = buildJobManifest(ctx, { namespace: "ns" });
     const c = j.spec?.template.spec?.containers[0];
     expect(c?.envFrom).toContainEqual(
-      expect.objectContaining({ secretRef: expect.objectContaining({ name: "md-benchmark-storage" }) }),
+      expect.objectContaining({
+        secretRef: expect.objectContaining({ name: "md-benchmark-storage" }),
+      }),
     );
   });
 

--- a/apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts
+++ b/apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts
@@ -14,6 +14,10 @@ const LABELS = {
   "app.kubernetes.io/managed-by": "modeldoctor-api",
 };
 
+/** Operator-created Secret holding S3 credentials shared across all benchmark Jobs.
+ *  Per-run Secret (callback token + tool API keys) stays separate. */
+const STORAGE_SECRET_NAME = "md-benchmark-storage";
+
 // Encode an inputFiles alias into a Secret-key-safe form. Aliases are
 // arbitrary strings (e.g. "targets.txt"); Secret keys must be DNS-
 // segment-like ([A-Za-z0-9._-]). Base64-url-no-pad gives a deterministic
@@ -99,7 +103,10 @@ export function buildJobManifest(ctx: BenchmarkRunInput, opts: JobManifestOption
               image: ctx.image,
               imagePullPolicy: "IfNotPresent",
               env,
-              envFrom: [{ secretRef: { name: secretName(ctx.runId) } }],
+              envFrom: [
+                { secretRef: { name: secretName(ctx.runId) } },
+                { secretRef: { name: STORAGE_SECRET_NAME } },
+              ],
               ...(hasInputFiles
                 ? {
                     volumeMounts: [

--- a/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.spec.ts
@@ -4,9 +4,14 @@ import {
   podFailed,
   podPendingWaiting,
   podRunId,
+  podRunning,
   podSucceeded,
 } from "./__fixtures__/pod-fixtures.js";
-import { K8sJobWatcherService, type WatcherDeps } from "./k8s-job-watcher.service.js";
+import {
+  K8sJobWatcherService,
+  type WatcherDeps,
+  type WatcherMode,
+} from "./k8s-job-watcher.service.js";
 
 function makeFakeInformer() {
   const handlers = new Map<string, Array<(arg: unknown) => void>>();
@@ -33,11 +38,12 @@ function makeFakeInformer() {
   return informer;
 }
 
-function makeDeps(mode: "off" | "backstop" = "backstop"): {
+function makeDeps(mode: WatcherMode = "backstop"): {
   deps: WatcherDeps;
   informer: ReturnType<typeof makeFakeInformer>;
   repo: { findById: ReturnType<typeof vi.fn>; updateGuarded: ReturnType<typeof vi.fn> };
   reconciler: { run: ReturnType<typeof vi.fn> };
+  reportLoader: { tryLoad: ReturnType<typeof vi.fn> };
 } {
   const informer = makeFakeInformer();
   const repo = {
@@ -45,6 +51,7 @@ function makeDeps(mode: "off" | "backstop" = "backstop"): {
     updateGuarded: vi.fn(async () => null),
   };
   const reconciler = { run: vi.fn(async () => undefined) };
+  const reportLoader = { tryLoad: vi.fn(async () => {}) };
   return {
     deps: {
       mode,
@@ -57,10 +64,12 @@ function makeDeps(mode: "off" | "backstop" = "backstop"): {
       makeInformer: () => informer as unknown as Informer<V1Pod>,
       repo: repo as never,
       reconciler: reconciler as never,
+      reportLoader: reportLoader as never,
     },
     informer,
     repo,
     reconciler,
+    reportLoader,
   };
 }
 
@@ -213,5 +222,64 @@ describe("K8sJobWatcherService event handling", () => {
     informer.fire("update", podSucceeded());
     await new Promise((r) => setTimeout(r, 5));
     expect(repo.updateGuarded).not.toHaveBeenCalled();
+  });
+});
+
+describe("K8sJobWatcherService — primary mode", () => {
+  it("mode=primary starts informer + runs reconciler on init (no throw)", async () => {
+    const { deps, informer, reconciler } = makeDeps("primary");
+    const svc = new K8sJobWatcherService(deps);
+    await svc.onModuleInit();
+    expect(informer.start).toHaveBeenCalledOnce();
+    expect(reconciler.run).toHaveBeenCalledOnce();
+  });
+
+  it("Succeeded pod → reportLoader.tryLoad called with runId", async () => {
+    const { deps, informer, repo, reportLoader } = makeDeps("primary");
+    repo.findById.mockResolvedValue({ id: podRunId(), status: "running" });
+    const svc = new K8sJobWatcherService(deps);
+    await svc.onModuleInit();
+
+    informer.fire("update", podSucceeded());
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(reportLoader.tryLoad).toHaveBeenCalledOnce();
+    expect(reportLoader.tryLoad).toHaveBeenCalledWith(podRunId());
+    expect(repo.updateGuarded).not.toHaveBeenCalled();
+  });
+
+  it("Running ready pod + status=submitted → updateGuarded(['submitted'], { status: 'running' })", async () => {
+    const { deps, informer, repo } = makeDeps("primary");
+    repo.findById.mockResolvedValue({ id: podRunId(), status: "submitted" });
+    repo.updateGuarded.mockResolvedValue({ id: podRunId() });
+    const svc = new K8sJobWatcherService(deps);
+    await svc.onModuleInit();
+
+    informer.fire("update", podRunning());
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(repo.updateGuarded).toHaveBeenCalledWith(
+      podRunId(),
+      ["submitted"],
+      expect.objectContaining({ status: "running", startedAt: expect.any(Date) }),
+    );
+  });
+
+  it("Failed pod (primary) → updateGuarded(IN_PROGRESS_STATES, { status: 'failed' }) immediately (no grace)", async () => {
+    const { deps, informer, repo } = makeDeps("primary");
+    repo.findById.mockResolvedValue({ id: podRunId(), status: "running" });
+    repo.updateGuarded.mockResolvedValue({ id: podRunId() });
+    const svc = new K8sJobWatcherService(deps);
+    await svc.onModuleInit();
+
+    // No firstTerminalAt seed needed — primary mode ignores grace period for Failed
+    informer.fire("update", podFailed(1, "Error", "tool exit 1"));
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(repo.updateGuarded).toHaveBeenCalledWith(
+      podRunId(),
+      ["pending", "submitted", "running"],
+      expect.objectContaining({ status: "failed" }),
+    );
   });
 });

--- a/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts
+++ b/apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts
@@ -2,6 +2,7 @@ import type { Informer, V1Pod } from "@kubernetes/client-node";
 import { Injectable, Logger, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
 import type { BenchmarkRepository } from "../benchmark.repository.js";
 import { IN_PROGRESS_STATES } from "../constants.js";
+import type { ReportLoader } from "../storage/report-loader.js";
 import { type DesiredTransition, type ReducerConfig, reduce } from "./pod-state-reducer.js";
 import { getRunnerStatus } from "./runner-container.js";
 import type { StartupReconciler } from "./startup-reconciler.js";
@@ -17,6 +18,7 @@ export interface WatcherDeps {
   makeInformer: () => Informer<V1Pod>;
   repo: BenchmarkRepository;
   reconciler: StartupReconciler;
+  reportLoader: ReportLoader;
 }
 
 @Injectable()
@@ -34,9 +36,6 @@ export class K8sJobWatcherService implements OnModuleInit, OnModuleDestroy {
       this.log.log("K8S_WATCHER_MODE=off → skipping informer + reconciler");
       return;
     }
-    if (this.deps.mode === "primary") {
-      throw new Error("K8S_WATCHER_MODE=primary is reserved for Phase 2; not yet implemented");
-    }
     this.informer = this.deps.makeInformer();
     this.informer.on("add", (p) => this.handlePodEvent(p));
     this.informer.on("update", (p) => this.handlePodEvent(p));
@@ -53,7 +52,7 @@ export class K8sJobWatcherService implements OnModuleInit, OnModuleDestroy {
       // The informer auto-reconnects; we only log. Future: emit ops alert at threshold.
     });
     await this.informer.start();
-    this.log.log(`K8s watcher started (mode=backstop, ns=${this.deps.namespace})`);
+    this.log.log(`K8s watcher started (mode=${this.deps.mode}, ns=${this.deps.namespace})`);
     await this.deps.reconciler.run();
   }
 
@@ -115,6 +114,7 @@ export class K8sJobWatcherService implements OnModuleInit, OnModuleDestroy {
       firstTerminalAt: this.firstTerminalAt.get(runId) ?? null,
       now,
       config: this.deps.reducerConfig,
+      mode: this.deps.mode === "off" ? "backstop" : this.deps.mode,
     });
 
     await this.execute(runId, transition, now);
@@ -128,22 +128,49 @@ export class K8sJobWatcherService implements OnModuleInit, OnModuleDestroy {
   }
 
   private async execute(runId: string, t: DesiredTransition, now: Date): Promise<void> {
-    if (t.kind === "noop") return;
-    try {
-      const updated = await this.deps.repo.updateGuarded(runId, IN_PROGRESS_STATES, {
-        status: "failed",
-        statusMessage: t.message,
-        completedAt: now,
-      });
-      if (!updated) {
-        this.log.log(
-          `guard rejected update for ${runId} (status already terminal); watcher backed off`,
-        );
+    switch (t.kind) {
+      case "noop":
+        return;
+
+      case "running": {
+        try {
+          const updated = await this.deps.repo.updateGuarded(runId, ["submitted"], {
+            status: "running",
+            startedAt: t.startedAt,
+          });
+          if (updated) this.log.log(`watcher marked ${runId} running`);
+        } catch (e) {
+          this.log.warn(`updateGuarded(${runId}) running failed: ${(e as Error).message}`);
+        }
         return;
       }
-      this.log.log(`watcher marked ${runId} failed: ${t.kind}`);
-    } catch (e) {
-      this.log.warn(`updateGuarded(${runId}) failed: ${(e as Error).message}`);
+
+      case "load-report": {
+        // Fire-and-forget — ReportLoader handles its own errors and writes.
+        void this.deps.reportLoader.tryLoad(runId);
+        return;
+      }
+
+      case "failed-pre-start":
+      case "failed-terminal": {
+        try {
+          const updated = await this.deps.repo.updateGuarded(runId, IN_PROGRESS_STATES, {
+            status: "failed",
+            statusMessage: t.message,
+            completedAt: now,
+          });
+          if (!updated) {
+            this.log.log(
+              `guard rejected update for ${runId} (status already terminal); watcher backed off`,
+            );
+            return;
+          }
+          this.log.log(`watcher marked ${runId} failed: ${t.kind}`);
+        } catch (e) {
+          this.log.warn(`updateGuarded(${runId}) failed: ${(e as Error).message}`);
+        }
+        return;
+      }
     }
   }
 }

--- a/apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts
@@ -1,3 +1,4 @@
+import type { V1Pod } from "@kubernetes/client-node";
 import { describe, expect, it } from "vitest";
 import {
   podFailed,
@@ -26,6 +27,7 @@ describe("PodStateReducer", () => {
         firstTerminalAt: null,
         now: NOW,
         config: CONFIG,
+        mode: "backstop",
       });
       expect(r.kind).toBe("noop");
     });
@@ -38,6 +40,7 @@ describe("PodStateReducer", () => {
         firstTerminalAt: null,
         now: NOW,
         config: CONFIG,
+        mode: "backstop",
       });
       expect(r.kind).toBe("noop");
     });
@@ -50,6 +53,7 @@ describe("PodStateReducer", () => {
         firstTerminalAt: null,
         now: NOW,
         config: CONFIG,
+        mode: "backstop",
       });
       expect(r.kind).toBe("noop");
     });
@@ -62,6 +66,7 @@ describe("PodStateReducer", () => {
         firstTerminalAt: null,
         now: NOW,
         config: CONFIG,
+        mode: "backstop",
       });
       expect(r.kind).toBe("noop");
     });
@@ -78,6 +83,7 @@ describe("PodStateReducer", () => {
           firstTerminalAt: null,
           now: NOW,
           config: CONFIG,
+          mode: "backstop",
         });
         expect(r.kind).toBe("failed-pre-start");
         if (r.kind === "failed-pre-start") {
@@ -96,6 +102,7 @@ describe("PodStateReducer", () => {
         firstTerminalAt: null,
         now: NOW,
         config: CONFIG,
+        mode: "backstop",
       });
       expect(r.kind).toBe("noop");
     });
@@ -108,6 +115,7 @@ describe("PodStateReducer", () => {
         firstTerminalAt: null,
         now: NOW,
         config: CONFIG,
+        mode: "backstop",
       });
       expect(r.kind).toBe("noop");
     });
@@ -123,6 +131,7 @@ describe("PodStateReducer", () => {
         firstTerminalAt: firstTerm,
         now: NOW,
         config: CONFIG,
+        mode: "backstop",
       });
       expect(r.kind).toBe("failed-terminal");
       if (r.kind === "failed-terminal") {
@@ -141,6 +150,7 @@ describe("PodStateReducer", () => {
         firstTerminalAt: firstTerm,
         now: NOW,
         config: CONFIG,
+        mode: "backstop",
       });
       expect(r.kind).toBe("failed-terminal");
       if (r.kind === "failed-terminal") {
@@ -158,6 +168,7 @@ describe("PodStateReducer", () => {
         firstTerminalAt: firstTerm,
         now: NOW,
         config: CONFIG,
+        mode: "backstop",
       });
       expect(r.kind).toBe("noop");
     });
@@ -171,6 +182,7 @@ describe("PodStateReducer", () => {
         firstTerminalAt: firstTerm,
         now: NOW,
         config: CONFIG,
+        mode: "backstop",
       });
       expect(r.kind).toBe("noop");
     });
@@ -187,6 +199,7 @@ describe("PodStateReducer", () => {
         firstTerminalAt: firstTerm,
         now: NOW,
         config: CONFIG,
+        mode: "backstop",
       });
       expect(r.kind).toBe("failed-terminal");
       if (r.kind === "failed-terminal") {
@@ -195,5 +208,100 @@ describe("PodStateReducer", () => {
         expect(r.message.startsWith("Error: ")).toBe(true);
       }
     });
+  });
+});
+
+describe("PodStateReducer — primary mode", () => {
+  const baseConfig: ReducerConfig = {
+    fatalWaitingReasons: ["ImagePullBackOff", "CrashLoopBackOff"],
+    waitingFatalGraceSec: 60,
+    terminalReconcileGraceSec: 60,
+  };
+  const now = new Date("2026-05-25T01:00:00Z");
+
+  function makePod(status: Partial<NonNullable<V1Pod["status"]>>): V1Pod {
+    return {
+      metadata: { labels: { "modeldoctor.ai/run-id": "r1" } },
+      status: { phase: "Pending", ...status },
+    } as V1Pod;
+  }
+
+  it("Succeeded + IN_PROGRESS → load-report", () => {
+    const out = reduce({
+      pod: makePod({ phase: "Succeeded" }), currentStatus: "running",
+      firstFatalWaitingAt: null, firstTerminalAt: null, now, config: baseConfig, mode: "primary",
+    });
+    expect(out).toEqual({ kind: "load-report" });
+  });
+
+  it("Failed + IN_PROGRESS → failed-terminal (no grace)", () => {
+    const out = reduce({
+      pod: makePod({ phase: "Failed", containerStatuses: [{
+        name: "runner", ready: false, image: "x", imageID: "x", restartCount: 0,
+        state: { terminated: { exitCode: 1, reason: "Error", message: "boom" } },
+      }] }),
+      currentStatus: "running", firstFatalWaitingAt: null, firstTerminalAt: null,
+      now, config: baseConfig, mode: "primary",
+    });
+    expect(out).toMatchObject({ kind: "failed-terminal", exitCode: 1, reason: "Error" });
+  });
+
+  it("Running + container ready + status=submitted → running", () => {
+    const startedAt = "2026-05-25T00:50:00Z";
+    const out = reduce({
+      pod: makePod({ phase: "Running", containerStatuses: [{
+        name: "runner", ready: true, image: "x", imageID: "x", restartCount: 0,
+        state: { running: { startedAt: new Date(startedAt) } },
+      }] }),
+      currentStatus: "submitted", firstFatalWaitingAt: null, firstTerminalAt: null,
+      now, config: baseConfig, mode: "primary",
+    });
+    expect(out).toEqual({ kind: "running", startedAt: new Date(startedAt) });
+  });
+
+  it("Running + container NOT ready → noop", () => {
+    const out = reduce({
+      pod: makePod({ phase: "Running", containerStatuses: [{
+        name: "runner", ready: false, image: "x", imageID: "x", restartCount: 0,
+        state: { running: { startedAt: new Date(now) } },
+      }] }),
+      currentStatus: "submitted", firstFatalWaitingAt: null, firstTerminalAt: null,
+      now, config: baseConfig, mode: "primary",
+    });
+    expect(out).toEqual({ kind: "noop" });
+  });
+
+  it("Pending + ImagePullBackOff + grace not elapsed → noop", () => {
+    const out = reduce({
+      pod: makePod({ phase: "Pending", containerStatuses: [{
+        name: "runner", ready: false, image: "x", imageID: "x", restartCount: 0,
+        state: { waiting: { reason: "ImagePullBackOff", message: "no such image" } },
+      }] }),
+      currentStatus: "submitted",
+      firstFatalWaitingAt: new Date(now.getTime() - 30_000), firstTerminalAt: null,
+      now, config: baseConfig, mode: "primary",
+    });
+    expect(out).toEqual({ kind: "noop" });
+  });
+
+  it("Pending + ImagePullBackOff + grace elapsed → failed-pre-start", () => {
+    const out = reduce({
+      pod: makePod({ phase: "Pending", containerStatuses: [{
+        name: "runner", ready: false, image: "x", imageID: "x", restartCount: 0,
+        state: { waiting: { reason: "ImagePullBackOff", message: "no such image" } },
+      }] }),
+      currentStatus: "submitted",
+      firstFatalWaitingAt: new Date(now.getTime() - 70_000), firstTerminalAt: null,
+      now, config: baseConfig, mode: "primary",
+    });
+    expect(out).toMatchObject({ kind: "failed-pre-start", reason: "ImagePullBackOff" });
+  });
+
+  it("any phase + terminal benchmark status → noop", () => {
+    const out = reduce({
+      pod: makePod({ phase: "Succeeded" }), currentStatus: "completed",
+      firstFatalWaitingAt: null, firstTerminalAt: null, now, config: baseConfig, mode: "primary",
+    });
+    expect(out).toEqual({ kind: "noop" });
   });
 });

--- a/apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts
@@ -228,20 +228,38 @@ describe("PodStateReducer — primary mode", () => {
 
   it("Succeeded + IN_PROGRESS → load-report", () => {
     const out = reduce({
-      pod: makePod({ phase: "Succeeded" }), currentStatus: "running",
-      firstFatalWaitingAt: null, firstTerminalAt: null, now, config: baseConfig, mode: "primary",
+      pod: makePod({ phase: "Succeeded" }),
+      currentStatus: "running",
+      firstFatalWaitingAt: null,
+      firstTerminalAt: null,
+      now,
+      config: baseConfig,
+      mode: "primary",
     });
     expect(out).toEqual({ kind: "load-report" });
   });
 
   it("Failed + IN_PROGRESS → failed-terminal (no grace)", () => {
     const out = reduce({
-      pod: makePod({ phase: "Failed", containerStatuses: [{
-        name: "runner", ready: false, image: "x", imageID: "x", restartCount: 0,
-        state: { terminated: { exitCode: 1, reason: "Error", message: "boom" } },
-      }] }),
-      currentStatus: "running", firstFatalWaitingAt: null, firstTerminalAt: null,
-      now, config: baseConfig, mode: "primary",
+      pod: makePod({
+        phase: "Failed",
+        containerStatuses: [
+          {
+            name: "runner",
+            ready: false,
+            image: "x",
+            imageID: "x",
+            restartCount: 0,
+            state: { terminated: { exitCode: 1, reason: "Error", message: "boom" } },
+          },
+        ],
+      }),
+      currentStatus: "running",
+      firstFatalWaitingAt: null,
+      firstTerminalAt: null,
+      now,
+      config: baseConfig,
+      mode: "primary",
     });
     expect(out).toMatchObject({ kind: "failed-terminal", exitCode: 1, reason: "Error" });
   });
@@ -249,58 +267,113 @@ describe("PodStateReducer — primary mode", () => {
   it("Running + container ready + status=submitted → running", () => {
     const startedAt = "2026-05-25T00:50:00Z";
     const out = reduce({
-      pod: makePod({ phase: "Running", containerStatuses: [{
-        name: "runner", ready: true, image: "x", imageID: "x", restartCount: 0,
-        state: { running: { startedAt: new Date(startedAt) } },
-      }] }),
-      currentStatus: "submitted", firstFatalWaitingAt: null, firstTerminalAt: null,
-      now, config: baseConfig, mode: "primary",
+      pod: makePod({
+        phase: "Running",
+        containerStatuses: [
+          {
+            name: "runner",
+            ready: true,
+            image: "x",
+            imageID: "x",
+            restartCount: 0,
+            state: { running: { startedAt: new Date(startedAt) } },
+          },
+        ],
+      }),
+      currentStatus: "submitted",
+      firstFatalWaitingAt: null,
+      firstTerminalAt: null,
+      now,
+      config: baseConfig,
+      mode: "primary",
     });
     expect(out).toEqual({ kind: "running", startedAt: new Date(startedAt) });
   });
 
   it("Running + container NOT ready → noop", () => {
     const out = reduce({
-      pod: makePod({ phase: "Running", containerStatuses: [{
-        name: "runner", ready: false, image: "x", imageID: "x", restartCount: 0,
-        state: { running: { startedAt: new Date(now) } },
-      }] }),
-      currentStatus: "submitted", firstFatalWaitingAt: null, firstTerminalAt: null,
-      now, config: baseConfig, mode: "primary",
+      pod: makePod({
+        phase: "Running",
+        containerStatuses: [
+          {
+            name: "runner",
+            ready: false,
+            image: "x",
+            imageID: "x",
+            restartCount: 0,
+            state: { running: { startedAt: new Date(now) } },
+          },
+        ],
+      }),
+      currentStatus: "submitted",
+      firstFatalWaitingAt: null,
+      firstTerminalAt: null,
+      now,
+      config: baseConfig,
+      mode: "primary",
     });
     expect(out).toEqual({ kind: "noop" });
   });
 
   it("Pending + ImagePullBackOff + grace not elapsed → noop", () => {
     const out = reduce({
-      pod: makePod({ phase: "Pending", containerStatuses: [{
-        name: "runner", ready: false, image: "x", imageID: "x", restartCount: 0,
-        state: { waiting: { reason: "ImagePullBackOff", message: "no such image" } },
-      }] }),
+      pod: makePod({
+        phase: "Pending",
+        containerStatuses: [
+          {
+            name: "runner",
+            ready: false,
+            image: "x",
+            imageID: "x",
+            restartCount: 0,
+            state: { waiting: { reason: "ImagePullBackOff", message: "no such image" } },
+          },
+        ],
+      }),
       currentStatus: "submitted",
-      firstFatalWaitingAt: new Date(now.getTime() - 30_000), firstTerminalAt: null,
-      now, config: baseConfig, mode: "primary",
+      firstFatalWaitingAt: new Date(now.getTime() - 30_000),
+      firstTerminalAt: null,
+      now,
+      config: baseConfig,
+      mode: "primary",
     });
     expect(out).toEqual({ kind: "noop" });
   });
 
   it("Pending + ImagePullBackOff + grace elapsed → failed-pre-start", () => {
     const out = reduce({
-      pod: makePod({ phase: "Pending", containerStatuses: [{
-        name: "runner", ready: false, image: "x", imageID: "x", restartCount: 0,
-        state: { waiting: { reason: "ImagePullBackOff", message: "no such image" } },
-      }] }),
+      pod: makePod({
+        phase: "Pending",
+        containerStatuses: [
+          {
+            name: "runner",
+            ready: false,
+            image: "x",
+            imageID: "x",
+            restartCount: 0,
+            state: { waiting: { reason: "ImagePullBackOff", message: "no such image" } },
+          },
+        ],
+      }),
       currentStatus: "submitted",
-      firstFatalWaitingAt: new Date(now.getTime() - 70_000), firstTerminalAt: null,
-      now, config: baseConfig, mode: "primary",
+      firstFatalWaitingAt: new Date(now.getTime() - 70_000),
+      firstTerminalAt: null,
+      now,
+      config: baseConfig,
+      mode: "primary",
     });
     expect(out).toMatchObject({ kind: "failed-pre-start", reason: "ImagePullBackOff" });
   });
 
   it("any phase + terminal benchmark status → noop", () => {
     const out = reduce({
-      pod: makePod({ phase: "Succeeded" }), currentStatus: "completed",
-      firstFatalWaitingAt: null, firstTerminalAt: null, now, config: baseConfig, mode: "primary",
+      pod: makePod({ phase: "Succeeded" }),
+      currentStatus: "completed",
+      firstFatalWaitingAt: null,
+      firstTerminalAt: null,
+      now,
+      config: baseConfig,
+      mode: "primary",
     });
     expect(out).toEqual({ kind: "noop" });
   });

--- a/apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts
+++ b/apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts
@@ -25,6 +25,8 @@ export interface ReducerConfig {
 }
 
 export type DesiredTransition =
+  | { kind: "running"; startedAt: Date }
+  | { kind: "load-report" }
   | { kind: "failed-pre-start"; reason: string; message: string }
   | { kind: "failed-terminal"; exitCode: number; reason: string; message: string }
   | { kind: "noop" };
@@ -40,6 +42,7 @@ export interface ReducerInput {
   firstTerminalAt: Date | null;
   now: Date;
   config: ReducerConfig;
+  mode: "backstop" | "primary";
 }
 
 /** 2 KiB cap: statusMessage is TEXT in Postgres but watcher-sourced messages
@@ -73,6 +76,11 @@ export function reduce(input: ReducerInput): DesiredTransition {
 
   // Hard guard: never touch benchmarks that are already in a terminal state.
   if (!isInProgressStatus(currentStatus)) return { kind: "noop" };
+
+  if (input.mode === "primary") {
+    return reducePrimary(input);
+  }
+  // fall through to existing backstop body
 
   const phase = pod.status?.phase;
 
@@ -120,5 +128,51 @@ export function reduce(input: ReducerInput): DesiredTransition {
   }
 
   // 3. Running / Pending / Unknown — backstop does nothing.
+  return { kind: "noop" };
+}
+
+function reducePrimary(input: ReducerInput): DesiredTransition {
+  const { pod, currentStatus, firstFatalWaitingAt, now, config } = input;
+  const phase = pod.status?.phase;
+
+  // 1. Succeeded → trigger ReportLoader
+  if (phase === "Succeeded") return { kind: "load-report" };
+
+  // 2. Failed → write failed directly (no grace)
+  if (phase === "Failed") {
+    const term = getTerminated(pod);
+    return {
+      kind: "failed-terminal",
+      exitCode: term?.exitCode ?? -1,
+      reason: term?.reason ?? "PodFailed",
+      message: truncate(term ? `${term.reason}: ${term.message}` : "pod in Failed phase"),
+    };
+  }
+
+  // 3. FATAL waiting + grace elapsed
+  const waiting = getWaitingReason(pod);
+  if (waiting && config.fatalWaitingReasons.includes(waiting.reason)) {
+    if (firstFatalWaitingAt) {
+      const elapsedSec = (now.getTime() - firstFatalWaitingAt.getTime()) / 1000;
+      if (elapsedSec >= config.waitingFatalGraceSec) {
+        return {
+          kind: "failed-pre-start",
+          reason: waiting.reason,
+          message: truncate(`${waiting.reason}: ${waiting.message}`),
+        };
+      }
+    }
+    return { kind: "noop" };
+  }
+
+  // 4. Running + container ready + currentStatus=submitted → mark running
+  if (phase === "Running" && currentStatus === "submitted") {
+    const runner = getRunnerStatus(pod);
+    if (runner?.ready) {
+      const startedAt = runner.state?.running?.startedAt ?? now;
+      return { kind: "running", startedAt: new Date(startedAt) };
+    }
+  }
+
   return { kind: "noop" };
 }

--- a/apps/api/src/modules/benchmark/k8s/startup-reconciler.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/startup-reconciler.spec.ts
@@ -14,14 +14,21 @@ function podWithRunId(runId: string): V1Pod {
   };
 }
 
-function makeDeps(opts: {
-  podsInCache?: V1Pod[];
-  storageExists?: boolean | ((key: string) => Promise<boolean>);
-} = {}): {
+function makeDeps(
+  opts: {
+    podsInCache?: V1Pod[];
+    storageExists?: boolean | ((key: string) => Promise<boolean>);
+  } = {},
+): {
   deps: ReconcilerDeps;
   repo: { listByStatus: ReturnType<typeof vi.fn>; updateGuarded: ReturnType<typeof vi.fn> };
   cache: { list: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn> };
-  storage: { exists: ReturnType<typeof vi.fn>; readJson: ReturnType<typeof vi.fn>; readText: ReturnType<typeof vi.fn>; readBytes: ReturnType<typeof vi.fn> };
+  storage: {
+    exists: ReturnType<typeof vi.fn>;
+    readJson: ReturnType<typeof vi.fn>;
+    readText: ReturnType<typeof vi.fn>;
+    readBytes: ReturnType<typeof vi.fn>;
+  };
   reportLoader: { tryLoad: ReturnType<typeof vi.fn> };
 } {
   const repo = {
@@ -121,7 +128,9 @@ describe("StartupReconciler", () => {
 
   it("storage.exists throws → logs + falls back to pod check", async () => {
     const { deps, repo, cache, storage, reportLoader } = makeDeps({
-      storageExists: async () => { throw new Error("s3 down"); },
+      storageExists: async () => {
+        throw new Error("s3 down");
+      },
     });
     repo.listByStatus.mockResolvedValueOnce([{ id: "r1", status: "running" }]);
 

--- a/apps/api/src/modules/benchmark/k8s/startup-reconciler.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/startup-reconciler.spec.ts
@@ -14,30 +14,47 @@ function podWithRunId(runId: string): V1Pod {
   };
 }
 
-function makeDeps(podsInCache: V1Pod[] = []): {
+function makeDeps(opts: {
+  podsInCache?: V1Pod[];
+  storageExists?: boolean | ((key: string) => Promise<boolean>);
+} = {}): {
   deps: ReconcilerDeps;
-  repo: {
-    listByStatus: ReturnType<typeof vi.fn>;
-    updateGuarded: ReturnType<typeof vi.fn>;
-  };
+  repo: { listByStatus: ReturnType<typeof vi.fn>; updateGuarded: ReturnType<typeof vi.fn> };
   cache: { list: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn> };
+  storage: { exists: ReturnType<typeof vi.fn>; readJson: ReturnType<typeof vi.fn>; readText: ReturnType<typeof vi.fn>; readBytes: ReturnType<typeof vi.fn> };
+  reportLoader: { tryLoad: ReturnType<typeof vi.fn> };
 } {
   const repo = {
     listByStatus: vi.fn(async () => []),
     updateGuarded: vi.fn(async () => ({ id: "x" })),
   };
   const cache = {
-    list: vi.fn(() => podsInCache),
+    list: vi.fn(() => opts.podsInCache ?? []),
     get: vi.fn(() => undefined),
   };
+  const storage = {
+    exists: vi.fn(async (k: string) =>
+      typeof opts.storageExists === "function"
+        ? opts.storageExists(k)
+        : (opts.storageExists ?? false),
+    ),
+    readJson: vi.fn(),
+    readText: vi.fn(),
+    readBytes: vi.fn(),
+  };
+  const reportLoader = { tryLoad: vi.fn(async () => {}) };
   return {
     deps: {
       namespace: "modeldoctor-benchmarks",
       repo: repo as never,
       podCache: cache as never,
+      storage: storage as never,
+      reportLoader: reportLoader as never,
     },
     repo,
     cache,
+    storage,
+    reportLoader,
   };
 }
 
@@ -51,7 +68,7 @@ describe("StartupReconciler", () => {
   });
 
   it("leaves benchmark alone when a pod with matching run-id label exists", async () => {
-    const { deps, repo, cache } = makeDeps([podWithRunId("abc")]);
+    const { deps, repo, cache } = makeDeps({ podsInCache: [podWithRunId("abc")] });
     repo.listByStatus.mockResolvedValue([{ id: "abc", status: "running" }]);
     await new StartupReconciler(deps).run();
     expect(cache.list).toHaveBeenCalledWith("modeldoctor-benchmarks");
@@ -60,7 +77,7 @@ describe("StartupReconciler", () => {
 
   it("marks failed when no pod with matching run-id label is in the cache", async () => {
     // Cache contains a pod, but with a DIFFERENT run-id — should NOT save us.
-    const { deps, repo } = makeDeps([podWithRunId("someone-else")]);
+    const { deps, repo } = makeDeps({ podsInCache: [podWithRunId("someone-else")] });
     repo.listByStatus.mockResolvedValue([{ id: "abc", status: "running" }]);
     await new StartupReconciler(deps).run();
     expect(repo.updateGuarded).toHaveBeenCalledWith(
@@ -75,7 +92,7 @@ describe("StartupReconciler", () => {
 
   it("processes multiple benchmarks independently using label-based lookup", async () => {
     // Cache contains only pod for "b". "a" and "c" are orphans.
-    const { deps, repo } = makeDeps([podWithRunId("b")]);
+    const { deps, repo } = makeDeps({ podsInCache: [podWithRunId("b")] });
     repo.listByStatus.mockResolvedValue([
       { id: "a", status: "running" },
       { id: "b", status: "submitted" },
@@ -85,5 +102,39 @@ describe("StartupReconciler", () => {
     expect(repo.updateGuarded).toHaveBeenCalledTimes(2);
     expect(repo.updateGuarded).toHaveBeenCalledWith("a", expect.any(Array), expect.any(Object));
     expect(repo.updateGuarded).toHaveBeenCalledWith("c", expect.any(Array), expect.any(Object));
+  });
+
+  it("storage has result.json → calls reportLoader.tryLoad and skips pod check", async () => {
+    const { deps, repo, cache, storage, reportLoader } = makeDeps({
+      storageExists: true,
+    });
+    repo.listByStatus.mockResolvedValueOnce([{ id: "r1", status: "running" }]);
+
+    await new StartupReconciler(deps).run();
+
+    expect(storage.exists).toHaveBeenCalledWith("r1/result.json");
+    expect(reportLoader.tryLoad).toHaveBeenCalledWith("r1");
+    // Should NOT fall through to pod-cache check or updateGuarded
+    expect(cache.list).not.toHaveBeenCalled();
+    expect(repo.updateGuarded).not.toHaveBeenCalled();
+  });
+
+  it("storage.exists throws → logs + falls back to pod check", async () => {
+    const { deps, repo, cache, storage, reportLoader } = makeDeps({
+      storageExists: async () => { throw new Error("s3 down"); },
+    });
+    repo.listByStatus.mockResolvedValueOnce([{ id: "r1", status: "running" }]);
+
+    await new StartupReconciler(deps).run();
+
+    expect(storage.exists).toHaveBeenCalledOnce();
+    expect(reportLoader.tryLoad).not.toHaveBeenCalled();
+    // Falls back: pod-cache check fires; runId not in cache → updateGuarded(failed)
+    expect(cache.list).toHaveBeenCalled();
+    expect(repo.updateGuarded).toHaveBeenCalledWith(
+      "r1",
+      expect.anything(),
+      expect.objectContaining({ status: "failed" }),
+    );
   });
 });

--- a/apps/api/src/modules/benchmark/k8s/startup-reconciler.ts
+++ b/apps/api/src/modules/benchmark/k8s/startup-reconciler.ts
@@ -1,7 +1,10 @@
 import type { ObjectCache, V1Pod } from "@kubernetes/client-node";
 import { Injectable, Logger } from "@nestjs/common";
+import { reportStorageKeys } from "@modeldoctor/contracts";
 import type { BenchmarkRepository } from "../benchmark.repository.js";
 import { IN_PROGRESS_STATES } from "../constants.js";
+import type { ReportLoader } from "../storage/report-loader.js";
+import type { ReportStorage } from "../storage/report-storage.js";
 
 const RUN_ID_LABEL = "modeldoctor.ai/run-id";
 const MAX_RECONCILE_ROWS = 500;
@@ -10,6 +13,8 @@ export interface ReconcilerDeps {
   namespace: string;
   repo: BenchmarkRepository;
   podCache: ObjectCache<V1Pod>;
+  storage: ReportStorage;
+  reportLoader: ReportLoader;
 }
 
 @Injectable()
@@ -33,23 +38,45 @@ export class StartupReconciler {
     }
     this.log.log(`reconcile: ${inProgress.length} IN_PROGRESS benchmark(s) to check`);
 
-    // Build a Set of runIds whose pod is present in the informer cache. We
-    // can't use ObjectCache.get(name, ns) because K8s appends a random suffix
+    // Build the live-pod set lazily — only on the first benchmark that reaches
+    // the pod-cache fallback. If every benchmark has result.json in storage,
+    // the informer cache is never queried at all.
+    // We can't use ObjectCache.get(name, ns) because K8s appends a random suffix
     // to Job-spawned pods (run-<id>-<5-char-suffix>), so exact-name lookup
     // misses every actual pod. Filter by label instead.
-    const livePodRunIds = new Set<string>();
-    for (const pod of this.deps.podCache.list(this.deps.namespace)) {
-      const runId = pod.metadata?.labels?.[RUN_ID_LABEL];
-      if (runId) livePodRunIds.add(runId);
-    }
+    let livePodRunIds: Set<string> | null = null;
+    const getLivePodRunIds = (): Set<string> => {
+      if (livePodRunIds === null) {
+        livePodRunIds = new Set<string>();
+        for (const pod of this.deps.podCache.list(this.deps.namespace)) {
+          const runId = pod.metadata?.labels?.[RUN_ID_LABEL];
+          if (runId) livePodRunIds.add(runId);
+        }
+      }
+      return livePodRunIds;
+    };
 
     for (const b of inProgress) {
-      if (livePodRunIds.has(b.id)) {
+      // 1. Storage is ground truth — if runner finished writing result.json
+      //    before pod TTL'd away (long downtime), reload from storage.
+      const resultKey = reportStorageKeys(b.id).result;
+      try {
+        if (await this.deps.storage.exists(resultKey)) {
+          this.log.log(`reconcile: ${b.id} has result.json → loading report`);
+          await this.deps.reportLoader.tryLoad(b.id);
+          continue;
+        }
+      } catch (e) {
+        this.log.warn(
+          `reconcile: storage.exists(${b.id}) failed: ${(e as Error).message}; falling back to pod check`,
+        );
+      }
+
+      // 2. Storage was empty (or storage.exists threw); fall back to pod-presence check.
+      if (getLivePodRunIds().has(b.id)) {
         // Informer will deliver events for this pod; nothing to do here.
         continue;
       }
-      // Phase 1 scope: no storage yet, so any orphan IN_PROGRESS → failed.
-      // Phase 2 will check storage first (report file may exist even if pod is gone).
       const updated = await this.deps.repo.updateGuarded(b.id, IN_PROGRESS_STATES, {
         status: "failed",
         statusMessage: "pod gone before reconcile",

--- a/apps/api/src/modules/benchmark/k8s/startup-reconciler.ts
+++ b/apps/api/src/modules/benchmark/k8s/startup-reconciler.ts
@@ -1,6 +1,6 @@
 import type { ObjectCache, V1Pod } from "@kubernetes/client-node";
-import { Injectable, Logger } from "@nestjs/common";
 import { reportStorageKeys } from "@modeldoctor/contracts";
+import { Injectable, Logger } from "@nestjs/common";
 import type { BenchmarkRepository } from "../benchmark.repository.js";
 import { IN_PROGRESS_STATES } from "../constants.js";
 import type { ReportLoader } from "../storage/report-loader.js";

--- a/apps/api/src/modules/benchmark/storage/report-loader.spec.ts
+++ b/apps/api/src/modules/benchmark/storage/report-loader.spec.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ReportLoader, type ReportLoaderDeps } from "./report-loader.js";
+import type { ReportStorage } from "./report-storage.js";
+
+const fixtureMeta = { toolVersion: "guidellm 0.2.1", startTimeIso: "2026-05-25T00:00:00.000Z" };
+const fixtureResult = { exitCode: 0, finishTimeIso: "2026-05-25T01:00:00.000Z", files: { "report.json": "files/report.json" } };
+
+function makeDeps() {
+  const storage: ReportStorage = {
+    exists: vi.fn(async () => true),
+    readJson: vi.fn(async (k: string) => {
+      if (k.endsWith("meta.json")) return fixtureMeta;
+      if (k.endsWith("result.json")) return fixtureResult;
+      throw new Error(`unexpected key ${k}`);
+    }),
+    readText: vi.fn(async () => "stdout content"),
+    readBytes: vi.fn(async () => Buffer.from("file content")),
+  };
+  const repo = {
+    findById: vi.fn(async (id: string) => ({
+      id, status: "running", tool: "guidellm", userId: "u1",
+      name: "n", scenario: "inference", connectionId: null,
+    })),
+    updateGuarded: vi.fn(async () => ({ id: "r1" })),
+  };
+  const notify = { emit: vi.fn(async () => {}) };
+  const sse = { close: vi.fn() };
+  const adapter = { parseFinalReport: vi.fn(() => ({ tool: "guidellm" as const, data: { latency: 42 } })) };
+  const byTool = vi.fn(() => adapter);
+  return { storage, repo, notify, sse, byTool, adapter };
+}
+
+function newLoader(d: ReturnType<typeof makeDeps>): ReportLoader {
+  return new ReportLoader({
+    storage: d.storage,
+    repo: d.repo as never,
+    notify: d.notify as never,
+    sse: d.sse as never,
+    byTool: d.byTool as never,
+  } as ReportLoaderDeps);
+}
+
+describe("ReportLoader", () => {
+  let deps: ReturnType<typeof makeDeps>;
+  beforeEach(() => { deps = makeDeps(); });
+
+  it("success path → updateGuarded(completed) + notify benchmark.completed", async () => {
+    const loader = newLoader(deps);
+    await loader.tryLoad("r1");
+    expect(deps.repo.updateGuarded).toHaveBeenCalledWith(
+      "r1",
+      expect.arrayContaining(["submitted", "running"]),
+      expect.objectContaining({ status: "completed", toolVersion: "guidellm 0.2.1" }),
+    );
+    expect(deps.notify.emit).toHaveBeenCalledWith(expect.objectContaining({ eventType: "benchmark.completed" }));
+    expect(deps.sse.close).toHaveBeenCalledWith("r1");
+  });
+
+  it("storage timeout → updateGuarded(failed) + notify benchmark.failed", async () => {
+    (deps.storage.readJson as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("timeout"));
+    const loader = newLoader(deps);
+    await loader.tryLoad("r1");
+    expect(deps.repo.updateGuarded).toHaveBeenCalledWith(
+      "r1",
+      expect.anything(),
+      expect.objectContaining({ status: "failed", statusMessage: expect.stringContaining("report load") }),
+    );
+  });
+
+  it("file missing → updateGuarded(failed)", async () => {
+    (deps.storage.readJson as ReturnType<typeof vi.fn>).mockRejectedValueOnce(Object.assign(new Error("NotFound"), { name: "NotFound" }));
+    const loader = newLoader(deps);
+    await loader.tryLoad("r1");
+    expect(deps.repo.updateGuarded).toHaveBeenCalledWith(
+      "r1",
+      expect.anything(),
+      expect.objectContaining({ status: "failed" }),
+    );
+  });
+
+  it("parse failure → updateGuarded(failed)", async () => {
+    deps.adapter.parseFinalReport = vi.fn(() => { throw new Error("bad json"); });
+    const loader = newLoader(deps);
+    await loader.tryLoad("r1");
+    expect(deps.repo.updateGuarded).toHaveBeenCalledWith(
+      "r1",
+      expect.anything(),
+      expect.objectContaining({ status: "failed", statusMessage: expect.stringContaining("report load: bad json") }),
+    );
+  });
+
+  it("benchmark already terminal → noop (no storage reads)", async () => {
+    deps.repo.findById = vi.fn(async () => ({
+      id: "r1", status: "cancelled", tool: "guidellm", userId: "u1",
+      name: "n", scenario: "inference", connectionId: null,
+    }));
+    const loader = newLoader(deps);
+    await loader.tryLoad("r1");
+    expect(deps.storage.readJson).not.toHaveBeenCalled();
+    expect(deps.repo.updateGuarded).not.toHaveBeenCalled();
+  });
+
+  it("guard race: updateGuarded returns null → no notify", async () => {
+    deps.repo.updateGuarded = vi.fn(async () => null);
+    const loader = newLoader(deps);
+    await loader.tryLoad("r1");
+    expect(deps.notify.emit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/benchmark/storage/report-loader.spec.ts
+++ b/apps/api/src/modules/benchmark/storage/report-loader.spec.ts
@@ -136,4 +136,28 @@ describe("ReportLoader", () => {
     await loader.tryLoad("r1");
     expect(deps.notify.emit).not.toHaveBeenCalled();
   });
+
+  it("files total > 500MB → updateGuarded(failed) with 'exceed' statusMessage", async () => {
+    // Create a fake Buffer with .length=400MB without actually allocating that memory
+    const fake400MB = Buffer.alloc(0);
+    Object.defineProperty(fake400MB, "length", { value: 400 * 1024 * 1024 });
+    (deps.storage.readBytes as ReturnType<typeof vi.fn>).mockResolvedValue(fake400MB);
+    // Two files each 400MB → total 800MB → cap blown on second iteration
+    (deps.storage.readJson as ReturnType<typeof vi.fn>).mockImplementation(async (k: string) => {
+      if (k.endsWith("meta.json")) return fixtureMeta;
+      if (k.endsWith("result.json"))
+        return { ...fixtureResult, files: { a: "files/a.bin", b: "files/b.bin" } };
+      throw new Error(`unexpected key ${k}`);
+    });
+    const loader = newLoader(deps);
+    await loader.tryLoad("r1");
+    expect(deps.repo.updateGuarded).toHaveBeenCalledWith(
+      "r1",
+      expect.anything(),
+      expect.objectContaining({
+        status: "failed",
+        statusMessage: expect.stringContaining("exceed"),
+      }),
+    );
+  });
 });

--- a/apps/api/src/modules/benchmark/storage/report-loader.spec.ts
+++ b/apps/api/src/modules/benchmark/storage/report-loader.spec.ts
@@ -3,7 +3,11 @@ import { ReportLoader, type ReportLoaderDeps } from "./report-loader.js";
 import type { ReportStorage } from "./report-storage.js";
 
 const fixtureMeta = { toolVersion: "guidellm 0.2.1", startTimeIso: "2026-05-25T00:00:00.000Z" };
-const fixtureResult = { exitCode: 0, finishTimeIso: "2026-05-25T01:00:00.000Z", files: { "report.json": "files/report.json" } };
+const fixtureResult = {
+  exitCode: 0,
+  finishTimeIso: "2026-05-25T01:00:00.000Z",
+  files: { "report.json": "files/report.json" },
+};
 
 function makeDeps() {
   const storage = {
@@ -18,14 +22,21 @@ function makeDeps() {
   } as unknown as ReportStorage;
   const repo = {
     findById: vi.fn(async (id: string) => ({
-      id, status: "running", tool: "guidellm", userId: "u1",
-      name: "n", scenario: "inference", connectionId: null,
+      id,
+      status: "running",
+      tool: "guidellm",
+      userId: "u1",
+      name: "n",
+      scenario: "inference",
+      connectionId: null,
     })),
     updateGuarded: vi.fn(async () => ({ id: "r1" })),
   };
   const notify = { emit: vi.fn(async () => {}) };
   const sse = { close: vi.fn() };
-  const adapter = { parseFinalReport: vi.fn(() => ({ tool: "guidellm" as const, data: { latency: 42 } })) };
+  const adapter = {
+    parseFinalReport: vi.fn(() => ({ tool: "guidellm" as const, data: { latency: 42 } })),
+  };
   const byTool = vi.fn(() => adapter);
   return { storage, repo, notify, sse, byTool, adapter };
 }
@@ -42,7 +53,9 @@ function newLoader(d: ReturnType<typeof makeDeps>): ReportLoader {
 
 describe("ReportLoader", () => {
   let deps: ReturnType<typeof makeDeps>;
-  beforeEach(() => { deps = makeDeps(); });
+  beforeEach(() => {
+    deps = makeDeps();
+  });
 
   it("success path → updateGuarded(completed) + notify benchmark.completed", async () => {
     const loader = newLoader(deps);
@@ -52,7 +65,9 @@ describe("ReportLoader", () => {
       expect.arrayContaining(["submitted", "running"]),
       expect.objectContaining({ status: "completed", toolVersion: "guidellm 0.2.1" }),
     );
-    expect(deps.notify.emit).toHaveBeenCalledWith(expect.objectContaining({ eventType: "benchmark.completed" }));
+    expect(deps.notify.emit).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: "benchmark.completed" }),
+    );
     expect(deps.sse.close).toHaveBeenCalledWith("r1");
   });
 
@@ -63,12 +78,17 @@ describe("ReportLoader", () => {
     expect(deps.repo.updateGuarded).toHaveBeenCalledWith(
       "r1",
       expect.anything(),
-      expect.objectContaining({ status: "failed", statusMessage: expect.stringContaining("report load") }),
+      expect.objectContaining({
+        status: "failed",
+        statusMessage: expect.stringContaining("report load"),
+      }),
     );
   });
 
   it("file missing → updateGuarded(failed)", async () => {
-    (deps.storage.readJson as ReturnType<typeof vi.fn>).mockRejectedValueOnce(Object.assign(new Error("NotFound"), { name: "NotFound" }));
+    (deps.storage.readJson as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      Object.assign(new Error("NotFound"), { name: "NotFound" }),
+    );
     const loader = newLoader(deps);
     await loader.tryLoad("r1");
     expect(deps.repo.updateGuarded).toHaveBeenCalledWith(
@@ -79,20 +99,30 @@ describe("ReportLoader", () => {
   });
 
   it("parse failure → updateGuarded(failed)", async () => {
-    deps.adapter.parseFinalReport = vi.fn(() => { throw new Error("bad json"); });
+    deps.adapter.parseFinalReport = vi.fn(() => {
+      throw new Error("bad json");
+    });
     const loader = newLoader(deps);
     await loader.tryLoad("r1");
     expect(deps.repo.updateGuarded).toHaveBeenCalledWith(
       "r1",
       expect.anything(),
-      expect.objectContaining({ status: "failed", statusMessage: expect.stringContaining("report load: bad json") }),
+      expect.objectContaining({
+        status: "failed",
+        statusMessage: expect.stringContaining("report load: bad json"),
+      }),
     );
   });
 
   it("benchmark already terminal → noop (no storage reads)", async () => {
     deps.repo.findById = vi.fn(async () => ({
-      id: "r1", status: "cancelled", tool: "guidellm", userId: "u1",
-      name: "n", scenario: "inference", connectionId: null,
+      id: "r1",
+      status: "cancelled",
+      tool: "guidellm",
+      userId: "u1",
+      name: "n",
+      scenario: "inference",
+      connectionId: null,
     }));
     const loader = newLoader(deps);
     await loader.tryLoad("r1");

--- a/apps/api/src/modules/benchmark/storage/report-loader.spec.ts
+++ b/apps/api/src/modules/benchmark/storage/report-loader.spec.ts
@@ -6,7 +6,7 @@ const fixtureMeta = { toolVersion: "guidellm 0.2.1", startTimeIso: "2026-05-25T0
 const fixtureResult = { exitCode: 0, finishTimeIso: "2026-05-25T01:00:00.000Z", files: { "report.json": "files/report.json" } };
 
 function makeDeps() {
-  const storage: ReportStorage = {
+  const storage = {
     exists: vi.fn(async () => true),
     readJson: vi.fn(async (k: string) => {
       if (k.endsWith("meta.json")) return fixtureMeta;
@@ -15,7 +15,7 @@ function makeDeps() {
     }),
     readText: vi.fn(async () => "stdout content"),
     readBytes: vi.fn(async () => Buffer.from("file content")),
-  };
+  } as unknown as ReportStorage;
   const repo = {
     findById: vi.fn(async (id: string) => ({
       id, status: "running", tool: "guidellm", userId: "u1",
@@ -101,7 +101,7 @@ describe("ReportLoader", () => {
   });
 
   it("guard race: updateGuarded returns null → no notify", async () => {
-    deps.repo.updateGuarded = vi.fn(async () => null);
+    deps.repo.updateGuarded = vi.fn(async () => null) as never;
     const loader = newLoader(deps);
     await loader.tryLoad("r1");
     expect(deps.notify.emit).not.toHaveBeenCalled();

--- a/apps/api/src/modules/benchmark/storage/report-loader.ts
+++ b/apps/api/src/modules/benchmark/storage/report-loader.ts
@@ -1,10 +1,10 @@
-import { Injectable, Logger } from "@nestjs/common";
-import { reportStorageKeys, type ReportMeta, type ReportResult } from "@modeldoctor/contracts";
+import { type ReportMeta, type ReportResult, reportStorageKeys } from "@modeldoctor/contracts";
 import { byTool as defaultByTool, type ToolName } from "@modeldoctor/tool-adapters";
+import { Injectable, Logger } from "@nestjs/common";
 import type { Prisma } from "@prisma/client";
+import type { NotifyService } from "../../notifications/notify.service.js";
 import type { BenchmarkRepository } from "../benchmark.repository.js";
 import { IN_PROGRESS_STATES } from "../constants.js";
-import type { NotifyService } from "../../notifications/notify.service.js";
 import type { SseHub } from "../sse/sse-hub.service.js";
 import type { ReportStorage } from "./report-storage.js";
 
@@ -30,7 +30,8 @@ export class ReportLoader {
 
   async tryLoad(runId: string): Promise<void> {
     const bench = await this.deps.repo.findById(runId);
-    if (!bench || !IN_PROGRESS_STATES.includes(bench.status as (typeof IN_PROGRESS_STATES)[number])) return;
+    if (!bench || !IN_PROGRESS_STATES.includes(bench.status as (typeof IN_PROGRESS_STATES)[number]))
+      return;
     const keys = reportStorageKeys(runId);
     try {
       const [meta, result, stdout, stderr] = await Promise.all([
@@ -100,7 +101,10 @@ export class ReportLoader {
     }
   }
 
-  private async loadFiles(runId: string, fileMap: Record<string, string>): Promise<Record<string, Buffer>> {
+  private async loadFiles(
+    runId: string,
+    fileMap: Record<string, string>,
+  ): Promise<Record<string, Buffer>> {
     const entries: Array<[string, Buffer]> = [];
     for (const [alias, relPath] of Object.entries(fileMap)) {
       const key = `${runId}/${relPath}`;

--- a/apps/api/src/modules/benchmark/storage/report-loader.ts
+++ b/apps/api/src/modules/benchmark/storage/report-loader.ts
@@ -1,0 +1,111 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { reportStorageKeys, type ReportMeta, type ReportResult } from "@modeldoctor/contracts";
+import { byTool as defaultByTool, type ToolName } from "@modeldoctor/tool-adapters";
+import type { Prisma } from "@prisma/client";
+import type { BenchmarkRepository } from "../benchmark.repository.js";
+import { IN_PROGRESS_STATES } from "../constants.js";
+import type { NotifyService } from "../../notifications/notify.service.js";
+import type { SseHub } from "../sse/sse-hub.service.js";
+import type { ReportStorage } from "./report-storage.js";
+
+const STATUS_MESSAGE_MAX = 2048;
+const RAW_OUTPUT_TAIL_MAX = 64 * 1024;
+
+export interface ReportLoaderDeps {
+  storage: ReportStorage;
+  repo: BenchmarkRepository;
+  notify: NotifyService;
+  sse: SseHub;
+  byTool?: typeof defaultByTool;
+}
+
+@Injectable()
+export class ReportLoader {
+  private readonly log = new Logger(ReportLoader.name);
+  private readonly byTool: typeof defaultByTool;
+
+  constructor(private readonly deps: ReportLoaderDeps) {
+    this.byTool = deps.byTool ?? defaultByTool;
+  }
+
+  async tryLoad(runId: string): Promise<void> {
+    const bench = await this.deps.repo.findById(runId);
+    if (!bench || !IN_PROGRESS_STATES.includes(bench.status as (typeof IN_PROGRESS_STATES)[number])) return;
+    const keys = reportStorageKeys(runId);
+    try {
+      const [meta, result, stdout, stderr] = await Promise.all([
+        this.deps.storage.readJson<ReportMeta>(keys.meta),
+        this.deps.storage.readJson<ReportResult>(keys.result),
+        this.deps.storage.readText(keys.stdout),
+        this.deps.storage.readText(keys.stderr),
+      ]);
+      const files = await this.loadFiles(runId, result.files);
+      const summary = this.byTool(bench.tool as ToolName).parseFinalReport(stdout, files);
+      const updated = await this.deps.repo.updateGuarded(runId, IN_PROGRESS_STATES, {
+        status: "completed",
+        toolVersion: meta.toolVersion,
+        statusMessage: null,
+        summaryMetrics: (summary ?? null) as Prisma.InputJsonValue,
+        rawOutput: {
+          stdout: stdout.slice(-RAW_OUTPUT_TAIL_MAX),
+          stderr: stderr.slice(-RAW_OUTPUT_TAIL_MAX),
+          files: result.files,
+        } as Prisma.InputJsonValue,
+        completedAt: new Date(result.finishTimeIso),
+      });
+      if (updated && bench.userId) {
+        await this.deps.notify.emit({
+          eventType: "benchmark.completed",
+          userId: bench.userId,
+          connectionId: bench.connectionId ?? undefined,
+          payload: {
+            benchmarkId: bench.id,
+            name: bench.name,
+            status: "completed",
+            scenario: bench.scenario,
+            tool: bench.tool,
+            connectionId: bench.connectionId,
+            summaryMetrics: summary,
+            message: null,
+          },
+        });
+      }
+    } catch (e) {
+      const msg = `report load: ${(e as Error).message}`.slice(0, STATUS_MESSAGE_MAX);
+      const updated = await this.deps.repo.updateGuarded(runId, IN_PROGRESS_STATES, {
+        status: "failed",
+        statusMessage: msg,
+        completedAt: new Date(),
+      });
+      if (updated && bench.userId) {
+        await this.deps.notify.emit({
+          eventType: "benchmark.failed",
+          userId: bench.userId,
+          connectionId: bench.connectionId ?? undefined,
+          payload: {
+            benchmarkId: bench.id,
+            name: bench.name,
+            status: "failed",
+            scenario: bench.scenario,
+            tool: bench.tool,
+            connectionId: bench.connectionId,
+            summaryMetrics: null,
+            message: msg,
+          },
+        });
+      }
+      this.log.warn(`tryLoad(${runId}) failed: ${(e as Error).message}`);
+    } finally {
+      this.deps.sse.close(runId);
+    }
+  }
+
+  private async loadFiles(runId: string, fileMap: Record<string, string>): Promise<Record<string, Buffer>> {
+    const entries: Array<[string, Buffer]> = [];
+    for (const [alias, relPath] of Object.entries(fileMap)) {
+      const key = `${runId}/${relPath}`;
+      entries.push([alias, await this.deps.storage.readBytes(key)]);
+    }
+    return Object.fromEntries(entries);
+  }
+}

--- a/apps/api/src/modules/benchmark/storage/report-loader.ts
+++ b/apps/api/src/modules/benchmark/storage/report-loader.ts
@@ -10,6 +10,7 @@ import type { ReportStorage } from "./report-storage.js";
 
 const STATUS_MESSAGE_MAX = 2048;
 const RAW_OUTPUT_TAIL_MAX = 64 * 1024;
+const REPORT_FILES_TOTAL_MAX_BYTES = 500 * 1024 * 1024;
 
 export interface ReportLoaderDeps {
   storage: ReportStorage;
@@ -106,9 +107,15 @@ export class ReportLoader {
     fileMap: Record<string, string>,
   ): Promise<Record<string, Buffer>> {
     const entries: Array<[string, Buffer]> = [];
+    let totalSize = 0;
     for (const [alias, relPath] of Object.entries(fileMap)) {
       const key = `${runId}/${relPath}`;
-      entries.push([alias, await this.deps.storage.readBytes(key)]);
+      const bytes = await this.deps.storage.readBytes(key);
+      totalSize += bytes.length;
+      if (totalSize > REPORT_FILES_TOTAL_MAX_BYTES) {
+        throw new Error(`report files exceed ${REPORT_FILES_TOTAL_MAX_BYTES} bytes limit`);
+      }
+      entries.push([alias, bytes]);
     }
     return Object.fromEntries(entries);
   }

--- a/apps/api/src/modules/benchmark/storage/report-storage.ts
+++ b/apps/api/src/modules/benchmark/storage/report-storage.ts
@@ -1,0 +1,17 @@
+/**
+ * Report-side read interface for shared object storage (MinIO / S3).
+ *
+ * Phase 2 of #237: API only reads — runner writes via boto3 directly.
+ * Implementations: S3ReportStorage (prod / dev), in-memory mock (tests).
+ *
+ * Throws when the network round-trip fails or auth is rejected.
+ * Returns `false` from exists() when the object is genuinely absent.
+ */
+export interface ReportStorage {
+  exists(key: string): Promise<boolean>;
+  readJson<T>(key: string): Promise<T>;
+  readText(key: string): Promise<string>;
+  readBytes(key: string): Promise<Buffer>;
+}
+
+export const REPORT_STORAGE = Symbol("REPORT_STORAGE");

--- a/apps/api/src/modules/benchmark/storage/report-storage.ts
+++ b/apps/api/src/modules/benchmark/storage/report-storage.ts
@@ -1,3 +1,5 @@
+import type { Readable } from "node:stream";
+
 /**
  * Report-side read interface for shared object storage (MinIO / S3).
  *
@@ -12,6 +14,8 @@ export interface ReportStorage {
   readJson<T>(key: string): Promise<T>;
   readText(key: string): Promise<string>;
   readBytes(key: string): Promise<Buffer>;
+  /** Returns a Readable stream without draining the object into memory. */
+  readStream(key: string): Promise<Readable>;
 }
 
 export const REPORT_STORAGE = Symbol("REPORT_STORAGE");

--- a/apps/api/src/modules/benchmark/storage/s3-report-storage.spec.ts
+++ b/apps/api/src/modules/benchmark/storage/s3-report-storage.spec.ts
@@ -1,5 +1,5 @@
-import { GetObjectCommand, HeadObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { Readable } from "node:stream";
+import { GetObjectCommand, HeadObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { mockClient } from "aws-sdk-client-mock";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { S3ReportStorage } from "./s3-report-storage.js";
@@ -31,7 +31,9 @@ describe("S3ReportStorage", () => {
   });
 
   it("exists() returns false on NotFound", async () => {
-    s3Mock.on(HeadObjectCommand).rejects(Object.assign(new Error("not found"), { name: "NotFound" }));
+    s3Mock
+      .on(HeadObjectCommand)
+      .rejects(Object.assign(new Error("not found"), { name: "NotFound" }));
     const storage = makeStorage();
     expect(await storage.exists("run-1/result.json")).toBe(false);
   });

--- a/apps/api/src/modules/benchmark/storage/s3-report-storage.spec.ts
+++ b/apps/api/src/modules/benchmark/storage/s3-report-storage.spec.ts
@@ -61,4 +61,13 @@ describe("S3ReportStorage", () => {
     const storage = makeStorage();
     expect((await storage.readBytes("run-1/files/x")).toString("utf8")).toBe("binary");
   });
+
+  it("readStream() returns Readable", async () => {
+    s3Mock.on(GetObjectCommand).resolves({ Body: bodyFromString("stream-content") as never });
+    const storage = makeStorage();
+    const stream = await storage.readStream("run-1/files/x");
+    const chunks: Buffer[] = [];
+    for await (const c of stream) chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c));
+    expect(Buffer.concat(chunks).toString("utf8")).toBe("stream-content");
+  });
 });

--- a/apps/api/src/modules/benchmark/storage/s3-report-storage.spec.ts
+++ b/apps/api/src/modules/benchmark/storage/s3-report-storage.spec.ts
@@ -1,0 +1,62 @@
+import { GetObjectCommand, HeadObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { Readable } from "node:stream";
+import { mockClient } from "aws-sdk-client-mock";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { S3ReportStorage } from "./s3-report-storage.js";
+
+const s3Mock = mockClient(S3Client);
+
+function bodyFromString(s: string) {
+  return Readable.from([Buffer.from(s, "utf8")]) as unknown as ReturnType<typeof Readable.from>;
+}
+
+function makeStorage() {
+  return new S3ReportStorage({
+    endpoint: "http://localhost:9999",
+    region: "us-east-1",
+    accessKeyId: "test",
+    secretAccessKey: "test",
+    bucket: "test-bucket",
+  });
+}
+
+describe("S3ReportStorage", () => {
+  beforeEach(() => s3Mock.reset());
+  afterEach(() => s3Mock.reset());
+
+  it("exists() returns true when HeadObject succeeds", async () => {
+    s3Mock.on(HeadObjectCommand).resolves({});
+    const storage = makeStorage();
+    expect(await storage.exists("run-1/result.json")).toBe(true);
+  });
+
+  it("exists() returns false on NotFound", async () => {
+    s3Mock.on(HeadObjectCommand).rejects(Object.assign(new Error("not found"), { name: "NotFound" }));
+    const storage = makeStorage();
+    expect(await storage.exists("run-1/result.json")).toBe(false);
+  });
+
+  it("exists() rethrows on non-NotFound errors", async () => {
+    s3Mock.on(HeadObjectCommand).rejects(new Error("network down"));
+    const storage = makeStorage();
+    await expect(storage.exists("run-1/result.json")).rejects.toThrow("network down");
+  });
+
+  it("readJson() parses GetObject body", async () => {
+    s3Mock.on(GetObjectCommand).resolves({ Body: bodyFromString('{"exitCode":0}') as never });
+    const storage = makeStorage();
+    expect(await storage.readJson("run-1/result.json")).toEqual({ exitCode: 0 });
+  });
+
+  it("readText() returns full body as string", async () => {
+    s3Mock.on(GetObjectCommand).resolves({ Body: bodyFromString("hello\nworld") as never });
+    const storage = makeStorage();
+    expect(await storage.readText("run-1/stdout.log")).toBe("hello\nworld");
+  });
+
+  it("readBytes() returns Buffer", async () => {
+    s3Mock.on(GetObjectCommand).resolves({ Body: bodyFromString("binary") as never });
+    const storage = makeStorage();
+    expect((await storage.readBytes("run-1/files/x")).toString("utf8")).toBe("binary");
+  });
+});

--- a/apps/api/src/modules/benchmark/storage/s3-report-storage.ts
+++ b/apps/api/src/modules/benchmark/storage/s3-report-storage.ts
@@ -1,5 +1,5 @@
 import { GetObjectCommand, HeadObjectCommand, NotFound, S3Client } from "@aws-sdk/client-s3";
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { Readable } from "node:stream";
 import type { ReportStorage } from "./report-storage.js";
 
@@ -13,7 +13,6 @@ export interface S3ReportStorageConfig {
 
 @Injectable()
 export class S3ReportStorage implements ReportStorage {
-  private readonly log = new Logger(S3ReportStorage.name);
   private readonly client: S3Client;
   private readonly bucket: string;
 

--- a/apps/api/src/modules/benchmark/storage/s3-report-storage.ts
+++ b/apps/api/src/modules/benchmark/storage/s3-report-storage.ts
@@ -1,6 +1,6 @@
+import { Readable } from "node:stream";
 import { GetObjectCommand, HeadObjectCommand, NotFound, S3Client } from "@aws-sdk/client-s3";
 import { Injectable } from "@nestjs/common";
-import { Readable } from "node:stream";
 import type { ReportStorage } from "./report-storage.js";
 
 export interface S3ReportStorageConfig {
@@ -54,7 +54,8 @@ export class S3ReportStorage implements ReportStorage {
     if (!res.Body) throw new Error(`S3 GetObject ${key} returned empty body`);
     const stream = res.Body as Readable;
     const chunks: Buffer[] = [];
-    for await (const chunk of stream) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    for await (const chunk of stream)
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
     return Buffer.concat(chunks);
   }
 }

--- a/apps/api/src/modules/benchmark/storage/s3-report-storage.ts
+++ b/apps/api/src/modules/benchmark/storage/s3-report-storage.ts
@@ -1,0 +1,61 @@
+import { GetObjectCommand, HeadObjectCommand, NotFound, S3Client } from "@aws-sdk/client-s3";
+import { Injectable, Logger } from "@nestjs/common";
+import { Readable } from "node:stream";
+import type { ReportStorage } from "./report-storage.js";
+
+export interface S3ReportStorageConfig {
+  endpoint: string;
+  region: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  bucket: string;
+}
+
+@Injectable()
+export class S3ReportStorage implements ReportStorage {
+  private readonly log = new Logger(S3ReportStorage.name);
+  private readonly client: S3Client;
+  private readonly bucket: string;
+
+  constructor(cfg: S3ReportStorageConfig) {
+    this.client = new S3Client({
+      endpoint: cfg.endpoint,
+      region: cfg.region,
+      forcePathStyle: true,
+      credentials: { accessKeyId: cfg.accessKeyId, secretAccessKey: cfg.secretAccessKey },
+      maxAttempts: 2,
+    });
+    this.bucket = cfg.bucket;
+  }
+
+  async exists(key: string): Promise<boolean> {
+    try {
+      await this.client.send(new HeadObjectCommand({ Bucket: this.bucket, Key: key }));
+      return true;
+    } catch (e) {
+      // SDK v3 surfaces 404 as NotFound class instance OR { name: "NotFound" } depending on path
+      if (e instanceof NotFound) return false;
+      if ((e as { name?: string }).name === "NotFound") return false;
+      throw e;
+    }
+  }
+
+  async readJson<T>(key: string): Promise<T> {
+    const text = await this.readText(key);
+    return JSON.parse(text) as T;
+  }
+
+  async readText(key: string): Promise<string> {
+    const buf = await this.readBytes(key);
+    return buf.toString("utf8");
+  }
+
+  async readBytes(key: string): Promise<Buffer> {
+    const res = await this.client.send(new GetObjectCommand({ Bucket: this.bucket, Key: key }));
+    if (!res.Body) throw new Error(`S3 GetObject ${key} returned empty body`);
+    const stream = res.Body as Readable;
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    return Buffer.concat(chunks);
+  }
+}

--- a/apps/api/src/modules/benchmark/storage/s3-report-storage.ts
+++ b/apps/api/src/modules/benchmark/storage/s3-report-storage.ts
@@ -58,4 +58,10 @@ export class S3ReportStorage implements ReportStorage {
       chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
     return Buffer.concat(chunks);
   }
+
+  async readStream(key: string): Promise<Readable> {
+    const res = await this.client.send(new GetObjectCommand({ Bucket: this.bucket, Key: key }));
+    if (!res.Body) throw new Error(`S3 GetObject ${key} returned empty body`);
+    return res.Body as Readable;
+  }
 }

--- a/apps/api/test/e2e/benchmark-watcher-primary.e2e-spec.ts
+++ b/apps/api/test/e2e/benchmark-watcher-primary.e2e-spec.ts
@@ -1,0 +1,146 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Readable } from "node:stream";
+import { fileURLToPath } from "node:url";
+import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { mockClient } from "aws-sdk-client-mock";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { PrismaService } from "../../src/database/prisma.service.js";
+import { ReportLoader } from "../../src/modules/benchmark/storage/report-loader.js";
+import { bootE2E, registerUser, type E2EContext, type RegisteredUser } from "../helpers/app.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// Guidellm report fixture — same file used by packages/tool-adapters unit tests
+const GUIDELLM_REPORT_BUF = fs.readFileSync(
+  path.join(
+    __dirname,
+    "../../../../packages/tool-adapters/src/guidellm/__fixtures__/report.json",
+  ),
+);
+
+const s3Mock = mockClient(S3Client);
+
+function bodyOf(s: string) {
+  return Readable.from([Buffer.from(s, "utf8")]) as never;
+}
+
+let ctx: E2EContext;
+let user: RegisteredUser;
+let prisma: PrismaService;
+let loader: ReportLoader;
+
+beforeAll(async () => {
+  ctx = await bootE2E();
+  user = await registerUser(ctx.app, `watcher-primary-${Date.now()}@example.com`);
+  prisma = ctx.app.get(PrismaService);
+  loader = ctx.app.get(ReportLoader);
+}, 180_000);
+
+afterAll(async () => {
+  if (ctx) await ctx.teardown();
+});
+
+beforeEach(() => s3Mock.reset());
+afterEach(() => s3Mock.reset());
+
+async function seedBenchmark(id: string) {
+  return prisma.benchmark.create({
+    data: {
+      id,
+      userId: user.user.id,
+      status: "running",
+      tool: "guidellm",
+      scenario: "inference",
+      name: `e2e-${id}`,
+      params: {},
+      connectionId: null,
+    },
+  });
+}
+
+describe("Benchmark watcher primary mode (e2e)", () => {
+  it("Succeeded pod → ReportLoader reads S3 → status=completed + summaryMetrics + toolVersion", async () => {
+    const benchId = "00000000-0000-0000-0000-000000000a01";
+    await seedBenchmark(benchId);
+
+    // Mock S3 — result.json references a "report" file alias so loadFiles reads it
+    s3Mock.on(GetObjectCommand, { Key: `${benchId}/meta.json` }).resolves({
+      Body: bodyOf(
+        JSON.stringify({ toolVersion: "guidellm 0.2.1", startTimeIso: "2026-05-25T00:00:00.000Z" }),
+      ),
+    } as never);
+    s3Mock.on(GetObjectCommand, { Key: `${benchId}/result.json` }).resolves({
+      Body: bodyOf(
+        JSON.stringify({
+          exitCode: 0,
+          finishTimeIso: "2026-05-25T01:00:00.000Z",
+          // "report" alias maps to files/report.json — consumed by guidellm.parseFinalReport
+          files: { report: "files/report.json" },
+        }),
+      ),
+    } as never);
+    s3Mock.on(GetObjectCommand, { Key: `${benchId}/stdout.log` }).resolves({
+      Body: bodyOf("PROGRESS:1.0\nDone"),
+    } as never);
+    s3Mock.on(GetObjectCommand, { Key: `${benchId}/stderr.log` }).resolves({
+      Body: bodyOf(""),
+    } as never);
+    // guidellm report file used by parseFinalReport
+    s3Mock.on(GetObjectCommand, { Key: `${benchId}/files/report.json` }).resolves({
+      Body: Readable.from([GUIDELLM_REPORT_BUF]) as never,
+    } as never);
+
+    await loader.tryLoad(benchId);
+
+    const row = await prisma.benchmark.findUniqueOrThrow({ where: { id: benchId } });
+    expect(row.status).toBe("completed");
+    expect(row.toolVersion).toBe("guidellm 0.2.1");
+    expect(row.completedAt).toBeTruthy();
+    expect(row.summaryMetrics).not.toBeNull();
+  });
+
+  it("Succeeded pod but S3 returns NoSuchKey → status=failed + statusMessage contains 'report load'", async () => {
+    const benchId = "00000000-0000-0000-0000-000000000a02";
+    await seedBenchmark(benchId);
+
+    s3Mock
+      .on(GetObjectCommand)
+      .rejects(Object.assign(new Error("NoSuchKey"), { name: "NoSuchKey" }));
+
+    await loader.tryLoad(benchId);
+
+    const row = await prisma.benchmark.findUniqueOrThrow({ where: { id: benchId } });
+    expect(row.status).toBe("failed");
+    expect(row.statusMessage).toContain("report load");
+    expect(row.completedAt).toBeTruthy();
+  });
+
+  it("benchmark already terminal → noop (S3 not read)", async () => {
+    const benchId = "00000000-0000-0000-0000-000000000a03";
+    await prisma.benchmark.create({
+      data: {
+        id: benchId,
+        userId: user.user.id,
+        status: "cancelled",
+        tool: "guidellm",
+        scenario: "inference",
+        name: "e2e-cancelled",
+        params: {},
+        connectionId: null,
+        completedAt: new Date("2026-05-24T00:00:00.000Z"),
+      },
+    });
+
+    let s3Called = false;
+    s3Mock.on(GetObjectCommand).callsFake(() => {
+      s3Called = true;
+      throw new Error("should not be called");
+    });
+
+    await loader.tryLoad(benchId);
+
+    expect(s3Called).toBe(false);
+    const row = await prisma.benchmark.findUniqueOrThrow({ where: { id: benchId } });
+    expect(row.status).toBe("cancelled");
+  });
+});

--- a/apps/api/test/setup/e2e-env-defaults.ts
+++ b/apps/api/test/setup/e2e-env-defaults.ts
@@ -43,4 +43,14 @@ export const E2E_ENV_DEFAULTS = {
   ALERTMANAGER_WEBHOOK_SECRET: required("ALERTMANAGER_WEBHOOK_SECRET"),
   MCP_BEARER_TOKEN: required("MCP_BEARER_TOKEN"),
   MCP_USER_ID: required("MCP_USER_ID"),
+  // Watcher: tests override the production default ("primary") back to "off"
+  // so informers don't attempt to connect to a real K8s API server.
+  K8S_WATCHER_MODE: required("K8S_WATCHER_MODE"),
+  // S3: placeholder values — tests mock the AWS SDK client and never hit a
+  // real endpoint; these just satisfy env schema validation at boot.
+  S3_ENDPOINT: required("S3_ENDPOINT"),
+  S3_ACCESS_KEY: required("S3_ACCESS_KEY"),
+  S3_SECRET_KEY: required("S3_SECRET_KEY"),
+  S3_BUCKET: required("S3_BUCKET"),
+  S3_REGION: required("S3_REGION"),
 } as const;

--- a/apps/benchmark-runner/pyproject.toml
+++ b/apps/benchmark-runner/pyproject.toml
@@ -13,11 +13,13 @@ dependencies = [
   # Dockerfile, NOT by this file. Bumping the image is a deliberate PR with
   # new fixture-based metrics-mapper tests. Local dev installs only the
   # runner's own runtime deps below.
+  "boto3>=1.34,<2",
   "requests>=2.31,<3",
 ]
 
 [project.optional-dependencies]
 dev = [
+  "moto[s3]>=5,<6",
   "pytest>=8,<9",
   "pytest-mock>=3.12,<4",
   "ruff>=0.5,<1",

--- a/apps/benchmark-runner/runner/callback.py
+++ b/apps/benchmark-runner/runner/callback.py
@@ -42,5 +42,3 @@ def post_log_batch(
         token,
         {"stream": stream, "lines": lines},
     )
-
-

--- a/apps/benchmark-runner/runner/callback.py
+++ b/apps/benchmark-runner/runner/callback.py
@@ -28,31 +28,6 @@ def _post(url: str, token: str, body: dict) -> None:
         raise RuntimeError(f"Callback POST {url} returned {resp.status_code}: {resp.text[:200]}")
 
 
-def post_state_running(
-    *,
-    callback_url: str,
-    token: str,
-    benchmark_id: str,
-    tool_version: str | None = None,
-) -> None:
-    """POST {state: 'running', toolVersion?} to the v2 /state endpoint.
-
-    ``tool_version`` is the first stripped line of ``<tool> --version``
-    output, captured at runner boot. The BFF persists it on the
-    benchmark row so users can see exactly which tool build produced
-    the result. Optional: when ``None`` the field is omitted from the
-    body so older BFFs that don't accept it still succeed.
-    """
-    body: dict = {"state": "running"}
-    if tool_version is not None:
-        body["toolVersion"] = tool_version
-    _post(
-        _join(callback_url, f"api/internal/benchmarks/{benchmark_id}/state"),
-        token,
-        body,
-    )
-
-
 def post_log_batch(
     *,
     callback_url: str,
@@ -69,27 +44,3 @@ def post_log_batch(
     )
 
 
-def post_finish(
-    *,
-    callback_url: str,
-    token: str,
-    benchmark_id: str,
-    state: str,
-    exit_code: int,
-    stdout: str,
-    stderr: str,
-    files: dict[str, str],
-    message: str | None,
-) -> None:
-    """POST the terminal payload (state, exit code, full logs, output files)
-    to the v2 /finish endpoint."""
-    body: dict = {
-        "state": state,
-        "exitCode": exit_code,
-        "stdout": stdout,
-        "stderr": stderr,
-        "files": files,
-    }
-    if message is not None:
-        body["message"] = message
-    _post(_join(callback_url, f"api/internal/benchmarks/{benchmark_id}/finish"), token, body)

--- a/apps/benchmark-runner/runner/main.py
+++ b/apps/benchmark-runner/runner/main.py
@@ -223,10 +223,13 @@ def main() -> int:
     keys = keys_for(benchmark_id)
 
     # 1. Write meta.json — runner has started, tool version known.
-    s3.put_json(keys.meta, {
-        "toolVersion": tool_version or "",
-        "startTimeIso": _iso_now(),
-    })
+    s3.put_json(
+        keys.meta,
+        {
+            "toolVersion": tool_version or "",
+            "startTimeIso": _iso_now(),
+        },
+    )
 
     argv = _inject_api_key_into_backend_kwargs(argv)
     log.info("running: %s", " ".join(_redacted(argv)))
@@ -266,11 +269,14 @@ def main() -> int:
     s3.put_text(keys.stderr, "\n".join(list(err_pump.full)))
 
     # 4. Sentinel — result.json LAST. API uses this to determine "storage complete".
-    s3.put_json(keys.result, {
-        "exitCode": proc.returncode,
-        "finishTimeIso": _iso_now(),
-        "files": files_map,
-    })
+    s3.put_json(
+        keys.result,
+        {
+            "exitCode": proc.returncode,
+            "finishTimeIso": _iso_now(),
+            "files": files_map,
+        },
+    )
 
     # Propagate the tool's exit code so pod.phase reflects success/failure.
     # Watcher: exit=0 → pod.Succeeded → ReportLoader; exit!=0 → pod.Failed → failed-terminal.

--- a/apps/benchmark-runner/runner/main.py
+++ b/apps/benchmark-runner/runner/main.py
@@ -30,10 +30,9 @@ LOG_LINE_MAX_BYTES = 64 * 1024
 LOG_TAIL_MAX_BYTES = 64 * 1024  # per stream
 # S3 enforces its own object size limits; output files stream via put_file
 # (multipart-aware for objects >5 MB), so no in-memory cap is needed here.
-# Cap version string length stored in meta.json. The contract
-# (`benchmarkStateCallbackSchema.toolVersion`) hard-caps at 50; truncating
-# here mirrors that so a tool with a verbose `--version` banner doesn't
-# violate the cap.
+# Cap version string length stored in meta.json. The reportMetaSchema
+# toolVersion field hard-caps at 50; truncating here mirrors that so a tool
+# with a verbose `--version` banner doesn't violate the cap.
 TOOL_VERSION_MAX_CHARS = 50
 TOOL_VERSION_TIMEOUT_SEC = 10
 

--- a/apps/benchmark-runner/runner/main.py
+++ b/apps/benchmark-runner/runner/main.py
@@ -1,5 +1,5 @@
 """Generic tool wrapper. Reads MD_* env, spawns argv, batches /log,
-collects outputFiles, posts /finish.
+collects outputFiles, writes report to S3.
 
 Phase 3 of #53: replaces the guidellm-specific runner. This file
 contains zero tool-specific knowledge.
@@ -7,7 +7,6 @@ contains zero tool-specific knowledge.
 
 from __future__ import annotations
 
-import base64
 import json
 import logging
 import os
@@ -16,28 +15,34 @@ import sys
 import threading
 import time
 from collections import deque
+from datetime import UTC, datetime
 from pathlib import Path
 
-from runner.callback import post_finish, post_log_batch, post_state_running
+from runner.callback import post_log_batch
+from runner.s3_writer import S3Writer
+from runner.storage_keys import file_key, keys_for
 
 LOG_BATCH_INTERVAL_SEC = 0.25
 LOG_LINE_MAX_BYTES = 64 * 1024
-# Bounds the /finish POST body and runner RSS for long-running benchmarks.
-# /finish's stdout/stderr role is post-mortem only (/log already streamed
+# Bounds the S3 stdout/stderr objects and runner RSS for long-running benchmarks.
+# stdout.log/stderr.log are post-mortem only (/log already streamed
 # everything live), so 64 KB per stream is sufficient for triage.
 LOG_TAIL_MAX_BYTES = 64 * 1024  # per stream
-# vegeta attack.bin for a long load test can exceed 100 MB; base64-encoding
-# that entirely in memory would OOM the runner process.
-OUTPUT_FILE_MAX_BYTES = 50 * 1024 * 1024  # per output file
-# Cap version string length sent in the /state callback body. The contract
+# S3 enforces its own object size limits; output files stream via put_file
+# (multipart-aware for objects >5 MB), so no in-memory cap is needed here.
+# Cap version string length stored in meta.json. The contract
 # (`benchmarkStateCallbackSchema.toolVersion`) hard-caps at 50; truncating
 # here mirrors that so a tool with a verbose `--version` banner doesn't
-# flunk validation.
+# violate the cap.
 TOOL_VERSION_MAX_CHARS = 50
 TOOL_VERSION_TIMEOUT_SEC = 10
 
 logging.basicConfig(level=logging.INFO, format="[runner] %(message)s")
 log = logging.getLogger("runner")
+
+
+def _iso_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
 def detect_tool_version(tool: str) -> str | None:
@@ -214,15 +219,15 @@ def main() -> int:
     if tool_version is None and tool_name:
         log.warning("detect_tool_version(%s) returned None", tool_name)
 
-    try:
-        post_state_running(
-            callback_url=callback_url,
-            token=token,
-            benchmark_id=benchmark_id,
-            tool_version=tool_version,
-        )
-    except Exception as e:
-        log.warning("post_state_running failed: %s", e)
+    # S3 writer — fail-fast if env is misconfigured.
+    s3 = S3Writer.from_env()
+    keys = keys_for(benchmark_id)
+
+    # 1. Write meta.json — runner has started, tool version known.
+    s3.put_json(keys.meta, {
+        "toolVersion": tool_version or "",
+        "startTimeIso": _iso_now(),
+    })
 
     argv = _inject_api_key_into_backend_kwargs(argv)
     log.info("running: %s", " ".join(_redacted(argv)))
@@ -244,47 +249,33 @@ def main() -> int:
     t1.join(timeout=5)
     t2.join(timeout=5)
 
-    files_b64: dict[str, str] = {}
+    # 2. Upload output files via put_file (auto-multipart for >5 MB)
+    files_map: dict[str, str] = {}
     for alias, rel_path in output_files.items():
         full = Path.cwd() / rel_path
         if not full.exists():
             continue
-        size = full.stat().st_size
-        if size > OUTPUT_FILE_MAX_BYTES:
-            log.warning(
-                "output file %s (%d bytes) exceeds %d byte cap; skipping",
-                alias,
-                size,
-                OUTPUT_FILE_MAX_BYTES,
-            )
-            continue
-        files_b64[alias] = base64.b64encode(full.read_bytes()).decode("ascii")
+        rel = f"files/{alias}"
+        s3.put_file(file_key(benchmark_id, alias), str(full))
+        files_map[alias] = rel
 
-    state = "completed" if proc.returncode == 0 else "failed"
-    message = None if state == "completed" else f"tool exited with code {proc.returncode}"
-
+    # 3. Upload stdout/stderr (tailed buffer from StreamPump)
     # Snapshot deques into lists in case a daemon pump thread is still
     # alive after join(timeout=5) — protects against "deque mutated
     # during iteration" RuntimeError under unusual EOF behavior.
-    try:
-        post_finish(
-            callback_url=callback_url,
-            token=token,
-            benchmark_id=benchmark_id,
-            state=state,
-            exit_code=proc.returncode,
-            stdout="\n".join(list(out_pump.full)),
-            stderr="\n".join(list(err_pump.full)),
-            files=files_b64,
-            message=message,
-        )
-    except Exception as e:
-        log.error("post_finish failed: %s", e)
-        return 1
+    s3.put_text(keys.stdout, "\n".join(list(out_pump.full)))
+    s3.put_text(keys.stderr, "\n".join(list(err_pump.full)))
 
-    # Always exit 0 from the wrapper itself — failure of the inner tool is
-    # already conveyed via /finish state=failed.
-    return 0
+    # 4. Sentinel — result.json LAST. API uses this to determine "storage complete".
+    s3.put_json(keys.result, {
+        "exitCode": proc.returncode,
+        "finishTimeIso": _iso_now(),
+        "files": files_map,
+    })
+
+    # Propagate the tool's exit code so pod.phase reflects success/failure.
+    # Watcher: exit=0 → pod.Succeeded → ReportLoader; exit!=0 → pod.Failed → failed-terminal.
+    return proc.returncode
 
 
 if __name__ == "__main__":

--- a/apps/benchmark-runner/runner/s3_writer.py
+++ b/apps/benchmark-runner/runner/s3_writer.py
@@ -15,7 +15,7 @@ from botocore.config import Config
 
 class S3Writer:
     @classmethod
-    def from_env(cls) -> "S3Writer":
+    def from_env(cls) -> S3Writer:
         region = os.environ.get("S3_REGION", "us-east-1")
         client = boto3.client(
             "s3",
@@ -38,7 +38,12 @@ class S3Writer:
 
     def put_json(self, key: str, obj: object) -> None:
         body = json.dumps(obj).encode("utf-8")
-        self.client.put_object(Bucket=self.bucket, Key=key, Body=body, ContentType="application/json")
+        self.client.put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=body,
+            ContentType="application/json",
+        )
 
     def put_text(self, key: str, text: str) -> None:
         self.client.put_object(

--- a/apps/benchmark-runner/runner/s3_writer.py
+++ b/apps/benchmark-runner/runner/s3_writer.py
@@ -1,0 +1,53 @@
+"""boto3 wrapper for runner→S3 writes.
+
+Single-purpose: read S3_* from env, write objects under <runId>/...
+Multipart handled automatically by upload_file for objects >5MB.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import boto3
+from botocore.config import Config
+
+
+class S3Writer:
+    @classmethod
+    def from_env(cls) -> "S3Writer":
+        region = os.environ.get("S3_REGION", "us-east-1")
+        client = boto3.client(
+            "s3",
+            endpoint_url=os.environ["S3_ENDPOINT"],
+            aws_access_key_id=os.environ["S3_ACCESS_KEY"],
+            aws_secret_access_key=os.environ["S3_SECRET_KEY"],
+            region_name=region,
+            config=Config(
+                signature_version="s3v4",
+                retries={"max_attempts": 2, "mode": "standard"},
+                connect_timeout=5,
+                read_timeout=30,
+            ),
+        )
+        return cls(client=client, bucket=os.environ["S3_BUCKET"])
+
+    def __init__(self, *, client: object, bucket: str):
+        self.client = client
+        self.bucket = bucket
+
+    def put_json(self, key: str, obj: object) -> None:
+        body = json.dumps(obj).encode("utf-8")
+        self.client.put_object(Bucket=self.bucket, Key=key, Body=body, ContentType="application/json")
+
+    def put_text(self, key: str, text: str) -> None:
+        self.client.put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=text.encode("utf-8"),
+            ContentType="text/plain; charset=utf-8",
+        )
+
+    def put_file(self, key: str, local_path: str) -> None:
+        # upload_file handles multipart automatically for objects > 5MB
+        self.client.upload_file(local_path, self.bucket, key)

--- a/apps/benchmark-runner/runner/storage_keys.py
+++ b/apps/benchmark-runner/runner/storage_keys.py
@@ -1,0 +1,28 @@
+"""Object keys for the shared report storage layer.
+
+Mirror of packages/contracts/src/benchmark.ts:reportStorageKeys.
+Keep both in sync — runner writes, API reads, both must agree.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class StorageKeys:
+    meta: str
+    result: str
+    stdout: str
+    stderr: str
+
+
+def keys_for(run_id: str) -> StorageKeys:
+    return StorageKeys(
+        meta=f"{run_id}/meta.json",
+        result=f"{run_id}/result.json",
+        stdout=f"{run_id}/stdout.log",
+        stderr=f"{run_id}/stderr.log",
+    )
+
+
+def file_key(run_id: str, alias: str) -> str:
+    return f"{run_id}/files/{alias}"

--- a/apps/benchmark-runner/tests/test_callback.py
+++ b/apps/benchmark-runner/tests/test_callback.py
@@ -1,4 +1,4 @@
-"""Tests for the v2 callback HTTP client (api/internal/benchmarks/<id>/{state,log,finish})."""
+"""Tests for the v2 callback HTTP client (api/internal/benchmarks/<id>/log)."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
-from runner.callback import post_finish, post_log_batch, post_state_running
+from runner.callback import post_log_batch
 
 
 @pytest.fixture
@@ -15,65 +15,6 @@ def fake_post(mocker: MockerFixture) -> MagicMock:
     mock = mocker.patch("runner.callback.requests.post")
     mock.return_value = MagicMock(status_code=200, ok=True)
     return mock
-
-
-class TestPostStateRunning:
-    def test_url_path_includes_benchmark_id(self, fake_post: MagicMock) -> None:
-        post_state_running(callback_url="http://api:3001", token="t", benchmark_id="b-xyz")
-        url = fake_post.call_args.args[0]
-        assert url == "http://api:3001/api/internal/benchmarks/b-xyz/state"
-
-    def test_url_normalizes_trailing_slash(self, fake_post: MagicMock) -> None:
-        post_state_running(callback_url="http://api:3001/", token="t", benchmark_id="b-xyz")
-        url = fake_post.call_args.args[0]
-        assert url == "http://api:3001/api/internal/benchmarks/b-xyz/state"
-
-    def test_url_no_double_slash(self, fake_post: MagicMock) -> None:
-        post_state_running(callback_url="http://api:3001", token="t", benchmark_id="b-xyz")
-        url = fake_post.call_args.args[0]
-        # No double slash anywhere after the scheme.
-        assert "://" in url
-        assert "//" not in url.split("://", 1)[1]
-
-    def test_authorization_header_is_bearer(self, fake_post: MagicMock) -> None:
-        post_state_running(callback_url="http://api:3001", token="hmac-token", benchmark_id="b")
-        headers = fake_post.call_args.kwargs["headers"]
-        assert headers["Authorization"] == "Bearer hmac-token"
-
-    def test_body_is_state_running_when_no_tool_version(self, fake_post: MagicMock) -> None:
-        post_state_running(callback_url="http://api:3001", token="t", benchmark_id="b")
-        assert fake_post.call_args.kwargs["json"] == {"state": "running"}
-
-    def test_body_includes_tool_version_when_provided(self, fake_post: MagicMock) -> None:
-        # The scenario this test guards: the runner detects guidellm 0.5.2
-        # at boot via `guidellm --version` and the BFF must persist it.
-        post_state_running(
-            callback_url="http://api:3001",
-            token="t",
-            benchmark_id="b",
-            tool_version="guidellm 0.5.2",
-        )
-        body = fake_post.call_args.kwargs["json"]
-        assert body == {"state": "running", "toolVersion": "guidellm 0.5.2"}
-
-    def test_body_omits_tool_version_when_explicit_none(self, fake_post: MagicMock) -> None:
-        # tool_version=None must be omitted from the body so older BFFs that
-        # don't accept the field still succeed (forward-compat hedge).
-        post_state_running(
-            callback_url="http://api:3001",
-            token="t",
-            benchmark_id="b",
-            tool_version=None,
-        )
-        body = fake_post.call_args.kwargs["json"]
-        assert "toolVersion" not in body
-        assert body == {"state": "running"}
-
-    def test_raises_on_non_2xx(self, mocker: MockerFixture) -> None:
-        mock = mocker.patch("runner.callback.requests.post")
-        mock.return_value = MagicMock(status_code=500, ok=False, text="boom")
-        with pytest.raises(RuntimeError, match="500"):
-            post_state_running(callback_url="http://api:3001", token="t", benchmark_id="b")
 
 
 class TestPostLogBatch:
@@ -108,91 +49,3 @@ class TestPostLogBatch:
             lines=[],
         )
         assert fake_post.call_args.kwargs["headers"]["Authorization"] == "Bearer hmac-token"
-
-
-class TestPostFinish:
-    def test_url_path_is_finish(self, fake_post: MagicMock) -> None:
-        post_finish(
-            callback_url="http://api:3001",
-            token="t",
-            benchmark_id="b-xyz",
-            state="completed",
-            exit_code=0,
-            stdout="ok",
-            stderr="",
-            files={},
-            message=None,
-        )
-        url = fake_post.call_args.args[0]
-        assert url == "http://api:3001/api/internal/benchmarks/b-xyz/finish"
-
-    def test_body_contains_assembled_payload(self, fake_post: MagicMock) -> None:
-        post_finish(
-            callback_url="http://api:3001",
-            token="t",
-            benchmark_id="b",
-            state="completed",
-            exit_code=0,
-            stdout="hello",
-            stderr="",
-            files={"report": "QkFTRTY0"},
-            message=None,
-        )
-        body = fake_post.call_args.kwargs["json"]
-        assert body == {
-            "state": "completed",
-            "exitCode": 0,
-            "stdout": "hello",
-            "stderr": "",
-            "files": {"report": "QkFTRTY0"},
-        }
-        assert "message" not in body
-
-    def test_body_includes_message_when_set(self, fake_post: MagicMock) -> None:
-        post_finish(
-            callback_url="http://api:3001",
-            token="t",
-            benchmark_id="b",
-            state="failed",
-            exit_code=1,
-            stdout="",
-            stderr="oh no",
-            files={},
-            message="tool exited with code 1",
-        )
-        body = fake_post.call_args.kwargs["json"]
-        assert body["state"] == "failed"
-        assert body["exitCode"] == 1
-        assert body["stderr"] == "oh no"
-        assert body["message"] == "tool exited with code 1"
-
-    def test_url_normalizes_trailing_slash(self, fake_post: MagicMock) -> None:
-        post_finish(
-            callback_url="http://api:3001/",
-            token="t",
-            benchmark_id="b",
-            state="completed",
-            exit_code=0,
-            stdout="",
-            stderr="",
-            files={},
-            message=None,
-        )
-        url = fake_post.call_args.args[0]
-        assert url == "http://api:3001/api/internal/benchmarks/b/finish"
-
-    def test_raises_on_non_2xx(self, mocker: MockerFixture) -> None:
-        mock = mocker.patch("runner.callback.requests.post")
-        mock.return_value = MagicMock(status_code=502, ok=False, text="bad gateway")
-        with pytest.raises(RuntimeError, match="502"):
-            post_finish(
-                callback_url="http://api:3001",
-                token="t",
-                benchmark_id="b",
-                state="completed",
-                exit_code=0,
-                stdout="",
-                stderr="",
-                files={},
-                message=None,
-            )

--- a/apps/benchmark-runner/tests/test_main.py
+++ b/apps/benchmark-runner/tests/test_main.py
@@ -291,11 +291,7 @@ def test_log_batches_posted_with_correct_kwargs(
     assert mock_post_log.call_count >= 1
 
     # All stdout-stream calls should target benchmark_id=b-test and stream=stdout.
-    stdout_calls = [
-        c
-        for c in mock_post_log.call_args_list
-        if c.kwargs.get("stream") == "stdout"
-    ]
+    stdout_calls = [c for c in mock_post_log.call_args_list if c.kwargs.get("stream") == "stdout"]
     assert len(stdout_calls) >= 1
     for c in stdout_calls:
         assert c.kwargs["benchmark_id"] == "b-test"

--- a/apps/benchmark-runner/tests/test_main.py
+++ b/apps/benchmark-runner/tests/test_main.py
@@ -1,19 +1,17 @@
 """Tests for the generic tool-agnostic wrapper in runner.main.
 
 The wrapper reads MD_* env, spawns the given argv, batches stdout/stderr
-lines into /log POSTs, then POSTs /finish with full buffers + base64-encoded
-output files.
+lines into /log POSTs, then writes meta.json → files → stdout/stderr →
+result.json (sentinel) to S3.
 """
 
 from __future__ import annotations
 
-import base64
 import io
 import json
-import logging
 import os
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pytest_mock import MockerFixture
@@ -99,137 +97,203 @@ class TestInjectApiKeyIntoBackendKwargs:
             main_mod._inject_api_key_into_backend_kwargs(argv)
 
 
-@pytest.fixture
-def patched_callbacks(mocker: MockerFixture) -> dict[str, MagicMock]:
-    """Patch every callback function on runner.main."""
+# ── S3-write order and exit-code propagation ────────────────────────────
+
+
+def _s3_env(md_env: dict[str, str]) -> dict[str, str]:
+    """Merge minimal S3 env vars into an md_env dict."""
     return {
-        "post_state_running": mocker.patch("runner.main.post_state_running"),
-        "post_log_batch": mocker.patch("runner.main.post_log_batch"),
-        "post_finish": mocker.patch("runner.main.post_finish"),
+        **md_env,
+        "S3_ENDPOINT": "http://localhost:9999",
+        "S3_ACCESS_KEY": "k",
+        "S3_SECRET_KEY": "s",
+        "S3_BUCKET": "b",
+        "S3_REGION": "us-east-1",
     }
 
 
-def test_happy_path_posts_state_running_and_finish_completed(
-    patched_callbacks: dict[str, MagicMock],
-    md_env_minimal: dict[str, str],
-    mocker: MockerFixture,
-) -> None:
-    mocker.patch.dict("os.environ", md_env_minimal, clear=True)
-    proc = _fake_proc(stdout=b"hello\n", stderr=b"", returncode=0)
-    mocker.patch("runner.main.subprocess.Popen", return_value=proc)
-    # detect_tool_version invokes subprocess.run; stub it out so the test
-    # is hermetic (no dependency on a host `echo --version`).
-    mocker.patch("runner.main.detect_tool_version", return_value=None)
-
-    rc = main_mod.main()
-
-    assert rc == 0
-    assert patched_callbacks["post_state_running"].call_count == 1
-    sr_kwargs = patched_callbacks["post_state_running"].call_args.kwargs
-    assert sr_kwargs["benchmark_id"] == "b-test"
-    assert sr_kwargs["token"] == "hmac-test-token"
-
-    assert patched_callbacks["post_finish"].call_count == 1
-    finish_kwargs = patched_callbacks["post_finish"].call_args.kwargs
-    assert finish_kwargs["state"] == "completed"
-    assert finish_kwargs["exit_code"] == 0
-    assert finish_kwargs["stdout"] == "hello"
-    assert finish_kwargs["stderr"] == ""
-    assert finish_kwargs["files"] == {}
-    assert finish_kwargs["message"] is None
-
-
-def test_failure_path_posts_finish_failed_with_message(
-    patched_callbacks: dict[str, MagicMock],
-    md_env_minimal: dict[str, str],
-    mocker: MockerFixture,
-) -> None:
-    mocker.patch.dict("os.environ", md_env_minimal, clear=True)
-    proc = _fake_proc(stdout=b"", stderr=b"BOOM\n", returncode=1)
-    mocker.patch("runner.main.subprocess.Popen", return_value=proc)
-    mocker.patch("runner.main.detect_tool_version", return_value=None)
-
-    rc = main_mod.main()
-
-    # Wrapper itself always exits 0 — failure is conveyed via /finish state.
-    assert rc == 0
-    finish_kwargs = patched_callbacks["post_finish"].call_args.kwargs
-    assert finish_kwargs["state"] == "failed"
-    assert finish_kwargs["exit_code"] == 1
-    assert finish_kwargs["stderr"] == "BOOM"
-    assert finish_kwargs["message"] == "tool exited with code 1"
-
-
-def test_output_file_collected_as_base64(
-    patched_callbacks: dict[str, MagicMock],
+def test_main_writes_meta_then_result_last(
     md_env_minimal: dict[str, str],
     mocker: MockerFixture,
     tmp_path: Path,
 ) -> None:
-    md_env_minimal["MD_OUTPUT_FILES"] = json.dumps({"report": "report.json"})
-    mocker.patch.dict("os.environ", md_env_minimal, clear=True)
+    """meta.json is first; result.json is the sentinel written last."""
+    mocker.patch.dict("os.environ", _s3_env(md_env_minimal), clear=True)
+    mocker.patch("runner.main.Path.cwd", return_value=tmp_path)
+    mocker.patch("runner.main.os.getcwd", return_value=str(tmp_path))
+    proc = _fake_proc(stdout=b"hello\n", stderr=b"", returncode=0)
+    mocker.patch("runner.main.subprocess.Popen", return_value=proc)
+    mocker.patch("runner.main.detect_tool_version", return_value=None)
 
-    # Place the output file in tmp_path and run the wrapper with cwd=tmp_path.
+    writer = MagicMock()
+    calls: list[tuple[str, str]] = []
+    writer.put_json.side_effect = lambda key, _obj: calls.append(("json", key))
+    writer.put_text.side_effect = lambda key, _text: calls.append(("text", key))
+    writer.put_file.side_effect = lambda key, _path: calls.append(("file", key))
+
+    with patch("runner.main.S3Writer") as MockS3:
+        MockS3.from_env.return_value = writer
+        rc = main_mod.main()
+
+    assert rc == 0
+    # meta.json must be first write of any kind
+    assert calls[0] == ("json", "b-test/meta.json")
+    # result.json must be the last json call (sentinel)
+    json_calls = [c for c in calls if c[0] == "json"]
+    assert json_calls[-1] == ("json", "b-test/result.json")
+
+
+def test_main_propagates_subprocess_exit_code(
+    md_env_minimal: dict[str, str],
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    """main() returns proc.returncode, not always 0."""
+    md_env_minimal["MD_ARGV"] = json.dumps(["false"])  # always exits 1
+    mocker.patch.dict("os.environ", _s3_env(md_env_minimal), clear=True)
+    mocker.patch("runner.main.Path.cwd", return_value=tmp_path)
+    mocker.patch("runner.main.os.getcwd", return_value=str(tmp_path))
+    mocker.patch("runner.main.detect_tool_version", return_value=None)
+
+    writer = MagicMock()
+    with patch("runner.main.S3Writer") as MockS3:
+        MockS3.from_env.return_value = writer
+        rc = main_mod.main()
+
+    assert rc == 1
+    # result.json still written even on failure (watcher needs sentinel)
+    keys_written = [call.args[0] for call in writer.put_json.call_args_list]
+    assert "b-test/result.json" in keys_written
+
+
+def test_main_raises_when_s3_put_fails(
+    md_env_minimal: dict[str, str],
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    """S3 write failure propagates as an exception (no try/except swallowing)."""
+    mocker.patch.dict("os.environ", _s3_env(md_env_minimal), clear=True)
+    mocker.patch("runner.main.Path.cwd", return_value=tmp_path)
+    mocker.patch("runner.main.os.getcwd", return_value=str(tmp_path))
+    mocker.patch("runner.main.detect_tool_version", return_value=None)
+
+    writer = MagicMock()
+    writer.put_json.side_effect = RuntimeError("s3 down")
+    with patch("runner.main.S3Writer") as MockS3:
+        MockS3.from_env.return_value = writer
+        with pytest.raises(RuntimeError, match="s3 down"):
+            main_mod.main()
+
+
+def test_output_file_uploaded_to_s3(
+    md_env_minimal: dict[str, str],
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    """Output files present on disk are uploaded via put_file; absent files are silently skipped."""
+    md_env_minimal["MD_OUTPUT_FILES"] = json.dumps({"report": "report.json"})
+    mocker.patch.dict("os.environ", _s3_env(md_env_minimal), clear=True)
     (tmp_path / "report.json").write_bytes(b"REPORT_BYTES")
     mocker.patch("runner.main.os.getcwd", return_value=str(tmp_path))
-    # Path.cwd() is also used to resolve output files.
     mocker.patch("runner.main.Path.cwd", return_value=tmp_path)
-
-    proc = _fake_proc(stdout=b"hello\n", stderr=b"", returncode=0)
-    mocker.patch("runner.main.subprocess.Popen", return_value=proc)
-    mocker.patch("runner.main.detect_tool_version", return_value=None)
-
-    rc = main_mod.main()
-
-    assert rc == 0
-    files = patched_callbacks["post_finish"].call_args.kwargs["files"]
-    assert "report" in files
-    assert files["report"] == base64.b64encode(b"REPORT_BYTES").decode("ascii")
-
-
-def test_missing_output_file_silently_dropped(
-    patched_callbacks: dict[str, MagicMock],
-    md_env_minimal: dict[str, str],
-    mocker: MockerFixture,
-    tmp_path: Path,
-) -> None:
-    md_env_minimal["MD_OUTPUT_FILES"] = json.dumps({"missing": "nope.txt"})
-    mocker.patch.dict("os.environ", md_env_minimal, clear=True)
-    mocker.patch("runner.main.os.getcwd", return_value=str(tmp_path))
-    mocker.patch("runner.main.Path.cwd", return_value=tmp_path)
-
     proc = _fake_proc(stdout=b"", stderr=b"", returncode=0)
     mocker.patch("runner.main.subprocess.Popen", return_value=proc)
     mocker.patch("runner.main.detect_tool_version", return_value=None)
 
-    rc = main_mod.main()
+    writer = MagicMock()
+    with patch("runner.main.S3Writer") as MockS3:
+        MockS3.from_env.return_value = writer
+        rc = main_mod.main()
 
     assert rc == 0
-    files = patched_callbacks["post_finish"].call_args.kwargs["files"]
-    assert files == {}
+    # put_file called with correct S3 key
+    writer.put_file.assert_called_once_with(
+        "b-test/files/report",
+        str(tmp_path / "report.json"),
+    )
+    # result.json files map records relative path
+    result_payload = writer.put_json.call_args_list[-1].args[1]
+    assert result_payload["files"] == {"report": "files/report"}
+
+
+def test_missing_output_file_silently_dropped(
+    md_env_minimal: dict[str, str],
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    """Output files that don't exist on disk are silently excluded from files_map."""
+    md_env_minimal["MD_OUTPUT_FILES"] = json.dumps({"missing": "nope.txt"})
+    mocker.patch.dict("os.environ", _s3_env(md_env_minimal), clear=True)
+    mocker.patch("runner.main.os.getcwd", return_value=str(tmp_path))
+    mocker.patch("runner.main.Path.cwd", return_value=tmp_path)
+    proc = _fake_proc(stdout=b"", stderr=b"", returncode=0)
+    mocker.patch("runner.main.subprocess.Popen", return_value=proc)
+    mocker.patch("runner.main.detect_tool_version", return_value=None)
+
+    writer = MagicMock()
+    with patch("runner.main.S3Writer") as MockS3:
+        MockS3.from_env.return_value = writer
+        rc = main_mod.main()
+
+    assert rc == 0
+    writer.put_file.assert_not_called()
+    result_payload = writer.put_json.call_args_list[-1].args[1]
+    assert result_payload["files"] == {}
+
+
+def test_meta_json_contains_tool_version(
+    md_env_minimal: dict[str, str],
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    """meta.json carries the detected tool version."""
+    md_env_minimal["MD_ARGV"] = json.dumps(["guidellm", "benchmark", "run"])
+    mocker.patch.dict("os.environ", _s3_env(md_env_minimal), clear=True)
+    mocker.patch("runner.main.Path.cwd", return_value=tmp_path)
+    mocker.patch("runner.main.os.getcwd", return_value=str(tmp_path))
+    proc = _fake_proc(stdout=b"", stderr=b"", returncode=0)
+    mocker.patch("runner.main.subprocess.Popen", return_value=proc)
+    mocker.patch("runner.main.detect_tool_version", return_value="guidellm 0.5.2")
+
+    writer = MagicMock()
+    with patch("runner.main.S3Writer") as MockS3:
+        MockS3.from_env.return_value = writer
+        rc = main_mod.main()
+
+    assert rc == 0
+    meta_key, meta_payload = writer.put_json.call_args_list[0].args
+    assert meta_key == "b-test/meta.json"
+    assert meta_payload["toolVersion"] == "guidellm 0.5.2"
+    assert "startTimeIso" in meta_payload
 
 
 def test_log_batches_posted_with_correct_kwargs(
-    patched_callbacks: dict[str, MagicMock],
     md_env_minimal: dict[str, str],
     mocker: MockerFixture,
+    tmp_path: Path,
 ) -> None:
-    mocker.patch.dict("os.environ", md_env_minimal, clear=True)
+    mocker.patch.dict("os.environ", _s3_env(md_env_minimal), clear=True)
+    mocker.patch("runner.main.Path.cwd", return_value=tmp_path)
+    mocker.patch("runner.main.os.getcwd", return_value=str(tmp_path))
     # Several lines so the end-of-stream flush has something to send.
     stdout_blob = b"line one\nline two\nline three\n"
     proc = _fake_proc(stdout=stdout_blob, stderr=b"", returncode=0)
     mocker.patch("runner.main.subprocess.Popen", return_value=proc)
     mocker.patch("runner.main.detect_tool_version", return_value=None)
+    mock_post_log = mocker.patch("runner.main.post_log_batch")
 
-    rc = main_mod.main()
+    writer = MagicMock()
+    with patch("runner.main.S3Writer") as MockS3:
+        MockS3.from_env.return_value = writer
+        rc = main_mod.main()
 
     assert rc == 0
-    assert patched_callbacks["post_log_batch"].call_count >= 1
+    assert mock_post_log.call_count >= 1
 
     # All stdout-stream calls should target benchmark_id=b-test and stream=stdout.
     stdout_calls = [
         c
-        for c in patched_callbacks["post_log_batch"].call_args_list
+        for c in mock_post_log.call_args_list
         if c.kwargs.get("stream") == "stdout"
     ]
     assert len(stdout_calls) >= 1
@@ -245,18 +309,22 @@ def test_log_batches_posted_with_correct_kwargs(
     assert "line two" in all_lines
     assert "line three" in all_lines
 
-    # And /finish should include the tail stdout (within LOG_TAIL_MAX_BYTES).
-    finish_kwargs = patched_callbacks["post_finish"].call_args.kwargs
-    assert finish_kwargs["stdout"] == "line one\nline two\nline three"
+    # stdout.log written to S3 should include all lines
+    text_calls = {call.args[0]: call.args[1] for call in writer.put_text.call_args_list}
+    assert "b-test/stdout.log" in text_calls
+    assert "line one" in text_calls["b-test/stdout.log"]
+    assert "line three" in text_calls["b-test/stdout.log"]
 
 
 def test_stdout_tail_caps_at_64kb(
-    patched_callbacks: dict[str, MagicMock],
     md_env_minimal: dict[str, str],
     mocker: MockerFixture,
+    tmp_path: Path,
 ) -> None:
-    """StreamPump.full is bounded at LOG_TAIL_MAX_BYTES; /finish receives the tail."""
-    mocker.patch.dict("os.environ", md_env_minimal, clear=True)
+    """StreamPump.full is bounded at LOG_TAIL_MAX_BYTES; stdout.log receives the tail."""
+    mocker.patch.dict("os.environ", _s3_env(md_env_minimal), clear=True)
+    mocker.patch("runner.main.Path.cwd", return_value=tmp_path)
+    mocker.patch("runner.main.os.getcwd", return_value=str(tmp_path))
     # Build 200 distinguishable lines (~1 KB each) so we can prove FIFO
     # eviction: the first lines must be dropped, the last must survive.
     lines_in = [f"line-{i:04d}-" + "x" * (1023 - 11) for i in range(200)]
@@ -265,22 +333,28 @@ def test_stdout_tail_caps_at_64kb(
     mocker.patch("runner.main.subprocess.Popen", return_value=proc)
     mocker.patch("runner.main.detect_tool_version", return_value=None)
 
-    rc = main_mod.main()
+    writer = MagicMock()
+    captured_stdout: list[str] = []
+
+    def capture_put_text(key: str, text: str) -> None:
+        if key.endswith("stdout.log"):
+            captured_stdout.append(text)
+
+    writer.put_text.side_effect = capture_put_text
+
+    with patch("runner.main.S3Writer") as MockS3:
+        MockS3.from_env.return_value = writer
+        rc = main_mod.main()
 
     assert rc == 0
-    finish_kwargs = patched_callbacks["post_finish"].call_args.kwargs
-    captured = finish_kwargs["stdout"]
+    assert len(captured_stdout) == 1
+    captured = captured_stdout[0]
     captured_bytes = len(captured.encode("utf-8"))
-    # Upper bound: the join produces N-1 newlines, so the on-the-wire
-    # bytes are always strictly less than the cap. The +1 accounting in
-    # StreamPump charges +1 per line (for the join newline), so once we
-    # evict to fit the cap, the actual bytes are ≤ cap - 1.
+    # Upper bound: within the cap
     assert captured_bytes <= main_mod.LOG_TAIL_MAX_BYTES, (
         f"stdout {captured_bytes} bytes exceeded cap {main_mod.LOG_TAIL_MAX_BYTES}"
     )
-    # Lower bound: the buffer should actually be near-full — fed 200 KB,
-    # expect the tail to be within 1 KB of the cap (room for the last
-    # partial line eviction).
+    # Lower bound: near-full
     assert captured_bytes >= main_mod.LOG_TAIL_MAX_BYTES - 1024, (
         f"stdout {captured_bytes} bytes is suspiciously below cap {main_mod.LOG_TAIL_MAX_BYTES}"
     )
@@ -298,19 +372,24 @@ def test_stdout_tail_caps_at_64kb(
 
 
 def test_redaction_in_log_line(
-    patched_callbacks: dict[str, MagicMock],
     md_env_minimal: dict[str, str],
     mocker: MockerFixture,
+    tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     md_env_minimal["MD_ARGV"] = json.dumps(["guidellm", '--backend-kwargs={"api_key":"sk-secret"}'])
-    mocker.patch.dict("os.environ", md_env_minimal, clear=True)
+    mocker.patch.dict("os.environ", _s3_env(md_env_minimal), clear=True)
+    mocker.patch("runner.main.Path.cwd", return_value=tmp_path)
+    mocker.patch("runner.main.os.getcwd", return_value=str(tmp_path))
     proc = _fake_proc(stdout=b"", stderr=b"", returncode=0)
     mocker.patch("runner.main.subprocess.Popen", return_value=proc)
     mocker.patch("runner.main.detect_tool_version", return_value=None)
 
-    with caplog.at_level("INFO", logger="runner"):
-        rc = main_mod.main()
+    writer = MagicMock()
+    with patch("runner.main.S3Writer") as MockS3:
+        MockS3.from_env.return_value = writer
+        with caplog.at_level("INFO", logger="runner"):
+            rc = main_mod.main()
 
     assert rc == 0
     log_text = "\n".join(r.message for r in caplog.records)
@@ -319,9 +398,9 @@ def test_redaction_in_log_line(
 
 
 def test_injected_api_key_is_redacted_in_log(
-    patched_callbacks: dict[str, MagicMock],
     md_env_minimal: dict[str, str],
     mocker: MockerFixture,
+    tmp_path: Path,
     caplog,
 ) -> None:
     """End-to-end: env-set OPENAI_API_KEY merges into --backend-kwargs at
@@ -329,19 +408,25 @@ def test_injected_api_key_is_redacted_in_log(
     line so the secret never appears in stdout/captured pod logs."""
     md_env_minimal["MD_ARGV"] = json.dumps(["guidellm", "--backend-kwargs={}"])
     md_env_minimal["OPENAI_API_KEY"] = "sk-from-env-secret"
-    mocker.patch.dict("os.environ", md_env_minimal, clear=True)
+    mocker.patch.dict("os.environ", _s3_env(md_env_minimal), clear=True)
+    mocker.patch("runner.main.Path.cwd", return_value=tmp_path)
+    mocker.patch("runner.main.os.getcwd", return_value=str(tmp_path))
     proc = _fake_proc(stdout=b"", stderr=b"", returncode=0)
     mocker.patch("runner.main.subprocess.Popen", return_value=proc)
     mocker.patch("runner.main.detect_tool_version", return_value=None)
-    with caplog.at_level("INFO", logger="runner"):
-        main_mod.main()
+
+    writer = MagicMock()
+    with patch("runner.main.S3Writer") as MockS3:
+        MockS3.from_env.return_value = writer
+        with caplog.at_level("INFO", logger="runner"):
+            main_mod.main()
+
     log_text = "\n".join(r.message for r in caplog.records)
     assert "***REDACTED***" in log_text
     assert "sk-from-env-secret" not in log_text
 
 
 def test_missing_required_env_raises_key_error(
-    patched_callbacks: dict[str, MagicMock],
     md_env_minimal: dict[str, str],
     mocker: MockerFixture,
 ) -> None:
@@ -367,41 +452,6 @@ def test_redacted_helper_redacts_backend_kwargs() -> None:
     out = main_mod._redacted(argv)
     assert out[0] == "guidellm"
     assert out[1] == "--backend-kwargs=***REDACTED***"
-
-
-def test_oversized_output_file_skipped_with_warning(
-    patched_callbacks: dict[str, MagicMock],
-    md_env_minimal: dict[str, str],
-    mocker: MockerFixture,
-    tmp_path: Path,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Output files over OUTPUT_FILE_MAX_BYTES are skipped rather than OOMing."""
-    md_env_minimal["MD_OUTPUT_FILES"] = json.dumps({"attack": "attack.bin"})
-    mocker.patch.dict("os.environ", md_env_minimal, clear=True)
-
-    # Write a small file but lower the cap to 1 KB so the test stays fast.
-    big_file = tmp_path / "attack.bin"
-    big_file.write_bytes(b"B" * 2048)  # 2 KB — over the patched 1 KB cap
-    mocker.patch("runner.main.os.getcwd", return_value=str(tmp_path))
-    mocker.patch("runner.main.Path.cwd", return_value=tmp_path)
-    mocker.patch("runner.main.OUTPUT_FILE_MAX_BYTES", 1024)
-
-    proc = _fake_proc(stdout=b"", stderr=b"", returncode=0)
-    mocker.patch("runner.main.subprocess.Popen", return_value=proc)
-    mocker.patch("runner.main.detect_tool_version", return_value=None)
-
-    with caplog.at_level("WARNING", logger="runner"):
-        rc = main_mod.main()
-
-    assert rc == 0
-    files = patched_callbacks["post_finish"].call_args.kwargs["files"]
-    assert "attack" not in files, "oversized file must not appear in /finish files"
-
-    warning_messages = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
-    assert any("exceeds" in msg and "attack" in msg for msg in warning_messages), (
-        f"expected a warning about 'attack' exceeding cap; got: {warning_messages}"
-    )
 
 
 def test_materialize_input_files_symlinks_into_cwd(
@@ -494,45 +544,3 @@ class TestDetectToolVersion:
         out = main_mod.detect_tool_version("guidellm")
         assert out is not None
         assert len(out) == main_mod.TOOL_VERSION_MAX_CHARS
-
-
-def test_state_running_callback_includes_detected_tool_version(
-    patched_callbacks: dict[str, MagicMock],
-    md_env_minimal: dict[str, str],
-    mocker: MockerFixture,
-) -> None:
-    """End-to-end: main() detects argv[0]'s --version and forwards it as
-    tool_version on the /state callback so the BFF can persist it on the
-    benchmark row."""
-    md_env_minimal["MD_ARGV"] = json.dumps(["guidellm", "benchmark", "run"])
-    mocker.patch.dict("os.environ", md_env_minimal, clear=True)
-    proc = _fake_proc(stdout=b"", stderr=b"", returncode=0)
-    mocker.patch("runner.main.subprocess.Popen", return_value=proc)
-    mocker.patch("runner.main.detect_tool_version", return_value="guidellm 0.5.2")
-
-    rc = main_mod.main()
-
-    assert rc == 0
-    sr_kwargs = patched_callbacks["post_state_running"].call_args.kwargs
-    assert sr_kwargs["tool_version"] == "guidellm 0.5.2"
-    assert sr_kwargs["benchmark_id"] == "b-test"
-
-
-def test_state_running_callback_passes_none_when_version_undetectable(
-    patched_callbacks: dict[str, MagicMock],
-    md_env_minimal: dict[str, str],
-    mocker: MockerFixture,
-) -> None:
-    """When the tool isn't on PATH, main() still posts /state — just with
-    tool_version=None — so the benchmark transitions to running."""
-    md_env_minimal["MD_ARGV"] = json.dumps(["nonexistent-tool"])
-    mocker.patch.dict("os.environ", md_env_minimal, clear=True)
-    proc = _fake_proc(stdout=b"", stderr=b"", returncode=0)
-    mocker.patch("runner.main.subprocess.Popen", return_value=proc)
-    mocker.patch("runner.main.detect_tool_version", return_value=None)
-
-    rc = main_mod.main()
-
-    assert rc == 0
-    sr_kwargs = patched_callbacks["post_state_running"].call_args.kwargs
-    assert sr_kwargs["tool_version"] is None

--- a/apps/benchmark-runner/tests/test_s3_writer.py
+++ b/apps/benchmark-runner/tests/test_s3_writer.py
@@ -2,6 +2,7 @@ import json
 
 import boto3
 import pytest
+from botocore.exceptions import ClientError
 from moto import mock_aws
 
 from runner.s3_writer import S3Writer
@@ -33,9 +34,11 @@ def test_writer_puts_json_text_and_file(s3_env, tmp_path):
 
     meta = json.loads(s3_client.get_object(Bucket="test-bucket", Key="r1/meta.json")["Body"].read())
     assert meta == {"toolVersion": "x"}
-    stdout = s3_client.get_object(Bucket="test-bucket", Key="r1/stdout.log")["Body"].read().decode()
+    stdout_resp = s3_client.get_object(Bucket="test-bucket", Key="r1/stdout.log")
+    stdout = stdout_resp["Body"].read().decode()
     assert stdout == "hello\nworld"
-    report = s3_client.get_object(Bucket="test-bucket", Key="r1/files/report.json")["Body"].read().decode()
+    report_resp = s3_client.get_object(Bucket="test-bucket", Key="r1/files/report.json")
+    report = report_resp["Body"].read().decode()
     assert report == '{"ok":true}'
 
 
@@ -44,5 +47,5 @@ def test_writer_raises_when_bucket_missing(s3_env):
     # No bucket created — put should raise
     s3_client = boto3.client("s3", region_name="us-east-1")
     writer = S3Writer(client=s3_client, bucket="test-bucket")
-    with pytest.raises(Exception):
+    with pytest.raises(ClientError):
         writer.put_json("r1/meta.json", {})

--- a/apps/benchmark-runner/tests/test_s3_writer.py
+++ b/apps/benchmark-runner/tests/test_s3_writer.py
@@ -1,0 +1,48 @@
+import json
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from runner.s3_writer import S3Writer
+
+
+@pytest.fixture
+def s3_env(monkeypatch):
+    monkeypatch.setenv("S3_ENDPOINT", "http://localhost:9999")
+    monkeypatch.setenv("S3_ACCESS_KEY", "test")
+    monkeypatch.setenv("S3_SECRET_KEY", "test")
+    monkeypatch.setenv("S3_BUCKET", "test-bucket")
+    monkeypatch.setenv("S3_REGION", "us-east-1")
+
+
+@mock_aws
+def test_writer_puts_json_text_and_file(s3_env, tmp_path):
+    # Use a moto-intercepted client (no custom endpoint_url) injected directly
+    # so moto can intercept calls — from_env() would set endpoint_url which
+    # bypasses moto's botocore shim.
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    s3_client.create_bucket(Bucket="test-bucket")
+    writer = S3Writer(client=s3_client, bucket="test-bucket")
+
+    writer.put_json("r1/meta.json", {"toolVersion": "x"})
+    writer.put_text("r1/stdout.log", "hello\nworld")
+    local = tmp_path / "report.json"
+    local.write_text('{"ok":true}')
+    writer.put_file("r1/files/report.json", str(local))
+
+    meta = json.loads(s3_client.get_object(Bucket="test-bucket", Key="r1/meta.json")["Body"].read())
+    assert meta == {"toolVersion": "x"}
+    stdout = s3_client.get_object(Bucket="test-bucket", Key="r1/stdout.log")["Body"].read().decode()
+    assert stdout == "hello\nworld"
+    report = s3_client.get_object(Bucket="test-bucket", Key="r1/files/report.json")["Body"].read().decode()
+    assert report == '{"ok":true}'
+
+
+@mock_aws
+def test_writer_raises_when_bucket_missing(s3_env):
+    # No bucket created — put should raise
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    writer = S3Writer(client=s3_client, bucket="test-bucket")
+    with pytest.raises(Exception):
+        writer.put_json("r1/meta.json", {})

--- a/apps/benchmark-runner/tests/test_storage_keys.py
+++ b/apps/benchmark-runner/tests/test_storage_keys.py
@@ -1,4 +1,4 @@
-from runner.storage_keys import keys_for, file_key
+from runner.storage_keys import file_key, keys_for
 
 
 def test_keys_for_basic():

--- a/apps/benchmark-runner/tests/test_storage_keys.py
+++ b/apps/benchmark-runner/tests/test_storage_keys.py
@@ -1,0 +1,13 @@
+from runner.storage_keys import keys_for, file_key
+
+
+def test_keys_for_basic():
+    k = keys_for("run-abc")
+    assert k.meta == "run-abc/meta.json"
+    assert k.result == "run-abc/result.json"
+    assert k.stdout == "run-abc/stdout.log"
+    assert k.stderr == "run-abc/stderr.log"
+
+
+def test_file_key():
+    assert file_key("run-abc", "report.json") == "run-abc/files/report.json"

--- a/apps/benchmark-runner/uv.lock
+++ b/apps/benchmark-runner/uv.lock
@@ -3,12 +3,110 @@ revision = 1
 requires-python = ">=3.11"
 
 [[package]]
+name = "boto3"
+version = "1.43.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/4b/616367e871ce3f1cb3e8545a97736b6331b9fb081497f2d44c5b2aa6959d/boto3-1.43.14.tar.gz", hash = "sha256:5c0a994b3182061ee101812e721100717a4d664f9f4ceaf4a86b6d032ce9fc2d", size = 113142 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/00/59cb9329c18e2d3aa23062ceaa87d065f2e81e7d2931df24d64e9a7815aa/boto3-1.43.14-py3-none-any.whl", hash = "sha256:574335744656cfed0b362a0a0467aaf2eb2bf15526edcd02d31d3c661f4b09e4", size = 140536 },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/3c/798d2f7deb118241930c7c6bcfb0b970d3f0245bf580700663199aeed2c3/botocore-1.43.14.tar.gz", hash = "sha256:b9e500737e43d2f147c9d4e23b54360335e77d4c0ba90a318f51b65e06cb8516", size = 15382604 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/7e/6e64821077cd2efc4aa51b7d638fb6d48e1c7c450201c529fbaf1de8bfd3/botocore-1.43.14-py3-none-any.whl", hash = "sha256:1f4a2a95ea78c10398e78431e98c1fe47adb54a7b10a32975144c1f541186658", size = 15061424 },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707 },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344 },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560 },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613 },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476 },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374 },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597 },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574 },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971 },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972 },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078 },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076 },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820 },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635 },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271 },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048 },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529 },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097 },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983 },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519 },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572 },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963 },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361 },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932 },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557 },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762 },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230 },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043 },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446 },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101 },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948 },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422 },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499 },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928 },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302 },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909 },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402 },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780 },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320 },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487 },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049 },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793 },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300 },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244 },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828 },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926 },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328 },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650 },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687 },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773 },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013 },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593 },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354 },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480 },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584 },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443 },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437 },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487 },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726 },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195 },
 ]
 
 [[package]]
@@ -110,6 +208,65 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587 },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433 },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620 },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283 },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573 },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677 },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808 },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941 },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579 },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326 },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672 },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574 },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868 },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107 },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556 },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776 },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121 },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042 },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526 },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116 },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030 },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640 },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657 },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362 },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580 },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283 },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954 },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313 },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482 },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266 },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228 },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097 },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582 },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479 },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481 },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713 },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165 },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947 },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059 },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575 },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117 },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100 },
+    { url = "https://files.pythonhosted.org/packages/be/d2/024b5e06be9d44cb021fb0e1a03d34d63989cf56a0fe62f3dfbab695b9b4/cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855", size = 3950391 },
+    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126 },
+    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270 },
+    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797 },
+    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800 },
+    { url = "https://files.pythonhosted.org/packages/a2/ca/7e8365deec19afb2b2c7be7c1c0aa8f99633b54e90c570999acda93260fc/cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a", size = 3739536 },
+]
+
+[[package]]
 name = "idna"
 version = "3.13"
 source = { registry = "https://pypi.org/simple" }
@@ -128,15 +285,100 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419 },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631 },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058 },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287 },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940 },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887 },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692 },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471 },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923 },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572 },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077 },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876 },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615 },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020 },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332 },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947 },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962 },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760 },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529 },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015 },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540 },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105 },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906 },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622 },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029 },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374 },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980 },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990 },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784 },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588 },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041 },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543 },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113 },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911 },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658 },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066 },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639 },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569 },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284 },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801 },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769 },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642 },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612 },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200 },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973 },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619 },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029 },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408 },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005 },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048 },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821 },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606 },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043 },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747 },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341 },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073 },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661 },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069 },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670 },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598 },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261 },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835 },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733 },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672 },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819 },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426 },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146 },
+]
+
+[[package]]
 name = "modeldoctor-benchmark-runner"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "boto3" },
     { name = "requests" },
 ]
 
 [package.optional-dependencies]
 dev = [
+    { name = "moto", extra = ["s3"] },
     { name = "pytest" },
     { name = "pytest-mock" },
     { name = "ruff" },
@@ -144,12 +386,38 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", specifier = ">=1.34,<2" },
+    { name = "moto", extras = ["s3"], marker = "extra == 'dev'", specifier = ">=5,<6" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8,<9" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12,<4" },
     { name = "requests", specifier = ">=2.31,<3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5,<1" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "moto"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "cryptography" },
+    { name = "requests" },
+    { name = "responses" },
+    { name = "werkzeug" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/e9/c38202162db2e76623176be9f1dbc9aa41228ffa91ee8da2d3986082c3e3/moto-5.2.1.tar.gz", hash = "sha256:ccb2f3e1dfa82e50e054bda98b0be708d244d2668364dcc1d45e8d3de6091bde", size = 8634437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/79/8085b7c1ecd48d0535c3c8444a1d8df2926e457dce8e55fabc332a382c9c/moto-5.2.1-py3-none-any.whl", hash = "sha256:19d2fbd6e613aa5b4e364c52cd5d3cea371643a0f4210689a703227bd2924c5c", size = 6671379 },
+]
+
+[package.optional-dependencies]
+s3 = [
+    { name = "py-partiql-parser" },
+    { name = "pyyaml" },
+]
 
 [[package]]
 name = "packaging"
@@ -167,6 +435,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+]
+
+[[package]]
+name = "py-partiql-parser"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/7a/a0f6bda783eb4df8e3dfd55973a1ac6d368a89178c300e1b5b91cd181e5e/py_partiql_parser-0.6.3.tar.gz", hash = "sha256:09cecf916ce6e3da2c050f0cb6106166de42c33d34a078ec2eb19377ea70389a", size = 17456 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl", hash = "sha256:deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582", size = 23752 },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172 },
 ]
 
 [[package]]
@@ -207,6 +493,73 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826 },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577 },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556 },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114 },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638 },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463 },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986 },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543 },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763 },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063 },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973 },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116 },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011 },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870 },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089 },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181 },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658 },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003 },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344 },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669 },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252 },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081 },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159 },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626 },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613 },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115 },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427 },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090 },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246 },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814 },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809 },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454 },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355 },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175 },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228 },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194 },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429 },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912 },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108 },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641 },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901 },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132 },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261 },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272 },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923 },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062 },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341 },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -219,6 +572,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947 },
+]
+
+[[package]]
+name = "responses"
+version = "0.26.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/58/1fb6de3503428196df78638f991ec8095274f1ee9723e272ee4d9ff0092b/responses-0.26.1.tar.gz", hash = "sha256:2eb3218553cc8f79b57d257bac23af5e1bf381f5b9390b1767816f0843e01dc2", size = 83088 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/31/6a620b4427d546b9e7cca8b3b8c5f0559d9cef2bb9eedcda7f73c1473c19/responses-0.26.1-py3-none-any.whl", hash = "sha256:8aacc4586eb08fb2208ef64a9eb4258d9b0c6e6f4260845f2f018ab847495345", size = 35502 },
 ]
 
 [[package]]
@@ -247,10 +614,52 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811 },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584 },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459 },
+]
+
+[[package]]
+name = "xmltodict"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580 },
 ]

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -53,3 +53,58 @@ pnpm -F @modeldoctor/api start:dev
 `host.k3d.internal` is how a pod inside the cluster reaches the dev machine
 (use `host.docker.internal` if you're on kind + Docker Desktop). No tunnel
 required.
+
+## Report storage (MinIO / S3)
+
+Phase 2 of #237 — the runner writes benchmark reports (`meta.json`,
+`result.json`, `stdout.log`, `stderr.log`, output files) to a shared
+S3-compatible bucket. The API reads them when the pod reaches its
+terminal phase. The bucket and credentials must exist **before** the
+API and runner Job can start.
+
+### 1. Configure a bucket lifecycle (once per environment)
+
+```bash
+mc alias set myminio http://10.100.121.67:31871 <access-key> <secret-key>
+mc ilm rule add --expire-days 30 myminio/<bucket>
+```
+
+30 days is the V1 retention. Adjust as ops sees fit; don't go shorter
+than the longest expected benchmark duration plus a few hours of
+investigation buffer.
+
+### 2. Create the K8s Secret
+
+The runner Job mounts `md-benchmark-storage` in the benchmarks namespace,
+and the API reads the same values from its own pod env.
+
+```bash
+kubectl -n modeldoctor-benchmarks create secret generic md-benchmark-storage \
+  --from-literal=S3_ENDPOINT=http://10.100.121.67:31871 \
+  --from-literal=S3_ACCESS_KEY=<key> \
+  --from-literal=S3_SECRET_KEY=<secret> \
+  --from-literal=S3_BUCKET=<bucket> \
+  --from-literal=S3_REGION=us-east-1
+
+# Same Secret in the API namespace too (if different from modeldoctor-benchmarks):
+kubectl -n modeldoctor create secret generic md-benchmark-storage --from-literal=...
+```
+
+The runner Job manifest auto-mounts this Secret via `envFrom`
+(see `apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts`).
+
+### 3. Verify with `mc`
+
+```bash
+mc ls myminio/<bucket>/   # should succeed
+```
+
+### Pre-deploy checklist (Phase 2 ramp)
+
+- [ ] MinIO bucket exists with lifecycle configured
+- [ ] `md-benchmark-storage` Secret exists in both namespaces
+- [ ] No long-running in-flight benchmark when deploying (recommended;
+      otherwise the watcher will auto-fail it after pod phase transitions
+      since the old runner wrote no `result.json`)
+- [ ] `K8S_WATCHER_MODE=primary` (this is now the env-schema default —
+      no override needed)

--- a/docs/superpowers/plans/2026-05-25-report-storage-and-watcher-primary.md
+++ b/docs/superpowers/plans/2026-05-25-report-storage-and-watcher-primary.md
@@ -1,0 +1,2517 @@
+# Report shared storage + watcher primary mode — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace runner→API `/state` + `/finish` callbacks with K8s informer + shared S3 storage. Runner writes report artifacts to S3; API watcher reads them when the pod reaches terminal phase. Phase 0 (storage layer) + Phase 2 (watcher primary mode) of #237, in one atomic rewrite — no deprecated endpoints, no dual-write.
+
+**Architecture:** Phase 1 already shipped `K8sJobWatcherService` + `PodStateReducer` + `StartupReconciler` + `BenchmarkRepository.updateGuarded()` as backstop. This plan activates `K8S_WATCHER_MODE=primary`: the reducer now emits `running` and `load-report` transitions; a new `ReportLoader` consumes `load-report` by reading runner-written `meta.json`/`result.json`/`stdout.log`/`stderr.log`/`files/*` from S3, parsing through the existing `byTool().parseFinalReport()` adapter, and committing the final benchmark row via `updateGuarded()`. Runner replaces `post_state_running`/`post_finish` POSTs with `boto3` writes against a shared MinIO bucket. `/log` callback path is untouched (Phase 3 territory).
+
+**Tech Stack:** TypeScript / NestJS / Prisma (apps/api), Python 3 (apps/benchmark-runner), `@kubernetes/client-node@0.21`, `@aws-sdk/client-s3` (new), `boto3` (new), Vitest + `aws-sdk-client-mock` for API tests, pytest + `moto` for runner tests.
+
+**Spec:** [`docs/superpowers/specs/2026-05-25-report-storage-and-watcher-primary-design.md`](../specs/2026-05-25-report-storage-and-watcher-primary-design.md)
+
+**Branch / worktree:** `feat/phase2-watcher-primary-and-storage` at `/Users/fangyong/vllm/modeldoctor/feat-phase2-watcher-primary` (already created; the spec lives on this branch as commit `60b038d`).
+
+---
+
+## File structure
+
+**New (API):**
+
+```
+packages/contracts/src/benchmark.ts                                    # ADD reportStorageKeys + meta/result types
+apps/api/src/modules/benchmark/storage/report-storage.ts               # ReportStorage interface
+apps/api/src/modules/benchmark/storage/s3-report-storage.ts            # @aws-sdk/client-s3 impl
+apps/api/src/modules/benchmark/storage/s3-report-storage.spec.ts       # aws-sdk-client-mock unit tests
+apps/api/src/modules/benchmark/storage/report-loader.ts                # ReportLoader service
+apps/api/src/modules/benchmark/storage/report-loader.spec.ts           # 5-path unit tests
+apps/api/src/modules/benchmark/benchmark-files.controller.ts           # GET /benchmarks/:id/files/:alias proxy
+apps/api/src/modules/benchmark/benchmark-files.controller.spec.ts      # NestJS controller tests
+apps/api/test/e2e/benchmark-watcher-primary.e2e-spec.ts                # nock K8s + S3 mock e2e
+```
+
+**New (runner):**
+
+```
+apps/benchmark-runner/runner/storage_keys.py                           # key factory (mirrors TS)
+apps/benchmark-runner/runner/s3_writer.py                              # boto3 wrapper
+apps/benchmark-runner/tests/test_storage_keys.py
+apps/benchmark-runner/tests/test_s3_writer.py                          # moto S3 mock
+```
+
+**Modify (API):**
+
+```
+apps/api/src/config/env.schema.ts                                      # +S3_*, change K8S_WATCHER_MODE default
+apps/api/test/setup/e2e-env-defaults.ts                                # +S3_* + K8S_WATCHER_MODE=off
+apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts                # +primary branch, +mode input
+apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts           # +primary matrix
+apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts          # primary mode wiring, +ReportLoader dep
+apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.spec.ts     # +primary flows
+apps/api/src/modules/benchmark/k8s/startup-reconciler.ts               # storage-first branch
+apps/api/src/modules/benchmark/k8s/startup-reconciler.spec.ts          # +storage case
+apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts                 # +md-benchmark-storage envFrom
+apps/api/src/modules/benchmark/k8s/k8s-job-manifest.spec.ts            # +envFrom assertion
+apps/api/src/modules/benchmark/benchmark.module.ts                     # wire storage + loader + files controller
+apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.ts       # DELETE handleState + handleFinish
+apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.spec.ts  # DELETE corresponding cases
+packages/contracts/src/benchmark.ts                                    # DELETE state + finish callback schemas
+deploy/k8s/README.md                                                   # +MinIO setup instructions
+```
+
+**Modify (runner):**
+
+```
+apps/benchmark-runner/requirements.txt                                 # +boto3
+apps/benchmark-runner/runner/main.py                                   # rewrite main: write S3 instead of POST /state /finish
+apps/benchmark-runner/runner/callback.py                               # DELETE post_state_running + post_finish
+apps/benchmark-runner/tests/test_main.py                               # update for new flow
+```
+
+**Don't touch:** `/log` callback handler, `HmacCallbackGuard`, `benchmarkLogCallbackSchema`, `post_log_batch`, `MD_CALLBACK_URL/TOKEN` env injection.
+
+---
+
+## Task ordering rationale
+
+1. Bottom-up: types/contracts → pure functions → services → wiring → deletions → e2e.
+2. Deletions come AFTER new path is wired + tested so we don't break old e2e while building.
+3. Runner work parallelizes with API work but keep it after API contracts settle so paths/keys line up.
+
+---
+
+### Task 1: Add reportStorageKeys + meta/result types to contracts
+
+**Files:**
+- Modify: `packages/contracts/src/benchmark.ts` (add to end, near existing callback schemas)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/contracts/src/benchmark.spec.ts` (or append if file already exists, check first with `ls packages/contracts/src/benchmark.spec.ts`):
+
+```ts
+import { describe, expect, it } from "vitest";
+import { reportStorageKeys, reportMetaSchema, reportResultSchema } from "./benchmark.js";
+
+describe("reportStorageKeys", () => {
+  it("produces stable keys for a runId", () => {
+    const k = reportStorageKeys("run-abc");
+    expect(k.meta).toBe("run-abc/meta.json");
+    expect(k.result).toBe("run-abc/result.json");
+    expect(k.stdout).toBe("run-abc/stdout.log");
+    expect(k.stderr).toBe("run-abc/stderr.log");
+    expect(k.file("report.json")).toBe("run-abc/files/report.json");
+  });
+});
+
+describe("reportMetaSchema", () => {
+  it("accepts a valid meta payload", () => {
+    expect(reportMetaSchema.parse({ toolVersion: "guidellm 0.2.1", startTimeIso: "2026-05-25T00:00:00.000Z" })).toBeTruthy();
+  });
+  it("rejects missing startTimeIso", () => {
+    expect(() => reportMetaSchema.parse({ toolVersion: "x" })).toThrow();
+  });
+});
+
+describe("reportResultSchema", () => {
+  it("accepts a valid result payload", () => {
+    expect(reportResultSchema.parse({
+      exitCode: 0,
+      finishTimeIso: "2026-05-25T01:00:00.000Z",
+      files: { "report-json": "files/report.json" },
+    })).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm -F @modeldoctor/contracts test -- benchmark.spec
+```
+Expected: FAIL — `reportStorageKeys is not a function` or similar import errors.
+
+- [ ] **Step 3: Append to `packages/contracts/src/benchmark.ts`**
+
+```ts
+// Report shared storage — Phase 2 of #237. Object keys runner writes and
+// ReportLoader reads. Keep in sync with apps/benchmark-runner/runner/storage_keys.py.
+export const reportStorageKeys = (runId: string) => ({
+  meta: `${runId}/meta.json`,
+  result: `${runId}/result.json`,
+  stdout: `${runId}/stdout.log`,
+  stderr: `${runId}/stderr.log`,
+  file: (alias: string) => `${runId}/files/${alias}`,
+});
+
+export const reportMetaSchema = z.object({
+  toolVersion: z.string().max(50),
+  startTimeIso: z.string().datetime(),
+});
+export type ReportMeta = z.infer<typeof reportMetaSchema>;
+
+export const reportResultSchema = z.object({
+  exitCode: z.number().int(),
+  finishTimeIso: z.string().datetime(),
+  files: z.record(z.string()), // alias → relative path under <runId>/
+});
+export type ReportResult = z.infer<typeof reportResultSchema>;
+```
+
+(`z` is already imported in this file.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm -F @modeldoctor/contracts test -- benchmark.spec
+```
+Expected: PASS.
+
+- [ ] **Step 5: Build contracts so consumers can pick up the new exports**
+
+```bash
+pnpm -F @modeldoctor/contracts build
+```
+Expected: builds without error; `packages/contracts/dist/benchmark.js` updated.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/contracts/src/benchmark.ts packages/contracts/src/benchmark.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(contracts): add reportStorageKeys + meta/result schemas for Phase 2
+
+Shared key factory and zod schemas for the runner→storage handshake.
+Runner Python mirrors keys in storage_keys.py; API ReportLoader uses
+reportMetaSchema / reportResultSchema to parse what comes out of S3.
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Add S3 env vars + flip K8S_WATCHER_MODE default to primary
+
+**Files:**
+- Modify: `apps/api/src/config/env.schema.ts:60` (K8S_WATCHER_MODE) + add S3_* keys
+- Modify: `apps/api/test/setup/e2e-env-defaults.ts` (export S3 + watcher mode defaults for tests)
+
+- [ ] **Step 1: Read current env schema near line 60**
+
+```bash
+sed -n '55,75p' apps/api/src/config/env.schema.ts
+```
+
+- [ ] **Step 2: Modify `apps/api/src/config/env.schema.ts` — add S3_* keys, change watcher default**
+
+Find the existing line `K8S_WATCHER_MODE: z.enum(["off", "backstop", "primary"]).default("off"),` and change `default("off")` to `default("primary")`.
+
+Add immediately after that line (still inside the schema object):
+
+```ts
+S3_ENDPOINT: z.string().url(),
+S3_ACCESS_KEY: z.string().min(1),
+S3_SECRET_KEY: z.string().min(1),
+S3_BUCKET: z.string().min(1),
+S3_REGION: z.string().default("us-east-1"),
+```
+
+(All five required except S3_REGION because MinIO ignores it but the AWS SDK requires it.)
+
+- [ ] **Step 3: Modify `apps/api/test/setup/e2e-env-defaults.ts`**
+
+Read existing structure first:
+
+```bash
+sed -n '38,80p' apps/api/test/setup/e2e-env-defaults.ts
+```
+
+Inside the `E2E_ENV_DEFAULTS` const, add:
+
+```ts
+K8S_WATCHER_MODE: "off",
+S3_ENDPOINT: "http://localhost:9999",
+S3_ACCESS_KEY: "test-access-key",
+S3_SECRET_KEY: "test-secret-key",
+S3_BUCKET: "test-bucket",
+S3_REGION: "us-east-1",
+```
+
+Rationale: tests don't need real S3; this just makes env validation pass. E2E tests that exercise primary mode override `K8S_WATCHER_MODE` explicitly.
+
+- [ ] **Step 4: Verify API still type-checks**
+
+```bash
+pnpm -F @modeldoctor/api type-check
+```
+Expected: PASS.
+
+- [ ] **Step 5: Run existing unit tests to confirm no regression from default flip**
+
+```bash
+pnpm -F @modeldoctor/api test
+```
+Expected: PASS (tests that construct env should pick up E2E_ENV_DEFAULTS or already supply explicit values).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/config/env.schema.ts apps/api/test/setup/e2e-env-defaults.ts
+git commit -m "$(cat <<'EOF'
+feat(api): add S3 env schema + flip K8S_WATCHER_MODE default to primary
+
+S3_ENDPOINT/ACCESS_KEY/SECRET_KEY/BUCKET required; S3_REGION defaults
+to us-east-1 (MinIO ignores it but AWS SDK requires a region string).
+
+K8S_WATCHER_MODE default off→primary. Tests override to "off" via
+E2E_ENV_DEFAULTS so unrelated tests don't spin up informers.
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Define `ReportStorage` interface
+
+**Files:**
+- Create: `apps/api/src/modules/benchmark/storage/report-storage.ts`
+
+This is a pure interface file — no test needed on its own (consumed via other tests).
+
+- [ ] **Step 1: Create the interface file**
+
+```ts
+// apps/api/src/modules/benchmark/storage/report-storage.ts
+
+/**
+ * Report-side read interface for shared object storage (MinIO / S3).
+ *
+ * Phase 2 of #237: API only reads — runner writes via boto3 directly.
+ * Implementations: S3ReportStorage (prod / dev), in-memory mock (tests).
+ *
+ * Throws when the network round-trip fails or auth is rejected.
+ * Returns `false` from exists() when the object is genuinely absent.
+ */
+export interface ReportStorage {
+  exists(key: string): Promise<boolean>;
+  readJson<T>(key: string): Promise<T>;
+  readText(key: string): Promise<string>;
+  readBytes(key: string): Promise<Buffer>;
+}
+
+export const REPORT_STORAGE = Symbol("REPORT_STORAGE");
+```
+
+- [ ] **Step 2: Verify type-check**
+
+```bash
+pnpm -F @modeldoctor/api type-check
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/modules/benchmark/storage/report-storage.ts
+git commit -m "$(cat <<'EOF'
+feat(api): add ReportStorage interface (no impl)
+
+Pure interface for the report-side read path. Implementations land
+in subsequent commits (S3ReportStorage). REPORT_STORAGE token used
+by Nest DI to swap implementations in tests.
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Add `@aws-sdk/client-s3` + `aws-sdk-client-mock` dependencies
+
+**Files:**
+- Modify: `apps/api/package.json` (dependencies + devDependencies)
+- Modify: `pnpm-lock.yaml` (regenerated by pnpm)
+
+- [ ] **Step 1: Install runtime + dev deps**
+
+```bash
+pnpm -F @modeldoctor/api add @aws-sdk/client-s3
+pnpm -F @modeldoctor/api add -D aws-sdk-client-mock
+```
+
+Expected: pnpm pulls `@aws-sdk/client-s3` (~3.x) and `aws-sdk-client-mock`. Lockfile updated.
+
+- [ ] **Step 2: Verify install**
+
+```bash
+pnpm -F @modeldoctor/api list @aws-sdk/client-s3 aws-sdk-client-mock
+```
+Expected: shows both with concrete versions.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/package.json pnpm-lock.yaml
+git commit -m "$(cat <<'EOF'
+build(api): add @aws-sdk/client-s3 + aws-sdk-client-mock
+
+@aws-sdk/client-s3 is the API-side read client against MinIO / S3.
+aws-sdk-client-mock is the v3-SDK-native mocking lib used in unit
+tests (preferred over generic vitest mocks for SDK v3 command shapes).
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Implement `S3ReportStorage` with TDD
+
+**Files:**
+- Create: `apps/api/src/modules/benchmark/storage/s3-report-storage.ts`
+- Test: `apps/api/src/modules/benchmark/storage/s3-report-storage.spec.ts`
+
+- [ ] **Step 1: Write the failing test file**
+
+```ts
+// apps/api/src/modules/benchmark/storage/s3-report-storage.spec.ts
+import { GetObjectCommand, HeadObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { Readable } from "node:stream";
+import { mockClient } from "aws-sdk-client-mock";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { S3ReportStorage } from "./s3-report-storage.js";
+
+const s3Mock = mockClient(S3Client);
+
+function bodyFromString(s: string) {
+  return Readable.from([Buffer.from(s, "utf8")]) as unknown as ReturnType<typeof Readable.from>;
+}
+
+function makeStorage() {
+  return new S3ReportStorage({
+    endpoint: "http://localhost:9999",
+    region: "us-east-1",
+    accessKeyId: "test",
+    secretAccessKey: "test",
+    bucket: "test-bucket",
+  });
+}
+
+describe("S3ReportStorage", () => {
+  beforeEach(() => s3Mock.reset());
+  afterEach(() => s3Mock.reset());
+
+  it("exists() returns true when HeadObject succeeds", async () => {
+    s3Mock.on(HeadObjectCommand).resolves({});
+    const storage = makeStorage();
+    expect(await storage.exists("run-1/result.json")).toBe(true);
+  });
+
+  it("exists() returns false on NotFound", async () => {
+    s3Mock.on(HeadObjectCommand).rejects(Object.assign(new Error("not found"), { name: "NotFound" }));
+    const storage = makeStorage();
+    expect(await storage.exists("run-1/result.json")).toBe(false);
+  });
+
+  it("exists() rethrows on non-NotFound errors", async () => {
+    s3Mock.on(HeadObjectCommand).rejects(new Error("network down"));
+    const storage = makeStorage();
+    await expect(storage.exists("run-1/result.json")).rejects.toThrow("network down");
+  });
+
+  it("readJson() parses GetObject body", async () => {
+    s3Mock.on(GetObjectCommand).resolves({ Body: bodyFromString('{"exitCode":0}') as never });
+    const storage = makeStorage();
+    expect(await storage.readJson("run-1/result.json")).toEqual({ exitCode: 0 });
+  });
+
+  it("readText() returns full body as string", async () => {
+    s3Mock.on(GetObjectCommand).resolves({ Body: bodyFromString("hello\nworld") as never });
+    const storage = makeStorage();
+    expect(await storage.readText("run-1/stdout.log")).toBe("hello\nworld");
+  });
+
+  it("readBytes() returns Buffer", async () => {
+    s3Mock.on(GetObjectCommand).resolves({ Body: bodyFromString("binary") as never });
+    const storage = makeStorage();
+    expect((await storage.readBytes("run-1/files/x")).toString("utf8")).toBe("binary");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+pnpm -F @modeldoctor/api test -- s3-report-storage.spec
+```
+Expected: FAIL — can't import `S3ReportStorage`.
+
+- [ ] **Step 3: Implement `S3ReportStorage`**
+
+```ts
+// apps/api/src/modules/benchmark/storage/s3-report-storage.ts
+import { GetObjectCommand, HeadObjectCommand, NotFound, S3Client } from "@aws-sdk/client-s3";
+import { Injectable, Logger } from "@nestjs/common";
+import { Readable } from "node:stream";
+import type { ReportStorage } from "./report-storage.js";
+
+export interface S3ReportStorageConfig {
+  endpoint: string;
+  region: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  bucket: string;
+}
+
+@Injectable()
+export class S3ReportStorage implements ReportStorage {
+  private readonly log = new Logger(S3ReportStorage.name);
+  private readonly client: S3Client;
+  private readonly bucket: string;
+
+  constructor(cfg: S3ReportStorageConfig) {
+    this.client = new S3Client({
+      endpoint: cfg.endpoint,
+      region: cfg.region,
+      forcePathStyle: true,
+      credentials: { accessKeyId: cfg.accessKeyId, secretAccessKey: cfg.secretAccessKey },
+      maxAttempts: 2,
+    });
+    this.bucket = cfg.bucket;
+  }
+
+  async exists(key: string): Promise<boolean> {
+    try {
+      await this.client.send(new HeadObjectCommand({ Bucket: this.bucket, Key: key }));
+      return true;
+    } catch (e) {
+      // SDK v3 surfaces 404 as NotFound class instance OR { name: "NotFound" } depending on path
+      if (e instanceof NotFound) return false;
+      if ((e as { name?: string }).name === "NotFound") return false;
+      throw e;
+    }
+  }
+
+  async readJson<T>(key: string): Promise<T> {
+    const text = await this.readText(key);
+    return JSON.parse(text) as T;
+  }
+
+  async readText(key: string): Promise<string> {
+    const buf = await this.readBytes(key);
+    return buf.toString("utf8");
+  }
+
+  async readBytes(key: string): Promise<Buffer> {
+    const res = await this.client.send(new GetObjectCommand({ Bucket: this.bucket, Key: key }));
+    if (!res.Body) throw new Error(`S3 GetObject ${key} returned empty body`);
+    const stream = res.Body as Readable;
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    return Buffer.concat(chunks);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+```bash
+pnpm -F @modeldoctor/api test -- s3-report-storage.spec
+```
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/benchmark/storage/s3-report-storage.ts apps/api/src/modules/benchmark/storage/s3-report-storage.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(api): S3ReportStorage implementing ReportStorage
+
+@aws-sdk/client-s3 wrapper with forcePathStyle for MinIO, 2-attempt
+retry (default 3 too aggressive for our case), and NotFound→false
+on exists(). readJson/Text/Bytes share the same stream→Buffer drain.
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Extend `PodStateReducer` for primary mode
+
+**Files:**
+- Modify: `apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts`
+- Test: `apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts`
+
+- [ ] **Step 1: Read current reducer + test files to understand shape**
+
+```bash
+sed -n '20,50p' apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts
+wc -l apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts
+```
+
+- [ ] **Step 2: Add `mode` to ReducerInput and new DesiredTransition kinds**
+
+In `pod-state-reducer.ts`, change `DesiredTransition` to add two kinds:
+
+```ts
+export type DesiredTransition =
+  | { kind: "running"; startedAt: Date }
+  | { kind: "load-report" }
+  | { kind: "failed-pre-start"; reason: string; message: string }
+  | { kind: "failed-terminal"; exitCode: number; reason: string; message: string }
+  | { kind: "noop" };
+```
+
+Change `ReducerInput` to add `mode`:
+
+```ts
+export interface ReducerInput {
+  pod: V1Pod;
+  currentStatus: string;
+  firstFatalWaitingAt: Date | null;
+  firstTerminalAt: Date | null;
+  now: Date;
+  config: ReducerConfig;
+  mode: "backstop" | "primary";
+}
+```
+
+Then refactor the existing `reduce()` function. Keep the existing backstop branch verbatim (don't touch behavior); wrap primary in an early check at the top of the body, AFTER the existing `if (!isInProgressStatus(currentStatus)) return { kind: "noop" }` guard.
+
+Insert after the guard:
+
+```ts
+if (input.mode === "primary") {
+  return reducePrimary(input);
+}
+// fall through to existing backstop body
+```
+
+Append at the bottom of the file:
+
+```ts
+function reducePrimary(input: ReducerInput): DesiredTransition {
+  const { pod, currentStatus, firstFatalWaitingAt, now, config } = input;
+  const phase = pod.status?.phase;
+
+  // 1. Succeeded → trigger ReportLoader
+  if (phase === "Succeeded") return { kind: "load-report" };
+
+  // 2. Failed → write failed directly (no grace)
+  if (phase === "Failed") {
+    const term = getTerminatedOf(pod);
+    return {
+      kind: "failed-terminal",
+      exitCode: term?.exitCode ?? -1,
+      reason: term?.reason ?? "PodFailed",
+      message: truncatePrimary(term ? `${term.reason}: ${term.message}` : "pod in Failed phase"),
+    };
+  }
+
+  // 3. FATAL waiting + grace elapsed
+  const waiting = getWaitingOf(pod);
+  if (waiting && config.fatalWaitingReasons.includes(waiting.reason)) {
+    if (firstFatalWaitingAt) {
+      const elapsedSec = (now.getTime() - firstFatalWaitingAt.getTime()) / 1000;
+      if (elapsedSec >= config.waitingFatalGraceSec) {
+        return {
+          kind: "failed-pre-start",
+          reason: waiting.reason,
+          message: truncatePrimary(`${waiting.reason}: ${waiting.message}`),
+        };
+      }
+    }
+    return { kind: "noop" };
+  }
+
+  // 4. Running + ready + currentStatus=submitted → mark running
+  if (phase === "Running" && currentStatus === "submitted") {
+    const runner = pod.status?.containerStatuses?.find((c) => c.name === "runner");
+    if (runner?.ready) {
+      const startedAt = runner.state?.running?.startedAt ?? now;
+      return { kind: "running", startedAt: new Date(startedAt) };
+    }
+  }
+
+  return { kind: "noop" };
+}
+
+// Helpers — reuse existing if file already has equivalents; if so use those names.
+function truncatePrimary(s: string): string { return s.length > 2048 ? s.slice(0, 2048) : s; }
+function getWaitingOf(pod: V1Pod): { reason: string; message: string } | null {
+  const cs = pod.status?.containerStatuses?.find((c) => c.name === "runner");
+  const w = cs?.state?.waiting;
+  if (!w?.reason) return null;
+  return { reason: w.reason, message: w.message ?? "" };
+}
+function getTerminatedOf(pod: V1Pod): { exitCode: number; reason: string; message: string } | null {
+  const cs = pod.status?.containerStatuses?.find((c) => c.name === "runner");
+  const t = cs?.state?.terminated;
+  if (!t) return null;
+  return { exitCode: t.exitCode ?? -1, reason: t.reason ?? "Unknown", message: t.message ?? "" };
+}
+```
+
+If file already has `truncate` / `getWaitingReason` / `getTerminated`, delete the duplicate local helpers and reuse — check first with `grep -n "function truncate\|function getWaitingReason\|function getTerminated" apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts`. The reducer file already exports these as module-private; primary branch should use the same names rather than `truncatePrimary` etc.
+
+- [ ] **Step 3: Update existing backstop test cases to pass `mode: "backstop"` explicitly**
+
+In `pod-state-reducer.spec.ts`, every `reduce({ ... })` call needs `mode: "backstop"` added (the existing tests have no `mode`; they'll fail type-check now). Use a sed or batch find-replace, then sanity-check by running the existing test names.
+
+```bash
+pnpm -F @modeldoctor/api test -- pod-state-reducer.spec
+```
+Expected at this point: TYPE errors or test setup failures because `mode` is required. Fix by adding `mode: "backstop"` to each `reduce(...)` call.
+
+- [ ] **Step 4: Add primary-mode test matrix**
+
+Append to `pod-state-reducer.spec.ts`:
+
+```ts
+describe("PodStateReducer — primary mode", () => {
+  const baseConfig: ReducerConfig = {
+    fatalWaitingReasons: ["ImagePullBackOff", "CrashLoopBackOff"],
+    waitingFatalGraceSec: 60,
+    terminalReconcileGraceSec: 60,
+  };
+  const now = new Date("2026-05-25T01:00:00Z");
+
+  function makePod(status: Partial<V1Pod["status"]>): V1Pod {
+    return {
+      metadata: { labels: { "modeldoctor.ai/run-id": "r1" } },
+      status: { phase: "Pending", ...status },
+    } as V1Pod;
+  }
+
+  it("Succeeded + IN_PROGRESS → load-report", () => {
+    const out = reduce({
+      pod: makePod({ phase: "Succeeded" }), currentStatus: "running",
+      firstFatalWaitingAt: null, firstTerminalAt: null, now, config: baseConfig, mode: "primary",
+    });
+    expect(out).toEqual({ kind: "load-report" });
+  });
+
+  it("Failed + IN_PROGRESS → failed-terminal (no grace)", () => {
+    const out = reduce({
+      pod: makePod({ phase: "Failed", containerStatuses: [{
+        name: "runner", ready: false, image: "x", imageID: "x", restartCount: 0,
+        state: { terminated: { exitCode: 1, reason: "Error", message: "boom" } },
+      }] }),
+      currentStatus: "running", firstFatalWaitingAt: null, firstTerminalAt: null,
+      now, config: baseConfig, mode: "primary",
+    });
+    expect(out).toMatchObject({ kind: "failed-terminal", exitCode: 1, reason: "Error" });
+  });
+
+  it("Running + container ready + status=submitted → running", () => {
+    const startedAt = "2026-05-25T00:50:00Z";
+    const out = reduce({
+      pod: makePod({ phase: "Running", containerStatuses: [{
+        name: "runner", ready: true, image: "x", imageID: "x", restartCount: 0,
+        state: { running: { startedAt: new Date(startedAt) } },
+      }] }),
+      currentStatus: "submitted", firstFatalWaitingAt: null, firstTerminalAt: null,
+      now, config: baseConfig, mode: "primary",
+    });
+    expect(out).toEqual({ kind: "running", startedAt: new Date(startedAt) });
+  });
+
+  it("Running + container NOT ready → noop", () => {
+    const out = reduce({
+      pod: makePod({ phase: "Running", containerStatuses: [{
+        name: "runner", ready: false, image: "x", imageID: "x", restartCount: 0,
+        state: { running: { startedAt: new Date(now) } },
+      }] }),
+      currentStatus: "submitted", firstFatalWaitingAt: null, firstTerminalAt: null,
+      now, config: baseConfig, mode: "primary",
+    });
+    expect(out).toEqual({ kind: "noop" });
+  });
+
+  it("Pending + ImagePullBackOff + grace not elapsed → noop", () => {
+    const out = reduce({
+      pod: makePod({ phase: "Pending", containerStatuses: [{
+        name: "runner", ready: false, image: "x", imageID: "x", restartCount: 0,
+        state: { waiting: { reason: "ImagePullBackOff", message: "no such image" } },
+      }] }),
+      currentStatus: "submitted",
+      firstFatalWaitingAt: new Date(now.getTime() - 30_000), firstTerminalAt: null,
+      now, config: baseConfig, mode: "primary",
+    });
+    expect(out).toEqual({ kind: "noop" });
+  });
+
+  it("Pending + ImagePullBackOff + grace elapsed → failed-pre-start", () => {
+    const out = reduce({
+      pod: makePod({ phase: "Pending", containerStatuses: [{
+        name: "runner", ready: false, image: "x", imageID: "x", restartCount: 0,
+        state: { waiting: { reason: "ImagePullBackOff", message: "no such image" } },
+      }] }),
+      currentStatus: "submitted",
+      firstFatalWaitingAt: new Date(now.getTime() - 70_000), firstTerminalAt: null,
+      now, config: baseConfig, mode: "primary",
+    });
+    expect(out).toMatchObject({ kind: "failed-pre-start", reason: "ImagePullBackOff" });
+  });
+
+  it("any phase + terminal benchmark status → noop", () => {
+    const out = reduce({
+      pod: makePod({ phase: "Succeeded" }), currentStatus: "completed",
+      firstFatalWaitingAt: null, firstTerminalAt: null, now, config: baseConfig, mode: "primary",
+    });
+    expect(out).toEqual({ kind: "noop" });
+  });
+});
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+pnpm -F @modeldoctor/api test -- pod-state-reducer.spec
+```
+Expected: PASS (existing backstop tests still pass with `mode: "backstop"`, new primary tests pass).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(api): PodStateReducer primary mode + load-report transition
+
+Adds 'running' and 'load-report' DesiredTransition kinds plus a 'mode'
+input. Backstop branch unchanged (existing tests still green with
+mode: "backstop"). Primary branch:
+  - phase=Succeeded → load-report (no grace)
+  - phase=Failed → failed-terminal (no grace)
+  - phase=Pending + FATAL waiting + grace → failed-pre-start
+  - phase=Running + ready + submitted → running
+  - else → noop
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Implement `ReportLoader` with TDD (5-path coverage)
+
+**Files:**
+- Create: `apps/api/src/modules/benchmark/storage/report-loader.ts`
+- Test: `apps/api/src/modules/benchmark/storage/report-loader.spec.ts`
+
+- [ ] **Step 1: Write failing tests covering all 5 paths**
+
+```ts
+// apps/api/src/modules/benchmark/storage/report-loader.spec.ts
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { ReportLoader } from "./report-loader.js";
+import type { ReportStorage } from "./report-storage.js";
+
+const fixtureMeta = { toolVersion: "guidellm 0.2.1", startTimeIso: "2026-05-25T00:00:00.000Z" };
+const fixtureResult = { exitCode: 0, finishTimeIso: "2026-05-25T01:00:00.000Z", files: { "report.json": "files/report.json" } };
+
+function makeDeps() {
+  const storage: ReportStorage = {
+    exists: vi.fn(async () => true),
+    readJson: vi.fn(async (k: string) => {
+      if (k.endsWith("meta.json")) return fixtureMeta;
+      if (k.endsWith("result.json")) return fixtureResult;
+      throw new Error(`unexpected key ${k}`);
+    }),
+    readText: vi.fn(async () => "stdout content"),
+    readBytes: vi.fn(async () => Buffer.from("file content")),
+  };
+  const repo = {
+    findById: vi.fn(async (id: string) => ({ id, status: "running", tool: "guidellm", userId: "u1", name: "n", scenario: "s", connectionId: null })),
+    updateGuarded: vi.fn(async () => ({ id: "r1" })),
+  };
+  const notify = { emit: vi.fn(async () => {}) };
+  const sse = { close: vi.fn() };
+  const adapter = { parseFinalReport: vi.fn(() => ({ tool: "guidellm" as const, data: { latency: 42 } })) };
+  const byTool = vi.fn(() => adapter);
+  return { storage, repo, notify, sse, byTool, adapter };
+}
+
+describe("ReportLoader", () => {
+  let deps: ReturnType<typeof makeDeps>;
+  beforeEach(() => { deps = makeDeps(); });
+
+  function newLoader(d: ReturnType<typeof makeDeps>) {
+    return new ReportLoader({
+      storage: d.storage, repo: d.repo as never, notify: d.notify as never,
+      sse: d.sse as never, byTool: d.byTool as never,
+    });
+  }
+
+  it("success path → updateGuarded(completed) + notify benchmark.completed", async () => {
+    const loader = newLoader(deps);
+    await loader.tryLoad("r1");
+    expect(deps.repo.updateGuarded).toHaveBeenCalledWith(
+      "r1",
+      expect.arrayContaining(["submitted", "running"]),
+      expect.objectContaining({ status: "completed", toolVersion: "guidellm 0.2.1" }),
+    );
+    expect(deps.notify.emit).toHaveBeenCalledWith(expect.objectContaining({ eventType: "benchmark.completed" }));
+    expect(deps.sse.close).toHaveBeenCalledWith("r1");
+  });
+
+  it("storage timeout → updateGuarded(failed) + notify benchmark.failed", async () => {
+    (deps.storage.readJson as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("timeout"));
+    const loader = newLoader(deps);
+    await loader.tryLoad("r1");
+    expect(deps.repo.updateGuarded).toHaveBeenCalledWith(
+      "r1", expect.anything(), expect.objectContaining({ status: "failed", statusMessage: expect.stringContaining("report load") }),
+    );
+  });
+
+  it("file missing → updateGuarded(failed)", async () => {
+    (deps.storage.readJson as ReturnType<typeof vi.fn>).mockRejectedValueOnce(Object.assign(new Error("NotFound"), { name: "NotFound" }));
+    const loader = newLoader(deps);
+    await loader.tryLoad("r1");
+    expect(deps.repo.updateGuarded).toHaveBeenCalledWith(
+      "r1", expect.anything(), expect.objectContaining({ status: "failed" }),
+    );
+  });
+
+  it("parse failure → updateGuarded(failed)", async () => {
+    deps.adapter.parseFinalReport = vi.fn(() => { throw new Error("bad json"); });
+    const loader = newLoader(deps);
+    await loader.tryLoad("r1");
+    expect(deps.repo.updateGuarded).toHaveBeenCalledWith(
+      "r1", expect.anything(), expect.objectContaining({ status: "failed", statusMessage: expect.stringContaining("report load: bad json") }),
+    );
+  });
+
+  it("benchmark already terminal → noop (no storage reads)", async () => {
+    deps.repo.findById = vi.fn(async () => ({ id: "r1", status: "cancelled", tool: "guidellm", userId: "u1", name: "n", scenario: "s", connectionId: null }));
+    const loader = newLoader(deps);
+    await loader.tryLoad("r1");
+    expect(deps.storage.readJson).not.toHaveBeenCalled();
+    expect(deps.repo.updateGuarded).not.toHaveBeenCalled();
+  });
+
+  it("guard race: updateGuarded returns null → no notify", async () => {
+    deps.repo.updateGuarded = vi.fn(async () => null);
+    const loader = newLoader(deps);
+    await loader.tryLoad("r1");
+    expect(deps.notify.emit).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm failure**
+
+```bash
+pnpm -F @modeldoctor/api test -- report-loader.spec
+```
+Expected: FAIL — can't import `ReportLoader`.
+
+- [ ] **Step 3: Implement `ReportLoader`**
+
+```ts
+// apps/api/src/modules/benchmark/storage/report-loader.ts
+import { Inject, Injectable, Logger } from "@nestjs/common";
+import {
+  type ReportMeta,
+  type ReportResult,
+  reportStorageKeys,
+} from "@modeldoctor/contracts";
+import type { Prisma } from "@prisma/client";
+import { byTool as defaultByTool } from "@modeldoctor/tool-adapters";
+import type { ToolName } from "@modeldoctor/contracts";
+import type { BenchmarkRepository } from "../benchmark.repository.js";
+import { IN_PROGRESS_STATES } from "../constants.js";
+import type { NotifyService } from "../../notify/notify.service.js";
+import type { SseHub } from "../sse.hub.js";
+import { REPORT_STORAGE, type ReportStorage } from "./report-storage.js";
+
+const STATUS_MESSAGE_MAX = 2048;
+const RAW_OUTPUT_TAIL_MAX = 64 * 1024;
+
+export interface ReportLoaderDeps {
+  storage: ReportStorage;
+  repo: BenchmarkRepository;
+  notify: NotifyService;
+  sse: SseHub;
+  byTool?: typeof defaultByTool;
+}
+
+@Injectable()
+export class ReportLoader {
+  private readonly log = new Logger(ReportLoader.name);
+  private readonly byTool: typeof defaultByTool;
+
+  constructor(
+    @Inject(REPORT_STORAGE) storage: ReportStorage,
+    repo: BenchmarkRepository,
+    notify: NotifyService,
+    sse: SseHub,
+  );
+  constructor(deps: ReportLoaderDeps);
+  constructor(...args: unknown[]) {
+    // Support both DI and direct construction (for tests)
+    if (args.length === 1 && typeof args[0] === "object") {
+      const d = args[0] as ReportLoaderDeps;
+      this.storage = d.storage; this.repo = d.repo; this.notify = d.notify; this.sse = d.sse;
+      this.byTool = d.byTool ?? defaultByTool;
+    } else {
+      this.storage = args[0] as ReportStorage;
+      this.repo = args[1] as BenchmarkRepository;
+      this.notify = args[2] as NotifyService;
+      this.sse = args[3] as SseHub;
+      this.byTool = defaultByTool;
+    }
+  }
+
+  private readonly storage!: ReportStorage;
+  private readonly repo!: BenchmarkRepository;
+  private readonly notify!: NotifyService;
+  private readonly sse!: SseHub;
+
+  async tryLoad(runId: string): Promise<void> {
+    const bench = await this.repo.findById(runId);
+    if (!bench || !IN_PROGRESS_STATES.includes(bench.status)) return;
+    const keys = reportStorageKeys(runId);
+    try {
+      const [meta, result, stdout, stderr] = await Promise.all([
+        this.storage.readJson<ReportMeta>(keys.meta),
+        this.storage.readJson<ReportResult>(keys.result),
+        this.storage.readText(keys.stdout),
+        this.storage.readText(keys.stderr),
+      ]);
+      const files = await this.loadFiles(runId, result.files);
+      const summary = this.byTool(bench.tool as ToolName).parseFinalReport(stdout, files);
+      const updated = await this.repo.updateGuarded(runId, IN_PROGRESS_STATES, {
+        status: "completed",
+        toolVersion: meta.toolVersion,
+        statusMessage: null,
+        summaryMetrics: (summary ?? null) as Prisma.InputJsonValue,
+        rawOutput: {
+          stdout: stdout.slice(-RAW_OUTPUT_TAIL_MAX),
+          stderr: stderr.slice(-RAW_OUTPUT_TAIL_MAX),
+          files: result.files,
+        } as Prisma.InputJsonValue,
+        completedAt: new Date(result.finishTimeIso),
+      });
+      if (updated && bench.userId) {
+        await this.notify.emit({
+          eventType: "benchmark.completed",
+          userId: bench.userId,
+          connectionId: bench.connectionId ?? undefined,
+          payload: {
+            benchmarkId: bench.id, name: bench.name, status: "completed",
+            scenario: bench.scenario, tool: bench.tool, connectionId: bench.connectionId,
+            summaryMetrics: summary, message: null,
+          },
+        });
+      }
+    } catch (e) {
+      const msg = `report load: ${(e as Error).message}`.slice(0, STATUS_MESSAGE_MAX);
+      const updated = await this.repo.updateGuarded(runId, IN_PROGRESS_STATES, {
+        status: "failed",
+        statusMessage: msg,
+        completedAt: new Date(),
+      });
+      if (updated && bench.userId) {
+        await this.notify.emit({
+          eventType: "benchmark.failed",
+          userId: bench.userId,
+          connectionId: bench.connectionId ?? undefined,
+          payload: {
+            benchmarkId: bench.id, name: bench.name, status: "failed",
+            scenario: bench.scenario, tool: bench.tool, connectionId: bench.connectionId,
+            summaryMetrics: null, message: msg,
+          },
+        });
+      }
+      this.log.warn(`tryLoad(${runId}) failed: ${(e as Error).message}`);
+    } finally {
+      this.sse.close(runId);
+    }
+  }
+
+  private async loadFiles(runId: string, fileMap: Record<string, string>): Promise<Record<string, Buffer>> {
+    const entries: Array<[string, Buffer]> = [];
+    for (const [alias, relPath] of Object.entries(fileMap)) {
+      const key = `${runId}/${relPath}`;
+      entries.push([alias, await this.storage.readBytes(key)]);
+    }
+    return Object.fromEntries(entries);
+  }
+}
+```
+
+> Note: the constructor overload above is awkward but lets tests inject deps without Nest DI. Cleaner alternative: extract a `ReportLoaderImpl` class taking `ReportLoaderDeps` and a thin `@Injectable()` NestJS wrapper around it. Use whichever the rest of the codebase prefers (check `K8sJobWatcherService` constructor pattern — it uses `private readonly deps: WatcherDeps`, mirror that).
+
+If `K8sJobWatcherService` uses the deps-object pattern, **prefer the same shape**:
+
+```ts
+@Injectable()
+export class ReportLoader {
+  constructor(private readonly deps: ReportLoaderDeps) {}
+  async tryLoad(runId: string) { /* uses this.deps.storage etc. */ }
+}
+```
+
+and update tests to construct it the same way. Confirm by grepping `constructor(private readonly deps:` in the file you're mirroring.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+pnpm -F @modeldoctor/api test -- report-loader.spec
+```
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/benchmark/storage/report-loader.ts apps/api/src/modules/benchmark/storage/report-loader.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(api): ReportLoader — read S3 fixture and write final benchmark row
+
+tryLoad(runId) reads meta/result/stdout/stderr/files from ReportStorage,
+calls byTool().parseFinalReport, then BenchmarkRepository.updateGuarded
+with status=completed (or failed on any storage/parse error). Notify
+emitted only when guard accepts the write — cancel races silently lose.
+
+Six unit tests cover: happy path, storage timeout, file missing, parse
+failure, already-terminal noop, and guard race (affected=0 → no notify).
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: Wire ReportLoader into watcher service + handle new transitions
+
+**Files:**
+- Modify: `apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts`
+- Modify: `apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.spec.ts`
+
+- [ ] **Step 1: Read existing watcher service to identify event handler**
+
+```bash
+sed -n '100,160p' apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts
+```
+
+Note `WatcherDeps` shape — add `reportLoader` and pass `mode` into reducer.
+
+- [ ] **Step 2: Update `WatcherDeps` and the handler**
+
+In `k8s-job-watcher.service.ts`, modify `WatcherDeps`:
+
+```ts
+export interface WatcherDeps {
+  mode: WatcherMode;
+  namespace: string;
+  reducerConfig: ReducerConfig;
+  makeInformer: () => Informer<V1Pod>;
+  repo: BenchmarkRepository;
+  reconciler: StartupReconciler;
+  reportLoader: ReportLoader;   // NEW
+}
+```
+
+In `onModuleInit`, remove the `if (this.deps.mode === "primary") throw` early-return — `primary` is now supported.
+
+In the event handler (find `handlePodEvent`), where it calls `reduce(...)`, pass `mode: this.deps.mode`:
+
+```ts
+const transition = reduce({
+  pod, currentStatus: bench.status,
+  firstFatalWaitingAt: this.firstFatalWaitingAt.get(runId) ?? null,
+  firstTerminalAt: this.firstTerminalAt.get(runId) ?? null,
+  now, config: this.deps.reducerConfig,
+  mode: this.deps.mode === "off" ? "backstop" : this.deps.mode,
+});
+```
+
+(`off` shouldn't reach here since onModuleInit early-returns, but the typing demands a literal — coerce to backstop for safety.)
+
+Replace the switch on `transition.kind` to handle the new kinds. Current Phase 1 code only handles `failed-pre-start | failed-terminal | noop`. Add:
+
+```ts
+switch (transition.kind) {
+  case "running": {
+    const updated = await this.deps.repo.updateGuarded(runId, ["submitted"], {
+      status: "running", startedAt: transition.startedAt,
+    });
+    if (updated) this.log.log(`${runId}: running (watcher)`);
+    return;
+  }
+  case "load-report": {
+    void this.deps.reportLoader.tryLoad(runId);  // fire-and-forget, self-handled
+    return;
+  }
+  case "failed-pre-start":
+  case "failed-terminal": {
+    // ... existing logic, now uses updateGuarded(IN_PROGRESS_STATES, {...})
+    const updated = await this.deps.repo.updateGuarded(runId, IN_PROGRESS_STATES, {
+      status: "failed", statusMessage: transition.message, completedAt: now,
+    });
+    if (updated) this.log.log(`${runId}: failed (watcher: ${transition.reason})`);
+    return;
+  }
+  case "noop":
+    return;
+}
+```
+
+Adapt to actual surrounding code (existing handler likely already has the failed-pre-start path — only add the new cases).
+
+- [ ] **Step 3: Update watcher service tests**
+
+In `k8s-job-watcher.service.spec.ts`:
+1. Add `reportLoader: { tryLoad: vi.fn(async () => {}) }` to the deps fixture.
+2. Existing tests pass `mode: "backstop"` (the Phase 1 default) — confirm those still work.
+3. Add a new `describe("K8sJobWatcherService — primary mode")` block with cases:
+   - Succeeded pod → `reportLoader.tryLoad(runId)` called, no direct updateGuarded
+   - Running ready pod + status=submitted → `updateGuarded(["submitted"], { status: "running" })` called
+   - Failed pod → `updateGuarded(IN_PROGRESS_STATES, { status: "failed" })` called immediately (no grace)
+   - Backstop mode still works (smoke check: one existing case under `mode: "backstop"`)
+
+Example primary-mode test:
+
+```ts
+describe("K8sJobWatcherService — primary mode", () => {
+  let svc: K8sJobWatcherService;
+  let deps: { /* same shape as existing tests, but mode: "primary" */ };
+  beforeEach(() => {
+    // construct same fixture but deps.mode = "primary"
+    // ...
+  });
+
+  it("Succeeded pod → reportLoader.tryLoad called", async () => {
+    /* feed informer event with Succeeded pod; assert reportLoader.tryLoad called once with the runId */
+  });
+
+  it("Running ready pod + submitted status → updateGuarded({running})", async () => {
+    /* feed Running pod; assert updateGuarded called with ["submitted"], { status: "running" } */
+  });
+
+  it("Failed pod → updateGuarded({failed}) immediately", async () => {
+    /* assert no waiting on terminalReconcileGraceSec; called immediately */
+  });
+});
+```
+
+- [ ] **Step 4: Run watcher tests**
+
+```bash
+pnpm -F @modeldoctor/api test -- k8s-job-watcher
+```
+Expected: existing backstop tests pass; new primary tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(api): wire ReportLoader into K8sJobWatcherService primary mode
+
+Removes 'primary is not yet implemented' guard; passes mode into the
+reducer so it returns running/load-report transitions; switch handler
+now routes load-report → reportLoader.tryLoad (fire-and-forget) and
+running → updateGuarded(['submitted'], { status: 'running' }).
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 9: StartupReconciler — storage-first branch
+
+**Files:**
+- Modify: `apps/api/src/modules/benchmark/k8s/startup-reconciler.ts`
+- Modify: `apps/api/src/modules/benchmark/k8s/startup-reconciler.spec.ts`
+
+- [ ] **Step 1: Read existing reconciler to understand current branches**
+
+```bash
+sed -n '1,80p' apps/api/src/modules/benchmark/k8s/startup-reconciler.ts
+```
+
+- [ ] **Step 2: Add `reportLoader` + `storage` to StartupReconcilerDeps**
+
+```ts
+export interface StartupReconcilerDeps {
+  // ... existing fields
+  storage: ReportStorage;
+  reportLoader: ReportLoader;
+}
+```
+
+- [ ] **Step 3: Modify `run()` to check storage first**
+
+Inside the loop over in-progress benchmarks, BEFORE the existing pod-cache check:
+
+```ts
+const keys = reportStorageKeys(b.id);
+if (await this.deps.storage.exists(keys.result)) {
+  await this.deps.reportLoader.tryLoad(b.id);
+  continue;
+}
+// fall through to existing pod-exists check
+```
+
+- [ ] **Step 4: Update test fixture to provide storage + reportLoader**
+
+In `startup-reconciler.spec.ts`, add mocks:
+
+```ts
+const storage = { exists: vi.fn(async () => false), readJson: vi.fn(), readText: vi.fn(), readBytes: vi.fn() };
+const reportLoader = { tryLoad: vi.fn(async () => {}) };
+// pass into deps
+```
+
+Add a new test case:
+
+```ts
+it("storage has result.json → calls reportLoader.tryLoad and skips pod check", async () => {
+  storage.exists.mockResolvedValueOnce(true);
+  await reconciler.run();
+  expect(reportLoader.tryLoad).toHaveBeenCalledWith("r1");
+  expect(/* pod cache mock */).not.toHaveBeenCalled();
+});
+```
+
+Verify existing tests still pass — they should because storage.exists defaults to `false` so the original pod-cache branch is hit.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+pnpm -F @modeldoctor/api test -- startup-reconciler
+```
+Expected: existing + new test pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/modules/benchmark/k8s/startup-reconciler.ts apps/api/src/modules/benchmark/k8s/startup-reconciler.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(api): StartupReconciler storage-first branch
+
+On boot, in-progress benchmarks with result.json present in S3 take
+the ReportLoader path (storage is ground truth when pod TTL'd away
+during downtime). Pod-exists check falls through unchanged when
+storage is empty.
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 10: K8s Job manifest — add `md-benchmark-storage` envFrom
+
+**Files:**
+- Modify: `apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts`
+- Modify: `apps/api/src/modules/benchmark/k8s/k8s-job-manifest.spec.ts`
+
+- [ ] **Step 1: Find current container env construction**
+
+```bash
+grep -n "envFrom\|container.env\|MD_CALLBACK" apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts
+```
+
+- [ ] **Step 2: Add second `envFrom` entry**
+
+In `k8s-job-manifest.ts`, find where the container is built and add `envFrom` (if absent) or append to existing list:
+
+```ts
+envFrom: [
+  { secretRef: { name: perRunSecretName } },
+  { secretRef: { name: "md-benchmark-storage" } },
+],
+```
+
+If today's code only sets `env: [...]` and not `envFrom`, add `envFrom` next to it. The per-run Secret still carries `MD_CALLBACK_TOKEN` (we don't delete that until Phase 3); the storage Secret is operator-created.
+
+- [ ] **Step 3: Update tests**
+
+In `k8s-job-manifest.spec.ts`, find the existing manifest assertions and add:
+
+```ts
+expect(manifest.spec.template.spec.containers[0].envFrom).toEqual(
+  expect.arrayContaining([
+    expect.objectContaining({ secretRef: expect.objectContaining({ name: "md-benchmark-storage" }) }),
+  ]),
+);
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm -F @modeldoctor/api test -- k8s-job-manifest
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts apps/api/src/modules/benchmark/k8s/k8s-job-manifest.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(api): inject md-benchmark-storage Secret into runner Job
+
+Adds envFrom: secretRef to point at the operator-created
+md-benchmark-storage Secret (S3_ENDPOINT/ACCESS_KEY/SECRET_KEY/BUCKET/REGION).
+The per-run Secret keeps MD_CALLBACK_TOKEN — still needed for /log
+HMAC (Phase 3 removes it).
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 11: New `GET /benchmarks/:id/files/:alias` controller
+
+**Files:**
+- Create: `apps/api/src/modules/benchmark/benchmark-files.controller.ts`
+- Create: `apps/api/src/modules/benchmark/benchmark-files.controller.spec.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// apps/api/src/modules/benchmark/benchmark-files.controller.spec.ts
+import { ForbiddenException, NotFoundException, StreamableFile } from "@nestjs/common";
+import { describe, expect, it, vi } from "vitest";
+import { BenchmarkFilesController } from "./benchmark-files.controller.js";
+
+function makeCtrl(opts: {
+  bench?: { id: string; userId: string | null; tool: string; status: string; rawOutput: unknown } | null;
+  fileExists?: boolean;
+  fileBytes?: Buffer;
+}) {
+  const repo = {
+    findById: vi.fn(async () => opts.bench ?? null),
+  };
+  const storage = {
+    exists: vi.fn(async () => opts.fileExists ?? true),
+    readBytes: vi.fn(async () => opts.fileBytes ?? Buffer.from("data")),
+    readJson: vi.fn(), readText: vi.fn(),
+  };
+  return { ctrl: new BenchmarkFilesController(repo as never, storage as never), repo, storage };
+}
+
+describe("BenchmarkFilesController", () => {
+  it("404 when benchmark not found", async () => {
+    const { ctrl } = makeCtrl({ bench: null });
+    await expect(ctrl.getFile({ user: { sub: "u1" } } as never, "r1", "report.json")).rejects.toThrow(NotFoundException);
+  });
+
+  it("403 when userId mismatch", async () => {
+    const { ctrl } = makeCtrl({ bench: { id: "r1", userId: "other-user", tool: "guidellm", status: "completed", rawOutput: { files: { "report.json": "files/report.json" } } } });
+    await expect(ctrl.getFile({ user: { sub: "u1" } } as never, "r1", "report.json")).rejects.toThrow(ForbiddenException);
+  });
+
+  it("404 when alias not in rawOutput.files", async () => {
+    const { ctrl } = makeCtrl({ bench: { id: "r1", userId: "u1", tool: "guidellm", status: "completed", rawOutput: { files: {} } } });
+    await expect(ctrl.getFile({ user: { sub: "u1" } } as never, "r1", "missing.json")).rejects.toThrow(NotFoundException);
+  });
+
+  it("returns StreamableFile with content for valid request", async () => {
+    const { ctrl, storage } = makeCtrl({
+      bench: { id: "r1", userId: "u1", tool: "guidellm", status: "completed", rawOutput: { files: { "report.json": "files/report.json" } } },
+      fileBytes: Buffer.from('{"ok":true}'),
+    });
+    const out = await ctrl.getFile({ user: { sub: "u1" } } as never, "r1", "report.json");
+    expect(out).toBeInstanceOf(StreamableFile);
+    expect(storage.readBytes).toHaveBeenCalledWith("r1/files/report.json");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+pnpm -F @modeldoctor/api test -- benchmark-files
+```
+Expected: FAIL — can't import.
+
+- [ ] **Step 3: Implement controller**
+
+```ts
+// apps/api/src/modules/benchmark/benchmark-files.controller.ts
+import { Controller, ForbiddenException, Get, Inject, NotFoundException, Param, Req, StreamableFile, UseGuards } from "@nestjs/common";
+import { ApiOperation, ApiTags } from "@nestjs/swagger";
+import type { Request } from "express";
+import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
+import { BenchmarkRepository } from "./benchmark.repository.js";
+import { REPORT_STORAGE, type ReportStorage } from "./storage/report-storage.js";
+
+interface AuthedRequest extends Request {
+  user?: { sub?: string };
+}
+
+@ApiTags("benchmarks")
+@Controller("benchmarks/:id/files")
+@UseGuards(JwtAuthGuard)
+export class BenchmarkFilesController {
+  constructor(
+    private readonly repo: BenchmarkRepository,
+    @Inject(REPORT_STORAGE) private readonly storage: ReportStorage,
+  ) {}
+
+  @Get(":alias")
+  @ApiOperation({ summary: "Stream an output file from the benchmark's S3 report" })
+  async getFile(@Req() req: AuthedRequest, @Param("id") id: string, @Param("alias") alias: string): Promise<StreamableFile> {
+    const bench = await this.repo.findById(id);
+    if (!bench) throw new NotFoundException(`benchmark ${id} not found`);
+    if (bench.userId && bench.userId !== req.user?.sub) throw new ForbiddenException();
+
+    const files = ((bench.rawOutput as { files?: Record<string, string> } | null) ?? {}).files ?? {};
+    const relPath = files[alias];
+    if (!relPath) throw new NotFoundException(`alias ${alias} not in this benchmark's files`);
+
+    const key = `${id}/${relPath}`;
+    const bytes = await this.storage.readBytes(key);
+    return new StreamableFile(bytes, { disposition: `attachment; filename="${alias}"` });
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+pnpm -F @modeldoctor/api test -- benchmark-files
+```
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/benchmark/benchmark-files.controller.ts apps/api/src/modules/benchmark/benchmark-files.controller.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(api): GET /benchmarks/:id/files/:alias proxies S3 read
+
+Authed via JwtAuthGuard + user-id ownership check. Streams the S3
+object as a StreamableFile with attachment Content-Disposition.
+404 / 403 / 404 alias-not-listed are explicit.
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 12: Wire all new providers in `benchmark.module.ts`
+
+**Files:**
+- Modify: `apps/api/src/modules/benchmark/benchmark.module.ts`
+
+- [ ] **Step 1: Read current module wiring**
+
+```bash
+sed -n '1,120p' apps/api/src/modules/benchmark/benchmark.module.ts
+```
+
+- [ ] **Step 2: Add storage providers + controller + ReportLoader wiring**
+
+Add imports at top:
+
+```ts
+import { REPORT_STORAGE } from "./storage/report-storage.js";
+import { S3ReportStorage } from "./storage/s3-report-storage.js";
+import { ReportLoader } from "./storage/report-loader.js";
+import { BenchmarkFilesController } from "./benchmark-files.controller.js";
+```
+
+Add to `controllers: [...]`:
+
+```ts
+controllers: [
+  BenchmarkController,
+  BenchmarkCallbackController,
+  BenchmarkFilesController,  // NEW
+],
+```
+
+Add to `providers: [...]`:
+
+```ts
+{
+  provide: REPORT_STORAGE,
+  useFactory: (config: ConfigService<Env, true>) => new S3ReportStorage({
+    endpoint: config.get("S3_ENDPOINT", { infer: true }),
+    region: config.get("S3_REGION", { infer: true }),
+    accessKeyId: config.get("S3_ACCESS_KEY", { infer: true }),
+    secretAccessKey: config.get("S3_SECRET_KEY", { infer: true }),
+    bucket: config.get("S3_BUCKET", { infer: true }),
+  }),
+  inject: [ConfigService],
+},
+ReportLoader,
+```
+
+Find where `K8sJobWatcherService` is wired (the `useFactory` block around line 75 per Phase 1 spec). Inject `ReportLoader` into its deps. Same for `StartupReconciler` — inject `REPORT_STORAGE` + `ReportLoader`.
+
+Example for watcher factory:
+
+```ts
+{
+  provide: K8sJobWatcherService,
+  useFactory: (config, repo, reconciler, reportLoader) => new K8sJobWatcherService({
+    mode: config.get("K8S_WATCHER_MODE", { infer: true }) as WatcherMode,
+    namespace: config.get("BENCHMARK_K8S_NAMESPACE", { infer: true }),
+    reducerConfig: { /* existing */ },
+    makeInformer: () => /* existing */,
+    repo,
+    reconciler,
+    reportLoader,   // NEW
+  }),
+  inject: [ConfigService, BenchmarkRepository, StartupReconciler, ReportLoader],
+},
+```
+
+- [ ] **Step 3: Build to verify wiring**
+
+```bash
+pnpm -F @modeldoctor/api type-check
+pnpm -F @modeldoctor/api build
+```
+Expected: PASS.
+
+- [ ] **Step 4: Run module-level test (if exists) or full unit suite**
+
+```bash
+pnpm -F @modeldoctor/api test
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/benchmark/benchmark.module.ts
+git commit -m "$(cat <<'EOF'
+feat(api): wire S3ReportStorage + ReportLoader into benchmark module
+
+REPORT_STORAGE provider constructs S3ReportStorage from env vars;
+ReportLoader injected into K8sJobWatcherService and StartupReconciler
+factories. BenchmarkFilesController registered alongside the existing
+benchmark + callback controllers.
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 13: Add boto3 to runner requirements
+
+**Files:**
+- Modify: `apps/benchmark-runner/requirements.txt`
+
+- [ ] **Step 1: Inspect current requirements**
+
+```bash
+cat apps/benchmark-runner/requirements.txt
+```
+
+- [ ] **Step 2: Append boto3**
+
+Add line: `boto3>=1.34,<2`
+
+- [ ] **Step 3: Verify install in a runner build context**
+
+If the project has a runner Dockerfile that pip-installs from requirements.txt, dry-run install locally:
+
+```bash
+cd apps/benchmark-runner && python3 -m pip install --dry-run boto3 2>&1 | tail -3
+```
+
+Expected: confirms boto3 + botocore + s3transfer dependencies resolve. (If `--dry-run` not supported on local pip, just confirm `pip install boto3` succeeds in a venv.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/benchmark-runner/requirements.txt
+git commit -m "$(cat <<'EOF'
+build(runner): add boto3 for S3 report writes
+
+boto3 >=1.34,<2 — used by the new runner/s3_writer.py to write
+meta/result/files/stdout/stderr to the shared MinIO bucket.
+Image size +~12MB; acceptable since it replaces the entire
+callback module's complexity.
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 14: Runner `storage_keys.py` (mirror of TS contract)
+
+**Files:**
+- Create: `apps/benchmark-runner/runner/storage_keys.py`
+- Create: `apps/benchmark-runner/tests/test_storage_keys.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# apps/benchmark-runner/tests/test_storage_keys.py
+from runner.storage_keys import keys_for, file_key
+
+
+def test_keys_for_basic():
+    k = keys_for("run-abc")
+    assert k.meta == "run-abc/meta.json"
+    assert k.result == "run-abc/result.json"
+    assert k.stdout == "run-abc/stdout.log"
+    assert k.stderr == "run-abc/stderr.log"
+
+
+def test_file_key():
+    assert file_key("run-abc", "report.json") == "run-abc/files/report.json"
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+cd apps/benchmark-runner && python3 -m pytest tests/test_storage_keys.py -v
+```
+Expected: FAIL — ModuleNotFoundError.
+
+- [ ] **Step 3: Implement**
+
+```python
+# apps/benchmark-runner/runner/storage_keys.py
+"""Object keys for the shared report storage layer.
+
+Mirror of packages/contracts/src/benchmark.ts:reportStorageKeys.
+Keep both in sync — runner writes, API reads, both must agree.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class StorageKeys:
+    meta: str
+    result: str
+    stdout: str
+    stderr: str
+
+
+def keys_for(run_id: str) -> StorageKeys:
+    return StorageKeys(
+        meta=f"{run_id}/meta.json",
+        result=f"{run_id}/result.json",
+        stdout=f"{run_id}/stdout.log",
+        stderr=f"{run_id}/stderr.log",
+    )
+
+
+def file_key(run_id: str, alias: str) -> str:
+    return f"{run_id}/files/{alias}"
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+```bash
+cd apps/benchmark-runner && python3 -m pytest tests/test_storage_keys.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/benchmark-runner/runner/storage_keys.py apps/benchmark-runner/tests/test_storage_keys.py
+git commit -m "$(cat <<'EOF'
+feat(runner): storage_keys.py mirrors contracts reportStorageKeys
+
+Single source of truth for object keys: runner writes <runId>/meta.json
+etc.; API ReportLoader reads from the same paths. Plain dataclass —
+no boto3 dep needed at this layer.
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 15: Runner `s3_writer.py` + moto tests
+
+**Files:**
+- Create: `apps/benchmark-runner/runner/s3_writer.py`
+- Create: `apps/benchmark-runner/tests/test_s3_writer.py`
+- Modify: `apps/benchmark-runner/requirements-dev.txt` (or wherever pytest deps live; add `moto[s3]`)
+
+- [ ] **Step 1: Add moto to dev requirements**
+
+Check current dev-deps location:
+
+```bash
+ls apps/benchmark-runner/requirements*.txt
+```
+
+Append `moto[s3]>=5,<6` to the dev requirements file (likely `requirements-dev.txt` or `pyproject.toml`).
+
+- [ ] **Step 2: Write failing test**
+
+```python
+# apps/benchmark-runner/tests/test_s3_writer.py
+import json
+import os
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from runner.s3_writer import S3Writer
+
+
+@pytest.fixture
+def s3_env(monkeypatch):
+    monkeypatch.setenv("S3_ENDPOINT", "http://localhost:9999")
+    monkeypatch.setenv("S3_ACCESS_KEY", "test")
+    monkeypatch.setenv("S3_SECRET_KEY", "test")
+    monkeypatch.setenv("S3_BUCKET", "test-bucket")
+    monkeypatch.setenv("S3_REGION", "us-east-1")
+
+
+@mock_aws
+def test_writer_puts_json_text_and_file(s3_env, tmp_path):
+    boto3.client("s3", region_name="us-east-1").create_bucket(Bucket="test-bucket")
+    writer = S3Writer.from_env()
+    writer.put_json("r1/meta.json", {"toolVersion": "x"})
+    writer.put_text("r1/stdout.log", "hello\nworld")
+    local = tmp_path / "report.json"
+    local.write_text('{"ok":true}')
+    writer.put_file("r1/files/report.json", str(local))
+
+    s3 = boto3.client("s3", region_name="us-east-1")
+    meta = json.loads(s3.get_object(Bucket="test-bucket", Key="r1/meta.json")["Body"].read())
+    assert meta == {"toolVersion": "x"}
+    stdout = s3.get_object(Bucket="test-bucket", Key="r1/stdout.log")["Body"].read().decode()
+    assert stdout == "hello\nworld"
+    report = s3.get_object(Bucket="test-bucket", Key="r1/files/report.json")["Body"].read().decode()
+    assert report == '{"ok":true}'
+
+
+@mock_aws
+def test_writer_raises_when_bucket_missing(s3_env):
+    # No bucket created — put should raise
+    writer = S3Writer.from_env()
+    with pytest.raises(Exception):
+        writer.put_json("r1/meta.json", {})
+```
+
+- [ ] **Step 3: Run test to verify failure**
+
+```bash
+cd apps/benchmark-runner && python3 -m pytest tests/test_s3_writer.py -v
+```
+Expected: FAIL — ModuleNotFoundError.
+
+- [ ] **Step 4: Implement S3Writer**
+
+```python
+# apps/benchmark-runner/runner/s3_writer.py
+"""boto3 wrapper for runner→S3 writes.
+
+Single-purpose: read S3_* from env, write objects under <runId>/...
+Multipart handled automatically by upload_file for objects >5MB.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import boto3
+from botocore.config import Config
+
+
+class S3Writer:
+    @classmethod
+    def from_env(cls) -> "S3Writer":
+        return cls(
+            endpoint=os.environ["S3_ENDPOINT"],
+            access_key=os.environ["S3_ACCESS_KEY"],
+            secret_key=os.environ["S3_SECRET_KEY"],
+            bucket=os.environ["S3_BUCKET"],
+            region=os.environ.get("S3_REGION", "us-east-1"),
+        )
+
+    def __init__(self, *, endpoint: str, access_key: str, secret_key: str, bucket: str, region: str):
+        self.client = boto3.client(
+            "s3",
+            endpoint_url=endpoint,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            region_name=region,
+            config=Config(
+                signature_version="s3v4",
+                retries={"max_attempts": 2, "mode": "standard"},
+                connect_timeout=5,
+                read_timeout=30,
+            ),
+        )
+        self.bucket = bucket
+
+    def put_json(self, key: str, obj: object) -> None:
+        body = json.dumps(obj).encode("utf-8")
+        self.client.put_object(Bucket=self.bucket, Key=key, Body=body, ContentType="application/json")
+
+    def put_text(self, key: str, text: str) -> None:
+        self.client.put_object(Bucket=self.bucket, Key=key, Body=text.encode("utf-8"), ContentType="text/plain; charset=utf-8")
+
+    def put_file(self, key: str, local_path: str) -> None:
+        # upload_file handles multipart automatically for objects > 5MB
+        self.client.upload_file(local_path, self.bucket, key)
+```
+
+- [ ] **Step 5: Run test to verify pass**
+
+```bash
+cd apps/benchmark-runner && python3 -m pytest tests/test_s3_writer.py -v
+```
+Expected: 2 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/benchmark-runner/runner/s3_writer.py apps/benchmark-runner/tests/test_s3_writer.py apps/benchmark-runner/requirements-dev.txt
+git commit -m "$(cat <<'EOF'
+feat(runner): S3Writer — boto3 wrapper for report uploads
+
+put_json / put_text / put_file. upload_file auto-multiparts for
+objects > 5MB (vegeta attack.bin will hit this regularly). Tests
+use moto[s3] to mock S3 in-memory; no MinIO required for CI.
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 16: Rewrite `runner/main.py` to write S3 instead of POST /state /finish
+
+**Files:**
+- Modify: `apps/benchmark-runner/runner/main.py`
+- Modify: `apps/benchmark-runner/tests/test_main.py`
+
+This is the biggest single change in the plan. Approach: rewrite the main flow, keep StreamPump's `post_log_batch` invocation intact (Phase 3 territory).
+
+- [ ] **Step 1: Read current main.py end-to-end**
+
+```bash
+cat apps/benchmark-runner/runner/main.py
+```
+
+Identify:
+- Where `post_state_running` is called (likely right after `detect_tool_version`)
+- Where `post_finish` is called (end of run, with rawOutput + files)
+- Where output files are gathered (probably from CLI args + StreamPump)
+
+- [ ] **Step 2: Modify `main.py` — replace post_state_running and post_finish with S3 writes**
+
+Top of file:
+
+```python
+# DELETE
+from runner.callback import post_finish, post_log_batch, post_state_running
+# REPLACE with
+from runner.callback import post_log_batch
+from runner.s3_writer import S3Writer
+from runner.storage_keys import file_key, keys_for
+```
+
+In main flow, after `tool_version = detect_tool_version(...)`:
+
+```python
+# REMOVE: post_state_running(... tool_version ...)
+# REPLACE with:
+s3 = S3Writer.from_env()
+keys = keys_for(run_id)
+s3.put_json(keys.meta, {
+    "toolVersion": tool_version or "",
+    "startTimeIso": iso_now(),  # use existing datetime utility
+})
+```
+
+At end of run (after subprocess + StreamPump joins):
+
+```python
+# REMOVE the existing post_finish(...) call entirely
+# REPLACE with:
+finish_time = iso_now()
+
+# Upload output files — adapt to whatever current code uses to collect them
+files_map: dict[str, str] = {}
+for alias, local_path in collect_output_files(args).items():  # whatever existing fn is
+    rel = f"files/{alias}"
+    s3.put_file(file_key(run_id, alias), str(local_path))
+    files_map[alias] = rel
+
+# Upload stdout/stderr tails (full buffer from StreamPump, NOT capped to 64KB —
+# API-side ReportLoader will tail-cap. Runner writes everything so partial
+# reads still see context).
+s3.put_text(keys.stdout, stdout_pump.full_buffer())
+s3.put_text(keys.stderr, stderr_pump.full_buffer())
+
+# result.json is the sentinel — write LAST.
+s3.put_json(keys.result, {
+    "exitCode": proc.returncode,
+    "finishTimeIso": finish_time,
+    "files": files_map,
+})
+
+sys.exit(proc.returncode)
+```
+
+Critical invariant: **any S3 write failure must propagate up, causing non-zero exit so pod.phase=Failed**. boto3 raises by default; don't add `try/except` around the writes in the main path.
+
+Pseudocode template — adapt to actual variable names in current `main.py`. The key swaps:
+1. `post_state_running` → `s3.put_json(keys.meta, ...)`
+2. `post_finish(state=..., files={alias: base64_bytes}, ...)` → multiple `s3.put_file` + final `s3.put_json(keys.result, ...)`
+3. `post_log_batch` stays — log batching still goes through callback in Phase 2
+
+- [ ] **Step 3: Update `tests/test_main.py`**
+
+The existing test mocks `post_finish` etc. We now need to mock `S3Writer` (or use moto end-to-end). Simpler: mock `S3Writer.from_env` to return a Mock with `put_json/put_text/put_file` spies.
+
+Add test:
+
+```python
+from unittest.mock import patch, MagicMock
+
+@patch("runner.main.S3Writer")
+def test_main_writes_meta_then_result_with_files_between(MockS3, ...existing fixtures...):
+    writer = MagicMock()
+    MockS3.from_env.return_value = writer
+    # ... run main with a fake tool that exits 0
+    main(...)
+    # verify call order
+    calls = [c.args[0] for c in writer.put_json.call_args_list + writer.put_text.call_args_list + writer.put_file.call_args_list]
+    assert calls.index("r1/meta.json") < calls.index("r1/result.json")
+    # verify last call is result.json
+    last_json_call = writer.put_json.call_args_list[-1]
+    assert last_json_call.args[0] == "r1/result.json"
+
+@patch("runner.main.S3Writer")
+def test_main_exits_nonzero_when_s3_put_raises(MockS3, ...existing fixtures...):
+    writer = MagicMock()
+    writer.put_file.side_effect = RuntimeError("s3 down")
+    MockS3.from_env.return_value = writer
+    with pytest.raises(RuntimeError):
+        main(...)
+```
+
+Delete tests that exercise `post_state_running` / `post_finish` paths.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd apps/benchmark-runner && python3 -m pytest tests/test_main.py -v
+```
+Expected: PASS (with new path); old failing tests deleted.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/benchmark-runner/runner/main.py apps/benchmark-runner/tests/test_main.py
+git commit -m "$(cat <<'EOF'
+feat(runner): write S3 report instead of POST /state /finish
+
+Replaces post_state_running / post_finish calls with S3 writes via
+S3Writer. Key sequence: meta.json (start) → files → stdout/stderr →
+result.json (sentinel, LAST). Any S3 failure raises, leading to
+pod.phase=Failed, which the watcher resolves via failed-terminal.
+
+post_log_batch retained — /log callback is Phase 3.
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 17: Delete `/state` + `/finish` handlers and contracts schemas
+
+**Files:**
+- Modify: `apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.ts` (delete two handlers)
+- Modify: `apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.spec.ts` (delete corresponding cases)
+- Modify: `packages/contracts/src/benchmark.ts` (delete two schemas + their types)
+- Modify: `apps/benchmark-runner/runner/callback.py` (delete two functions)
+
+- [ ] **Step 1: Remove handlers from API controller**
+
+In `benchmark-callback.controller.ts`, delete:
+- `@Post("state") handleState(...)` and its entire method body
+- `@Post("finish") handleFinish(...)` and its entire method body
+- Imports: `benchmarkStateCallbackSchema`, `benchmarkFinishCallbackSchema`, `BenchmarkStateCallback`, `BenchmarkFinishCallback`, `byTool`, `ToolName` (if only used by handleFinish), `Prisma` (likewise), `ZodValidationPipe` (if only used here)
+
+Verify only `handleLog` remains:
+
+```bash
+grep -n "@Post\|handleState\|handleFinish\|handleLog" apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.ts
+```
+
+- [ ] **Step 2: Remove corresponding test cases**
+
+In `benchmark-callback.controller.spec.ts`, delete every `it(...)` block that calls `ctrl.handleState` or `ctrl.handleFinish`. Keep `handleLog` cases.
+
+- [ ] **Step 3: Delete contracts schemas + types**
+
+In `packages/contracts/src/benchmark.ts`, delete:
+- `benchmarkStateCallbackSchema` + `BenchmarkStateCallback` type
+- `benchmarkFinishCallbackSchema` + `BenchmarkFinishCallback` type
+
+Keep `benchmarkLogCallbackSchema` + `BenchmarkLogCallback`.
+
+If these are re-exported in a barrel `packages/contracts/src/index.ts`, remove those re-exports too:
+
+```bash
+grep -n "benchmarkStateCallback\|benchmarkFinishCallback" packages/contracts/src/index.ts
+```
+
+- [ ] **Step 4: Delete runner callback functions**
+
+In `apps/benchmark-runner/runner/callback.py`, delete `post_state_running` and `post_finish` functions and any imports only they need. Keep `post_log_batch`.
+
+- [ ] **Step 5: Type-check + test API**
+
+```bash
+pnpm -F @modeldoctor/contracts build
+pnpm -F @modeldoctor/api type-check
+pnpm -F @modeldoctor/api test
+```
+Expected: PASS. If type-check fails because something still imports the deleted schemas, follow up and clean.
+
+- [ ] **Step 6: Test runner**
+
+```bash
+cd apps/benchmark-runner && python3 -m pytest -v
+```
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.ts \
+        apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.spec.ts \
+        packages/contracts/src/benchmark.ts \
+        packages/contracts/src/index.ts \
+        apps/benchmark-runner/runner/callback.py
+git commit -m "$(cat <<'EOF'
+refactor: delete /state + /finish callback endpoints — replaced by S3 + watcher
+
+API:
+- delete handleState + handleFinish from BenchmarkCallbackController
+- delete benchmarkStateCallback + benchmarkFinishCallback schemas + types
+- delete corresponding controller-spec cases
+
+Runner:
+- delete post_state_running + post_finish from callback.py
+
+Keeping /log + benchmarkLogCallback + HmacCallbackGuard + post_log_batch
+(Phase 3 will retire those).
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 18: End-to-end test — watcher primary path
+
+**Files:**
+- Create: `apps/api/test/e2e/benchmark-watcher-primary.e2e-spec.ts`
+- Delete: `apps/api/test/e2e/benchmark-callback.e2e-spec.ts` (if exists and contains /state /finish e2e)
+
+- [ ] **Step 1: Check if a callback e2e currently exists for /state /finish**
+
+```bash
+ls apps/api/test/e2e/ | grep -i callback
+```
+
+If a file exclusively tests /state /finish, delete it (Task 17 already deletes the controller handlers, so its tests will fail). If the file has /log tests too, delete only the /state /finish blocks.
+
+- [ ] **Step 2: Write new e2e**
+
+```ts
+// apps/api/test/e2e/benchmark-watcher-primary.e2e-spec.ts
+import { GetObjectCommand, HeadObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { Readable } from "node:stream";
+import { mockClient } from "aws-sdk-client-mock";
+import nock from "nock";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { setupE2EApp, teardownE2EApp, type E2EAppContext } from "../setup/e2e-app.js";
+import { E2E_ENV_DEFAULTS } from "../setup/e2e-env-defaults.js";
+
+const s3Mock = mockClient(S3Client);
+
+function body(s: string) {
+  return Readable.from([Buffer.from(s, "utf8")]) as never;
+}
+
+describe("Benchmark watcher primary mode (e2e)", () => {
+  let ctx: E2EAppContext;
+
+  beforeAll(async () => {
+    ctx = await setupE2EApp({
+      env: { ...E2E_ENV_DEFAULTS, K8S_WATCHER_MODE: "primary" },
+    });
+  });
+
+  beforeEach(() => { s3Mock.reset(); nock.cleanAll(); });
+  afterEach(() => { s3Mock.reset(); nock.cleanAll(); });
+
+  it("Succeeded pod → ReportLoader reads S3 → benchmark.status=completed", async () => {
+    // 1. Seed benchmark in 'running' status owned by ctx.testUser
+    const benchId = "00000000-0000-0000-0000-000000000001";
+    await ctx.prisma.benchmark.create({
+      data: {
+        id: benchId,
+        userId: ctx.testUser.id,
+        status: "running",
+        tool: "guidellm",
+        scenario: "inference",
+        name: "e2e-watcher-primary",
+        params: {},
+        connectionId: null,
+      },
+    });
+
+    // 2. Mock S3 returns fixture meta + result + stdout/stderr + file
+    s3Mock.on(GetObjectCommand, { Key: `${benchId}/meta.json` }).resolves({ Body: body(JSON.stringify({ toolVersion: "guidellm 0.2.1", startTimeIso: "2026-05-25T00:00:00.000Z" })) });
+    s3Mock.on(GetObjectCommand, { Key: `${benchId}/result.json` }).resolves({ Body: body(JSON.stringify({ exitCode: 0, finishTimeIso: "2026-05-25T01:00:00.000Z", files: { "report.json": "files/report.json" } })) });
+    s3Mock.on(GetObjectCommand, { Key: `${benchId}/stdout.log` }).resolves({ Body: body("PROGRESS:1.0\nDone") });
+    s3Mock.on(GetObjectCommand, { Key: `${benchId}/stderr.log` }).resolves({ Body: body("") });
+    s3Mock.on(GetObjectCommand, { Key: `${benchId}/files/report.json` }).resolves({ Body: body('{"latency_p50":42}') });
+
+    // 3. Simulate watcher event by calling ReportLoader directly (or trigger via informer fixture if your e2e plumbing supports it)
+    await ctx.app.get("ReportLoader").tryLoad(benchId);
+
+    // 4. Assert row updated
+    const row = await ctx.prisma.benchmark.findUniqueOrThrow({ where: { id: benchId } });
+    expect(row.status).toBe("completed");
+    expect(row.toolVersion).toBe("guidellm 0.2.1");
+    expect(row.summaryMetrics).toMatchObject({ tool: "guidellm" });
+    expect(row.completedAt).toBeTruthy();
+  });
+
+  it("Succeeded pod but result.json missing → failed with statusMessage", async () => {
+    const benchId = "00000000-0000-0000-0000-000000000002";
+    await ctx.prisma.benchmark.create({ data: { id: benchId, userId: ctx.testUser.id, status: "running", tool: "guidellm", scenario: "inference", name: "missing-report", params: {}, connectionId: null } });
+    s3Mock.on(GetObjectCommand).rejects(Object.assign(new Error("NoSuchKey"), { name: "NoSuchKey" }));
+    await ctx.app.get("ReportLoader").tryLoad(benchId);
+    const row = await ctx.prisma.benchmark.findUniqueOrThrow({ where: { id: benchId } });
+    expect(row.status).toBe("failed");
+    expect(row.statusMessage).toContain("report load");
+  });
+});
+```
+
+> If your `setupE2EApp` doesn't already expose a way to override env or yield the Nest container directly, adapt to the actual plumbing — `e2e/playwright.config.ts` and existing e2e specs are precedent.
+
+- [ ] **Step 3: Run e2e**
+
+```bash
+pnpm -F @modeldoctor/api test:e2e -- benchmark-watcher-primary
+```
+Expected: PASS (both cases).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/test/e2e/benchmark-watcher-primary.e2e-spec.ts
+git commit -m "$(cat <<'EOF'
+test(api): e2e for watcher primary mode + ReportLoader
+
+Two scenarios:
+1. S3 has a full fixture (meta/result/stdout/file) → ReportLoader
+   writes status=completed with parsed summaryMetrics.
+2. S3 returns NoSuchKey → ReportLoader writes status=failed with
+   statusMessage containing 'report load: ...'.
+
+S3 client mocked with aws-sdk-client-mock. K8S_WATCHER_MODE=primary
+forced via env override on the app fixture.
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 19: Operations docs — MinIO bucket setup
+
+**Files:**
+- Modify: `deploy/k8s/README.md`
+
+- [ ] **Step 1: Read current README**
+
+```bash
+cat deploy/k8s/README.md
+```
+
+- [ ] **Step 2: Append a `## Report storage (MinIO / S3)` section**
+
+```markdown
+## Report storage (MinIO / S3)
+
+Phase 2 of #237 — runner writes benchmark reports to a shared bucket;
+API reads them at terminal phase. The bucket and credentials must
+exist BEFORE the API and runner Job can run.
+
+### 1. Configure a bucket lifecycle (once per environment)
+
+```bash
+mc alias set myminio http://10.100.121.67:31871 <access-key> <secret-key>
+mc ilm rule add --expire-days 30 myminio/<bucket>
+```
+
+30 days is the V1 retention. Adjust as ops sees fit; just don't go shorter
+than the longest expected benchmark duration plus a few hours of investigation buffer.
+
+### 2. Create the K8s Secret
+
+The runner Job mounts `md-benchmark-storage` in the benchmarks namespace,
+and the API reads the same values from its own pod env.
+
+```bash
+kubectl -n modeldoctor-benchmarks create secret generic md-benchmark-storage \
+  --from-literal=S3_ENDPOINT=http://10.100.121.67:31871 \
+  --from-literal=S3_ACCESS_KEY=<key> \
+  --from-literal=S3_SECRET_KEY=<secret> \
+  --from-literal=S3_BUCKET=<bucket> \
+  --from-literal=S3_REGION=us-east-1
+# Same Secret in the API namespace too (if different from modeldoctor-benchmarks)
+kubectl -n modeldoctor create secret generic md-benchmark-storage --from-literal=...
+```
+
+### 3. Verify with `mc`
+
+```bash
+mc ls myminio/<bucket>/  # should succeed
+```
+
+### Pre-deploy checklist (Phase 2)
+
+- [ ] MinIO bucket exists with lifecycle configured
+- [ ] `md-benchmark-storage` Secret exists in both namespaces
+- [ ] No long-running in-flight benchmark when deploying (recommended; otherwise
+      it will be auto-failed by the watcher after pod phase transitions)
+- [ ] `K8S_WATCHER_MODE=primary` (now the env-schema default, no override needed)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/k8s/README.md
+git commit -m "$(cat <<'EOF'
+docs(deploy): MinIO bucket + Secret setup for Phase 2
+
+Operator instructions: create bucket, configure 30-day lifecycle,
+create md-benchmark-storage Secret in both API and benchmarks
+namespaces. Pre-deploy checklist for Phase 2 ramp.
+
+refs #237
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 20: Full local verification + PR prep
+
+- [ ] **Step 1: Run the full API test suite**
+
+```bash
+pnpm -F @modeldoctor/api test
+```
+Expected: all green.
+
+- [ ] **Step 2: Run the full runner test suite**
+
+```bash
+cd apps/benchmark-runner && python3 -m pytest -v
+```
+Expected: all green.
+
+- [ ] **Step 3: Run contracts + workspace build**
+
+```bash
+pnpm -r build
+```
+Expected: all packages build clean.
+
+- [ ] **Step 4: Lint + type-check sweep**
+
+```bash
+pnpm -F @modeldoctor/api lint
+pnpm -F @modeldoctor/api type-check
+pnpm -F @modeldoctor/contracts type-check
+```
+Expected: all clean.
+
+- [ ] **Step 5: Run the API e2e suite (real Postgres, mocked S3 + K8s)**
+
+```bash
+pnpm test:e2e:api
+```
+Expected: all green, including the new `benchmark-watcher-primary.e2e-spec.ts`.
+
+- [ ] **Step 6: Browser e2e**
+
+```bash
+pnpm test:e2e:browser
+```
+Expected: existing benchmark.spec.ts still passes (SSE / detail page unchanged).
+
+- [ ] **Step 7: Push branch + open PR**
+
+```bash
+git push -u origin feat/phase2-watcher-primary-and-storage
+gh pr create --title "feat: Phase 0+2 — report shared storage + watcher primary mode" --body "$(cat <<'EOF'
+## Summary
+
+Atomic rewrite of runner→API status flip + final report channel for #237 Phase 2,
+folding in Phase 0 (shared storage layer) since `ReportLoader` is tightly coupled
+to `ReportStorage`.
+
+After this PR:
+- runner writes `meta.json` / `result.json` / `stdout.log` / `stderr.log` /
+  `files/*` to a shared S3-compatible bucket (MinIO in dev, real S3 in prod)
+- API `K8sJobWatcherService` in `primary` mode handles `running` / `Succeeded` /
+  `Failed` directly via informer + `ReportLoader` (no callback)
+- `/state` and `/finish` callback endpoints + runner POST calls **deleted**
+  (clean slate, no deprecated no-op)
+- `/log` callback path **unchanged** — Phase 3 will retire it
+
+## Spec / Plan
+
+- Spec: `docs/superpowers/specs/2026-05-25-report-storage-and-watcher-primary-design.md`
+- Plan: `docs/superpowers/plans/2026-05-25-report-storage-and-watcher-primary.md`
+
+## Pre-deploy (operator)
+
+See `deploy/k8s/README.md` "Report storage" section. Required:
+
+1. `md-benchmark-storage` Secret in both API and benchmarks namespaces
+2. MinIO bucket lifecycle (30-day expire) configured
+3. (Recommended) drain in-flight benchmarks before deploy
+
+## Test plan
+
+- [ ] `pnpm -F @modeldoctor/api test` green
+- [ ] `pnpm test:e2e:api` green including new `benchmark-watcher-primary.e2e-spec.ts`
+- [ ] `pnpm -F @modeldoctor/benchmark-runner test` green (rename to your actual pytest cmd)
+- [ ] Browser e2e: `pnpm test:e2e:browser` — existing benchmark spec passes
+- [ ] Manual cluster smoke: run a real benchmark against dev MinIO; verify
+      meta.json / result.json / stdout.log written, API marks completed with
+      parsed summaryMetrics
+
+refs #237
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 8: Watch CI**
+
+```bash
+gh pr checks --watch
+```
+
+Verify all checks pass. If anything red, fix in follow-up commit on the same branch — do not close + reopen.
+
+---
+
+## Self-review checklist (do NOT skip — run BEFORE handing back)
+
+After completing all tasks, run this cold-read against the spec:
+
+1. **Spec §1 Scope coverage:**
+   - [ ] §1 in-scope items each map to a task above?
+   - [ ] §1 out-of-scope items (Phase 3 / 4) NOT touched by any task?
+2. **Spec §2 Storage interface:**
+   - [ ] `reportStorageKeys` exists in contracts? (Task 1)
+   - [ ] `ReportStorage` interface + `S3ReportStorage` impl exists? (Tasks 3, 5)
+3. **Spec §3 K8s Secret:**
+   - [ ] Job manifest injects `md-benchmark-storage`? (Task 10)
+4. **Spec §4 reducer:**
+   - [ ] `mode` + `running` + `load-report` transitions wired? (Task 6, 8)
+5. **Spec §5 ReportLoader:**
+   - [ ] 5-path coverage + `updateGuarded` guard + sse.close in finally? (Task 7)
+6. **Spec §6 Watcher / Reconciler:**
+   - [ ] Primary mode no longer throws? (Task 8)
+   - [ ] Reconciler storage-first? (Task 9)
+7. **Spec §7 Runner:**
+   - [ ] `meta.json` written at start (Task 16)?
+   - [ ] `result.json` written LAST as sentinel (Task 16)?
+   - [ ] Any S3 write failure → non-zero exit (Task 16)?
+8. **Spec §"Code deletions":**
+   - [ ] All deletions covered? (Task 17)
+9. **Spec §Testing:**
+   - [ ] Unit tests: reducer matrix, S3 storage, ReportLoader 5-path, files controller (Tasks 5, 6, 7, 11)?
+   - [ ] e2e: primary mode + storage missing (Task 18)?
+   - [ ] Runner pytest: storage_keys + s3_writer + main (Tasks 14, 15, 16)?
+10. **Spec §Migration / Rollout:**
+    - [ ] Docs updated? (Task 19)
+
+If any box ends up unchecked, add a task to cover the gap before opening the PR.

--- a/docs/superpowers/specs/2026-05-25-report-storage-and-watcher-primary-design.md
+++ b/docs/superpowers/specs/2026-05-25-report-storage-and-watcher-primary-design.md
@@ -1,0 +1,753 @@
+# Report shared storage + watcher primary mode — Phase 0+2 合并：彻底重写 runner→API 通道
+
+**Status:** draft · 2026-05-25
+**Scope:** `apps/api` benchmark module + `apps/benchmark-runner`
+**Tracks:** [#237](https://github.com/weetime/modeldoctor/issues/237) Phase 0 + Phase 2（合并实施）
+**Builds on:** [Phase 1 watcher backstop](./2026-05-25-watch-based-runner-status-design.md)（已落地，[PR #238](https://github.com/weetime/modeldoctor/pull/238)）
+**Out of scope:** `/log` 通道、`PodLogStreamerPool`、删 `HmacCallbackGuard` —— 留 Phase 3
+
+## Goal
+
+把 runner→API 的 **状态翻转**（`running` / `completed` / `failed`）和 **终态报告**（`summaryMetrics` / `rawOutput` / `toolVersion`）从 push (HTTP callback) 改成 pull (K8s informer + S3 共享存储)：
+
+- 状态：API informer 看到 `pod.phase=Succeeded` 直接触发 `ReportLoader`；看到 `Failed` 直接写 `failed`
+- 报告 + toolVersion：runner 把 `meta.json` / `result.json` / `stdout.log` / `stderr.log` / `files/*` 写到 S3，API 在终态时读
+- runner 从此对 state/finish 这两条 callback **零依赖** —— 也不再装 deprecated no-op 兜底；`/log` 通道暂留给 Phase 3 处理
+
+口径：**彻底重写**，不留 deprecated endpoint，不双写，不带技术债。
+
+## Why this shape
+
+Phase 1 已把 watcher backstop 装好（`K8sJobWatcherService` + `PodStateReducer` + `StartupReconciler` + `BenchmarkRepository.updateGuarded()`），底座齐了。Phase 2 = 在底座上加：
+
+1. `S3ReportStorage` —— 唯一的报告/输出文件载体
+2. `ReportLoader` —— 把 storage 数据翻译成 benchmark 行更新
+3. `PodStateReducer` 扩 primary 模式 —— `running` / `load-report` 两条新 transition
+4. runner 改 —— `boto3` 直写 S3，删 `post_state_running` / `post_finish`
+
+`/log` 暂留是 Phase 3 决定：log streaming 用 `Log.log(follow:true)` 是另一摊事，跟 status flip 解耦能简化本 PR 范围。
+
+Phase 1 spec 的 "Phase 0 储存层 独立 spec" 决议在本 spec 合并 —— 因为 `ReportStorage` 接口和 `ReportLoader` 紧耦合，独立 PR 反而要先 freeze 接口再回头改，多走一步没意义。
+
+## Non-goals
+
+- **不动 `/log` 通道**：`benchmarkLogCallbackSchema`、`HmacCallbackGuard`、`BenchmarkCallbackController.handleLog` 全部保留；runner 仍然 POST `/log`。
+- **不引入 `'loading-report'` 中间状态**：保 status 枚举稳定（schema、前端、contracts 不动）。靠 reducer 的 currentStatus 守卫 + `try/finally` 防泄漏。
+- **不做 TTL janitor**：MinIO bucket lifecycle 一次性配（`mc ilm rule add --expire-days 30 myminio/<bucket>`），不进代码。
+- **不做 per-runId IAM scoping / presigned URL / STS**：单 K8s Secret + bucket-policy-pseudo 隔离即可，V1 不为这投资。
+- **不做 multi-replica API**：informer 仍单进程；HA 留 ESM Phase 2 + 1.x + leader election。
+- **不动 SSE 协议**：前端零改动。
+- **不动 cancel API**：`BenchmarkService.cancel()` 路径不变。
+
+## Architecture
+
+### 通道形态对比
+
+| 信号 | Phase 1 之后 (callback primary + watcher backstop) | 本 spec 之后 (watcher primary + S3) |
+|---|---|---|
+| 状态 `running` | runner POST `/state` | informer: `pod.phase=Running` + container ready |
+| 状态 `completed` | runner POST `/finish state=completed` | informer: `pod.phase=Succeeded` → `ReportLoader.tryLoad()` → parse OK |
+| 状态 `failed`（工具非零退出） | runner POST `/finish state=failed` | informer: `pod.phase=Failed` |
+| 状态 `failed`（pre-start） | watcher backstop（grace 60s） | watcher（grace 不变） |
+| 状态 `failed`（runner 静默挂） | watcher backstop（grace 60s） | watcher（grace 不变） |
+| `statusMessage` | runner 自填 / watcher backstop 拼 | watcher 拼 `terminated.{exitCode,reason,message}`；ReportLoader 拼 storage 异常 |
+| `startedAt` / `completedAt` | runner POST 时刻 | informer 事件时刻（pod condition transition time） |
+| `toolVersion` | runner POST `/state` | runner 写 `meta.json` → ReportLoader 读 |
+| live SSE log + `progress%` | runner POST `/log` 批量 | **不变**（Phase 3 才改） |
+| `summaryMetrics` + `rawOutput` | runner POST `/finish` | runner 写 `result.json` + `files/*` → ReportLoader 读 |
+
+### 组件图
+
+```
+              ┌─────────────────────────────────────────┐
+              │            apps/api (single)            │
+              │                                         │
+              │  K8sJobWatcherService (singleton)       │
+              │   mode = primary                        │
+              │    │                                    │
+              │    ▼                                    │
+              │  PodStateReducer (pure)                 │
+              │    primary transitions:                 │
+              │      running | load-report |            │
+              │      failed-pre-start | failed-terminal │
+              │    │                                    │
+              │    ▼                                    │
+              │  ┌──────────────┐ ┌──────────────────┐  │
+              │  │ updateGuarded│ │ ReportLoader     │  │
+              │  │ (running /   │ │  tryLoad(runId)  │  │
+              │  │  failed)     │ │   → S3ReportStor.│  │
+              │  └──────────────┘ │   → byTool.parse │  │
+              │                   │   → updateGuarded│  │
+              │  StartupReconciler│   (completed |   │  │
+              │   storage > pod   │    failed)       │  │
+              │   > fail          └──────────────────┘  │
+              └─────────────────────────────┬───────────┘
+                                            │
+                                            ▼
+                                ┌───────────────────────┐
+                                │ S3-compat (MinIO/AWS) │
+                                │  <bucket>/<runId>/...  │
+                                └───────────────────────┘
+                                            ▲
+                                            │  boto3
+                  ┌─────────────────────────┴───────────┐
+                  │  benchmark-runner pod (per Job)     │
+                  │   1. detect_tool_version → meta.json│
+                  │   2. spawn tool subprocess          │
+                  │   3. drain stdout/stderr            │
+                  │      → POST /log (Phase 3 改)       │
+                  │      → append local files           │
+                  │   4. on exit: write result.json +   │
+                  │      files/<alias> +                │
+                  │      stdout.log / stderr.log        │
+                  │   5. exit 0 if all writes OK        │
+                  │      else raise → exit non-zero     │
+                  └─────────────────────────────────────┘
+```
+
+### State machine（写权重新定义）
+
+**核心规则不变**：`benchmark.status` 只能 forward；所有写者走 `BenchmarkRepository.updateGuarded()`。
+
+| 写者 | 触发 | 目标 status | 附带写 |
+|---|---|---|---|
+| `BenchmarkService.submit()` | 用户创建 | `submitted` | — |
+| `K8sBenchmarkRunner.start()` | 投递 Job | (仍 `submitted`) | `runHandle` |
+| **Informer** (primary) | `pod.phase=Running` && container ready | `running` | `startedAt` |
+| **Informer** (primary) | `pod.phase=Failed` | `failed` | `statusMessage`, `completedAt` |
+| **Informer → ReportLoader** | `pod.phase=Succeeded` | (触发 ReportLoader) | — |
+| **ReportLoader** | parse OK | `completed` | `summaryMetrics`, `rawOutput`, `toolVersion`, `completedAt` |
+| **ReportLoader** | storage / parse 异常 | `failed` | `statusMessage="report load: ..."`, `completedAt` |
+| **Informer** (FATAL waiting) | `waiting.reason ∈ FATAL_WAITING_REASONS` 过 60s grace | `failed` | `statusMessage`, `completedAt` |
+| `BenchmarkService.cancel()` | 用户取消 | `cancelled` | `completedAt` |
+| **StartupReconciler** | storage 有 `<id>/result.json` | 走 ReportLoader 同路径 | 同上 |
+| **StartupReconciler** | storage 无 + pod 存在 | 不动（等 informer） | — |
+| **StartupReconciler** | storage 无 + pod 不在 | `failed` | `statusMessage="pod gone before reconcile"` |
+
+`/log` 通道**不写 status**（它今天也不写 status，纯流日志 + progress%）。
+
+`FATAL_WAITING_REASONS` 与 Phase 1 一致。`WAITING_FATAL_GRACE_SEC=60` 与 Phase 1 一致。
+
+`TERMINAL_RECONCILE_GRACE_SEC`（Phase 1 backstop 用）在 primary 模式下**不参与判定** —— terminal phase 直接动作，不等 grace。backstop 模式保留 grace 作 ops 降级用。
+
+## Storage 层设计
+
+### Key 约定（contracts 共享）
+
+```ts
+// packages/contracts/src/benchmark/storage-keys.ts
+export const reportStorageKeys = (runId: string) => ({
+  meta: `${runId}/meta.json`,
+  result: `${runId}/result.json`,
+  stdout: `${runId}/stdout.log`,
+  stderr: `${runId}/stderr.log`,
+  file: (alias: string) => `${runId}/files/${alias}`,
+});
+```
+
+runner 和 API 都从这个模块导入（runner Python 端复制一份常量到 `runner/storage_keys.py`，CI 加一行测试断言两边 prefix 一致）。
+
+### `meta.json` schema
+
+```json
+{
+  "toolVersion": "guidellm 0.2.1",
+  "startTimeIso": "2026-05-25T01:23:45.678Z"
+}
+```
+
+runner 在 `detect_tool_version()` 完成后**立即**写。
+
+### `result.json` schema
+
+```json
+{
+  "exitCode": 0,
+  "finishTimeIso": "2026-05-25T01:33:21.456Z",
+  "files": {
+    "report-json": "files/report.json",
+    "report-html": "files/report.html"
+  }
+}
+```
+
+`files` 是 alias → relative-path 的映射（相对于 `<runId>/`）。具体 alias 由各 tool adapter 在 runner 端约定（沿用现有 `outputFiles` 接口，但路径从 inline base64 改成 storage relative path）。
+
+### `ReportStorage` 接口（API 侧）
+
+```ts
+// apps/api/src/modules/benchmark/storage/report-storage.ts
+export interface ReportStorage {
+  exists(key: string): Promise<boolean>;
+  readJson<T>(key: string): Promise<T>;
+  readText(key: string): Promise<string>;
+  readBytes(key: string): Promise<Buffer>;
+}
+```
+
+API 侧只读，不暴露 write —— runner 不通过 API 写 S3。
+
+### `S3ReportStorage` 实现要点
+
+```ts
+// apps/api/src/modules/benchmark/storage/s3-report-storage.ts
+@Injectable()
+export class S3ReportStorage implements ReportStorage {
+  private readonly client: S3Client;
+  constructor(@Inject(ENV) env: Env) {
+    this.client = new S3Client({
+      endpoint: env.S3_ENDPOINT,
+      region: env.S3_REGION ?? "us-east-1",
+      forcePathStyle: true,           // MinIO 必需
+      credentials: {
+        accessKeyId: env.S3_ACCESS_KEY,
+        secretAccessKey: env.S3_SECRET_KEY,
+      },
+      maxAttempts: 2,                 // 1 retry (默认 3 太多)
+      requestHandler: new NodeHttpHandler({
+        connectionTimeout: 5_000,
+        socketTimeout: 30_000,
+      }),
+    });
+    this.bucket = env.S3_BUCKET;
+  }
+  // exists: HeadObjectCommand → NotFound 返 false, 其他抛
+  // readJson/Text/Bytes: GetObjectCommand → 流转 buffer → 解析
+}
+```
+
+### Env schema 新增
+
+```ts
+// apps/api/src/config/env.schema.ts
+S3_ENDPOINT: z.string().url(),
+S3_ACCESS_KEY: z.string().min(1),
+S3_SECRET_KEY: z.string().min(1),
+S3_BUCKET: z.string().min(1),
+S3_REGION: z.string().default("us-east-1"),
+K8S_WATCHER_MODE: z.enum(["off", "backstop", "primary"]).default("primary"),
+// 测试 fixtures 显式覆盖成 "off" / "backstop"
+```
+
+### MinIO Secret（运维一次性创建）
+
+```bash
+kubectl -n modeldoctor-benchmarks create secret generic md-benchmark-storage \
+  --from-literal=S3_ENDPOINT=http://10.100.121.67:31871 \
+  --from-literal=S3_ACCESS_KEY=<key> \
+  --from-literal=S3_SECRET_KEY=<secret> \
+  --from-literal=S3_BUCKET=weetime \
+  --from-literal=S3_REGION=us-east-1
+# 同一份在 API 所在 namespace 也复制一份（如果不同 ns）
+```
+
+Bucket lifecycle（一次性，运维侧）：
+
+```bash
+mc ilm rule add --expire-days 30 myminio/weetime
+```
+
+## PodStateReducer 改造
+
+```ts
+// apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts (扩展)
+export type DesiredTransition =
+  | { kind: "running"; startedAt: Date }
+  | { kind: "load-report" }
+  | { kind: "failed-pre-start"; reason: string; message: string }
+  | { kind: "failed-terminal"; exitCode: number; reason: string; message: string }
+  | { kind: "noop" };
+
+export interface ReducerInput {
+  pod: V1Pod;
+  currentStatus: string;
+  firstFatalWaitingAt: Date | null;
+  firstTerminalAt: Date | null;
+  now: Date;
+  config: ReducerConfig;
+  mode: WatcherMode;     // 新增
+}
+```
+
+primary 分支判定优先级（reducer 内部）：
+1. `currentStatus` 不是 IN_PROGRESS → `noop`
+2. `phase=Succeeded` → `load-report`
+3. `phase=Failed` → `failed-terminal`（statusMessage 从 `terminated.{reason,message}` 拼）
+4. `phase=Pending` 且 FATAL waiting 过 grace → `failed-pre-start`
+5. `phase=Running` && `containerStatuses[0].ready` && `currentStatus='submitted'` → `running`（startedAt = `now`，或更准是 `containerStatuses[0].state.running.startedAt`）
+6. otherwise → `noop`
+
+backstop 分支保留 Phase 1 现状不动 —— ops 降级用。
+
+`mode` 参数让一份纯函数承载两种行为，单测两条独立 case 矩阵。
+
+## Watcher service 改造
+
+`K8sJobWatcherService.onModuleInit()` 把 "`primary` throws not yet implemented" 那行去掉。其他主路径基本不变 —— event handler 拿到 reducer 输出后 switch on `kind`：
+
+```ts
+// 注意 updateGuarded(id, allowedStatuses, input) 的参数顺序
+switch (transition.kind) {
+  case "running":
+    await this.repo.updateGuarded(runId, ["submitted"], { status: "running", startedAt: transition.startedAt });
+    break;
+  case "load-report":
+    void this.reportLoader.tryLoad(runId);  // fire-and-forget；内部自带错误处理
+    break;
+  case "failed-pre-start":
+  case "failed-terminal":
+    await this.repo.updateGuarded(runId, IN_PROGRESS_STATES, { status: "failed", statusMessage: ..., completedAt: now });
+    break;
+  case "noop":
+    break;
+}
+```
+
+`load-report` 用 `void` 是因为 informer event handler 是同步收事件队列，ReportLoader 内部可能 30s S3 timeout，不能阻住 handler。`tryLoad` 内部一定要 `try/catch finally` 兜底，**不能向外抛**。
+
+## ReportLoader 行为
+
+```ts
+// apps/api/src/modules/benchmark/storage/report-loader.ts
+@Injectable()
+export class ReportLoader {
+  async tryLoad(runId: string): Promise<void> {
+    const bench = await this.repo.findById(runId);
+    if (!bench || !IN_PROGRESS_STATES.includes(bench.status)) return;
+    try {
+      const keys = reportStorageKeys(runId);
+      const [meta, result, stdout, stderr] = await Promise.all([
+        this.storage.readJson<{ toolVersion: string; startTimeIso: string }>(keys.meta),
+        this.storage.readJson<{ exitCode: number; finishTimeIso: string; files: Record<string, string> }>(keys.result),
+        this.storage.readText(keys.stdout),
+        this.storage.readText(keys.stderr),
+      ]);
+      const files = await this.loadOutputFiles(runId, result.files);
+      const summary = byTool(bench.tool).parseFinalReport(stdout, files);
+      // updateGuarded signature is (id, allowedStatuses, input) → row | null
+      const updated = await this.repo.updateGuarded(runId, IN_PROGRESS_STATES, {
+        status: "completed",
+        toolVersion: meta.toolVersion,
+        summaryMetrics: summary,
+        rawOutput: { stdout: stdout.slice(-LOG_TAIL_MAX), stderr: stderr.slice(-LOG_TAIL_MAX), files: result.files },
+        completedAt: new Date(result.finishTimeIso),
+      });
+      if (updated) await this.notify.emit({ eventType: "benchmark.completed", ... });
+    } catch (e) {
+      const updated = await this.repo.updateGuarded(runId, IN_PROGRESS_STATES, {
+        status: "failed",
+        statusMessage: `report load: ${truncate((e as Error).message, 2048)}`,
+        completedAt: new Date(),
+      });
+      if (updated) await this.notify.emit({ eventType: "benchmark.failed", ... });
+    } finally {
+      this.sse.close(runId);
+    }
+  }
+}
+```
+
+`rawOutput.stdout/stderr` 仍然按现有约定截尾（64KB），跟 callback 时代一致。
+
+`rawOutput.files` shape 改成 `{ alias: relativePath }`（不再 base64 inline）。前端 BenchmarkDetailPage 下载文件的路径 —— 走新 API `GET /benchmarks/:id/files/:alias` 由 ReportStorage 代理拉 S3 GetObject 返回；本 spec 包含这个 API 的 contract，不包含前端改动（前端已用代理路径而非 base64 即可，改动小，PR 内一起做）。
+
+### `loadOutputFiles` 行为
+
+把 `result.files = { alias: relativePath }` 转成 `{ alias: bytes }`，交给 `byTool(tool).parseFinalReport(stdout, files)` 解析。各 tool adapter 不动（它们已经预期 `Record<string, Buffer>`）。
+
+文件总大小硬上限：500MB。超过 → ReportLoader 抛 → 走 failed 路径，statusMessage="report files exceed 500MB"。
+
+## StartupReconciler 改造
+
+Phase 1 已有 cache.list + label 过滤 + pod exists 分支。Phase 2 把 "storage 优先" 加进来：
+
+```ts
+async run(): Promise<void> {
+  const inProgress = await this.repo.listByStatus(IN_PROGRESS_STATES);
+  for (const b of inProgress) {
+    if (await this.storage.exists(reportStorageKeys(b.id).result)) {
+      await this.reportLoader.tryLoad(b.id);
+      continue;
+    }
+    const pod = this.informer.cache.list().find(p => p.metadata?.labels?.["modeldoctor.ai/run-id"] === b.id);
+    if (pod) continue;  // pod 还在，informer 会处理
+    await this.repo.updateGuarded(b.id, IN_PROGRESS_STATES, {
+      status: "failed",
+      statusMessage: "pod gone before reconcile",
+      completedAt: new Date(),
+    });
+  }
+}
+```
+
+理由（沿用 Phase 1 spec D3 决策）：API 停机 > 1h（pod TTL）时 pod 已删；但 runner 在 pod 删除前完成了 storage 写。storage 是 ground truth。
+
+## Runner 改造
+
+### `runner/main.py` 主路径
+
+```python
+# 旧：
+from runner.callback import post_finish, post_log_batch, post_state_running
+# 新：
+from runner.callback import post_log_batch  # 只留 /log
+from runner.s3_writer import S3Writer
+from runner.storage_keys import keys_for
+
+def main():
+    args = parse_env()
+    s3 = S3Writer.from_env()
+    keys = keys_for(args.run_id)
+
+    tool_version = detect_tool_version(args.tool)
+    s3.put_json(keys.meta, {
+        "toolVersion": tool_version or "",
+        "startTimeIso": iso_now(),
+    })
+
+    proc = subprocess.Popen([...], ...)
+    pumps = [StreamPump(proc.stdout, "stdout", ...), StreamPump(proc.stderr, "stderr", ...)]
+    for p in pumps: p.start()
+    proc.wait()
+    for p in pumps: p.join()
+
+    finish_time = iso_now()
+    # 写 output files
+    files_map = {}
+    for alias, local_path in pumps_collect_output_files(args).items():
+        rel = f"files/{alias}"
+        s3.put_file(f"{args.run_id}/{rel}", local_path)
+        files_map[alias] = rel
+    # 写 stdout/stderr 全文
+    s3.put_text(keys.stdout, pumps[0].full_buffer())
+    s3.put_text(keys.stderr, pumps[1].full_buffer())
+    # 最后写 result.json（API 用 result.json 存在做 trigger）
+    s3.put_json(keys.result, {
+        "exitCode": proc.returncode,
+        "finishTimeIso": finish_time,
+        "files": files_map,
+    })
+
+    sys.exit(proc.returncode)
+```
+
+**关键不变量**：`result.json` 是最后写的 sentinel。API 看到 `result.json` 就认为 storage 已完整。**任何 S3 写失败 raise → 进程 exit 非 0 → pod.Failed → watcher 走 `failed-terminal` 路径**（不会走 load-report，因为 phase 不是 Succeeded）。
+
+StreamPump 行为本 spec 不动：它今天既写本地 buffer 又 POST `/log`，Phase 2 保持现状。Phase 3 时再把 POST 部分剔掉。
+
+### `runner/s3_writer.py`（新增）
+
+```python
+import boto3
+from botocore.config import Config
+
+class S3Writer:
+    @classmethod
+    def from_env(cls):
+        return cls(
+            endpoint=os.environ["S3_ENDPOINT"],
+            access_key=os.environ["S3_ACCESS_KEY"],
+            secret_key=os.environ["S3_SECRET_KEY"],
+            bucket=os.environ["S3_BUCKET"],
+            region=os.environ.get("S3_REGION", "us-east-1"),
+        )
+
+    def __init__(self, endpoint, access_key, secret_key, bucket, region):
+        self.client = boto3.client(
+            "s3",
+            endpoint_url=endpoint,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            region_name=region,
+            config=Config(
+                signature_version="s3v4",
+                retries={"max_attempts": 2, "mode": "standard"},
+                connect_timeout=5,
+                read_timeout=30,
+            ),
+        )
+        self.bucket = bucket
+
+    def put_json(self, key, obj): ...
+    def put_text(self, key, text): ...
+    def put_file(self, key, local_path): ...  # use upload_file (auto-multipart)
+```
+
+`upload_file` 处理 multipart，>5MB 自动分块，runner 不需要管。
+
+### `runner/storage_keys.py`（新增）
+
+```python
+def keys_for(run_id: str):
+    return SimpleNamespace(
+        meta=f"{run_id}/meta.json",
+        result=f"{run_id}/result.json",
+        stdout=f"{run_id}/stdout.log",
+        stderr=f"{run_id}/stderr.log",
+    )
+def file_key(run_id: str, alias: str) -> str:
+    return f"{run_id}/files/{alias}"
+```
+
+### `runner/callback.py` 改
+
+```python
+# 删：post_state_running, post_finish, 以及它们的所有 import/帮助函数
+# 留：post_log_batch（Phase 3 才会删）
+```
+
+### `requirements.txt` 改
+
+```
++ boto3>=1.34,<2
+```
+
+体积影响：boto3 + botocore 解压后 ~12MB。可接受。
+
+## Job manifest 改造
+
+`apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts`：
+
+```ts
+// container.envFrom 加入第二个 secretRef
+{
+  envFrom: [
+    { secretRef: { name: perRunSecretName } },     // 已有，含 OPENAI_API_KEY 等 + 旧 MD_CALLBACK_TOKEN（Phase 3 删）
+    { secretRef: { name: "md-benchmark-storage" } } // 新增，含 S3_*
+  ]
+}
+// container.env 删除 MD_CALLBACK_TOKEN 的注入（callback secret 不再含它）
+// container.env 保留 MD_CALLBACK_URL（/log 还用）—— Phase 3 删
+```
+
+`buildSecretManifest` 改：从 per-run Secret 里删 `MD_CALLBACK_TOKEN` —— 因为 token 给 `/state` `/finish` 用的，`/log` 用的另有处理。
+
+> ⚠️ 等等 —— 现状 `/log` HMAC guard 用的也是 `MD_CALLBACK_TOKEN`。从 callback secret 里删 token 会让 `/log` 鉴权失败。
+>
+> **修正**：`MD_CALLBACK_TOKEN` 暂留在 per-run Secret 里（Phase 3 删整套 callback 时再清）。本 PR 仅删 runner 代码里 `post_state_running` / `post_finish` 的调用 + 删 API 端 `/state` `/finish` controller handler。token env 还在但只服务 `/log`。
+
+修订后的删除清单见 §"代码面变更" 部分。
+
+## 代码面变更（精确清单）
+
+### 删
+
+| 文件 / 符号 | 备注 |
+|---|---|
+| `apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.ts` 中 `handleState`、`handleFinish` 方法 + 路由 | controller 文件本身保留（handleLog 还在） |
+| `apps/api/src/modules/benchmark/callbacks/benchmark-callback.controller.spec.ts` 中 `/state` `/finish` 的 case | 仅删 case，文件保留 |
+| `apps/api/test/e2e/benchmark-state-callback.e2e-spec.ts` | 如果存在；只针对 /state 的 e2e |
+| `apps/api/test/e2e/benchmark-finish-callback.e2e-spec.ts` | 如果存在；只针对 /finish 的 e2e |
+| `packages/contracts/src/benchmark.ts` 中 `benchmarkStateCallbackSchema`、`BenchmarkStateCallback`、`benchmarkFinishCallbackSchema`、`BenchmarkFinishCallback` 四个导出 | 文件保留（benchmarkLogCallbackSchema 还在） |
+| `apps/benchmark-runner/runner/callback.py` 中 `post_state_running` + `post_finish` + 它们的辅助 | 文件保留（post_log_batch 还在） |
+| `apps/benchmark-runner/tests/test_main.py` 中针对 /state /finish 的 case | 仅删 case，文件保留 |
+
+### 改
+
+| 文件 | 改动概述 |
+|---|---|
+| `apps/api/src/modules/benchmark/k8s/pod-state-reducer.ts` | + primary 分支（5 条优先级）+ `mode` 入参 |
+| `apps/api/src/modules/benchmark/k8s/pod-state-reducer.spec.ts` | 加 primary case 矩阵 |
+| `apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.ts` | 去掉 `primary throws`；event handler switch on 新 transition kinds；注入 ReportLoader |
+| `apps/api/src/modules/benchmark/k8s/k8s-job-watcher.service.spec.ts` | 加 primary mode 流转测试 |
+| `apps/api/src/modules/benchmark/k8s/startup-reconciler.ts` | storage > pod > fail 三分支 |
+| `apps/api/src/modules/benchmark/k8s/startup-reconciler.spec.ts` | 加 storage 路径 case |
+| `apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts` | envFrom 加第二个 secretRef |
+| `apps/api/src/modules/benchmark/k8s/k8s-job-manifest.spec.ts` | 验 envFrom |
+| `apps/api/src/modules/benchmark/benchmark.module.ts` | wire S3ReportStorage + ReportLoader |
+| `apps/api/src/config/env.schema.ts` | S3_* 必填、K8S_WATCHER_MODE 默认改为 `primary`（现状是 `off`） |
+| `apps/benchmark-runner/runner/main.py` | 删 post_state_running / post_finish 调用；走 S3 写主路径 |
+| `apps/benchmark-runner/requirements.txt` | + boto3 |
+| `apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx`（如有 base64 inline 假设） | 改走文件下载 API |
+
+### 新增
+
+| 文件 | 概述 |
+|---|---|
+| `packages/contracts/src/benchmark/storage-keys.ts` | `reportStorageKeys(runId)` 工厂 |
+| `apps/api/src/modules/benchmark/storage/report-storage.ts` | interface |
+| `apps/api/src/modules/benchmark/storage/s3-report-storage.ts` | `@aws-sdk/client-s3` 实现 |
+| `apps/api/src/modules/benchmark/storage/s3-report-storage.spec.ts` | `aws-sdk-client-mock` 单测 |
+| `apps/api/src/modules/benchmark/storage/report-loader.ts` | tryLoad 主路径 |
+| `apps/api/src/modules/benchmark/storage/report-loader.spec.ts` | 成功 / file missing / parse fail / s3 timeout / guard race 五条路径 |
+| `apps/api/src/modules/benchmark/benchmark-files.controller.ts` | `GET /benchmarks/:id/files/:alias` 代理 |
+| `apps/api/src/modules/benchmark/benchmark-files.controller.spec.ts` | — |
+| `apps/api/test/e2e/benchmark-watcher-primary.e2e-spec.ts` | informer fixture 发 Succeeded + S3 mock 返 fixture → 验 row=completed |
+| `apps/benchmark-runner/runner/s3_writer.py` | boto3 wrapper |
+| `apps/benchmark-runner/runner/storage_keys.py` | key 工厂 |
+| `apps/benchmark-runner/tests/test_s3_writer.py` | moto mock |
+| `apps/benchmark-runner/tests/test_main_phase2.py` | runner 主路径写 S3 顺序 + 异常退出非 0 |
+
+## 关键设计决策
+
+### D1 — `/state` `/finish` 彻底删，不留 deprecated no-op
+
+**决策**：API controller 删 handler，runner 代码删 POST 调用。无 deprecated endpoint。
+
+**为什么**：deprecated no-op 是技术债务的种子 —— 三个月后没人记得它是死的；而且不删 controller 就要继续验 HMAC、继续写 zod schema，跟"重写"口径冲突。用户明确选择了 clean slate。
+
+**代价**：旧 runner 镜像如果在 deploy 当时正在跑，POST 会撞 404。现有 `runner/callback.py` 内部对 HTTP 错误是 swallow 的（不向 main 路径 raise），所以 benchmark 不会因此挂；pod 完成后 watcher 走 `Succeeded` → ReportLoader 找不到 `result.json` → 走 storage exists=false → backstop grace 60s 后标 `failed`。可接受，运维 deploy 前建议 drain（参 §Migration）。
+
+### D2 — `K8S_WATCHER_MODE` 默认 `primary`
+
+**决策**：env.schema default 改成 `primary`。
+
+**为什么**：本 PR 的目标就是激活 primary；如果默认还是 `off` 或 `backstop`，等于"代码进了但不生效"，第二个 PR 改 default 的话又要做 ramp 通知，不如一次到位。测试 fixtures 显式覆盖成 `off`。
+
+**代价**：单元/集成测试如果没显式覆盖会 informer 启动。`env.schema.ts` 的测试 default 已有 fixture 机制（参考 `pickTestDatabaseUrl` 同套），加一个 `K8S_WATCHER_MODE=off` 到 `E2E_ENV_DEFAULTS` 即可。
+
+### D3 — 不引入 `'loading-report'` 中间状态
+
+**决策**：status 枚举不变。reducer 看 `IN_PROGRESS_STATES`（含 submitted, running）门控；ReportLoader 自己用 `try/finally` 保证不卡。
+
+**为什么**：引入新状态要动 prisma schema、benchmark contracts、前端列表筛选；收益小。
+
+**代价**：ReportLoader 跑期间如果 cancel 并发进来，cancel 先把 status 翻到 `cancelled`，ReportLoader 写 completed 时 affected=0 → 静默丢弃。这是 D5 守卫的"先到的胜"语义，已知且符合预期。
+
+### D4 — `result.json` 是 sentinel；S3 写顺序固定
+
+**决策**：runner 必须**最后**写 `result.json`，前面写 meta + files + stdout + stderr。ReportLoader 也好、StartupReconciler 也好，都用 `result.json` 存在做"storage 完整"判定。
+
+**为什么**：S3 单 object PUT 是原子的；多 object 没有事务。靠 sentinel 保证"半写"对 reader 不可见。
+
+**代价**：runner 必须保证写 result.json 之前其他文件已成功 —— 任何前置写失败必须 raise（exit 非 0），且不能往下走到写 result.json。
+
+### D5 — `MD_CALLBACK_TOKEN` 暂留在 per-run Secret
+
+**决策**：本 PR 不删 `MD_CALLBACK_TOKEN` 的注入。
+
+**为什么**：`/log` 通道还在用 HmacCallbackGuard。Phase 3 才能彻底删 token。本 spec 的"重写"口径限于 state+finish 通道，log 通道明确出 scope。
+
+### D6 — 单 K8s Secret + bucket prefix 隔离；不做 per-runId IAM
+
+**决策**：一个 `md-benchmark-storage` Secret 服务所有 Job。objects 用 `<runId>/...` 做逻辑隔离，不靠 IAM 强隔离。
+
+**为什么**：用户明确选择 simplest；per-runId STS / `mc admin user svcacct add` 给每个 Job 一份临时凭据是 V2 hardening 范畴。V1 信任 runner 不会故意去 GET 别人的 runId。
+
+### D7 — 文件下载走 API 代理，不直发 presigned URL
+
+**决策**：前端 `GET /benchmarks/:id/files/:alias` 命中 API → service 用 owner-id 校验 → `S3ReportStorage.readBytes` → 返二进制。
+
+**为什么**：用户已经登录的 API 是天然鉴权点；走 presigned URL 要在 API 临时签名 + 前端 fetch + CORS。代理虽然 API 多担一份带宽，但开发量小很多。鉴权沿用既有 `JwtAuthGuard`（class-level）+ service 内 `userId` 校验，与 `BenchmarkController` 一致。
+
+## 测试策略
+
+### 单测 (vitest)
+
+- `pod-state-reducer.spec.ts` —— primary mode 完整矩阵：
+  - phase × waiting.reason × currentStatus × ready × mode
+  - 至少覆盖：Succeeded/IN_PROGRESS → load-report；Failed/IN_PROGRESS → failed-terminal；Running/ready/submitted → running；Running/ready/running → noop；Pending/ImagePull → noop（不过 grace）；Pending/ImagePull + grace 过 → failed-pre-start；Pending/no-fatal → noop；任何 phase/非 IN_PROGRESS → noop
+- `s3-report-storage.spec.ts` —— `aws-sdk-client-mock`：
+  - exists 命中 / NotFound / NetworkError → 抛
+  - readJson 解析 OK / parse fail / NotFound
+  - timeout 行为（mock socket timeout）
+- `report-loader.spec.ts` —— 五条路径全覆盖：成功 / file missing → failed / parse fail → failed / s3 timeout → failed / 并发 cancel → noop（affected=0）
+- `startup-reconciler.spec.ts` —— 三分支：storage 有 result.json / pod 在 informer cache / pod 不在 → failed
+- `k8s-job-watcher.service.spec.ts` —— primary mode 下 reducer 各 transition 调对应 dependency（reportLoader.tryLoad / updateGuarded）
+
+### e2e API (vitest + supertest + nock)
+
+- 新增 `benchmark-watcher-primary.e2e-spec.ts`：
+  1. 启动测试 API（K8S_WATCHER_MODE=primary 显式）
+  2. nock 拦截 K8s apiserver 的 list+watch；先返一个 submitted benchmark 的 Running pod，再返 Succeeded pod
+  3. `aws-sdk-client-mock` mock S3 客户端返 fixture `meta.json` / `result.json` / stdout/stderr/files
+  4. 等 row.status 翻 `completed`，验 summaryMetrics + toolVersion + completedAt
+- 同样的骨架再写一份 failed 路径（Failed pod → row.failed）
+- 同样的骨架再写一份 storage missing（Succeeded pod 但 S3 返 NotFound → row.failed + statusMessage="report load: ..."）
+- 删 callback `/state` `/finish` 相关 e2e
+
+### Runner pytest (moto)
+
+- `test_s3_writer.py`：moto S3 mock，验 put_json/put_text/put_file 上传到正确 key，verifying re-read 得到一致内容
+- `test_main_phase2.py`：full e2e 模拟，验：写 meta → 跑 tool → 写 files → 写 result（顺序正确）；S3 写失败 → exit 非 0
+
+### Browser e2e (playwright)
+
+- 现有 `e2e/benchmark.spec.ts` 应该零修改通过 —— 通道层变了但 UI 行为对外一致（progress 仍走 SSE，detail 仍渲染 summaryMetrics）
+- 加：deploy 后用 dev MinIO 跑一遍真实 benchmark e2e（不在 CI，docs 描述 ops manual smoke）
+
+## Risks
+
+| Risk | 等级 | 缓解 |
+|---|---|---|
+| MinIO 不可达 → 所有 benchmark 终态都 failed | H | env.schema 校验 S3_* 非空；onModuleInit 时 HeadBucket 一次做 health check（失败立 boot fail，K8s 自动重启给运维诊断窗）；prometheus alert 加 `benchmark_status_message_like_report_load` 计数 |
+| runner 写 S3 部分成功后被 OOMKilled → 残留半写 objects | M | sentinel D4 保护读者；30 天 lifecycle 自动清理残留 |
+| reducer 漏掉 pod.status 边角组合（Evicted via `pod.status.reason`） | M | Phase 1 单测已覆盖 backstop；primary 加同样矩阵；CI 跑 K8s pod fixture 库回归 |
+| `K8S_WATCHER_MODE` 默认 primary 让旧测试意外启动 informer | L | `E2E_ENV_DEFAULTS` 加 `K8S_WATCHER_MODE=off`；单元测试 mock module 不构造 watcher |
+| Deploy 时 in-flight benchmarks 用旧 runner，没写 S3 | L | Phase 1 backstop 行为兜底（Succeeded 但找不到 callback → 60s 后 failed）；运维建议 deploy 前 cancel 长跑 |
+| boto3 import 失败 / 镜像构建失败 | L | requirements.txt 钉版本范围；CI build runner image |
+| 大文件 (>500MB) 把 API 撑爆 | M | ReportLoader `loadOutputFiles` 总大小校验 500MB；超 → failed + statusMessage |
+| 前端文件下载走代理后大文件下载体验差 | L | content-disposition stream；不在内存中缓存；V1 可接受 |
+
+## Migration / Rollout
+
+**Pre-deploy（运维侧）：**
+1. 在 MinIO 上确认 bucket `weetime` 存在；配 lifecycle rule（30 天过期）
+2. 在 K8s `modeldoctor-benchmarks` namespace 创建 `md-benchmark-storage` Secret
+3. 同 Secret 也在 API 所在 namespace 创建
+4. （建议）`kubectl -n modeldoctor-benchmarks get pods` 看在跑的 benchmark，等完或 cancel
+
+**Deploy：**
+1. 推新 runner image 到 registry
+2. 部署新 API（K8S_WATCHER_MODE 自动 default 成 primary）
+
+**Post-deploy 健康观察（第一周）：**
+- `benchmark_status_message LIKE 'report load:%'` 频率（应 ≈ 0）
+- watcher informer error 事件频率
+- S3 GetObject 延迟（API 侧 metrics）
+- 长 benchmark 完成时间分布对比
+
+**回滚：** 无降级路径 —— 本 PR 是 atomic 重写。如出严重 bug 走 git revert + 重新部署旧 image。
+
+## Accepted trade-offs
+
+| Trade-off | 理由 |
+|---|---|
+| toolVersion 运行中不可见，只在终态写入 | 跟 Phase 1 spec D2 一致；UI 显示 "loading..." |
+| Deploy 时 in-flight 旧 runner benchmark 会被标 failed | clean slate 口径的代价；运维侧 drain 解决 |
+| runner image +12MB (boto3) | 换 SDK 处理 multipart/sign/retry；纯 HTTP 走不通（multipart 太复杂） |
+| 文件下载走 API 代理（额外带宽） | 鉴权简单；V1 文件量级（<100MB / runId）API 撑得住 |
+| `'loading-report'` 不引中间状态 | 保 schema 稳定；try/finally + updateGuarded 保正确性 |
+| `MD_CALLBACK_TOKEN` 暂留在 Secret | `/log` 还在用；Phase 3 整体清 |
+| 单 K8s Secret 跨 Job 共享 | 拒绝 per-runId IAM；V2 hardening 范畴 |
+
+## Phase 3 / Phase 4 留下的明确路标
+
+便于后续 PR 准确收口：
+
+- Phase 3 = `PodLogStreamerPool` 替代 `/log` callback
+  - 加 `pods/log:get` 到 `deploy/k8s/rbac.yaml`
+  - 删 `BenchmarkCallbackController.handleLog`、`benchmarkLogCallbackSchema`、`HmacCallbackGuard`
+  - 删 `runner/callback.py` 整文件、删 `runner/main.py` 里 StreamPump 的 POST 部分
+  - 删 Job manifest 里 `MD_CALLBACK_URL` env 和 per-run Secret 里 `MD_CALLBACK_TOKEN`
+  - 删剩余 callback 相关 e2e
+- Phase 4 = runner 镜像净化（如还有残留）+ docs 同步
+
+## Open questions（spec 实施前确认）
+
+已答（self-review verified against current code）：
+- ✓ `updateGuarded(id, allowedStatuses, input) → row | null` —— signature 已统一到 spec
+- ✓ `MD_CALLBACK_TOKEN` 在 per-run Secret，Job manifest L36 写入；保留不动
+- ✓ `parseFinalReport(stdout, files: Record<string, Buffer>)` —— `Buffer` 入参与 spec 一致
+- ✓ Callback schemas 在 `packages/contracts/src/benchmark.ts` 同一个文件里（不是三个独立文件）
+- ✓ 现状 `K8S_WATCHER_MODE` default `off`，本 spec 改 `primary`
+- ✓ `BenchmarkController` 用 `JwtAuthGuard` class-level + service 内 ownership 校验；新 files controller 同套
+
+仍待 verify / 决策：
+1. `aws-sdk-client-mock` vs `vitest-mock-extended` —— 现有 e2e mock 库偏好；倾向前者（专为 SDK v3 设计）
+2. `moto` vs `boto3` stubber —— runner pytest 现有 mock 偏好；倾向 `moto`（语法更接近真实 S3）
+3. `LOG_TAIL_MAX` 当前 const 在哪？复用还是新建？（grep `LOG_TAIL_MAX_BYTES` runner 端有 `64 * 1024`；API 侧目前 callback `/finish` 的 rawOutput 切尾逻辑由 runner 完成；现在 API 端 ReportLoader 接管切尾，需要一个 const 落地点）
+4. 大文件下载流式响应实现 —— NestJS `StreamableFile`（`@nestjs/common`）vs 手动写 stream；倾向 `StreamableFile`，标准做法
+
+## References
+
+- Phase 1 spec：`docs/superpowers/specs/2026-05-25-watch-based-runner-status-design.md`
+- Phase 1 PR：[#238](https://github.com/weetime/modeldoctor/pull/238)
+- Tracking issue：[#237](https://github.com/weetime/modeldoctor/issues/237)
+- Roadmap umbrella：[#189](https://github.com/weetime/modeldoctor/issues/189)
+- `@kubernetes/client-node@0.21` informer：`dist/informer.d.ts`
+- `@aws-sdk/client-s3`：https://www.npmjs.com/package/@aws-sdk/client-s3
+- `aws-sdk-client-mock`：https://www.npmjs.com/package/aws-sdk-client-mock
+- `boto3` S3：https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html
+- `moto` S3 mock：https://docs.getmoto.org/en/latest/docs/services/s3.html
+- MinIO lifecycle：https://min.io/docs/minio/linux/administration/object-management/object-lifecycle-management.html

--- a/packages/contracts/src/benchmark.spec.ts
+++ b/packages/contracts/src/benchmark.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { benchmarkSchema, listBenchmarksQuerySchema, reportStorageKeys, reportMetaSchema, reportResultSchema } from "./benchmark.js";
+import {
+  benchmarkSchema,
+  listBenchmarksQuerySchema,
+  reportMetaSchema,
+  reportResultSchema,
+  reportStorageKeys,
+} from "./benchmark.js";
 
 describe("benchmarkSchema (baselineFor wiring)", () => {
   it("accepts baselineFor as null", () => {
@@ -54,7 +60,12 @@ describe("reportStorageKeys", () => {
 
 describe("reportMetaSchema", () => {
   it("accepts a valid meta payload", () => {
-    expect(reportMetaSchema.parse({ toolVersion: "guidellm 0.2.1", startTimeIso: "2026-05-25T00:00:00.000Z" })).toBeTruthy();
+    expect(
+      reportMetaSchema.parse({
+        toolVersion: "guidellm 0.2.1",
+        startTimeIso: "2026-05-25T00:00:00.000Z",
+      }),
+    ).toBeTruthy();
   });
   it("rejects missing startTimeIso", () => {
     expect(() => reportMetaSchema.parse({ toolVersion: "x" })).toThrow();
@@ -63,11 +74,13 @@ describe("reportMetaSchema", () => {
 
 describe("reportResultSchema", () => {
   it("accepts a valid result payload", () => {
-    expect(reportResultSchema.parse({
-      exitCode: 0,
-      finishTimeIso: "2026-05-25T01:00:00.000Z",
-      files: { "report-json": "files/report.json" },
-    })).toBeTruthy();
+    expect(
+      reportResultSchema.parse({
+        exitCode: 0,
+        finishTimeIso: "2026-05-25T01:00:00.000Z",
+        files: { "report-json": "files/report.json" },
+      }),
+    ).toBeTruthy();
   });
 });
 

--- a/packages/contracts/src/benchmark.spec.ts
+++ b/packages/contracts/src/benchmark.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { benchmarkSchema, listBenchmarksQuerySchema } from "./benchmark.js";
+import { benchmarkSchema, listBenchmarksQuerySchema, reportStorageKeys, reportMetaSchema, reportResultSchema } from "./benchmark.js";
 
 describe("benchmarkSchema (baselineFor wiring)", () => {
   it("accepts baselineFor as null", () => {
@@ -38,6 +38,36 @@ describe("listBenchmarksQuerySchema (baseline filters)", () => {
     expect(out.isBaseline).toBe(true);
     const out2 = listBenchmarksQuerySchema.parse({ referencesBaseline: "false" });
     expect(out2.referencesBaseline).toBe(false);
+  });
+});
+
+describe("reportStorageKeys", () => {
+  it("produces stable keys for a runId", () => {
+    const k = reportStorageKeys("run-abc");
+    expect(k.meta).toBe("run-abc/meta.json");
+    expect(k.result).toBe("run-abc/result.json");
+    expect(k.stdout).toBe("run-abc/stdout.log");
+    expect(k.stderr).toBe("run-abc/stderr.log");
+    expect(k.file("report.json")).toBe("run-abc/files/report.json");
+  });
+});
+
+describe("reportMetaSchema", () => {
+  it("accepts a valid meta payload", () => {
+    expect(reportMetaSchema.parse({ toolVersion: "guidellm 0.2.1", startTimeIso: "2026-05-25T00:00:00.000Z" })).toBeTruthy();
+  });
+  it("rejects missing startTimeIso", () => {
+    expect(() => reportMetaSchema.parse({ toolVersion: "x" })).toThrow();
+  });
+});
+
+describe("reportResultSchema", () => {
+  it("accepts a valid result payload", () => {
+    expect(reportResultSchema.parse({
+      exitCode: 0,
+      finishTimeIso: "2026-05-25T01:00:00.000Z",
+      files: { "report-json": "files/report.json" },
+    })).toBeTruthy();
   });
 });
 

--- a/packages/contracts/src/benchmark.ts
+++ b/packages/contracts/src/benchmark.ts
@@ -224,3 +224,27 @@ export const endpointReportsResponseSchema = z.object({
   items: z.array(endpointReportSchema),
 });
 export type EndpointReportsResponse = z.infer<typeof endpointReportsResponseSchema>;
+
+// ── Report shared storage — Phase 2 of #237 ─────────────────────────
+// Object keys the runner writes and ReportLoader reads.
+// Keep in sync with apps/benchmark-runner/runner/storage_keys.py.
+export const reportStorageKeys = (runId: string) => ({
+  meta: `${runId}/meta.json`,
+  result: `${runId}/result.json`,
+  stdout: `${runId}/stdout.log`,
+  stderr: `${runId}/stderr.log`,
+  file: (alias: string) => `${runId}/files/${alias}`,
+});
+
+export const reportMetaSchema = z.object({
+  toolVersion: z.string().max(50),
+  startTimeIso: z.string().datetime(),
+});
+export type ReportMeta = z.infer<typeof reportMetaSchema>;
+
+export const reportResultSchema = z.object({
+  exitCode: z.number().int(),
+  finishTimeIso: z.string().datetime(),
+  files: z.record(z.string()), // alias → relative path under <runId>/
+});
+export type ReportResult = z.infer<typeof reportResultSchema>;

--- a/packages/contracts/src/benchmark.ts
+++ b/packages/contracts/src/benchmark.ts
@@ -128,33 +128,11 @@ export const createBenchmarkRequestSchema = z.object({
 export type CreateBenchmarkRequest = z.infer<typeof createBenchmarkRequestSchema>;
 
 // ── Internal callback schemas (runner pod → API) ─────────────────────
-export const benchmarkStateCallbackSchema = z.object({
-  state: z.literal("running"),
-  toolVersion: z.string().max(50).optional(),
-});
-export type BenchmarkStateCallback = z.infer<typeof benchmarkStateCallbackSchema>;
-
 export const benchmarkLogCallbackSchema = z.object({
   stream: z.enum(["stdout", "stderr"]),
   lines: z.array(z.string().max(64 * 1024)).max(2000),
 });
 export type BenchmarkLogCallback = z.infer<typeof benchmarkLogCallbackSchema>;
-
-export const benchmarkFinishCallbackSchema = z.object({
-  state: z.enum(["completed", "failed"]),
-  exitCode: z.number().int(),
-  // Full stdout/stderr captured during the run; capped on the runner side
-  // to ~16 KB tail apiece for /log live stream, but /finish ships the full
-  // text. The /finish endpoint raises body-size to 10 MB to accommodate
-  // full reports + outputs.
-  stdout: z.string(),
-  stderr: z.string(),
-  // alias → base64-encoded file bytes. Aliases are stable per-tool and
-  // align with the adapter's BuildCommandResult.outputFiles map.
-  files: z.record(z.string()),
-  message: z.string().max(2048).optional(),
-});
-export type BenchmarkFinishCallback = z.infer<typeof benchmarkFinishCallbackSchema>;
 
 // ── Charts response (GET /api/benchmarks/:id/charts) ─────────────────
 // Server derives these from rawOutput.files.* on demand; not persisted.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1053.0
+        version: 3.1053.0
       '@kubernetes/client-node':
         specifier: ^0.21
         version: 0.21.0
@@ -159,6 +162,9 @@ importers:
       '@types/supertest':
         specifier: ^6
         version: 6.0.3
+      aws-sdk-client-mock:
+        specifier: ^4.1.0
+        version: 4.1.0
       dotenv:
         specifier: ^17.4.1
         version: 17.4.1
@@ -412,6 +418,125 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-s3@3.1053.0':
+    resolution: {integrity: sha512-/oGxoB6p1Nqs935Blt+v1o+anSCEf2n3RjIrcLz84i4cn2Gr+Z7JpDdUkG5+74r5ctqEPG7k/phTGbJ9fNKnHg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.13':
+    resolution: {integrity: sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/crc64-nvme@3.972.9':
+    resolution: {integrity: sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.39':
+    resolution: {integrity: sha512-29wX9zpAvEt1vcj0psha+y6ygBHy2V/S72mp6e7q0KARLWXq+pwE/lR6qGkwknQvruh52lXvlqZIga8Hdxkucw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.41':
+    resolution: {integrity: sha512-IA3CQTjtJkb6u1H4mE4936c8OPBMa9Jggtwe8U2Mqw/vvb/tZ5Ebd0mcZcX0uKWQhOyYo/+qNIwkV5Xh+FeJJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.43':
+    resolution: {integrity: sha512-4mzII+3mZEVXXE1xzrLQrCJL7/r62A63bA6SVzZoNL5rqCJghpf+xgGltVrIBBs0n+mOZBKrQl2tRREtvZ5l6A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.43':
+    resolution: {integrity: sha512-HG7kQCwXtbv3oBV61Ins0oNX8KKyvrMqqRkb6ZiAfQHbMuHaiNaEb2KnpKLPkNpqImSBK82UkVE/kaY6IfWikA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.44':
+    resolution: {integrity: sha512-sDaBIT0yrNNIPfvlsiTCmANm07zKju+ipWODjEXgZlsjMeIJR3LVp7RDyAOzUoAsTbDfYKDWp+i5WrFiQP6rmQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.39':
+    resolution: {integrity: sha512-2k/amBifLd75eXNwgvPw/2lKYSQ3NhvHQgkVKVjfUq13/eJ3JRtHmznuFenn74OK3sSfp4SMy1YB2w+UVXoKqA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.43':
+    resolution: {integrity: sha512-LPc3+Y4vhH1T4x6CMqwCM6hk5+SRf/Lwmgm8INm95wxTtIRHcMwQUVkDzWu4Iw/RSncxYM2BC01OrYbxOPZvyg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.43':
+    resolution: {integrity: sha512-wQtL34lUD/09VXjwAUo2T+I3aEXRDxMB3DKmTJL/Zj0Gi6sLDTrVhae1XVt01yzkquOWajI/sZW72JGDZ1ciTw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.15':
+    resolution: {integrity: sha512-O2HDANa+MrvbxpaRVQDiH3T13uAa9AkMjKyZmDygwauAmmvqZ5B0iRmKW+fuVGW6NPXuyXurFgIx69lSvmAWGA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-expect-continue@3.972.13':
+    resolution: {integrity: sha512-sHiqIFg8o2ipT7t40B89Vj0ubSUtY6OSt/+Ee/OXhHch5K4+81zP2+QX8Lkc/nJ2QSmCySxOke7TEbmX69fe2g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.21':
+    resolution: {integrity: sha512-alAu9heyiBK/OmRNXVxq8mmPTgeW2AQ6EYjRsI38kPZa1MZvt2Jh+BlGq7/GG9OVXOaEgD7DlGj/Lzfy5OmuEg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-location-constraint@3.972.11':
+    resolution: {integrity: sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.42':
+    resolution: {integrity: sha512-/xNqNGXv9LaxZd25L9VV4pnSOw9OdDNO4rAHamM+h3KQBSITljIH9vk3dveGga1I2j36lQd0rdG3gjNEXvtNew==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-ssec@3.972.11':
+    resolution: {integrity: sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.11':
+    resolution: {integrity: sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.28':
+    resolution: {integrity: sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1052.0':
+    resolution: {integrity: sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.9':
+    resolution: {integrity: sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.25':
+    resolution: {integrity: sha512-GH+Kjz4nPKWKHnsiQpnhP1MJdTGIcK4rAka6tzakgjjUkVgNsmPeEbbRAf09SzS1hjGu6duGHCBsxYke0BhHjQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1340,6 +1465,9 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2094,6 +2222,54 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@sinonjs/commons@3.0.1':
+    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
+
+  '@sinonjs/fake-timers@11.2.2':
+    resolution: {integrity: sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==}
+
+  '@sinonjs/fake-timers@15.4.0':
+    resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
+
+  '@sinonjs/samsam@8.0.3':
+    resolution: {integrity: sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==}
+
+  '@smithy/core@3.24.4':
+    resolution: {integrity: sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.4':
+    resolution: {integrity: sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.4':
+    resolution: {integrity: sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.4':
+    resolution: {integrity: sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.4.4':
+    resolution: {integrity: sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.2':
+    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2348,6 +2524,12 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/sinon@17.0.4':
+    resolution: {integrity: sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==}
+
+  '@types/sinonjs__fake-timers@15.0.1':
+    resolution: {integrity: sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==}
 
   '@types/ssh2-streams@0.1.13':
     resolution: {integrity: sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==}
@@ -2654,6 +2836,9 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  aws-sdk-client-mock@4.1.0:
+    resolution: {integrity: sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==}
+
   aws-sign2@0.7.0:
     resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
 
@@ -2737,6 +2922,9 @@ packages:
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   boxen@5.1.2:
     resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
@@ -3173,6 +3361,10 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  diff@5.2.2:
+    resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
+    engines: {node: '>=0.3.1'}
+
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
@@ -3418,6 +3610,13 @@ packages:
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
+    hasBin: true
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3846,6 +4045,9 @@ packages:
     resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
     engines: {node: '>=0.6.0'}
 
+  just-extend@6.2.0:
+    resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
+
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
@@ -4134,6 +4336,9 @@ packages:
       '@nestjs/swagger':
         optional: true
 
+  nise@6.1.5:
+    resolution: {integrity: sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==}
+
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
@@ -4274,6 +4479,10 @@ packages:
   passport@0.7.0:
     resolution: {integrity: sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==}
     engines: {node: '>= 0.4.0'}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -4815,6 +5024,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sinon@18.0.1:
+    resolution: {integrity: sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==}
+
   sirv@2.0.4:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
@@ -4937,6 +5149,9 @@ packages:
 
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
+
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
 
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
@@ -5163,6 +5378,10 @@ packages:
 
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
 
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
@@ -5502,6 +5721,10 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
@@ -5651,6 +5874,271 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1053.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/credential-provider-node': 3.972.44
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.15
+      '@aws-sdk/middleware-expect-continue': 3.972.13
+      '@aws-sdk/middleware-flexible-checksums': 3.974.21
+      '@aws-sdk/middleware-location-constraint': 3.972.11
+      '@aws-sdk/middleware-sdk-s3': 3.972.42
+      '@aws-sdk/middleware-ssec': 3.972.11
+      '@aws-sdk/signature-v4-multi-region': 3.996.28
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/xml-builder': 3.972.25
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.4
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/crc64-nvme@3.972.9':
+    dependencies:
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.39':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/credential-provider-env': 3.972.39
+      '@aws-sdk/credential-provider-http': 3.972.41
+      '@aws-sdk/credential-provider-login': 3.972.43
+      '@aws-sdk/credential-provider-process': 3.972.39
+      '@aws-sdk/credential-provider-sso': 3.972.43
+      '@aws-sdk/credential-provider-web-identity': 3.972.43
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/credential-provider-imds': 4.3.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.44':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.39
+      '@aws-sdk/credential-provider-http': 3.972.41
+      '@aws-sdk/credential-provider-ini': 3.972.43
+      '@aws-sdk/credential-provider-process': 3.972.39
+      '@aws-sdk/credential-provider-sso': 3.972.43
+      '@aws-sdk/credential-provider-web-identity': 3.972.43
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/credential-provider-imds': 4.3.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.39':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/token-providers': 3.1052.0
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.15':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-expect-continue@3.972.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.21':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/crc64-nvme': 3.972.9
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.28
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-ssec@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.11':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.28
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.28':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1052.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.9':
+    dependencies:
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.25':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.2
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -6425,6 +6913,8 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@nodable/entities@2.1.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -7125,6 +7615,71 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@sinonjs/commons@3.0.1':
+    dependencies:
+      type-detect: 4.0.8
+
+  '@sinonjs/fake-timers@11.2.2':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@sinonjs/fake-timers@15.4.0':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@sinonjs/samsam@8.0.3':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      type-detect: 4.1.0
+
+  '@smithy/core@3.24.4':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.4.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
   '@standard-schema/spec@1.1.0': {}
 
   '@swc/core-darwin-arm64@1.15.33':
@@ -7395,6 +7950,12 @@ snapshots:
     dependencies:
       '@types/http-errors': 2.0.5
       '@types/node': 20.19.39
+
+  '@types/sinon@17.0.4':
+    dependencies:
+      '@types/sinonjs__fake-timers': 15.0.1
+
+  '@types/sinonjs__fake-timers@15.0.1': {}
 
   '@types/ssh2-streams@0.1.13':
     dependencies:
@@ -7772,6 +8333,12 @@ snapshots:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
+  aws-sdk-client-mock@4.1.0:
+    dependencies:
+      '@types/sinon': 17.0.4
+      sinon: 18.0.1
+      tslib: 2.8.1
+
   aws-sign2@0.7.0: {}
 
   aws4@1.13.2: {}
@@ -7843,6 +8410,8 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  bowser@2.14.1: {}
 
   boxen@5.1.2:
     dependencies:
@@ -8265,6 +8834,8 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
+  diff@5.2.2: {}
+
   dlv@1.1.3: {}
 
   docker-compose@1.4.2:
@@ -8569,6 +9140,18 @@ snapshots:
   fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.0: {}
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
 
   fastq@1.20.1:
     dependencies:
@@ -9006,6 +9589,8 @@ snapshots:
       json-schema: 0.4.0
       verror: 1.10.0
 
+  just-extend@6.2.0: {}
+
   jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -9239,6 +9824,13 @@ snapshots:
     optionalDependencies:
       '@nestjs/swagger': 11.4.2(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.2.2)
 
+  nise@6.1.5:
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 15.4.0
+      just-extend: 6.2.0
+      path-to-regexp: 8.4.2
+
   node-abort-controller@3.1.1: {}
 
   node-addon-api@8.7.0: {}
@@ -9377,6 +9969,8 @@ snapshots:
       passport-strategy: 1.0.0
       pause: 0.0.1
       utils-merge: 1.0.1
+
+  path-expression-matcher@1.5.0: {}
 
   path-key@3.1.1: {}
 
@@ -9981,6 +10575,15 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  sinon@18.0.1:
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 11.2.2
+      '@sinonjs/samsam': 8.0.3
+      diff: 5.2.2
+      nise: 6.1.5
+      supports-color: 7.2.0
+
   sirv@2.0.4:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -10111,6 +10714,8 @@ snapshots:
   strip-literal@2.1.1:
     dependencies:
       js-tokens: 9.0.1
+
+  strnum@2.3.0: {}
 
   strtok3@10.3.5:
     dependencies:
@@ -10408,6 +11013,8 @@ snapshots:
       safe-buffer: 5.2.1
 
   tweetnacl@0.14.5: {}
+
+  type-detect@4.0.8: {}
 
   type-detect@4.1.0: {}
 
@@ -10752,6 +11359,8 @@ snapshots:
   ws@8.20.0: {}
 
   xml-name-validator@5.0.0: {}
+
+  xml-naming@0.1.0: {}
 
   xmlchars@2.2.0: {}
 


### PR DESCRIPTION
## Summary

Atomic rewrite of runner→API status flip + final report channel for #237 Phase 2, folding in Phase 0 (shared S3 storage layer) since `ReportLoader` is tightly coupled to `ReportStorage`.

After this PR:
- runner writes `meta.json` / `result.json` / `stdout.log` / `stderr.log` / `files/*` to a shared S3-compatible bucket (MinIO in dev, real S3 in prod)
- API `K8sJobWatcherService` in `primary` mode handles `Running` / `Succeeded` / `Failed` directly via informer + `ReportLoader` (no callback)
- `/state` and `/finish` callback endpoints + runner POST calls **deleted** — clean slate, no deprecated no-op
- `/log` callback path **unchanged** — Phase 3 will retire it
- `K8S_WATCHER_MODE` default flipped `off` → `primary`

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-05-25-report-storage-and-watcher-primary-design.md`
- Plan: `docs/superpowers/plans/2026-05-25-report-storage-and-watcher-primary.md`

## Commits (24 phase-per-commit)

```
feat(contracts): add reportStorageKeys + meta/result schemas for Phase 2
feat(api): add S3 env schema + flip K8S_WATCHER_MODE default to primary
feat(api): add ReportStorage interface (no impl)
build(api): add @aws-sdk/client-s3 + aws-sdk-client-mock
feat(api): S3ReportStorage implementing ReportStorage
refactor(api): remove unused Logger from S3ReportStorage
feat(api): PodStateReducer primary mode + load-report transition
feat(api): ReportLoader — read S3 fixture and write final benchmark row
feat(api): wire ReportLoader into K8sJobWatcherService primary mode
feat(api): StartupReconciler storage-first branch
feat(api): inject md-benchmark-storage Secret into runner Job
feat(api): GET /benchmarks/:id/files/:alias proxies S3 read
feat(api): wire S3ReportStorage + ReportLoader into benchmark module
build(runner): add boto3 + moto[s3] for S3 report writes
feat(runner): storage_keys.py mirrors contracts reportStorageKeys
feat(runner): S3Writer — boto3 wrapper for report uploads
feat(runner): write S3 report instead of POST /state /finish
chore(runner): ruff fixes for s3_writer + new tests
refactor: delete /state + /finish callback endpoints — replaced by S3 + watcher
chore(api): biome auto-format + add S3 keys to .env.example
test(api): e2e for watcher primary mode + ReportLoader
docs(deploy): MinIO bucket + Secret setup for Phase 2
```

## Pre-deploy (operator)

See `deploy/k8s/README.md` "Report storage" section. Required:

1. `md-benchmark-storage` Secret in both API and benchmarks namespaces (S3_ENDPOINT / ACCESS_KEY / SECRET_KEY / BUCKET / REGION)
2. MinIO bucket lifecycle (30-day expire) configured via `mc ilm rule add --expire-days 30 myminio/<bucket>`
3. (Recommended) drain in-flight benchmarks before deploy — old runners will 404 on POST /state /finish but watcher backstop will eventually mark them `failed`

## Test plan

- [x] `pnpm -F @modeldoctor/api type-check` — clean
- [x] `pnpm -F @modeldoctor/api lint` — clean
- [x] `pnpm -F @modeldoctor/api test` — 854/855 (1 pre-existing synthesize.service failure, acknowledged in #238)
- [x] `pnpm -F @modeldoctor/api test:e2e -- benchmark-watcher-primary` — 3/3 pass (success / storage missing / already-terminal noop)
- [x] `python3 -m pytest` in apps/benchmark-runner — 35/35 pass
- [x] `pnpm -F @modeldoctor/contracts test` — pass
- [x] `pnpm -r build` — clean
- [ ] Manual cluster smoke: real benchmark against dev MinIO → meta.json/result.json/stdout.log written, API marks completed with parsed summaryMetrics
- [ ] CI green

refs #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)