### PR TITLE
build(benchmark-runner): Makefile + per-tool on-demand build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,16 @@ _IMPORT_FLAG := $(if $(filter 0,$(IMPORT)),--no-import,)
 
 # ── Base images ───────────────────────────────────────────────────────────────
 
-base: $(addprefix base-,$(BASE_TOOLS))
+base:
+	bash tools/build-base-images.sh $(_BASE_FLAGS)
 
 $(addprefix base-,$(BASE_TOOLS)): base-%:
 	bash tools/build-base-images.sh $(_BASE_FLAGS) $*
 
 # ── Runner images ─────────────────────────────────────────────────────────────
 
-runner: $(addprefix runner-,$(RUNNER_TOOLS))
+runner:
+	K3D_CLUSTER=$(K3D_CLUSTER) bash tools/build-runner-images.sh $(_IMPORT_FLAG)
 
 $(addprefix runner-,$(RUNNER_TOOLS)): runner-%:
 	K3D_CLUSTER=$(K3D_CLUSTER) bash tools/build-runner-images.sh $(_IMPORT_FLAG) $*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+# Benchmark-runner image builds — run from the repository root.
+#
+# Base images  (ghcr.io/weetime/, rebuilt only on tool version bumps):
+#   make base                 build + push all; skips tags already in registry
+#   make base-vegeta          single tool
+#   make base-evalscope
+#   make base-aiperf
+#   make base FORCE=1         force-rebuild even if tag already in registry
+#   make base-vegeta FORCE=1
+#
+# Runner images  (local Docker + k3d import, rebuilt when runner/ changes):
+#   make runner               build + import all five; skips if local tag exists
+#   make runner-guidellm      single tool
+#   make runner-vegeta
+#   make runner-prefix-cache-probe
+#   make runner-evalscope
+#   make runner-aiperf
+#   make runner IMPORT=0      build only, skip k3d import
+
+K3D_CLUSTER ?= modeldoctor
+FORCE       ?= 0
+IMPORT      ?= 1
+
+BASE_TOOLS   := vegeta evalscope aiperf
+RUNNER_TOOLS := guidellm vegeta prefix-cache-probe evalscope aiperf
+
+_BASE_FLAGS  := $(if $(filter 1,$(FORCE)),--force,)
+_IMPORT_FLAG := $(if $(filter 0,$(IMPORT)),--no-import,)
+
+.PHONY: base runner \
+        $(addprefix base-,$(BASE_TOOLS)) \
+        $(addprefix runner-,$(RUNNER_TOOLS))
+
+# ── Base images ───────────────────────────────────────────────────────────────
+
+base: $(addprefix base-,$(BASE_TOOLS))
+
+$(addprefix base-,$(BASE_TOOLS)): base-%:
+	bash tools/build-base-images.sh $(_BASE_FLAGS) $*
+
+# ── Runner images ─────────────────────────────────────────────────────────────
+
+runner: $(addprefix runner-,$(RUNNER_TOOLS))
+
+$(addprefix runner-,$(RUNNER_TOOLS)): runner-%:
+	K3D_CLUSTER=$(K3D_CLUSTER) bash tools/build-runner-images.sh $(_IMPORT_FLAG) $*

