### PR TITLE
fix(runner+benchmark): boto3 + SSE log stream + review fixes + log panel

### DIFF
--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -4,12 +4,13 @@ import { PassportModule } from "@nestjs/passport";
 import { UsersModule } from "../users/users.module.js";
 import { AuthController } from "./auth.controller.js";
 import { AuthService } from "./auth.service.js";
+import { JwtSseStrategy } from "./jwt-sse.strategy.js";
 import { JwtStrategy } from "./jwt.strategy.js";
 
 @Module({
   imports: [UsersModule, PassportModule, JwtModule.register({})],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy],
+  providers: [AuthService, JwtStrategy, JwtSseStrategy],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -4,8 +4,8 @@ import { PassportModule } from "@nestjs/passport";
 import { UsersModule } from "../users/users.module.js";
 import { AuthController } from "./auth.controller.js";
 import { AuthService } from "./auth.service.js";
-import { JwtSseStrategy } from "./jwt-sse.strategy.js";
 import { JwtStrategy } from "./jwt.strategy.js";
+import { JwtSseStrategy } from "./jwt-sse.strategy.js";
 
 @Module({
   imports: [UsersModule, PassportModule, JwtModule.register({})],

--- a/apps/api/src/modules/auth/jwt-sse.strategy.ts
+++ b/apps/api/src/modules/auth/jwt-sse.strategy.ts
@@ -1,0 +1,33 @@
+import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { PassportStrategy } from "@nestjs/passport";
+import { ExtractJwt, Strategy } from "passport-jwt";
+import type { Env } from "../../config/env.schema.js";
+import type { JwtPayload } from "./jwt.strategy.js";
+
+/** Passport strategy for SSE endpoints only.
+ *  EventSource cannot set custom headers so the JWT is accepted via the
+ *  `?token=` query param in addition to the Authorization header.
+ *  Registered as 'jwt-sse'; used exclusively by @UseGuards(SseJwtAuthGuard). */
+@Injectable()
+export class JwtSseStrategy extends PassportStrategy(Strategy, "jwt-sse") {
+  constructor(config: ConfigService<Env, true>) {
+    const secret = config.get("JWT_ACCESS_SECRET", { infer: true }) ?? "";
+    super({
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        ExtractJwt.fromAuthHeaderAsBearerToken(),
+        // biome-ignore lint/suspicious/noExplicitAny: passport-jwt req is untyped
+        (req: any) => {
+          const t = req?.query?.token;
+          return typeof t === "string" ? t : null;
+        },
+      ]),
+      ignoreExpiration: false,
+      secretOrKey: secret,
+    });
+  }
+
+  validate(payload: JwtPayload): JwtPayload {
+    return payload;
+  }
+}

--- a/apps/api/src/modules/auth/jwt.strategy.ts
+++ b/apps/api/src/modules/auth/jwt.strategy.ts
@@ -21,17 +21,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     // JWT verification must set JWT_ACCESS_SECRET themselves.
     const secret = config.get("JWT_ACCESS_SECRET", { infer: true }) ?? "";
     super({
-      // SSE endpoints (EventSource) cannot set custom headers, so we also
-      // accept the token as a `?token=` query param as a fallback.
-      // All JWT cryptographic validation still applies.
-      jwtFromRequest: ExtractJwt.fromExtractors([
-        ExtractJwt.fromAuthHeaderAsBearerToken(),
-        // biome-ignore lint/suspicious/noExplicitAny: passport-jwt req is untyped
-        (req: any) => {
-          const t = req?.query?.token;
-          return typeof t === "string" ? t : null;
-        },
-      ]),
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
       secretOrKey: secret,
     });

--- a/apps/api/src/modules/auth/jwt.strategy.ts
+++ b/apps/api/src/modules/auth/jwt.strategy.ts
@@ -21,7 +21,17 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     // JWT verification must set JWT_ACCESS_SECRET themselves.
     const secret = config.get("JWT_ACCESS_SECRET", { infer: true }) ?? "";
     super({
-      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      // SSE endpoints (EventSource) cannot set custom headers, so we also
+      // accept the token as a `?token=` query param as a fallback.
+      // All JWT cryptographic validation still applies.
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        ExtractJwt.fromAuthHeaderAsBearerToken(),
+        // biome-ignore lint/suspicious/noExplicitAny: passport-jwt req is untyped
+        (req: any) => {
+          const t = req?.query?.token;
+          return typeof t === "string" ? t : null;
+        },
+      ]),
       ignoreExpiration: false,
       secretOrKey: secret,
     });

--- a/apps/api/src/modules/auth/sse-jwt-auth.guard.ts
+++ b/apps/api/src/modules/auth/sse-jwt-auth.guard.ts
@@ -1,0 +1,7 @@
+import { Injectable } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+
+/** Auth guard for SSE endpoints; uses the jwt-sse strategy which additionally
+ *  accepts the JWT via `?token=` query param (EventSource cannot set headers). */
+@Injectable()
+export class SseJwtAuthGuard extends AuthGuard("jwt-sse") {}

--- a/apps/api/src/modules/benchmark/benchmark.controller.spec.ts
+++ b/apps/api/src/modules/benchmark/benchmark.controller.spec.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { PrismaService } from "../../database/prisma.service.js";
 import type { JwtPayload } from "../auth/jwt.strategy.js";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
+import { SseJwtAuthGuard } from "../auth/sse-jwt-auth.guard.js";
 import { BaselineService } from "../baseline/baseline.service.js";
 import { BenchmarkTemplateRepository } from "../benchmark-template/benchmark-template.repository.js";
 import { ConnectionService } from "../connection/connection.service.js";
@@ -13,6 +14,7 @@ import { BenchmarkRepository } from "./benchmark.repository.js";
 import { BenchmarkService } from "./benchmark.service.js";
 import { BenchmarkChartsService } from "./benchmark-charts.service.js";
 import { K8sBenchmarkRunner } from "./k8s/k8s-benchmark-runner.js";
+import { SseHub } from "./sse/sse-hub.service.js";
 
 // Stub adapter registry to avoid pulling in the real (Phase 1 stubbed) adapters'
 // buildCommand which throws "not implemented". The controller spec only needs
@@ -107,9 +109,15 @@ describe("BenchmarkController", () => {
           useValue: { existsById: vi.fn(async () => false) },
         },
         { provide: NotifyService, useValue: { emit: vi.fn() } },
+        {
+          provide: SseHub,
+          useValue: { subscribe: vi.fn(), publish: vi.fn(), close: vi.fn(), has: vi.fn() },
+        },
       ],
     })
       .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(SseJwtAuthGuard)
       .useValue({ canActivate: () => true })
       .compile();
 
@@ -501,9 +509,15 @@ describe("BenchmarkController.getCharts (F3 #88)", () => {
           useValue: { existsById: vi.fn(async () => false) },
         },
         { provide: NotifyService, useValue: { emit: vi.fn() } },
+        {
+          provide: SseHub,
+          useValue: { subscribe: vi.fn(), publish: vi.fn(), close: vi.fn(), has: vi.fn() },
+        },
       ],
     })
       .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(SseJwtAuthGuard)
       .useValue({ canActivate: () => true })
       .compile();
 
@@ -621,9 +635,15 @@ describe("BenchmarkController.reportsByConnection", () => {
       providers: [
         { provide: BenchmarkService, useValue: svc },
         { provide: BenchmarkChartsService, useValue: {} },
+        {
+          provide: SseHub,
+          useValue: { subscribe: vi.fn(), publish: vi.fn(), close: vi.fn(), has: vi.fn() },
+        },
       ],
     })
       .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(SseJwtAuthGuard)
       .useValue({ canActivate: () => true })
       .compile();
     controller = moduleRef.get(BenchmarkController);

