### PR TITLE
docs: drop BENCHMARK_CALLBACK_* residue from root + deploy README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Health check: `GET /api/health` returns 200 with `{"status":"ok","info":{"databa
 | `BENCHMARK_RUNNER_IMAGE` | **Yes** (driver=`k8s`) | — | Container image for the runner (e.g. `gpustack/benchmark-runner:v0.0.4`) |
 | `BENCHMARK_DEFAULT_MAX_DURATION_SECONDS` | No | `1800` | Default `--max-seconds` cap applied to runs |
 
-In `NODE_ENV=test`, both `DATABASE_URL` and `JWT_ACCESS_SECRET` become optional so unit tests can boot `AppModule` without a real database. The e2e suite sets both itself via `vitest.e2e.config.mts` + testcontainers. Other `**Yes** (non-test)` keys follow the same rule.
+In `NODE_ENV=test`, both `DATABASE_URL` and `JWT_ACCESS_SECRET` become optional so unit tests can boot `AppModule` without a real database. The e2e suite sets both itself via `vitest.e2e.config.mts` + testcontainers. Other **Yes** (non-test) keys follow the same rule.
 
 ### Benchmark feature local workflows
 

--- a/README.md
+++ b/README.md
@@ -108,14 +108,12 @@ Health check: `GET /api/health` returns 200 with `{"status":"ok","info":{"databa
 | `JWT_REFRESH_EXPIRES_DAYS` | No | `7` | Refresh-token TTL (also the `md_refresh` cookie's Max-Age) |
 | `DISABLE_FIRST_USER_ADMIN` | No | `false` | When `true`, the first user registered is NOT auto-promoted to the `admin` role |
 | `BENCHMARK_DRIVER` | No | `subprocess` | `subprocess` (local guidellm) or `k8s` (creates a `batch/v1/Job`) |
-| `BENCHMARK_CALLBACK_URL` | **Yes** (non-test) | — | Base URL the runner posts back to (e.g. `http://localhost:3001`, `http://host.k3d.internal:3001`, or `http://modeldoctor-api.modeldoctor.svc:3001`) |
 | `CONNECTION_API_KEY_ENCRYPTION_KEY` | **Yes** (non-test) | — | 32-byte AES-256 key, base64-encoded — encrypts user-supplied benchmark API keys at rest. Also used by the LLM judge provider (`llm_judge_providers.api_key_cipher`). |
-| `BENCHMARK_CALLBACK_SECRET` | **Yes** (non-test) | — | ≥ 32 chars; per-run HMAC token signing key |
 | `BENCHMARK_K8S_NAMESPACE` | No | `modeldoctor-benchmarks` | Namespace where benchmark Jobs and Secrets land (only used when driver is `k8s`) |
 | `BENCHMARK_RUNNER_IMAGE` | **Yes** (driver=`k8s`) | — | Container image for the runner (e.g. `gpustack/benchmark-runner:v0.0.4`) |
 | `BENCHMARK_DEFAULT_MAX_DURATION_SECONDS` | No | `1800` | Default `--max-seconds` cap applied to runs |
 
-In `NODE_ENV=test`, both `DATABASE_URL` and `JWT_ACCESS_SECRET` become optional so unit tests can boot `AppModule` without a real database. The e2e suite sets both itself via `vitest.e2e.config.mts` + testcontainers. The `BENCHMARK_*` non-test-required keys follow the same rule.
+In `NODE_ENV=test`, both `DATABASE_URL` and `JWT_ACCESS_SECRET` become optional so unit tests can boot `AppModule` without a real database. The e2e suite sets both itself via `vitest.e2e.config.mts` + testcontainers. Other `**Yes** (non-test)` keys follow the same rule.
 
 ### Benchmark feature local workflows
 
@@ -134,7 +132,6 @@ which benchmark-runner
 
 # Generate secrets, then start the dev server.
 echo "CONNECTION_API_KEY_ENCRYPTION_KEY=$(openssl rand -base64 32)" >> apps/api/.env
-echo "BENCHMARK_CALLBACK_SECRET=$(openssl rand -base64 48)" >> apps/api/.env
 pnpm dev
 ```
 

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -41,7 +41,6 @@ Then in your API env (paste the tags printed by the script):
 ```bash
 # K8s is the only execution mode (#101) — no driver toggle.
 export BENCHMARK_K8S_NAMESPACE=modeldoctor-benchmarks
-export BENCHMARK_CALLBACK_URL=http://host.k3d.internal:3001
 export RUNNER_IMAGE_GUIDELLM=md-runner-guidellm:<sha-from-script>
 export RUNNER_IMAGE_VEGETA=md-runner-vegeta:<sha-from-script>
 export RUNNER_IMAGE_PREFIX_CACHE_PROBE=md-runner-prefix-cache-probe:<sha-from-script>


### PR DESCRIPTION
## Summary

Follow-up to #241 (Phase 4 of #237). That PR cleared `MD_CALLBACK_*` residue on the **runner-side** README but missed the matching `BENCHMARK_CALLBACK_*` env doc on the **API/operator side**.

This PR completes the doc-residue sweep:

- `README.md` — drop `BENCHMARK_CALLBACK_URL` / `BENCHMARK_CALLBACK_SECRET` table rows (`env.schema.ts` removed both in commit `351bcf6`); drop the matching `openssl rand … >> .env` line from the dev-workflow snippet; trim the trailing "`BENCHMARK_*` non-test-required keys follow the same rule" sentence — no `BENCHMARK_*` key is unconditionally required-non-test anymore.
- `deploy/k8s/README.md` — drop the `export BENCHMARK_CALLBACK_URL=...` line from the k3d dev-env setup snippet.

Pure documentation; no code or behavior change.

## Out of scope (flagged for future sweep)

Grep around the root README turned up unrelated staleness — none touched here so the PR stays scoped to "drop callback residue":

- `README.md` "Subprocess workflow" section (lines ~120-138) — `BENCHMARK_DRIVER=subprocess` was removed in #101; `env.schema.ts` has no `BENCHMARK_DRIVER` key. The subprocess workflow guidance is dead.
- Root README env table is missing **`S3_*`** rows (5 keys), the **`RUNNER_IMAGE_*`** split (5 per-tool keys instead of the single legacy `BENCHMARK_RUNNER_IMAGE`), `K8S_WATCHER_MODE`, `WAITING_FATAL_GRACE_SEC`, `TERMINAL_RECONCILE_GRACE_SEC`, `ALERTMANAGER_WEBHOOK_SECRET`, `MCP_*`. `apps/api/.env.example` is the current source of truth.
- `apps/api/src/config/env.schema.ts:41` ("The run callback path persists encrypted connection rows") and lines 53-55 / 69-71 (`K8S_WATCHER_MODE=backstop` description still says "callback still primary") are source-code comments referring to the deleted callback channel.
- `apps/api/src/main.ts:22-29` — the 64MB `json()` body-parser limit comment still references "benchmark runner metrics callbacks" / `/finish`; the controller is gone, so the rationale (and possibly the elevated limit) is stale.

## Test plan

- [x] \`grep -E 'BENCHMARK_CALLBACK_' . --include='*.md' --include='*.example' --include='*.yml'\` outside \`docs/superpowers/{plans,specs}/\` — zero matches.
- [x] No source code touched — no test/typecheck needed; CI will confirm.

refs #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)