--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -75,10 +75,15 @@ build_and_push() {
   local tool="$1" version="$2"
   local image="${REGISTRY}/md-base-${tool}:${version}"
   echo
-  # Skip if already in registry (only in push mode; --no-push always rebuilds locally).
-  if [[ "$PUSH" == "true" ]] && [[ "$FORCE" == "false" ]] && image_exists_remote "$image"; then
-    echo "==> ${image} already in registry, skipping (use --force to rebuild)"
-    return
+  # Skip if already exists: remote registry check for push mode, local image check for --no-push.
+  if [[ "$FORCE" == "false" ]]; then
+    if [[ "$PUSH" == "true" ]] && image_exists_remote "$image"; then
+      echo "==> ${image} already in registry, skipping (use --force to rebuild)"
+      return
+    elif [[ "$PUSH" == "false" ]] && docker image inspect "$image" >/dev/null 2>&1; then
+      echo "==> ${image} already built locally, skipping (use --force to rebuild)"
+      return
+    fi
   fi
   if [[ "$PUSH" == "true" ]]; then
     # Multi-platform push via buildx so amd64 and arm64 users share one tag.

--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -11,6 +11,7 @@
 #   ./tools/build-base-images.sh vegeta            # single tool
 #   ./tools/build-base-images.sh evalscope aiperf  # two tools
 #   ./tools/build-base-images.sh --no-push         # local test, skip push
+#   ./tools/build-base-images.sh --force           # rebuild even if tag already in registry
 
 set -euo pipefail
 
@@ -35,10 +36,12 @@ SHAREGPT_URL="https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unf
 # Argument parsing
 # ---------------------------------------------------------------------------
 PUSH=true
+FORCE=false
 TOOLS=()
 for arg in "$@"; do
   case "$arg" in
     --no-push) PUSH=false ;;
+    --force)   FORCE=true ;;
     vegeta|evalscope|aiperf) TOOLS+=("$arg") ;;
     *) echo "Unknown argument: $arg" >&2; exit 1 ;;
   esac
@@ -51,6 +54,9 @@ fi
 # Helpers
 # ---------------------------------------------------------------------------
 contains() { local e; for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0; done; return 1; }