--- a/apps/api/src/modules/benchmark/benchmark.controller.ts
+++ b/apps/api/src/modules/benchmark/benchmark.controller.ts
@@ -28,9 +28,11 @@ import {
 import { EMPTY, type Observable, from } from "rxjs";
 import { map, switchMap } from "rxjs/operators";
 import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
+import { Public } from "../../common/decorators/public.decorator.js";
 import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
 import type { JwtPayload } from "../auth/jwt.strategy.js";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
+import { SseJwtAuthGuard } from "../auth/sse-jwt-auth.guard.js";
 import { BenchmarkService } from "./benchmark.service.js";
 import { BenchmarkChartsService } from "./benchmark-charts.service.js";
 import { isInProgressStatus } from "./constants.js";
@@ -93,8 +95,11 @@ export class BenchmarkController {
   }
 
   /** Live log stream for an in-flight benchmark.
-   *  EventSource cannot set custom headers, so the JWT is accepted via
-   *  the `?token=` query param (handled by JwtStrategy.fromExtractors). */
+   *  @Public() bypasses the class-level JwtAuthGuard; SseJwtAuthGuard then
+   *  validates the JWT via Authorization header OR `?token=` query param,
+   *  which EventSource requires since it cannot set custom headers. */
+  @Public()
+  @UseGuards(SseJwtAuthGuard)
   @Sse(":id/events")
   events(@CurrentUser() user: JwtPayload, @Param("id") id: string): Observable<MessageEvent> {
     const isAdmin = user.roles.includes("admin");

--- a/apps/api/src/modules/benchmark/benchmark.controller.ts
+++ b/apps/api/src/modules/benchmark/benchmark.controller.ts
@@ -25,7 +25,7 @@ import {
   Sse,
   UseGuards,
 } from "@nestjs/common";
-import { EMPTY, type Observable, from } from "rxjs";
+import { EMPTY, from, type Observable } from "rxjs";
 import { map, switchMap } from "rxjs/operators";
 import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
 import { Public } from "../../common/decorators/public.decorator.js";
@@ -104,9 +104,7 @@ export class BenchmarkController {
   events(@CurrentUser() user: JwtPayload, @Param("id") id: string): Observable<MessageEvent> {
     const isAdmin = user.roles.includes("admin");
     return from(this.service.findByIdOrFail(id, isAdmin ? undefined : user.sub)).pipe(
-      switchMap((bench) =>
-        isInProgressStatus(bench.status) ? this.sse.subscribe(id) : EMPTY,
-      ),
+      switchMap((bench) => (isInProgressStatus(bench.status) ? this.sse.subscribe(id) : EMPTY)),
       map((evt) => ({ data: evt }) as MessageEvent),
     );
   }

--- a/apps/api/src/modules/benchmark/benchmark.controller.ts
+++ b/apps/api/src/modules/benchmark/benchmark.controller.ts
@@ -18,17 +18,23 @@ import {
   Get,
   Header,
   HttpCode,
+  type MessageEvent,
   Param,
   Post,
   Query,
+  Sse,
   UseGuards,
 } from "@nestjs/common";
+import { EMPTY, type Observable, from } from "rxjs";
+import { map, switchMap } from "rxjs/operators";
 import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
 import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
 import type { JwtPayload } from "../auth/jwt.strategy.js";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
 import { BenchmarkService } from "./benchmark.service.js";
 import { BenchmarkChartsService } from "./benchmark-charts.service.js";
+import { isInProgressStatus } from "./constants.js";
+import { SseHub } from "./sse/sse-hub.service.js";
 
 @Controller("benchmarks")
 @UseGuards(JwtAuthGuard)
@@ -36,6 +42,7 @@ export class BenchmarkController {
   constructor(
     private readonly service: BenchmarkService,
     private readonly charts: BenchmarkChartsService,
+    private readonly sse: SseHub,
   ) {}
 
   @Get()
@@ -83,6 +90,20 @@ export class BenchmarkController {
   @HttpCode(204)
   async delete(@CurrentUser() user: JwtPayload, @Param("id") id: string): Promise<void> {
     await this.service.delete(id, user.roles.includes("admin") ? undefined : user.sub);
+  }
+
+  /** Live log stream for an in-flight benchmark.
+   *  EventSource cannot set custom headers, so the JWT is accepted via
+   *  the `?token=` query param (handled by JwtStrategy.fromExtractors). */
+  @Sse(":id/events")
+  events(@CurrentUser() user: JwtPayload, @Param("id") id: string): Observable<MessageEvent> {
+    const isAdmin = user.roles.includes("admin");
+    return from(this.service.findByIdOrFail(id, isAdmin ? undefined : user.sub)).pipe(
+      switchMap((bench) =>
+        isInProgressStatus(bench.status) ? this.sse.subscribe(id) : EMPTY,
+      ),
+      map((evt) => ({ data: evt }) as MessageEvent),
+    );
   }
 
   @Get(":id/charts")

--- a/apps/api/src/modules/benchmark/k8s/pod-log-streamer-factory.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/pod-log-streamer-factory.spec.ts
@@ -41,12 +41,16 @@ describe("PodLogStreamerFactory", () => {
     expect(repo.update).toHaveBeenCalledWith("r1", { progress: 0.5 });
   });
 
-  it("buildHandleLine ignores parseProgress returning null", () => {
+  it("buildHandleLine forwards non-progress lines as info log events", () => {
     const { factory, sse, repo } = makeFactory();
     const throttle = new ProgressThrottle("r1", repo as never, 1000);
     const handle = factory.buildHandleLine("r1", "guidellm", throttle);
     handle("not a progress line");
-    expect(sse.publish).not.toHaveBeenCalled();
+    expect(sse.publish).toHaveBeenCalledWith("r1", {
+      kind: "log",
+      level: "info",
+      line: "not a progress line",
+    });
   });
 
   it("buildHandleLine wraps parseProgress throw in fallback log event", () => {

--- a/apps/api/src/modules/benchmark/k8s/pod-log-streamer-factory.ts
+++ b/apps/api/src/modules/benchmark/k8s/pod-log-streamer-factory.ts
@@ -53,13 +53,12 @@ export class PodLogStreamerFactory {
   ): (line: string) => void {
     const adapter = byTool(tool);
     return (line: string) => {
-      let evt: ProgressEvent | null;
+      let evt: ProgressEvent;
       try {
-        evt = adapter.parseProgress(line);
+        evt = adapter.parseProgress(line) ?? { kind: "log", level: "info", line };
       } catch {
         evt = { kind: "log", level: "warn", line };
       }
-      if (!evt) return;
       this.sse.publish(runId, evt);
       if (evt.kind === "progress") throttle.tick(evt.pct);
     };

--- a/apps/api/src/modules/benchmark/sse/sse-hub.service.ts
+++ b/apps/api/src/modules/benchmark/sse/sse-hub.service.ts
@@ -2,12 +2,18 @@ import type { ProgressEvent } from "@modeldoctor/tool-adapters";
 import { Injectable } from "@nestjs/common";
 import { EMPTY, type Observable, Subject } from "rxjs";
 
+/** Max number of completed runIds retained in the closed queue.
+ *  Each entry is just a string, so 1 000 entries ≈ a few KB. */
+const CLOSED_QUEUE_LIMIT = 1_000;
+
 @Injectable()
 export class SseHub {
   private readonly streams = new Map<string, Subject<ProgressEvent>>();
-  /** Tracks runIds whose Subject has been completed via close(). Prevents
-   *  subscribe() from creating a zombie Subject after the run finishes. */
-  private readonly closed = new Set<string>();
+  /** Bounded queue of recently-closed runIds. Prevents subscribe() from
+   *  creating a zombie Subject after close() is called. Evicts oldest
+   *  entries once the queue exceeds CLOSED_QUEUE_LIMIT. */
+  private readonly closedQueue: string[] = [];
+  private readonly closedSet = new Set<string>();
 
   publish(runId: string, evt: ProgressEvent): void {
     this.streams.get(runId)?.next(evt);
@@ -15,7 +21,7 @@ export class SseHub {
 
   /** Returns EMPTY if the run has already been closed (avoids zombie Subjects). */
   subscribe(runId: string): Observable<ProgressEvent> {
-    if (this.closed.has(runId)) return EMPTY;
+    if (this.closedSet.has(runId)) return EMPTY;
     let s = this.streams.get(runId);
     if (!s) {
       s = new Subject<ProgressEvent>();
@@ -25,7 +31,7 @@ export class SseHub {
   }
 
   has(runId: string): boolean {
-    return this.streams.has(runId) && !this.closed.has(runId);
+    return this.streams.has(runId) && !this.closedSet.has(runId);
   }
 
   /** Drop a runId's stream (called from BenchmarkService on terminal state). */
@@ -34,6 +40,11 @@ export class SseHub {
     if (!s) return;
     s.complete();
     this.streams.delete(runId);
-    this.closed.add(runId);
+    this.closedQueue.push(runId);
+    this.closedSet.add(runId);
+    if (this.closedQueue.length > CLOSED_QUEUE_LIMIT) {
+      const evicted = this.closedQueue.shift();
+      if (evicted) this.closedSet.delete(evicted);
+    }
   }
 }

--- a/apps/api/src/modules/benchmark/sse/sse-hub.service.ts
+++ b/apps/api/src/modules/benchmark/sse/sse-hub.service.ts
@@ -1,16 +1,21 @@
 import type { ProgressEvent } from "@modeldoctor/tool-adapters";
 import { Injectable } from "@nestjs/common";
-import { Observable, Subject } from "rxjs";
+import { EMPTY, type Observable, Subject } from "rxjs";
 
 @Injectable()
 export class SseHub {
   private readonly streams = new Map<string, Subject<ProgressEvent>>();
+  /** Tracks runIds whose Subject has been completed via close(). Prevents
+   *  subscribe() from creating a zombie Subject after the run finishes. */
+  private readonly closed = new Set<string>();
 
   publish(runId: string, evt: ProgressEvent): void {
     this.streams.get(runId)?.next(evt);
   }
 
+  /** Returns EMPTY if the run has already been closed (avoids zombie Subjects). */
   subscribe(runId: string): Observable<ProgressEvent> {
+    if (this.closed.has(runId)) return EMPTY;
     let s = this.streams.get(runId);
     if (!s) {
       s = new Subject<ProgressEvent>();
@@ -19,11 +24,16 @@ export class SseHub {
     return s.asObservable();
   }
 
+  has(runId: string): boolean {
+    return this.streams.has(runId) && !this.closed.has(runId);
+  }
+
   /** Drop a runId's stream (called from BenchmarkService on terminal state). */
   close(runId: string): void {
     const s = this.streams.get(runId);
     if (!s) return;
     s.complete();
     this.streams.delete(runId);
+    this.closed.add(runId);
   }
 }

--- a/apps/benchmark-runner/images/aiperf.Dockerfile
+++ b/apps/benchmark-runner/images/aiperf.Dockerfile
@@ -9,7 +9,7 @@ FROM ghcr.io/weetime/md-base-aiperf:0.7.0
 COPY runner runner
 
 # Pinned to match pyproject.toml's requests>=2.31,<3 declaration.
-RUN pip install --no-cache-dir 'requests>=2.31,<3'
+RUN pip install --no-cache-dir 'requests>=2.31,<3' 'boto3>=1.34,<2'
 
 RUN useradd --create-home --shell /sbin/nologin runner \
     && chown -R runner:runner /app

--- a/apps/benchmark-runner/images/evalscope.Dockerfile
+++ b/apps/benchmark-runner/images/evalscope.Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 COPY runner runner
 
 # Pinned to match pyproject.toml's requests>=2.31,<3 declaration.
-RUN pip install --no-cache-dir 'requests>=2.31,<3'
+RUN pip install --no-cache-dir 'requests>=2.31,<3' 'boto3>=1.34,<2'
 
 RUN useradd --create-home --shell /sbin/nologin runner \
     && chown -R runner:runner /app /opt/evalscope-datasets

--- a/apps/benchmark-runner/images/guidellm.Dockerfile
+++ b/apps/benchmark-runner/images/guidellm.Dockerfile
@@ -19,7 +19,7 @@ COPY runner runner
 # Pinned to match pyproject.toml's requests>=2.31,<3 declaration. Don't drop
 # the version constraint here — pip install requests is otherwise unconstrained
 # and will silently grab requests 3.x when it ships.
-RUN pip install --no-cache-dir 'requests>=2.31,<3'
+RUN pip install --no-cache-dir 'requests>=2.31,<3' 'boto3>=1.34,<2'
 
 # Run as a non-root user.
 RUN useradd --create-home --shell /sbin/nologin runner \

--- a/apps/benchmark-runner/images/prefix-cache-probe.Dockerfile
+++ b/apps/benchmark-runner/images/prefix-cache-probe.Dockerfile
@@ -12,7 +12,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # httpx for the probe; requests pinned to match runner wrapper's pyproject.
 RUN pip install --no-cache-dir \
         'httpx>=0.27,<1' \
-        'requests>=2.31,<3'
+        'requests>=2.31,<3' \
+        'boto3>=1.34,<2'
 
 WORKDIR /app
 

--- a/apps/benchmark-runner/images/vegeta.Dockerfile
+++ b/apps/benchmark-runner/images/vegeta.Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY runner runner
 
 # Pinned to match pyproject.toml's requests>=2.31,<3 declaration.
-RUN pip install --no-cache-dir 'requests>=2.31,<3'
+RUN pip install --no-cache-dir 'requests>=2.31,<3' 'boto3>=1.34,<2'
 
 RUN useradd --create-home --shell /sbin/nologin runner \
     && chown -R runner:runner /app

--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -35,37 +35,42 @@ interface ItemRowProps {
 }
 
 function ItemRow({ item, t, railCollapsed }: ItemRowProps) {
+  const activePath = useSidebarStore((s) => s.activePath);
   const Icon = item.icon;
   const label = t(item.labelKey);
   const link = (
     <NavLink
       to={item.to}
       aria-label={railCollapsed ? label : undefined}
-      className={({ isActive }) =>
-        cn(
+      className={({ isActive }) => {
+        const active = isActive || activePath === item.to;
+        return cn(
           "group relative flex items-center rounded-md text-sm",
           "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-          isActive && "bg-accent/50 text-foreground",
+          active && "bg-accent/50 text-foreground",
           railCollapsed ? "justify-center px-0 py-2" : "gap-2 px-3 py-1.5",
-        )
-      }
+        );
+      }}
     >
-      {({ isActive }) => (
-        <>
-          {isActive ? (
-            <span
-              className={cn(
-                "absolute rounded-r bg-foreground",
-                railCollapsed
-                  ? "left-0 top-1/2 h-5 w-0.5 -translate-y-1/2"
-                  : "left-0 top-1.5 h-5 w-0.5",
-              )}
-            />
-          ) : null}
-          <Icon className="h-4 w-4 shrink-0" strokeWidth={1.5} />
-          {railCollapsed ? null : <span className="flex-1">{label}</span>}
-        </>
-      )}
+      {({ isActive }) => {
+        const active = isActive || activePath === item.to;
+        return (
+          <>
+            {active ? (
+              <span
+                className={cn(
+                  "absolute rounded-r bg-foreground",
+                  railCollapsed
+                    ? "left-0 top-1/2 h-5 w-0.5 -translate-y-1/2"
+                    : "left-0 top-1.5 h-5 w-0.5",
+                )}
+              />
+            ) : null}
+            <Icon className="h-4 w-4 shrink-0" strokeWidth={1.5} />
+            {railCollapsed ? null : <span className="flex-1">{label}</span>}
+          </>
+        );
+      }}
     </NavLink>
   );
 

--- a/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
@@ -29,6 +29,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useDeleteBaseline } from "@/features/baseline/queries";
 import { useConnection } from "@/features/connections/queries";
 import { EngineMetricsSection } from "@/features/engine-metrics/EngineMetricsSection";
+import { useSidebarStore } from "@/stores/sidebar-store";
 import { BenchmarkDetailMetadata } from "./BenchmarkDetailMetadata";
 import { BenchmarkDetailRawOutput } from "./BenchmarkDetailRawOutput";
 import { DetailVerdictRow } from "./compare/DetailVerdictRow";
@@ -212,6 +213,13 @@ export function BenchmarkDetailPage() {
   const cancelBenchmark = useCancelBenchmark();
   const createBenchmark = useCreateBenchmark();
   const navigate = useNavigate();
+  const setActivePath = useSidebarStore((s) => s.setActivePath);
+
+  useEffect(() => {
+    if (!benchmark) return;
+    setActivePath(`/benchmarks/${benchmark.scenario}`);
+    return () => setActivePath(null);
+  }, [benchmark, setActivePath]);
 
   if (isLoading) {
     return (

--- a/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
@@ -53,70 +53,91 @@ import { UnknownReport } from "./reports/UnknownReport";
 import { SaveAsTemplateDialog } from "./SaveAsTemplateDialog";
 import { SetBaselineDialog } from "./SetBaselineDialog";
 
-/**
- * Pre-terminal placeholder rendered while the benchmark is still in flight.
- * Polls via `useBenchmarkDetail`; once the backend writes a terminal status
- * the parent flips to the metrics + raw-output report layout.
- */
-function RunningSection({
-  benchmark,
-  logLines,
-}: {
-  benchmark: Benchmark;
-  logLines: LogEvent[];
-}) {
+/** Spinner + elapsed time shown in the Overview tab while a run is in flight. */
+function RunningSection({ benchmark }: { benchmark: Benchmark }) {
   const { t } = useTranslation("benchmarks");
   const [now, setNow] = useState(() => Date.now());
-  const logEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const handle = window.setInterval(() => setNow(Date.now()), 1000);
     return () => window.clearInterval(handle);
   }, []);
 
-  useEffect(() => {
-    logEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [logLines]);
-
   const startedAt = benchmark.startedAt ?? benchmark.createdAt;
   const elapsedSec = Math.max(0, Math.floor((now - new Date(startedAt).getTime()) / 1000));
   const isPending = benchmark.status === "pending" || benchmark.status === "submitted";
 
   return (
-    <div className="space-y-4">
-      <output
-        aria-live="polite"
-        className="flex flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border p-12 text-center"
-      >
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" strokeWidth={1.5} />
-        <div className="text-sm font-medium">
-          {isPending ? t("detail.running.pending") : t("detail.running.title")}
-        </div>
-        <div className="text-xs text-muted-foreground tabular-nums">
-          {t("detail.running.elapsed", { sec: elapsedSec })}
-        </div>
-      </output>
-      {logLines.length > 0 && (
-        <pre className="max-h-[320px] overflow-auto rounded-md border border-border bg-muted/30 p-3 text-xs whitespace-pre-wrap break-all">
-          {logLines.map((l, i) => (
-            <span
-              key={i}
-              className={
-                l.level === "error"
-                  ? "text-destructive"
-                  : l.level === "warn"
-                    ? "text-yellow-500"
-                    : undefined
-              }
-            >
-              {l.line}
-              {"\n"}
-            </span>
-          ))}
-          <div ref={logEndRef} />
-        </pre>
-      )}
-    </div>
+    <output
+      aria-live="polite"
+      className="flex flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border p-12 text-center"
+    >
+      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" strokeWidth={1.5} />
+      <div className="text-sm font-medium">
+        {isPending ? t("detail.running.pending") : t("detail.running.title")}
+      </div>
+      <div className="text-xs text-muted-foreground tabular-nums">
+        {t("detail.running.elapsed", { sec: elapsedSec })}
+      </div>
+    </output>
+  );
+}
+
+/** Dark terminal-style log panel. Shows live SSE lines during run; stdout
+ *  from rawOutput after completion. Survives page refresh via DB fallback. */
+function LogPanel({
+  logLines,
+  stdout,
+}: {
+  logLines: LogEvent[];
+  stdout: string;
+}) {
+  const { t } = useTranslation("benchmarks");
+  const logEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    logEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [logLines, stdout]);
+
+  const hasLive = logLines.length > 0;
+  const hasStdout = stdout.trim().length > 0;
+
+  if (!hasLive && !hasStdout) {
+    return (
+      <div className="flex h-48 items-center justify-center rounded-md border border-border bg-zinc-950 text-xs text-zinc-500">
+        {t("detail.logs.empty")}
+      </div>
+    );
+  }
+
+  if (hasStdout) {
+    return (
+      <pre className="max-h-[60vh] min-h-48 overflow-auto rounded-md bg-zinc-950 p-4 font-mono text-xs leading-relaxed text-zinc-200 whitespace-pre-wrap break-all">
+        {stdout}
+        <div ref={logEndRef} />
+      </pre>
+    );
+  }
+
+  return (
+    <pre className="max-h-[60vh] min-h-48 overflow-auto rounded-md bg-zinc-950 p-4 font-mono text-xs leading-relaxed whitespace-pre-wrap break-all">
+      {logLines.map((l, i) => (
+        <span
+          key={i}
+          className={
+            l.level === "error"
+              ? "text-red-400"
+              : l.level === "warn"
+                ? "text-yellow-400"
+                : "text-zinc-200"
+          }
+        >
+          {l.line}
+          {"\n"}
+        </span>
+      ))}
+      <div ref={logEndRef} />
+    </pre>
   );
 }
 
@@ -153,21 +174,27 @@ function ReportSection({ benchmark }: { benchmark: Benchmark }) {
 function BenchmarkDetailTabs({
   benchmark,
   connection,
+  logLines,
 }: {
   benchmark: Benchmark;
   connection: ConnectionPublic | null;
+  logLines: LogEvent[];
 }) {
   const { t } = useTranslation("benchmarks");
-  const showCharts = benchmark.tool !== "prefix-cache-probe";
+  const isTerminal = isTerminalStatus(benchmark.status);
+  const showCharts = isTerminal && benchmark.tool !== "prefix-cache-probe";
   // Engine Metrics is reachable when the connection is bound to a Prometheus
   // datasource and the benchmark has a definite time window.
   const showEngineMetrics = Boolean(
-    connection?.prometheusDatasource &&
+    isTerminal &&
+      connection?.prometheusDatasource &&
       connection.serverKind &&
       benchmark.startedAt &&
       benchmark.completedAt,
   );
   const [active, setActive] = useState<string>("overview");
+
+  const stdout = (benchmark.rawOutput as { stdout?: string } | null)?.stdout ?? "";
 
   return (
     <Tabs value={active} onValueChange={setActive} className="w-full">
@@ -177,17 +204,24 @@ function BenchmarkDetailTabs({
         {showEngineMetrics && (
           <TabsTrigger value="engine">{t("detail.engineMetrics.title")}</TabsTrigger>
         )}
-        <TabsTrigger value="request">{t("detail.tabs.request")}</TabsTrigger>
+        <TabsTrigger value="logs">{t("detail.tabs.logs")}</TabsTrigger>
+        {isTerminal && <TabsTrigger value="request">{t("detail.tabs.request")}</TabsTrigger>}
       </TabsList>
 
       <TabsContent value="overview" className="space-y-6">
-        {benchmark.baselineId && (
-          <DetailVerdictRow benchmark={benchmark} baselineId={benchmark.baselineId} />
+        {isTerminal ? (
+          <>
+            {benchmark.baselineId && (
+              <DetailVerdictRow benchmark={benchmark} baselineId={benchmark.baselineId} />
+            )}
+            <section>
+              <h3 className="mb-3 text-sm font-semibold">{t("detail.metrics.title")}</h3>
+              <ReportSection benchmark={benchmark} />
+            </section>
+          </>
+        ) : (
+          <RunningSection benchmark={benchmark} />
         )}
-        <section>
-          <h3 className="mb-3 text-sm font-semibold">{t("detail.metrics.title")}</h3>
-          <ReportSection benchmark={benchmark} />
-        </section>
       </TabsContent>
 
       {showCharts && (
@@ -206,13 +240,19 @@ function BenchmarkDetailTabs({
         </TabsContent>
       )}
 
-      <TabsContent value="request" className="space-y-6">
-        <RequestSetupSection benchmark={benchmark} />
-        <BenchmarkDetailRawOutput
-          rawOutput={benchmark.rawOutput as Record<string, unknown> | null}
-          logs={benchmark.logs}
-        />
+      <TabsContent value="logs">
+        <LogPanel logLines={isTerminal ? [] : logLines} stdout={isTerminal ? stdout : ""} />
       </TabsContent>
+
+      {isTerminal && (
+        <TabsContent value="request" className="space-y-6">
+          <RequestSetupSection benchmark={benchmark} />
+          <BenchmarkDetailRawOutput
+            rawOutput={benchmark.rawOutput as Record<string, unknown> | null}
+            logs={benchmark.logs}
+          />
+        </TabsContent>
+      )}
     </Tabs>
   );
 }
@@ -249,11 +289,12 @@ export function BenchmarkDetailPage() {
   const navigate = useNavigate();
   const setActivePath = useSidebarStore((s) => s.setActivePath);
 
+  const scenario = benchmark?.scenario;
   useEffect(() => {
-    if (!benchmark) return;
-    setActivePath(`/benchmarks/${benchmark.scenario}`);
+    if (!scenario) return;
+    setActivePath(`/benchmarks/${scenario}`);
     return () => setActivePath(null);
-  }, [benchmark, setActivePath]);
+  }, [scenario, setActivePath]);
 
   const isTerminal = benchmark ? isTerminalStatus(benchmark.status) : true;
   const logLines = useRunEventStream(benchmark?.id, !isTerminal);
@@ -443,11 +484,11 @@ export function BenchmarkDetailPage() {
             })()}
           </details>
         )}
-        {isTerminal ? (
-          <BenchmarkDetailTabs benchmark={benchmark} connection={rerunConnection ?? null} />
-        ) : (
-          <RunningSection benchmark={benchmark} logLines={logLines} />
-        )}
+        <BenchmarkDetailTabs
+          benchmark={benchmark}
+          connection={rerunConnection ?? null}
+          logLines={logLines}
+        />
       </div>
 
       <SetBaselineDialog

--- a/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
@@ -90,7 +90,7 @@ function LogPanel({ logLines, stdout }: { logLines: LogEvent[]; stdout: string }
   const logEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    logEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    logEndRef.current?.scrollIntoView({ behavior: "auto" });
   }, [logLines, stdout]);
 
   const hasLive = logLines.length > 0;
@@ -235,7 +235,7 @@ function BenchmarkDetailTabs({
       )}
 
       <TabsContent value="logs">
-        <LogPanel logLines={isTerminal ? [] : logLines} stdout={isTerminal ? stdout : ""} />
+        <LogPanel logLines={logLines} stdout={stdout} />
       </TabsContent>
 
       {isTerminal && (

--- a/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
@@ -6,7 +6,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { Copy, Loader2, RefreshCw, SearchX } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
@@ -32,6 +32,7 @@ import { EngineMetricsSection } from "@/features/engine-metrics/EngineMetricsSec
 import { useSidebarStore } from "@/stores/sidebar-store";
 import { BenchmarkDetailMetadata } from "./BenchmarkDetailMetadata";
 import { BenchmarkDetailRawOutput } from "./BenchmarkDetailRawOutput";
+import { type LogEvent, useRunEventStream } from "./useRunEventStream";
 import { DetailVerdictRow } from "./compare/DetailVerdictRow";
 import {
   benchmarkKeys,
@@ -57,32 +58,65 @@ import { SetBaselineDialog } from "./SetBaselineDialog";
  * Polls via `useBenchmarkDetail`; once the backend writes a terminal status
  * the parent flips to the metrics + raw-output report layout.
  */
-function RunningSection({ benchmark }: { benchmark: Benchmark }) {
+function RunningSection({
+  benchmark,
+  logLines,
+}: {
+  benchmark: Benchmark;
+  logLines: LogEvent[];
+}) {
   const { t } = useTranslation("benchmarks");
   const [now, setNow] = useState(() => Date.now());
+  const logEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const handle = window.setInterval(() => setNow(Date.now()), 1000);
     return () => window.clearInterval(handle);
   }, []);
 
+  useEffect(() => {
+    logEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [logLines]);
+
   const startedAt = benchmark.startedAt ?? benchmark.createdAt;
   const elapsedSec = Math.max(0, Math.floor((now - new Date(startedAt).getTime()) / 1000));
   const isPending = benchmark.status === "pending" || benchmark.status === "submitted";
 
   return (
-    <output
-      aria-live="polite"
-      className="flex flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border p-12 text-center"
-    >
-      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" strokeWidth={1.5} />
-      <div className="text-sm font-medium">
-        {isPending ? t("detail.running.pending") : t("detail.running.title")}
-      </div>
-      <div className="text-xs text-muted-foreground tabular-nums">
-        {t("detail.running.elapsed", { sec: elapsedSec })}
-      </div>
-    </output>
+    <div className="space-y-4">
+      <output
+        aria-live="polite"
+        className="flex flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border p-12 text-center"
+      >
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" strokeWidth={1.5} />
+        <div className="text-sm font-medium">
+          {isPending ? t("detail.running.pending") : t("detail.running.title")}
+        </div>
+        <div className="text-xs text-muted-foreground tabular-nums">
+          {t("detail.running.elapsed", { sec: elapsedSec })}
+        </div>
+      </output>
+      {logLines.length > 0 && (
+        <pre className="max-h-[320px] overflow-auto rounded-md border border-border bg-muted/30 p-3 text-xs whitespace-pre-wrap break-all">
+          {logLines.map((l, i) => (
+            <span
+              key={i}
+              className={
+                l.level === "error"
+                  ? "text-destructive"
+                  : l.level === "warn"
+                    ? "text-yellow-500"
+                    : undefined
+              }
+            >
+              {l.line}
+              {"\n"}
+            </span>
+          ))}
+          <div ref={logEndRef} />
+        </pre>
+      )}
+    </div>
   );
 }
 
@@ -221,6 +255,9 @@ export function BenchmarkDetailPage() {
     return () => setActivePath(null);
   }, [benchmark, setActivePath]);
 
+  const isTerminal = benchmark ? isTerminalStatus(benchmark.status) : true;
+  const logLines = useRunEventStream(benchmark?.id, !isTerminal);
+
   if (isLoading) {
     return (
       <>
@@ -267,7 +304,6 @@ export function BenchmarkDetailPage() {
   });
 
   const isBaseline = benchmark.baselineFor !== null;
-  const isTerminal = isTerminalStatus(benchmark.status);
   // CreateBenchmarkRequest requires non-null connectionId; orphaned benchmarks
   // (FK SET NULL after Connection delete) cannot be cloned without picking a
   // new connection, and the spec is one-click rerun without an edit step.
@@ -410,7 +446,7 @@ export function BenchmarkDetailPage() {
         {isTerminal ? (
           <BenchmarkDetailTabs benchmark={benchmark} connection={rerunConnection ?? null} />
         ) : (
-          <RunningSection benchmark={benchmark} />
+          <RunningSection benchmark={benchmark} logLines={logLines} />
         )}
       </div>
 

--- a/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
@@ -32,7 +32,6 @@ import { EngineMetricsSection } from "@/features/engine-metrics/EngineMetricsSec
 import { useSidebarStore } from "@/stores/sidebar-store";
 import { BenchmarkDetailMetadata } from "./BenchmarkDetailMetadata";
 import { BenchmarkDetailRawOutput } from "./BenchmarkDetailRawOutput";
-import { type LogEvent, useRunEventStream } from "./useRunEventStream";
 import { DetailVerdictRow } from "./compare/DetailVerdictRow";
 import {
   benchmarkKeys,
@@ -52,6 +51,7 @@ import { PrefixCacheProbeReport } from "./reports/PrefixCacheProbeReport";
 import { UnknownReport } from "./reports/UnknownReport";
 import { SaveAsTemplateDialog } from "./SaveAsTemplateDialog";
 import { SetBaselineDialog } from "./SetBaselineDialog";
+import { type LogEvent, useRunEventStream } from "./useRunEventStream";
 
 /** Spinner + elapsed time shown in the Overview tab while a run is in flight. */
 function RunningSection({ benchmark }: { benchmark: Benchmark }) {
@@ -85,13 +85,7 @@ function RunningSection({ benchmark }: { benchmark: Benchmark }) {
 
 /** Dark terminal-style log panel. Shows live SSE lines during run; stdout
  *  from rawOutput after completion. Survives page refresh via DB fallback. */
-function LogPanel({
-  logLines,
-  stdout,
-}: {
-  logLines: LogEvent[];
-  stdout: string;
-}) {
+function LogPanel({ logLines, stdout }: { logLines: LogEvent[]; stdout: string }) {
   const { t } = useTranslation("benchmarks");
   const logEndRef = useRef<HTMLDivElement>(null);
 

--- a/apps/web/src/features/benchmarks/BenchmarkDetailRawOutput.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailRawOutput.tsx
@@ -16,7 +16,11 @@ function CollapseBlock({
   return (
     <div>
       <Button variant="ghost" size="sm" onClick={() => setOpen((s) => !s)}>
-        {open ? <ChevronDown className="mr-1 h-4 w-4" /> : <ChevronRight className="mr-1 h-4 w-4" />}
+        {open ? (
+          <ChevronDown className="mr-1 h-4 w-4" />
+        ) : (
+          <ChevronRight className="mr-1 h-4 w-4" />
+        )}
         {label}
       </Button>
       {open && (
@@ -41,7 +45,9 @@ export function BenchmarkDetailRawOutput({
   const stderr = (rawOutput?.stderr as string | undefined) ?? "";
   // rawOutput minus stdout/stderr for the raw JSON block
   const rawRest = rawOutput
-    ? Object.fromEntries(Object.entries(rawOutput).filter(([k]) => k !== "stdout" && k !== "stderr"))
+    ? Object.fromEntries(
+        Object.entries(rawOutput).filter(([k]) => k !== "stdout" && k !== "stderr"),
+      )
     : null;
 
   return (
@@ -49,12 +55,8 @@ export function BenchmarkDetailRawOutput({
       {stdout.trim() && (
         <CollapseBlock label={t("detail.logs.stdout")} content={stdout} defaultOpen />
       )}
-      {stderr.trim() && (
-        <CollapseBlock label={t("detail.logs.stderr")} content={stderr} />
-      )}
-      {logs && (
-        <CollapseBlock label={t("detail.logs.toggle")} content={logs} />
-      )}
+      {stderr.trim() && <CollapseBlock label={t("detail.logs.stderr")} content={stderr} />}
+      {logs && <CollapseBlock label={t("detail.logs.toggle")} content={logs} />}
       {rawRest && Object.keys(rawRest).length > 0 && (
         <CollapseBlock
           label={t("detail.rawOutput.toggle")}

--- a/apps/web/src/features/benchmarks/BenchmarkDetailRawOutput.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailRawOutput.tsx
@@ -3,6 +3,31 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 
+function CollapseBlock({
+  label,
+  content,
+  defaultOpen = false,
+}: {
+  label: string;
+  content: string;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div>
+      <Button variant="ghost" size="sm" onClick={() => setOpen((s) => !s)}>
+        {open ? <ChevronDown className="mr-1 h-4 w-4" /> : <ChevronRight className="mr-1 h-4 w-4" />}
+        {label}
+      </Button>
+      {open && (
+        <pre className="mt-2 max-h-[400px] overflow-auto rounded-md border border-border bg-muted/30 p-3 text-xs whitespace-pre-wrap break-all">
+          {content}
+        </pre>
+      )}
+    </div>
+  );
+}
+
 export function BenchmarkDetailRawOutput({
   rawOutput,
   logs,
@@ -11,44 +36,30 @@ export function BenchmarkDetailRawOutput({
   logs: string | null;
 }) {
   const { t } = useTranslation("benchmarks");
-  const [showRaw, setShowRaw] = useState(false);
-  const [showLogs, setShowLogs] = useState(false);
+
+  const stdout = (rawOutput?.stdout as string | undefined) ?? "";
+  const stderr = (rawOutput?.stderr as string | undefined) ?? "";
+  // rawOutput minus stdout/stderr for the raw JSON block
+  const rawRest = rawOutput
+    ? Object.fromEntries(Object.entries(rawOutput).filter(([k]) => k !== "stdout" && k !== "stderr"))
+    : null;
 
   return (
     <div className="space-y-3">
-      {rawOutput && Object.keys(rawOutput).length > 0 && (
-        <div>
-          <Button variant="ghost" size="sm" onClick={() => setShowRaw((s) => !s)}>
-            {showRaw ? (
-              <ChevronDown className="mr-1 h-4 w-4" />
-            ) : (
-              <ChevronRight className="mr-1 h-4 w-4" />
-            )}{" "}
-            {t("detail.rawOutput.toggle")}
-          </Button>
-          {showRaw && (
-            <pre className="mt-2 max-h-[400px] overflow-auto rounded-md border border-border bg-muted/30 p-3 text-xs">
-              {JSON.stringify(rawOutput, null, 2)}
-            </pre>
-          )}
-        </div>
+      {stdout.trim() && (
+        <CollapseBlock label={t("detail.logs.stdout")} content={stdout} defaultOpen />
+      )}
+      {stderr.trim() && (
+        <CollapseBlock label={t("detail.logs.stderr")} content={stderr} />
       )}
       {logs && (
-        <div>
-          <Button variant="ghost" size="sm" onClick={() => setShowLogs((s) => !s)}>
-            {showLogs ? (
-              <ChevronDown className="mr-1 h-4 w-4" />
-            ) : (
-              <ChevronRight className="mr-1 h-4 w-4" />
-            )}{" "}
-            {t("detail.logs.toggle")}
-          </Button>
-          {showLogs && (
-            <pre className="mt-2 max-h-[400px] overflow-auto rounded-md border border-border bg-muted/30 p-3 text-xs">
-              {logs}
-            </pre>
-          )}
-        </div>
+        <CollapseBlock label={t("detail.logs.toggle")} content={logs} />
+      )}
+      {rawRest && Object.keys(rawRest).length > 0 && (
+        <CollapseBlock
+          label={t("detail.rawOutput.toggle")}
+          content={JSON.stringify(rawRest, null, 2)}
+        />
       )}
     </div>
   );

--- a/apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
@@ -159,7 +159,10 @@ describe("BenchmarkDetailPage", () => {
   });
 
   it("renders metadata + Request·Response tab exposes raw output and logs toggles", async () => {
-    vi.mocked(api.get).mockResolvedValueOnce(makeBenchmark());
+    // rawOutput needs a non-stdout/stderr key to trigger the "Raw output (JSON)" block.
+    vi.mocked(api.get).mockResolvedValueOnce(
+      makeBenchmark({ rawOutput: { stdout: "ok", report: { tool: "guidellm" } } }),
+    );
     const user = userEvent.setup();
     render(<BenchmarkDetailPage />, { wrapper: Wrapper });
     expect(await screen.findByRole("heading", { name: "smoke" })).toBeInTheDocument();

--- a/apps/web/src/features/benchmarks/useRunEventStream.ts
+++ b/apps/web/src/features/benchmarks/useRunEventStream.ts
@@ -3,6 +3,8 @@ import { useAuthStore } from "@/stores/auth-store";
 
 export type LogEvent = { kind: "log"; level: "info" | "warn" | "error"; line: string };
 
+const MAX_LINES = 2000;
+
 /**
  * Opens an EventSource to /api/benchmarks/:id/events and collects log lines
  * while the benchmark is in flight. Closes automatically when `enabled`
@@ -36,7 +38,10 @@ export function useRunEventStream(runId: string | undefined, enabled: boolean): 
       try {
         const evt = JSON.parse(e.data as string) as { kind?: string; level?: string; line?: string };
         if (evt.kind === "log" && typeof evt.line === "string") {
-          setLines((prev) => [...prev, evt as LogEvent]);
+          setLines((prev) => {
+            const next = [...prev, evt as LogEvent];
+            return next.length > MAX_LINES ? next.slice(next.length - MAX_LINES) : next;
+          });
         }
       } catch {
         // ignore malformed frames

--- a/apps/web/src/features/benchmarks/useRunEventStream.ts
+++ b/apps/web/src/features/benchmarks/useRunEventStream.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from "react";
+import { useAuthStore } from "@/stores/auth-store";
+
+export type LogEvent = { kind: "log"; level: "info" | "warn" | "error"; line: string };
+
+/**
+ * Opens an EventSource to /api/benchmarks/:id/events and collects log lines
+ * while the benchmark is in flight. Closes automatically when `enabled`
+ * becomes false (i.e. the benchmark reaches a terminal status).
+ *
+ * Auth: JWT is passed as `?token=` because EventSource cannot set headers.
+ * The server's JwtStrategy accepts it via fromExtractors.
+ */
+export function useRunEventStream(runId: string | undefined, enabled: boolean): LogEvent[] {
+  const [lines, setLines] = useState<LogEvent[]>([]);
+  const token = useAuthStore((s) => s.accessToken);
+  const esRef = useRef<EventSource | null>(null);
+
+  // Reset lines when switching to a different run
+  useEffect(() => {
+    setLines([]);
+  }, [runId]);
+
+  useEffect(() => {
+    if (!runId || !enabled || !token) {
+      esRef.current?.close();
+      esRef.current = null;
+      return;
+    }
+
+    const url = `/api/benchmarks/${encodeURIComponent(runId)}/events?token=${encodeURIComponent(token)}`;
+    const es = new EventSource(url);
+    esRef.current = es;
+
+    es.onmessage = (e) => {
+      try {
+        const evt = JSON.parse(e.data as string) as { kind?: string; level?: string; line?: string };
+        if (evt.kind === "log" && typeof evt.line === "string") {
+          setLines((prev) => [...prev, evt as LogEvent]);
+        }
+      } catch {
+        // ignore malformed frames
+      }
+    };
+
+    return () => {
+      es.close();
+      esRef.current = null;
+    };
+  }, [runId, enabled, token]);
+
+  return lines;
+}

--- a/apps/web/src/features/benchmarks/useRunEventStream.ts
+++ b/apps/web/src/features/benchmarks/useRunEventStream.ts
@@ -36,7 +36,11 @@ export function useRunEventStream(runId: string | undefined, enabled: boolean): 
 
     es.onmessage = (e) => {
       try {
-        const evt = JSON.parse(e.data as string) as { kind?: string; level?: string; line?: string };
+        const evt = JSON.parse(e.data as string) as {
+          kind?: string;
+          level?: string;
+          line?: string;
+        };
         if (evt.kind === "log" && typeof evt.line === "string") {
           setLines((prev) => {
             const next = [...prev, evt as LogEvent];

--- a/apps/web/src/locales/en-US/benchmarks.json
+++ b/apps/web/src/locales/en-US/benchmarks.json
@@ -171,7 +171,8 @@
     "logs": {
       "toggle": "Logs",
       "stdout": "stdout",
-      "stderr": "stderr"
+      "stderr": "stderr",
+      "empty": "No logs available"
     },
     "baseline": {
       "setButton": "Set as baseline",
@@ -242,7 +243,8 @@
     "tabs": {
       "overview": "Overview",
       "raw": "Raw output",
-      "request": "Request · Response"
+      "request": "Request · Response",
+      "logs": "Run Logs"
     },
     "requestSetup": {
       "title": "Request setup",

--- a/apps/web/src/locales/en-US/benchmarks.json
+++ b/apps/web/src/locales/en-US/benchmarks.json
@@ -169,7 +169,9 @@
       "toggle": "Raw output (JSON)"
     },
     "logs": {
-      "toggle": "Logs"
+      "toggle": "Logs",
+      "stdout": "stdout",
+      "stderr": "stderr"
     },
     "baseline": {
       "setButton": "Set as baseline",

--- a/apps/web/src/locales/zh-CN/benchmarks.json
+++ b/apps/web/src/locales/zh-CN/benchmarks.json
@@ -171,7 +171,8 @@
     "logs": {
       "toggle": "日志",
       "stdout": "标准输出（stdout）",
-      "stderr": "标准错误（stderr）"
+      "stderr": "标准错误（stderr）",
+      "empty": "暂无日志"
     },
     "baseline": {
       "setButton": "设为基线",
@@ -242,7 +243,8 @@
     "tabs": {
       "overview": "概览",
       "raw": "原始输出",
-      "request": "请求 · 响应"
+      "request": "请求 · 响应",
+      "logs": "运行日志"
     },
     "requestSetup": {
       "title": "请求设置",

--- a/apps/web/src/locales/zh-CN/benchmarks.json
+++ b/apps/web/src/locales/zh-CN/benchmarks.json
@@ -169,7 +169,9 @@
       "toggle": "原始输出（JSON）"
     },
     "logs": {
-      "toggle": "日志"
+      "toggle": "日志",
+      "stdout": "标准输出（stdout）",
+      "stderr": "标准错误（stderr）"
     },
     "baseline": {
       "setButton": "设为基线",

--- a/apps/web/src/stores/sidebar-store.ts
+++ b/apps/web/src/stores/sidebar-store.ts
@@ -6,8 +6,13 @@ interface SidebarStore {
   collapsedGroups: Record<string, boolean>;
   /** Whole-sidebar rail mode: show icon-only column instead of full sidebar. */
   railCollapsed: boolean;
+  /** Transient override — detail pages set this so the parent list item stays
+   *  highlighted while viewing a record whose URL (/benchmarks/:id) doesn't
+   *  match the list URL (/benchmarks/gateway etc.). Not persisted. */
+  activePath: string | null;
   toggleGroup: (id: string) => void;
   toggleRail: () => void;
+  setActivePath: (path: string | null) => void;
   /** Forget group-collapse state and expand the rail. */
   reset: () => void;
 }
@@ -17,6 +22,7 @@ export const useSidebarStore = create<SidebarStore>()(
     (set) => ({
       collapsedGroups: {},
       railCollapsed: false,
+      activePath: null,
       toggleGroup: (id) =>
         set((s) => ({
           collapsedGroups: {
@@ -25,8 +31,12 @@ export const useSidebarStore = create<SidebarStore>()(
           },
         })),
       toggleRail: () => set((s) => ({ railCollapsed: !s.railCollapsed })),
+      setActivePath: (path) => set({ activePath: path }),
       reset: () => set({ collapsedGroups: {}, railCollapsed: false }),
     }),
-    { name: "md.sidebar-groups-collapsed.v1" },
+    {
+      name: "md.sidebar-groups-collapsed.v1",
+      partialize: (s) => ({ collapsedGroups: s.collapsedGroups, railCollapsed: s.railCollapsed }),
+    },
   ),
 );

--- a/packages/contracts/src/engine-metrics/manifests/__tests__/mindie.spec.ts
+++ b/packages/contracts/src/engine-metrics/manifests/__tests__/mindie.spec.ts
@@ -18,6 +18,7 @@ describe("mindie manifest", () => {
   it("snapshot is stable", () => {
     const rendered = mindieManifest.metrics.map((m) => ({
       key: m.key,
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: PromQL placeholder
       exprs: m.promql.map((v) => v.expr.replaceAll("${model}", "test-model")),
     }));
     expect(rendered).toMatchSnapshot();

--- a/packages/contracts/src/engine-metrics/manifests/__tests__/sglang.spec.ts
+++ b/packages/contracts/src/engine-metrics/manifests/__tests__/sglang.spec.ts
@@ -20,6 +20,7 @@ describe("sglang manifest", () => {
   it("snapshot of rendered PromQL is stable", () => {
     const rendered = sglangManifest.metrics.map((m) => ({
       key: m.key,
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: PromQL placeholder
       exprs: m.promql.map((v) => v.expr.replaceAll("${model}", "test-model")),
     }));
     expect(rendered).toMatchSnapshot();

--- a/packages/contracts/src/engine-metrics/manifests/__tests__/tei.spec.ts
+++ b/packages/contracts/src/engine-metrics/manifests/__tests__/tei.spec.ts
@@ -18,6 +18,7 @@ describe("tei manifest", () => {
   it("snapshot is stable", () => {
     const rendered = teiManifest.metrics.map((m) => ({
       key: m.key,
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: PromQL placeholder
       exprs: m.promql.map((v) => v.expr.replaceAll("${model}", "test-model")),
     }));
     expect(rendered).toMatchSnapshot();

--- a/packages/contracts/src/engine-metrics/manifests/__tests__/tgi.spec.ts
+++ b/packages/contracts/src/engine-metrics/manifests/__tests__/tgi.spec.ts
@@ -19,6 +19,7 @@ describe("tgi manifest", () => {
   it("snapshot of rendered PromQL is stable", () => {
     const rendered = tgiManifest.metrics.map((m) => ({
       key: m.key,
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: PromQL placeholder
       exprs: m.promql.map((v) => v.expr.replaceAll("${model}", "test-model")),
     }));
     expect(rendered).toMatchSnapshot();

--- a/packages/contracts/src/engine-metrics/manifests/__tests__/vllm.spec.ts
+++ b/packages/contracts/src/engine-metrics/manifests/__tests__/vllm.spec.ts
@@ -33,6 +33,7 @@ describe("vllm manifest", () => {
   it("snapshot of all rendered PromQL strings is stable", () => {
     const rendered = vllmManifest.metrics.map((m) => ({
       key: m.key,
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: PromQL placeholder
       exprs: m.promql.map((v) => v.expr.replace("${model}", "test-model")),
     }));
     expect(rendered).toMatchSnapshot();

--- a/packages/contracts/src/engine-metrics/manifests/mindie.ts
+++ b/packages/contracts/src/engine-metrics/manifests/mindie.ts
@@ -2,6 +2,7 @@ import type { EngineManifest, EngineMetricSpec } from "../../engine-metrics.js";
 
 // `${M}` is the literal placeholder string `${model}` — service.fetchSnapshot
 // does the runtime substitution.
+// biome-ignore lint/suspicious/noTemplateCurlyInString: PromQL template variable, not a JS expression
 const M = "${model}";
 
 const metrics: EngineMetricSpec[] = [

--- a/packages/contracts/src/engine-metrics/manifests/sglang.ts
+++ b/packages/contracts/src/engine-metrics/manifests/sglang.ts
@@ -2,6 +2,7 @@ import type { EngineManifest, EngineMetricSpec } from "../../engine-metrics.js";
 
 // `${M}` is the literal placeholder string `${model}` — service.fetchSnapshot
 // does the runtime substitution. The constant keeps multi-line PromQL readable.
+// biome-ignore lint/suspicious/noTemplateCurlyInString: PromQL template variable, not a JS expression
 const M = "${model}";
 
 const metrics: EngineMetricSpec[] = [

--- a/packages/contracts/src/engine-metrics/manifests/vllm.ts
+++ b/packages/contracts/src/engine-metrics/manifests/vllm.ts
@@ -3,6 +3,7 @@ import type { EngineManifest, EngineMetricSpec } from "../../engine-metrics.js";
 // M is the literal placeholder string `${model}` — service.fetchSnapshot
 // does the runtime replacement. We assign it once to a constant so the
 // surrounding template-literal noise stays readable.
+// biome-ignore lint/suspicious/noTemplateCurlyInString: PromQL template variable, not a JS expression
 const M = "${model}";
 
 const metrics: EngineMetricSpec[] = [

--- a/packages/tool-adapters/src/vegeta/migrate-params.ts
+++ b/packages/tool-adapters/src/vegeta/migrate-params.ts
@@ -6,22 +6,32 @@ type LegacyVegetaParams = Pick<VegetaParams, "apiType" | "rate" | "duration"> & 
   body?: string;
 };
 
+/** Placeholder used in seed templates; replaced at display / rerun time. */
+const SEED_MODEL_PLACEHOLDER = "<replace-with-your-model>";
+
 /**
  * Backwards-compat helper for benchmarks created before vegetaParamsSchema
  * required `path` + `body`. Fills the two new fields from the apiType-keyed
  * defaults so legacy rows survive both the detail-page render and the
  * "rerun" mutation (whose POST goes through the now-stricter schema).
+ *
+ * Also substitutes the seed-template placeholder model with the live
+ * connection model so Copy-as-cURL produces a runnable command.
  */
 export function migrateVegetaParams(
   params: LegacyVegetaParams,
   connectionModel: string | null | undefined,
 ): VegetaParams {
   const model = connectionModel ?? "<unknown>";
+  let body = params.body ?? API_TYPE_TO_BODY[params.apiType](model);
+  if (connectionModel && body.includes(SEED_MODEL_PLACEHOLDER)) {
+    body = body.replaceAll(SEED_MODEL_PLACEHOLDER, connectionModel);
+  }
   return {
     apiType: params.apiType,
     rate: params.rate,
     duration: params.duration,
     path: params.path ?? API_TYPE_TO_PATH[params.apiType],
-    body: params.body ?? API_TYPE_TO_BODY[params.apiType](model),
+    body,
   };
 }


### PR DESCRIPTION
## Summary

- **Runner**: adds `boto3>=1.34,<2` to all 5 runner Dockerfiles — fixes `ModuleNotFoundError: No module named 'boto3'` at runner startup when uploading artifacts to MinIO/S3
- **SSE log stream**: live pod-log → EventSource pipeline wired end-to-end; all pod lines forwarded to SSE (not just structured progress events)
- **Security (C1)**: `?token=` JWT extractor isolated to a new `JwtSseStrategy` / `SseJwtAuthGuard` scoped only to the SSE endpoint; global `JwtStrategy` reverts to Authorization header only; SSE route uses `@Public()` + `@UseGuards(SseJwtAuthGuard)`
- **Race fix (C2)**: `SseHub` tracks closed runIds in a `Set`; `subscribe()` returns `EMPTY` instead of creating a zombie Subject after `close()` is called
- **Unit test (C3)**: `pod-log-streamer-factory.spec.ts` assertion updated — null-returning `parseProgress` now produces an info log event (not silence)
- **Memory (C5)**: `useRunEventStream` caps the log array at `MAX_LINES=2000` with a ring-buffer slice
- **activePath flicker (C6)**: `useEffect` deps narrowed to `benchmark?.scenario` — eliminates sidebar highlight flicker on every 2s poll
- **Log panel**: dedicated "运行日志" tab with dark terminal UI (`bg-zinc-950`); shows live SSE during run, falls back to `rawOutput.stdout` from DB after completion — survives page refresh
- **Copy as cURL model**: `migrateVegetaParams` substitutes the seed-template placeholder `<replace-with-your-model>` with the live connection model

## Test plan

- [ ] Start a benchmark run → detail page "运行日志" tab shows live log lines in dark terminal style
- [ ] Refresh the detail page mid-run → log tab is empty (SSE only); after completion → log tab shows `rawOutput.stdout`
- [ ] Copy as cURL on a benchmark created from an official template → model field is the connection's actual model name, not `<replace-with-your-model>`
- [ ] SSE endpoint rejects unauthenticated requests; accepts `?token=<jwt>` from EventSource
- [ ] All other routes unaffected (standard Bearer header still works)
- [ ] Sidebar active highlight no longer flickers on 2s poll
- [ ] `pnpm -r build` passes; `pod-log-streamer-factory.spec.ts` 6/6 tests green

addresses #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)