+
+# Returns 0 if the image manifest already exists in the remote registry.
+image_exists_remote() { docker buildx imagetools inspect "$1" >/dev/null 2>&1; }
 
 # Cross-platform SHA256 check (Linux: sha256sum, macOS: shasum -a 256).
 verify_sha256() {
@@ -69,6 +75,11 @@ build_and_push() {
   local tool="$1" version="$2"
   local image="${REGISTRY}/md-base-${tool}:${version}"
   echo
+  # Skip if already in registry (only in push mode; --no-push always rebuilds locally).
+  if [[ "$PUSH" == "true" ]] && [[ "$FORCE" == "false" ]] && image_exists_remote "$image"; then
+    echo "==> ${image} already in registry, skipping (use --force to rebuild)"
+    return
+  fi
   if [[ "$PUSH" == "true" ]]; then
     # Multi-platform push via buildx so amd64 and arm64 users share one tag.
     echo "==> Building + pushing multi-platform ${image}"

--- a/tools/build-runner-images.sh
+++ b/tools/build-runner-images.sh
@@ -71,6 +71,6 @@ fi
 echo
 echo "==> Done. Set these in your .env (or export RUNNER_IMAGE_TAG=$TAG):"
 for tool in "${TOOLS[@]}"; do
-  VAR="RUNNER_IMAGE_$(echo "$tool" | tr '[:lower:]-' '[:upper:]_')"
+  VAR="RUNNER_IMAGE_$(echo "$tool" | tr '-' '_' | tr '[:lower:]' '[:upper:]')"
   echo "${VAR}=md-runner-${tool}:${TAG}"
 done

--- a/tools/build-runner-images.sh
+++ b/tools/build-runner-images.sh
@@ -8,8 +8,9 @@
 # images are not yet in the registry or need a version bump.
 #
 # Usage:
-#   ./tools/build-runner-images.sh               # build + import to k3d cluster "modeldoctor"
-#   ./tools/build-runner-images.sh --no-import   # build only, skip k3d import
+#   ./tools/build-runner-images.sh                      # build + import all five
+#   ./tools/build-runner-images.sh vegeta evalscope     # specific tools only
+#   ./tools/build-runner-images.sh --no-import          # build only, skip k3d import
 #   K3D_CLUSTER=other ./tools/build-runner-images.sh
 
 set -euo pipefail
@@ -33,36 +34,43 @@ fi
 
 K3D_CLUSTER="${K3D_CLUSTER:-modeldoctor}"
 IMPORT=true
-if [[ "${1:-}" == "--no-import" ]]; then
-  IMPORT=false
+TOOLS=()
+for arg in "$@"; do
+  case "$arg" in
+    --no-import) IMPORT=false ;;
+    guidellm|vegeta|prefix-cache-probe|evalscope|aiperf) TOOLS+=("$arg") ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
+if [[ ${#TOOLS[@]} -eq 0 ]]; then
+  TOOLS=(guidellm vegeta prefix-cache-probe evalscope aiperf)
 fi
 
-echo "==> Building runner images at tag :$TAG"
+echo "==> Runner images at tag :$TAG (tools: ${TOOLS[*]})"
 
-for tool in guidellm vegeta prefix-cache-probe evalscope aiperf; do
+for tool in "${TOOLS[@]}"; do
   image="md-runner-${tool}:${TAG}"
-  echo "==> docker build $image"
-  docker build \
-    -f "apps/benchmark-runner/images/${tool}.Dockerfile" \
-    -t "$image" \
-    apps/benchmark-runner/
+  if docker image inspect "$image" >/dev/null 2>&1; then
+    echo "==> ${image} already exists locally, skipping build"
+  else
+    echo "==> docker build ${image}"
+    docker build \
+      -f "apps/benchmark-runner/images/${tool}.Dockerfile" \
+      -t "$image" \
+      apps/benchmark-runner/
+  fi
 done
 
 if [[ "$IMPORT" == "true" ]]; then
   echo "==> k3d image import (cluster: $K3D_CLUSTER)"
-  k3d image import \
-    "md-runner-guidellm:${TAG}" \
-    "md-runner-vegeta:${TAG}" \
-    "md-runner-prefix-cache-probe:${TAG}" \
-    "md-runner-evalscope:${TAG}" \
-    "md-runner-aiperf:${TAG}" \
-    -c "$K3D_CLUSTER"
+  IMPORT_ARGS=()
+  for tool in "${TOOLS[@]}"; do IMPORT_ARGS+=("md-runner-${tool}:${TAG}"); done
+  k3d image import "${IMPORT_ARGS[@]}" -c "$K3D_CLUSTER"
 fi
 
 echo
 echo "==> Done. Set these in your .env (or export RUNNER_IMAGE_TAG=$TAG):"
-echo "RUNNER_IMAGE_GUIDELLM=md-runner-guidellm:${TAG}"
-echo "RUNNER_IMAGE_VEGETA=md-runner-vegeta:${TAG}"
-echo "RUNNER_IMAGE_PREFIX_CACHE_PROBE=md-runner-prefix-cache-probe:${TAG}"
-echo "RUNNER_IMAGE_EVALSCOPE=md-runner-evalscope:${TAG}"
-echo "RUNNER_IMAGE_AIPERF=md-runner-aiperf:${TAG}"
+for tool in "${TOOLS[@]}"; do
+  VAR="RUNNER_IMAGE_$(echo "$tool" | tr '[:lower:]-' '[:upper:]_')"
+  echo "${VAR}=md-runner-${tool}:${TAG}"
+done


### PR DESCRIPTION
## Summary

- **`build-base-images.sh`**: 新增注册表存在检查，tag 已在 ghcr.io 时自动跳过，无需重推；`--force` 强制重建
- **`build-runner-images.sh`**: 支持按 tool 选择性构建（`vegeta evalscope` 等位置参数）；本地 image 已存在时跳过 build，仍执行 k3d import 保持集群同步
- **`Makefile`**（根目录新增）：统一入口，支持 `make base`、`make runner`、`make base-vegeta`、`make runner-aiperf` 等细粒度目标；`FORCE=1` / `IMPORT=0` 变量透传

## Usage

```bash
make base              # 构建所有 base image（已推送的自动跳过）
make base-aiperf       # 只构建 aiperf base
make base FORCE=1      # 强制重建所有 base

make runner            # 构建所有 runner image（本地已存在的自动跳过）
make runner-vegeta     # 只构建 vegeta runner
make runner IMPORT=0   # 构建但不导入 k3d
```

## Test plan

- [ ] `make base-vegeta` 在已推送时输出 "already in registry, skipping"
- [ ] `make base-vegeta FORCE=1` 触发重建
- [ ] `make runner-vegeta` 在本地 image 已存在时输出 "already exists locally, skipping build"
- [ ] `make runner vegeta evalscope` 只构建两个 tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)