### PR TITLE
refactor(prometheus-rules): neutral metric namespace infer:* + OTel-aligned tpot

### DIFF
--- a/deploy/k8s/prometheus-rules/README.md
+++ b/deploy/k8s/prometheus-rules/README.md
@@ -2,7 +2,7 @@
 
 PrometheusRule CRDs (kube-prometheus-operator format) that normalize raw
 inference-engine, gateway, and accelerator metrics into the
-`modeldoctor:*` namespace, then declare SLO alerts on top.
+`infer:*` namespace, then declare SLO alerts on top.
 
 Background and design rationale:
 [`docs/superpowers/research/2026-05-15-inference-engine-metrics-survey.md`](../../../docs/superpowers/research/2026-05-15-inference-engine-metrics-survey.md).
@@ -21,7 +21,7 @@ recording/
     higress.yaml                  ← apply if you run Higress AI Statistics
   accelerator/
     accelerator.yaml              ← unified NVIDIA + Ascend; safe to always apply
-alerts/                           ← apply all four; they consume `modeldoctor:*` only
+alerts/                           ← apply all four; they consume `infer:*` only
   request-slo.yaml                ← TTFT, queue, hang, preemption
   cache.yaml                      ← KV / prefix cache pressure
   accelerator.yaml                ← GPU/NPU health, thermal, memory
@@ -80,7 +80,7 @@ your `Prometheus` resource).
 
 - Higress LLM duration counters are converted **microseconds → seconds**
   (divide by `1e6`). Some legacy plugin builds report milliseconds —
-  if your normalized `modeldoctor:gateway:llm_duration_seconds:avg`
+  if your normalized `infer:gateway:llm_duration_seconds:avg`
   is suspiciously 1000x off, change the divisor to `1e3` in
   `recording/gateway/higress.yaml`.
 - DCGM `FB_USED` / `FB_TOTAL` are MiB; we convert to bytes.

--- a/deploy/k8s/prometheus-rules/README.md
+++ b/deploy/k8s/prometheus-rules/README.md
@@ -11,9 +11,10 @@ Background and design rationale:
 
 ```
 recording/
-  engines/                        ← apply ONE per engine type per replica
-    vllm-v0.yaml                  ← vLLM 0.5.x / 0.6.x
-    vllm-v1.yaml                  ← vLLM 0.7.x+
+  engines/
+    vllm-common.yaml              ← vLLM shared metrics; auto-detects V0/V1 per instance. Apply with one or both version files below.
+    vllm-v0.yaml                  ← vLLM 0.5.x / 0.6.x — version-specific metrics only
+    vllm-v1.yaml                  ← vLLM 0.7.x+ — version-specific metrics only
     sglang-legacy.yaml            ← SGLang ≤ 0.5.3 (sglang: prefix)
     sglang-v0.5.4plus.yaml        ← SGLang ≥ 0.5.4 (sglang_ prefix)
     tgi.yaml                      ← HuggingFace TGI 1.x / 2.x
@@ -30,36 +31,71 @@ alerts/                           ← apply all four; they consume `infer:*` onl
 
 ## Design principle: version is engine
 
-Do NOT apply both `vllm-v0.yaml` and `vllm-v1.yaml` against the same
-inference replica. The two engine types are mutually exclusive — they
-target different raw metric names. Pick the one matching your deployed
-vLLM version. Same for `sglang-legacy.yaml` vs `sglang-v0.5.4plus.yaml`.
+Each `(engine, major version)` is treated as a distinct engine type with
+its own `engine` label, because the same engine renames metrics across
+major versions. How that label is attached depends on whether the raw
+metric NAMES collide between versions:
 
-Why: each rule file hard-codes its `engine` label and reads the raw
-metric names from the specific vLLM/SGLang major version. Layering two
-files would produce duplicate normalized series with different `engine`
-label values, which breaks downstream alert grouping and AI context join.
+**vLLM V0 vs V1 — shared `vllm:` prefix AND many identical metric names**
+(`vllm:num_requests_running`, `vllm:time_to_first_token_seconds`, …).
+This is the one case where a per-version file cannot own a metric without
+double-counting on a mixed fleet. So:
+
+- Shared-name metrics live in **`vllm-common.yaml`** and get their
+  `engine` label attached **per instance** by joining
+  `infer:meta:engine_id` — a value-1 identity derived non-invasively from
+  a version-exclusive gauge (`vllm:kv_cache_usage_perc` → V1,
+  `vllm:gpu_cache_usage_perc` → V0). No scrape/pod-label changes needed.
+- Version-exclusive metrics (cache semantics, TPOT source name) stay in
+  `vllm-v0.yaml` / `vllm-v1.yaml` with a static `engine` label.
+- On a **mixed V0+V1 fleet, apply `vllm-common.yaml` + BOTH version files**
+  — the version files only define version-exclusive raw names, so there is
+  no overlap.
+
+**SGLang legacy vs v0.5.4+ — different prefixes** (`sglang:` vs `sglang_`).
+No raw names collide, so each file naturally matches only its own
+version's pods. Applying both is safe; no common file is needed.
+
+The general rule: version-exclusive raw names can coexist directly;
+only *shared* raw names need the discriminator join (today, only vLLM).
 
 ## How to apply
 
-```bash
-# 1. Pick one engine recording file matching your inference workload
-kubectl apply -f recording/engines/vllm-v1.yaml -n monitoring
+> **First check your Prometheus's `ruleSelector`.** If it is non-empty
+> (kube-prometheus-stack uses `{release: <name>}`), a raw `kubectl apply`
+> is **silently ignored** — the PrometheusRule must carry the matching
+> label. Use the provided `kustomization.yaml` (which stamps the label
+> without polluting the engine-neutral base files):
+>
+> ```bash
+> # edit `release:` in kustomization.yaml to match your cluster, then:
+> kubectl apply -k deploy/k8s/prometheus-rules/
+> ```
+>
+> Inspect the selector with:
+> `kubectl get prometheus -A -o jsonpath='{.items[*].spec.ruleSelector}'`
 
-# 2. (Optional) Apply gateway recording if you use Higress
+Raw apply (only when `ruleSelector` is empty `{}`):
+
+```bash
+# 1. vLLM: common (shared metrics, auto-attributes engine) + version file(s).
+#    On a mixed V0+V1 fleet, apply common + BOTH version files.
+kubectl apply -f recording/engines/vllm-common.yaml -n monitoring
+kubectl apply -f recording/engines/vllm-v1.yaml -n monitoring   # and/or vllm-v0.yaml
+
+# 2. (Optional) Gateway recording if you use Higress
 kubectl apply -f recording/gateway/higress.yaml -n monitoring
 
-# 3. Apply accelerator recording (safe regardless of vendor)
+# 3. Accelerator recording (safe regardless of vendor)
 kubectl apply -f recording/accelerator/accelerator.yaml -n monitoring
 
-# 4. Apply all four alert files
+# 4. Alert files
 kubectl apply -f alerts/ -n monitoring
 ```
 
-The namespace `monitoring` is the kube-prometheus-stack default; adjust
-to wherever your Prometheus instance reads PrometheusRule from
-(check `Prometheus.spec.ruleSelector` + `ruleNamespaceSelector` on
-your `Prometheus` resource).
+`ruleNamespaceSelector` on the `Prometheus` resource controls which
+namespaces are searched (often `{}` = all); the `monitoring` namespace
+above is just an example.
 
 ## Prerequisites
 

--- a/deploy/k8s/prometheus-rules/alerts/accelerator.yaml
+++ b/deploy/k8s/prometheus-rules/alerts/accelerator.yaml
@@ -1,6 +1,6 @@
 # PrometheusRule: Accelerator (GPU/NPU) alerts
 #
-# Queries `modeldoctor:accelerator:*` only — vendor-agnostic.
+# Queries `infer:accelerator:*` only — vendor-agnostic.
 # Distinguishes NVIDIA vs Ascend via the `device_kind` label.
 #
 # Scenario covered (per survey §8):
@@ -19,7 +19,7 @@ spec:
     - name: modeldoctor.alerts.accelerator
       rules:
         - alert: ModelDoctorAcceleratorUnhealthy
-          expr: modeldoctor:accelerator:health_status == 0
+          expr: infer:accelerator:health_status == 0
           for: 2m
           labels:
             severity: critical
@@ -33,7 +33,7 @@ spec:
             modeldoctor_required_context: "accelerator:error_total, accelerator:temperature_celsius"
 
         - alert: ModelDoctorAcceleratorTempHigh
-          expr: modeldoctor:accelerator:temperature_celsius > 85
+          expr: infer:accelerator:temperature_celsius > 85
           for: 5m
           labels:
             severity: warning
@@ -48,7 +48,7 @@ spec:
         - alert: ModelDoctorAcceleratorTempCritical
           # NVIDIA H100 throttle is ~87°C; A100 ~85°C; Ascend 910B ~85°C.
           # 95° is a conservative critical line — adjust per device class.
-          expr: modeldoctor:accelerator:temperature_celsius > 95
+          expr: infer:accelerator:temperature_celsius > 95
           for: 1m
           labels:
             severity: critical
@@ -60,7 +60,7 @@ spec:
               cooling and consider draining workloads from this node.
 
         - alert: ModelDoctorAcceleratorMemoryHigh
-          expr: modeldoctor:accelerator:memory_usage_ratio > 0.95
+          expr: infer:accelerator:memory_usage_ratio > 0.95
           for: 5m
           labels:
             severity: warning
@@ -72,7 +72,7 @@ spec:
               KV cache will start evicting; OOM imminent if load grows.
 
         - alert: ModelDoctorAcceleratorErrors
-          expr: increase(modeldoctor:accelerator:error_total[5m]) > 0
+          expr: increase(infer:accelerator:error_total[5m]) > 0
           for: 1m
           labels:
             severity: warning

--- a/deploy/k8s/prometheus-rules/alerts/cache.yaml
+++ b/deploy/k8s/prometheus-rules/alerts/cache.yaml
@@ -1,6 +1,6 @@
 # PrometheusRule: KV cache + prefix cache alerts
 #
-# Queries `modeldoctor:cache:*` only — engine-agnostic.
+# Queries `infer:cache:*` only — engine-agnostic.
 # TGI and SGLang-without-prefix-cache will naturally produce empty
 # series and these alerts stay silent for those engines.
 #
@@ -21,7 +21,7 @@ spec:
     - name: modeldoctor.alerts.cache
       rules:
         - alert: ModelDoctorKvCacheHigh
-          expr: modeldoctor:cache:kv_usage_ratio > 0.85
+          expr: infer:cache:kv_usage_ratio > 0.85
           for: 5m
           labels:
             severity: warning
@@ -35,7 +35,7 @@ spec:
             modeldoctor_required_context: "request:ttft_seconds, request:preempted_total"
 
         - alert: ModelDoctorKvCacheCritical
-          expr: modeldoctor:cache:kv_usage_ratio > 0.95
+          expr: infer:cache:kv_usage_ratio > 0.95
           for: 1m
           labels:
             severity: critical
@@ -51,9 +51,9 @@ spec:
           # Drops below 30% hit rate AND there's meaningful traffic.
           # Without the rate guard, idle systems trip this trivially.
           expr: |
-            modeldoctor:cache:prefix_hit_ratio < 0.3
+            infer:cache:prefix_hit_ratio < 0.3
             and on (engine, model_name, instance)
-            rate(modeldoctor:throughput:prompt_tokens_total[5m]) > 10
+            rate(infer:throughput:prompt_tokens_total[5m]) > 10
           for: 10m
           labels:
             severity: info

--- a/deploy/k8s/prometheus-rules/alerts/gateway-consumer.yaml
+++ b/deploy/k8s/prometheus-rules/alerts/gateway-consumer.yaml
@@ -24,8 +24,7 @@ spec:
           # for 10 minutes = noisy neighbor.
           expr: |
             infer:gateway:input_tokens_rate
-            /
-            ignoring (ai_consumer) group_left
+            / on (ai_route, ai_cluster, ai_model) group_left
             sum by (ai_route, ai_cluster, ai_model) (infer:gateway:input_tokens_rate)
             > 0.7
           for: 10m
@@ -47,7 +46,7 @@ spec:
           # (long context, no prefix cache hit).
           expr: |
             infer:gateway:ttft_seconds:avg
-            >
+            > on (ai_route, ai_cluster, ai_model) group_left
             (avg by (ai_route, ai_cluster, ai_model) (infer:gateway:ttft_seconds:avg)) * 2
             and
             infer:gateway:ttft_seconds:avg > 2

--- a/deploy/k8s/prometheus-rules/alerts/gateway-consumer.yaml
+++ b/deploy/k8s/prometheus-rules/alerts/gateway-consumer.yaml
@@ -1,6 +1,6 @@
 # PrometheusRule: Gateway / multi-tenant alerts
 #
-# Queries `modeldoctor:gateway:*` only — Higress-sourced. This is the
+# Queries `infer:gateway:*` only — Higress-sourced. This is the
 # only layer that knows ai_consumer (tenant / API key) identity, so
 # tenant-isolation alerts must live here.
 #
@@ -23,10 +23,10 @@ spec:
           # A single consumer driving > 70% of input tokens on a model
           # for 10 minutes = noisy neighbor.
           expr: |
-            modeldoctor:gateway:input_tokens_rate
+            infer:gateway:input_tokens_rate
             /
             ignoring (ai_consumer) group_left
-            sum by (ai_route, ai_cluster, ai_model) (modeldoctor:gateway:input_tokens_rate)
+            sum by (ai_route, ai_cluster, ai_model) (infer:gateway:input_tokens_rate)
             > 0.7
           for: 10m
           labels:
@@ -46,11 +46,11 @@ spec:
           # model are fine = likely consumer-specific prompt pattern
           # (long context, no prefix cache hit).
           expr: |
-            modeldoctor:gateway:ttft_seconds:avg
+            infer:gateway:ttft_seconds:avg
             >
-            (avg by (ai_route, ai_cluster, ai_model) (modeldoctor:gateway:ttft_seconds:avg)) * 2
+            (avg by (ai_route, ai_cluster, ai_model) (infer:gateway:ttft_seconds:avg)) * 2
             and
-            modeldoctor:gateway:ttft_seconds:avg > 2
+            infer:gateway:ttft_seconds:avg > 2
           for: 10m
           labels:
             severity: info

--- a/deploy/k8s/prometheus-rules/alerts/request-slo.yaml
+++ b/deploy/k8s/prometheus-rules/alerts/request-slo.yaml
@@ -1,6 +1,6 @@
 # PrometheusRule: Request-level SLO alerts
 #
-# Queries the normalized `modeldoctor:request:*` namespace ONLY — engine-
+# Queries the normalized `infer:request:*` namespace ONLY — engine-
 # agnostic. As long as at least one recording rule (vllm-v0 / vllm-v1 /
 # sglang-* / tgi) is applied, these alerts will fire correctly. If no
 # engine recording rule is applied, the underlying series are simply
@@ -27,7 +27,7 @@ spec:
     - name: modeldoctor.alerts.request-slo
       rules:
         - alert: ModelDoctorTtftP99High
-          expr: modeldoctor:request:ttft_seconds:p99 > 5
+          expr: infer:request:ttft_seconds:p99 > 5
           for: 5m
           labels:
             severity: warning
@@ -42,7 +42,7 @@ spec:
             modeldoctor_required_context: "kv_usage_ratio, request:waiting, request:preempted_total"
 
         - alert: ModelDoctorTtftP99Critical
-          expr: modeldoctor:request:ttft_seconds:p99 > 15
+          expr: infer:request:ttft_seconds:p99 > 15
           for: 2m
           labels:
             severity: critical
@@ -55,7 +55,7 @@ spec:
               dependency degraded.
 
         - alert: ModelDoctorQueueBacklog
-          expr: modeldoctor:request:waiting > 50
+          expr: infer:request:waiting > 50
           for: 5m
           labels:
             severity: warning
@@ -71,9 +71,9 @@ spec:
           # engine is hung or completely idle. AI layer can disambiguate
           # by checking external traffic counters.
           expr: |
-            (modeldoctor:request:running == 0)
+            (infer:request:running == 0)
             and on (engine, model_name, instance)
-            (rate(modeldoctor:throughput:generation_tokens_total[10m]) == 0)
+            (rate(infer:throughput:generation_tokens_total[10m]) == 0)
           for: 10m
           labels:
             severity: warning
@@ -86,7 +86,7 @@ spec:
               the engine is hung. Cross-check with gateway QPS.
 
         - alert: ModelDoctorPreemptionStorm
-          expr: rate(modeldoctor:request:preempted_total[5m]) > 0.1
+          expr: rate(infer:request:preempted_total[5m]) > 0.1
           for: 5m
           labels:
             severity: warning

--- a/deploy/k8s/prometheus-rules/kustomization.yaml
+++ b/deploy/k8s/prometheus-rules/kustomization.yaml
@@ -1,0 +1,38 @@
+# Deploy-time overlay: stamp the label kube-prometheus-stack's
+# Prometheus.spec.ruleSelector requires ({release: prometheus}) WITHOUT
+# polluting the engine-neutral base rule files.
+#
+# Edit `release: <value>` to match your cluster's
+# `kubectl -n <ns> get prometheus -o jsonpath='{.items[*].spec.ruleSelector}'`.
+#
+# This set is recording-only (produces infer:* series). Add alerts/*.yaml
+# below once Alertmanager routing to ModelDoctor's webhook is configured.
+#
+# Apply:  kubectl apply -k deploy/k8s/prometheus-rules/
+# Remove: kubectl delete -k deploy/k8s/prometheus-rules/
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# ruleNamespaceSelector on the healthy Prometheus is {} (any namespace),
+# so landing them next to the stack is just tidy, not required.
+namespace: prometheus
+
+# `labels` (not `commonLabels`) with includeSelectors:false → adds to
+# metadata.labels only. Safe to extend this kustomization with
+# ServiceMonitors later without corrupting their selectors.
+labels:
+  - pairs:
+      release: prometheus
+    includeSelectors: false
+
+resources:
+  # vLLM common (shared metrics; auto-attributes engine per instance via the
+  # kv_cache_usage_perc / gpu_cache_usage_perc discriminator). Apply always.
+  - recording/engines/vllm-common.yaml
+  # Version-SPECIFIC metrics. 4pd runs mixed V0+V1, and these files now only
+  # define version-exclusive raw names, so applying BOTH is safe (no overlap).
+  - recording/engines/vllm-v0.yaml
+  - recording/engines/vllm-v1.yaml
+  # DCGM is scraped; NVIDIA branch populates. NPU branch stays empty until
+  # npu-exporter is scraped into this Prometheus.
+  - recording/accelerator/accelerator.yaml

--- a/deploy/k8s/prometheus-rules/recording/accelerator/accelerator.yaml
+++ b/deploy/k8s/prometheus-rules/recording/accelerator/accelerator.yaml
@@ -2,7 +2,7 @@
 #
 # Normalizes hardware metrics from both NVIDIA GPUs (via DCGM Exporter)
 # and Huawei Ascend NPUs (via npu-exporter) into a single
-# `modeldoctor:accelerator:*` namespace, distinguished by the
+# `infer:accelerator:*` namespace, distinguished by the
 # `device_kind` label:
 #   - device_kind="nvidia"  → sourced from DCGM_FI_*
 #   - device_kind="ascend"  → sourced from npu_chip_info_*
@@ -12,7 +12,7 @@
 # pure-NVIDIA cluster will simply leave the Ascend rules silent.
 #
 # We deliberately do not produce engine-level alerts in this file —
-# alerts that query `modeldoctor:accelerator:*` live in
+# alerts that query `infer:accelerator:*` live in
 # alerts/accelerator.yaml.
 
 apiVersion: monitoring.coreos.com/v1
@@ -28,37 +28,37 @@ spec:
     - name: modeldoctor.accelerator.nvidia
       interval: 30s
       rules:
-        - record: modeldoctor:accelerator:utilization_ratio
+        - record: infer:accelerator:utilization_ratio
           expr: DCGM_FI_DEV_GPU_UTIL / 100
           labels:
             device_kind: nvidia
-        - record: modeldoctor:accelerator:memory_used_bytes
+        - record: infer:accelerator:memory_used_bytes
           # DCGM reports MiB; convert to bytes.
           expr: DCGM_FI_DEV_FB_USED * 1024 * 1024
           labels:
             device_kind: nvidia
-        - record: modeldoctor:accelerator:memory_total_bytes
+        - record: infer:accelerator:memory_total_bytes
           expr: DCGM_FI_DEV_FB_TOTAL * 1024 * 1024
           labels:
             device_kind: nvidia
-        - record: modeldoctor:accelerator:memory_usage_ratio
+        - record: infer:accelerator:memory_usage_ratio
           expr: DCGM_FI_DEV_FB_USED / clamp_min(DCGM_FI_DEV_FB_TOTAL, 1)
           labels:
             device_kind: nvidia
-        - record: modeldoctor:accelerator:temperature_celsius
+        - record: infer:accelerator:temperature_celsius
           expr: DCGM_FI_DEV_GPU_TEMP
           labels:
             device_kind: nvidia
-        - record: modeldoctor:accelerator:power_watts
+        - record: infer:accelerator:power_watts
           expr: DCGM_FI_DEV_POWER_USAGE
           labels:
             device_kind: nvidia
         # Health = 1 when no XID errors in the last 5m, else 0.
-        - record: modeldoctor:accelerator:health_status
+        - record: infer:accelerator:health_status
           expr: (increase(DCGM_FI_DEV_XID_ERRORS[5m]) == bool 0)
           labels:
             device_kind: nvidia
-        - record: modeldoctor:accelerator:error_total
+        - record: infer:accelerator:error_total
           expr: DCGM_FI_DEV_XID_ERRORS
           labels:
             device_kind: nvidia
@@ -66,36 +66,36 @@ spec:
     - name: modeldoctor.accelerator.ascend
       interval: 30s
       rules:
-        - record: modeldoctor:accelerator:utilization_ratio
+        - record: infer:accelerator:utilization_ratio
           expr: npu_chip_info_utilization / 100
           labels:
             device_kind: ascend
-        - record: modeldoctor:accelerator:memory_used_bytes
+        - record: infer:accelerator:memory_used_bytes
           # npu-exporter reports DDR in MB; convert to bytes (1 MB = 1024*1024).
           expr: npu_chip_info_used_memory * 1024 * 1024
           labels:
             device_kind: ascend
-        - record: modeldoctor:accelerator:memory_total_bytes
+        - record: infer:accelerator:memory_total_bytes
           expr: npu_chip_info_total_memory * 1024 * 1024
           labels:
             device_kind: ascend
-        - record: modeldoctor:accelerator:memory_usage_ratio
+        - record: infer:accelerator:memory_usage_ratio
           expr: npu_chip_info_used_memory / clamp_min(npu_chip_info_total_memory, 1)
           labels:
             device_kind: ascend
-        - record: modeldoctor:accelerator:temperature_celsius
+        - record: infer:accelerator:temperature_celsius
           expr: npu_chip_info_temperature
           labels:
             device_kind: ascend
-        - record: modeldoctor:accelerator:power_watts
+        - record: infer:accelerator:power_watts
           expr: npu_chip_info_power
           labels:
             device_kind: ascend
-        - record: modeldoctor:accelerator:health_status
+        - record: infer:accelerator:health_status
           expr: npu_chip_info_health_status
           labels:
             device_kind: ascend
-        - record: modeldoctor:accelerator:error_total
+        - record: infer:accelerator:error_total
           expr: npu_chip_info_error_code != bool 0
           labels:
             device_kind: ascend

--- a/deploy/k8s/prometheus-rules/recording/engines/sglang-legacy.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/sglang-legacy.yaml
@@ -46,15 +46,15 @@ spec:
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(sglang:time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
-        - record: infer:request:itl_seconds:p50
+        - record: infer:request:tpot_seconds:p50
           expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(sglang:time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
-        - record: infer:request:itl_seconds:p95
+        - record: infer:request:tpot_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(sglang:time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
-        - record: infer:request:itl_seconds:p99
+        - record: infer:request:tpot_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(sglang:time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy

--- a/deploy/k8s/prometheus-rules/recording/engines/sglang-legacy.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/sglang-legacy.yaml
@@ -26,43 +26,43 @@ spec:
     - name: modeldoctor.sglang-legacy.request
       interval: 30s
       rules:
-        - record: modeldoctor:request:running
+        - record: infer:request:running
           expr: sglang:num_running_reqs
           labels:
             engine: sglang-legacy
-        - record: modeldoctor:request:waiting
+        - record: infer:request:waiting
           expr: sglang:num_queue_reqs
           labels:
             engine: sglang-legacy
-        - record: modeldoctor:request:ttft_seconds:p50
+        - record: infer:request:ttft_seconds:p50
           expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(sglang:time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
-        - record: modeldoctor:request:ttft_seconds:p95
+        - record: infer:request:ttft_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(sglang:time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
-        - record: modeldoctor:request:ttft_seconds:p99
+        - record: infer:request:ttft_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(sglang:time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
-        - record: modeldoctor:request:itl_seconds:p50
+        - record: infer:request:itl_seconds:p50
           expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(sglang:time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
-        - record: modeldoctor:request:itl_seconds:p95
+        - record: infer:request:itl_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(sglang:time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
-        - record: modeldoctor:request:itl_seconds:p99
+        - record: infer:request:itl_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(sglang:time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
-        - record: modeldoctor:request:e2e_seconds:p95
+        - record: infer:request:e2e_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(sglang:e2e_request_latency_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
-        - record: modeldoctor:request:e2e_seconds:p99
+        - record: infer:request:e2e_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(sglang:e2e_request_latency_seconds_bucket[5m])))
           labels:
             engine: sglang-legacy
@@ -70,15 +70,15 @@ spec:
     - name: modeldoctor.sglang-legacy.throughput
       interval: 30s
       rules:
-        - record: modeldoctor:throughput:prompt_tokens_total
+        - record: infer:throughput:prompt_tokens_total
           expr: sglang:prompt_tokens_total
           labels:
             engine: sglang-legacy
-        - record: modeldoctor:throughput:generation_tokens_total
+        - record: infer:throughput:generation_tokens_total
           expr: sglang:generation_tokens_total
           labels:
             engine: sglang-legacy
-        - record: modeldoctor:throughput:generation_rate_tps
+        - record: infer:throughput:generation_rate_tps
           expr: sglang:gen_throughput
           labels:
             engine: sglang-legacy
@@ -86,11 +86,11 @@ spec:
     - name: modeldoctor.sglang-legacy.cache
       interval: 30s
       rules:
-        - record: modeldoctor:cache:kv_usage_ratio
+        - record: infer:cache:kv_usage_ratio
           expr: sglang:token_usage
           labels:
             engine: sglang-legacy
-        - record: modeldoctor:cache:prefix_hit_ratio
+        - record: infer:cache:prefix_hit_ratio
           expr: sglang:cache_hit_rate
           labels:
             engine: sglang-legacy

--- a/deploy/k8s/prometheus-rules/recording/engines/sglang-v0.5.4plus.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/sglang-v0.5.4plus.yaml
@@ -21,43 +21,43 @@ spec:
     - name: modeldoctor.sglang-v0-5-4plus.request
       interval: 30s
       rules:
-        - record: modeldoctor:request:running
+        - record: infer:request:running
           expr: sglang_num_running_reqs
           labels:
             engine: sglang-v0.5.4plus
-        - record: modeldoctor:request:waiting
+        - record: infer:request:waiting
           expr: sglang_num_queue_reqs
           labels:
             engine: sglang-v0.5.4plus
-        - record: modeldoctor:request:ttft_seconds:p50
+        - record: infer:request:ttft_seconds:p50
           expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(sglang_time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
-        - record: modeldoctor:request:ttft_seconds:p95
+        - record: infer:request:ttft_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(sglang_time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
-        - record: modeldoctor:request:ttft_seconds:p99
+        - record: infer:request:ttft_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(sglang_time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
-        - record: modeldoctor:request:itl_seconds:p50
+        - record: infer:request:itl_seconds:p50
           expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(sglang_time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
-        - record: modeldoctor:request:itl_seconds:p95
+        - record: infer:request:itl_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(sglang_time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
-        - record: modeldoctor:request:itl_seconds:p99
+        - record: infer:request:itl_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(sglang_time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
-        - record: modeldoctor:request:e2e_seconds:p95
+        - record: infer:request:e2e_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(sglang_e2e_request_latency_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
-        - record: modeldoctor:request:e2e_seconds:p99
+        - record: infer:request:e2e_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(sglang_e2e_request_latency_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
@@ -65,15 +65,15 @@ spec:
     - name: modeldoctor.sglang-v0-5-4plus.throughput
       interval: 30s
       rules:
-        - record: modeldoctor:throughput:prompt_tokens_total
+        - record: infer:throughput:prompt_tokens_total
           expr: sglang_prompt_tokens_total
           labels:
             engine: sglang-v0.5.4plus
-        - record: modeldoctor:throughput:generation_tokens_total
+        - record: infer:throughput:generation_tokens_total
           expr: sglang_generation_tokens_total
           labels:
             engine: sglang-v0.5.4plus
-        - record: modeldoctor:throughput:generation_rate_tps
+        - record: infer:throughput:generation_rate_tps
           expr: sglang_gen_throughput
           labels:
             engine: sglang-v0.5.4plus
@@ -81,11 +81,11 @@ spec:
     - name: modeldoctor.sglang-v0-5-4plus.cache
       interval: 30s
       rules:
-        - record: modeldoctor:cache:kv_usage_ratio
+        - record: infer:cache:kv_usage_ratio
           expr: sglang_token_usage
           labels:
             engine: sglang-v0.5.4plus
-        - record: modeldoctor:cache:prefix_hit_ratio
+        - record: infer:cache:prefix_hit_ratio
           expr: sglang_cache_hit_rate
           labels:
             engine: sglang-v0.5.4plus

--- a/deploy/k8s/prometheus-rules/recording/engines/sglang-v0.5.4plus.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/sglang-v0.5.4plus.yaml
@@ -41,15 +41,15 @@ spec:
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(sglang_time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
-        - record: infer:request:itl_seconds:p50
+        - record: infer:request:tpot_seconds:p50
           expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(sglang_time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
-        - record: infer:request:itl_seconds:p95
+        - record: infer:request:tpot_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(sglang_time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus
-        - record: infer:request:itl_seconds:p99
+        - record: infer:request:tpot_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(sglang_time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: sglang-v0.5.4plus

--- a/deploy/k8s/prometheus-rules/recording/engines/tgi.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/tgi.yaml
@@ -1,13 +1,13 @@
 # PrometheusRule: TGI (Text Generation Inference) 1.x / 2.x
 #
-# Normalizes TGI raw metrics into the `modeldoctor:*` namespace.
+# Normalizes TGI raw metrics into the `infer:*` namespace.
 # Hard-coded label `engine="tgi"` is injected on every recorded metric.
 #
 # TGI quirks (see docs/superpowers/research/2026-05-15-inference-engine-metrics-survey.md §3):
 # - No native TTFT metric. We derive it from queue_duration + prefill
 #   forward duration. This is an approximation — for strict SLO use a
 #   client-side probe.
-# - No KV cache utilization metric. The `modeldoctor:cache:*` namespace
+# - No KV cache utilization metric. The `infer:cache:*` namespace
 #   stays empty for TGI (PagedAttention is internal black-box).
 # - The metric for ITL is `tgi_request_mean_time_per_token_duration`
 #   (a histogram of per-request average), not strict inter-token timing.
@@ -26,48 +26,48 @@ spec:
     - name: modeldoctor.tgi.request
       interval: 30s
       rules:
-        - record: modeldoctor:request:running
+        - record: infer:request:running
           expr: tgi_batch_current_size
           labels:
             engine: tgi
-        - record: modeldoctor:request:waiting
+        - record: infer:request:waiting
           expr: tgi_queue_size
           labels:
             engine: tgi
         # Derived TTFT: queue + prefill forward.
         # tgi_batch_forward_duration has a `stage` label distinguishing
         # "prefill" vs "decode".
-        - record: modeldoctor:request:ttft_seconds:p95
+        - record: infer:request:ttft_seconds:p95
           expr: |
             histogram_quantile(0.95, sum by (le, model_name, instance) (rate(tgi_request_queue_duration_bucket[5m])))
             +
             histogram_quantile(0.95, sum by (le, model_name, instance) (rate(tgi_batch_forward_duration_bucket{stage="prefill"}[5m])))
           labels:
             engine: tgi
-        - record: modeldoctor:request:ttft_seconds:p99
+        - record: infer:request:ttft_seconds:p99
           expr: |
             histogram_quantile(0.99, sum by (le, model_name, instance) (rate(tgi_request_queue_duration_bucket[5m])))
             +
             histogram_quantile(0.99, sum by (le, model_name, instance) (rate(tgi_batch_forward_duration_bucket{stage="prefill"}[5m])))
           labels:
             engine: tgi
-        - record: modeldoctor:request:itl_seconds:p95
+        - record: infer:request:itl_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(tgi_request_mean_time_per_token_duration_bucket[5m])))
           labels:
             engine: tgi
-        - record: modeldoctor:request:itl_seconds:p99
+        - record: infer:request:itl_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(tgi_request_mean_time_per_token_duration_bucket[5m])))
           labels:
             engine: tgi
-        - record: modeldoctor:request:e2e_seconds:p95
+        - record: infer:request:e2e_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(tgi_request_duration_bucket[5m])))
           labels:
             engine: tgi
-        - record: modeldoctor:request:e2e_seconds:p99
+        - record: infer:request:e2e_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(tgi_request_duration_bucket[5m])))
           labels:
             engine: tgi
-        - record: modeldoctor:request:queue_seconds:p95
+        - record: infer:request:queue_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(tgi_request_queue_duration_bucket[5m])))
           labels:
             engine: tgi
@@ -75,15 +75,15 @@ spec:
     - name: modeldoctor.tgi.throughput
       interval: 30s
       rules:
-        - record: modeldoctor:throughput:prompt_tokens_total
+        - record: infer:throughput:prompt_tokens_total
           expr: sum by (model_name, instance)(tgi_request_input_length_sum)
           labels:
             engine: tgi
-        - record: modeldoctor:throughput:generation_tokens_total
+        - record: infer:throughput:generation_tokens_total
           expr: sum by (model_name, instance)(tgi_request_generated_tokens_sum)
           labels:
             engine: tgi
-        - record: modeldoctor:throughput:generation_rate_tps
+        - record: infer:throughput:generation_rate_tps
           expr: sum by (model_name, instance)(rate(tgi_request_generated_tokens_sum[1m]))
           labels:
             engine: tgi

--- a/deploy/k8s/prometheus-rules/recording/engines/tgi.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/tgi.yaml
@@ -9,7 +9,7 @@
 #   client-side probe.
 # - No KV cache utilization metric. The `infer:cache:*` namespace
 #   stays empty for TGI (PagedAttention is internal black-box).
-# - The metric for ITL is `tgi_request_mean_time_per_token_duration`
+# - The metric for TPOT/ITL is `tgi_request_mean_time_per_token_duration`
 #   (a histogram of per-request average), not strict inter-token timing.
 
 apiVersion: monitoring.coreos.com/v1
@@ -51,11 +51,11 @@ spec:
             histogram_quantile(0.99, sum by (le, model_name, instance) (rate(tgi_batch_forward_duration_bucket{stage="prefill"}[5m])))
           labels:
             engine: tgi
-        - record: infer:request:itl_seconds:p95
+        - record: infer:request:tpot_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(tgi_request_mean_time_per_token_duration_bucket[5m])))
           labels:
             engine: tgi
-        - record: infer:request:itl_seconds:p99
+        - record: infer:request:tpot_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(tgi_request_mean_time_per_token_duration_bucket[5m])))
           labels:
             engine: tgi

--- a/deploy/k8s/prometheus-rules/recording/engines/vllm-common.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/vllm-common.yaml
@@ -1,0 +1,119 @@
+# PrometheusRule: vLLM common (version-agnostic) recording rules
+#
+# These normalize the vLLM metrics whose RAW NAME is identical across V0
+# and V1 (num_requests_*, num_preemptions, time_to_first_token,
+# e2e_request_latency, request_queue_time, prompt/generation_tokens).
+# Because the names are shared, a per-version file cannot own them without
+# double-counting on a mixed (V0+V1) fleet. They live here ONCE and get
+# their `engine` label attached PER INSTANCE via a join with
+# infer:meta:engine_id.
+#
+# infer:meta:engine_id is a value-1 identity series, one per
+# (instance, model_name), tagged with the detected vLLM major version.
+# The version is detected NON-INVASIVELY (no scrape/pod-label changes)
+# from a version-EXCLUSIVE, always-emitted gauge:
+#   - vllm:kv_cache_usage_perc  exists ONLY on V1  -> engine=vllm-v1
+#   - vllm:gpu_cache_usage_perc exists ONLY on V0  -> engine=vllm-v0
+# (V1 renamed gpu_cache_usage_perc -> kv_cache_usage_perc, so the two are
+# mutually exclusive: an instance matches exactly one.)
+#
+# Apply this file whenever ANY vLLM (V0 and/or V1) is present, together
+# with vllm-v0.yaml / vllm-v1.yaml (which carry the version-SPECIFIC
+# metrics). On a mixed fleet, apply BOTH version files — they only define
+# version-exclusive raw names, so no double-counting.
+#
+# Caveats:
+# - Instances we cannot version-identify (no discriminator gauge) are
+#   fail-closed: they produce no infer:* here.
+# - If a future vLLM major renames the discriminator gauge again, add a
+#   new engine_id line (version-is-engine maintenance).
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: modeldoctor-vllm-common
+  labels:
+    app.kubernetes.io/name: modeldoctor
+    app.kubernetes.io/component: prometheus-rules
+    modeldoctor.io/engine: vllm-common
+    modeldoctor.io/kind: recording
+spec:
+  groups:
+    # Single group: infer:meta:engine_id is defined FIRST so the joins
+    # below observe it within the same evaluation cycle (Prometheus
+    # evaluates the rules of a group sequentially, in order).
+    - name: modeldoctor.vllm-common.recording
+      interval: 30s
+      rules:
+        # --- per-instance version identity (non-invasive discriminator) ---
+        - record: infer:meta:engine_id
+          expr: group by (instance, model_name) (vllm:kv_cache_usage_perc)
+          labels:
+            engine: vllm-v1
+        - record: infer:meta:engine_id
+          expr: group by (instance, model_name) (vllm:gpu_cache_usage_perc)
+          labels:
+            engine: vllm-v0
+
+        # --- request lifecycle (shared raw names) ---
+        # sum by (instance, model_name) strips the source `engine="0"`
+        # (vLLM's engine-index label) and pod/container clutter so the
+        # group_left(engine) join has no label collision; the normalized
+        # identity is (instance, model_name, engine).
+        - record: infer:request:running
+          expr: |
+            sum by (instance, model_name) (vllm:num_requests_running)
+            * on (instance, model_name) group_left (engine) infer:meta:engine_id
+        - record: infer:request:waiting
+          expr: |
+            sum by (instance, model_name) (vllm:num_requests_waiting)
+            * on (instance, model_name) group_left (engine) infer:meta:engine_id
+        # swapped: V0-only in practice, but kept here (joined) so that if a
+        # V1 build ever emits it, it is attributed correctly rather than
+        # mislabeled vllm-v0.
+        - record: infer:request:swapped
+          expr: |
+            sum by (instance, model_name) (vllm:num_requests_swapped)
+            * on (instance, model_name) group_left (engine) infer:meta:engine_id
+        - record: infer:request:preempted_total
+          expr: |
+            sum by (instance, model_name) (vllm:num_preemptions_total)
+            * on (instance, model_name) group_left (engine) infer:meta:engine_id
+        - record: infer:request:ttft_seconds:p50
+          expr: |
+            histogram_quantile(0.50, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
+            * on (instance, model_name) group_left (engine) infer:meta:engine_id
+        - record: infer:request:ttft_seconds:p95
+          expr: |
+            histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
+            * on (instance, model_name) group_left (engine) infer:meta:engine_id
+        - record: infer:request:ttft_seconds:p99
+          expr: |
+            histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
+            * on (instance, model_name) group_left (engine) infer:meta:engine_id
+        - record: infer:request:e2e_seconds:p95
+          expr: |
+            histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:e2e_request_latency_seconds_bucket[5m])))
+            * on (instance, model_name) group_left (engine) infer:meta:engine_id
+        - record: infer:request:e2e_seconds:p99
+          expr: |
+            histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:e2e_request_latency_seconds_bucket[5m])))
+            * on (instance, model_name) group_left (engine) infer:meta:engine_id
+        - record: infer:request:queue_seconds:p95
+          expr: |
+            histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:request_queue_time_seconds_bucket[5m])))
+            * on (instance, model_name) group_left (engine) infer:meta:engine_id
+
+        # --- throughput (shared raw names) ---
+        - record: infer:throughput:prompt_tokens_total
+          expr: |
+            sum by (instance, model_name) (vllm:prompt_tokens_total)
+            * on (instance, model_name) group_left (engine) infer:meta:engine_id
+        - record: infer:throughput:generation_tokens_total
+          expr: |
+            sum by (instance, model_name) (vllm:generation_tokens_total)
+            * on (instance, model_name) group_left (engine) infer:meta:engine_id
+        - record: infer:throughput:generation_rate_tps
+          expr: |
+            sum by (model_name, instance) (rate(vllm:generation_tokens_total[1m]))
+            * on (instance, model_name) group_left (engine) infer:meta:engine_id

--- a/deploy/k8s/prometheus-rules/recording/engines/vllm-common.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/vllm-common.yaml
@@ -14,8 +14,10 @@
 # from a version-EXCLUSIVE, always-emitted gauge:
 #   - vllm:kv_cache_usage_perc  exists ONLY on V1  -> engine=vllm-v1
 #   - vllm:gpu_cache_usage_perc exists ONLY on V0  -> engine=vllm-v0
-# (V1 renamed gpu_cache_usage_perc -> kv_cache_usage_perc, so the two are
-# mutually exclusive: an instance matches exactly one.)
+# (V1 renamed gpu_cache_usage_perc -> kv_cache_usage_perc. Some vLLM builds
+# keep gpu_* as a DEPRECATED ALIAS, so the two are NOT naturally exclusive:
+# V0 is defined as gpu_* present AND kv_* absent (see the engine_id rules),
+# giving exactly one identity per instance. Presence of the V1 name wins.)
 #
 # Apply this file whenever ANY vLLM (V0 and/or V1) is present, together
 # with vllm-v0.yaml / vllm-v1.yaml (which carry the version-SPECIFIC
@@ -50,8 +52,15 @@ spec:
           expr: group by (instance, model_name) (vllm:kv_cache_usage_perc)
           labels:
             engine: vllm-v1
+        # V0 = has gpu_cache_usage_perc AND NOT kv_cache_usage_perc. The
+        # `unless` makes V1 win when a build dual-emits both names, so each
+        # instance gets exactly one engine_id (else the group_left joins below
+        # error with "multiple matches" and produce nothing).
         - record: infer:meta:engine_id
-          expr: group by (instance, model_name) (vllm:gpu_cache_usage_perc)
+          expr: |
+            group by (instance, model_name) (vllm:gpu_cache_usage_perc)
+            unless
+            group by (instance, model_name) (vllm:kv_cache_usage_perc)
           labels:
             engine: vllm-v0
 

--- a/deploy/k8s/prometheus-rules/recording/engines/vllm-v0.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/vllm-v0.yaml
@@ -1,6 +1,6 @@
 # PrometheusRule: vLLM V0 (0.5.x – 0.6.x legacy engine)
 #
-# Normalizes vLLM V0 raw metrics into the `modeldoctor:*` namespace.
+# Normalizes vLLM V0 raw metrics into the `infer:*` namespace.
 # Apply ONLY when your inference workload is vLLM 0.5.x or 0.6.x.
 # For vLLM 0.7+ (V1 engine), apply vllm-v1.yaml instead — do not apply both.
 #
@@ -26,59 +26,59 @@ spec:
     - name: modeldoctor.vllm-v0.request
       interval: 30s
       rules:
-        - record: modeldoctor:request:running
+        - record: infer:request:running
           expr: vllm:num_requests_running
           labels:
             engine: vllm-v0
-        - record: modeldoctor:request:waiting
+        - record: infer:request:waiting
           expr: vllm:num_requests_waiting
           labels:
             engine: vllm-v0
-        - record: modeldoctor:request:swapped
+        - record: infer:request:swapped
           expr: vllm:num_requests_swapped
           labels:
             engine: vllm-v0
-        - record: modeldoctor:request:preempted_total
+        - record: infer:request:preempted_total
           expr: vllm:num_preemptions_total
           labels:
             engine: vllm-v0
         # TTFT P50 / P95 / P99 over 5m
-        - record: modeldoctor:request:ttft_seconds:p50
+        - record: infer:request:ttft_seconds:p50
           expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: vllm-v0
-        - record: modeldoctor:request:ttft_seconds:p95
+        - record: infer:request:ttft_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: vllm-v0
-        - record: modeldoctor:request:ttft_seconds:p99
+        - record: infer:request:ttft_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: vllm-v0
         # ITL (inter-token latency, i.e. TPOT)
-        - record: modeldoctor:request:itl_seconds:p50
+        - record: infer:request:itl_seconds:p50
           expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(vllm:time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: vllm-v0
-        - record: modeldoctor:request:itl_seconds:p95
+        - record: infer:request:itl_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: vllm-v0
-        - record: modeldoctor:request:itl_seconds:p99
+        - record: infer:request:itl_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: vllm-v0
         # E2E latency
-        - record: modeldoctor:request:e2e_seconds:p95
+        - record: infer:request:e2e_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:e2e_request_latency_seconds_bucket[5m])))
           labels:
             engine: vllm-v0
-        - record: modeldoctor:request:e2e_seconds:p99
+        - record: infer:request:e2e_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:e2e_request_latency_seconds_bucket[5m])))
           labels:
             engine: vllm-v0
         # Queue time
-        - record: modeldoctor:request:queue_seconds:p95
+        - record: infer:request:queue_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:request_queue_time_seconds_bucket[5m])))
           labels:
             engine: vllm-v0
@@ -86,15 +86,15 @@ spec:
     - name: modeldoctor.vllm-v0.throughput
       interval: 30s
       rules:
-        - record: modeldoctor:throughput:prompt_tokens_total
+        - record: infer:throughput:prompt_tokens_total
           expr: vllm:prompt_tokens_total
           labels:
             engine: vllm-v0
-        - record: modeldoctor:throughput:generation_tokens_total
+        - record: infer:throughput:generation_tokens_total
           expr: vllm:generation_tokens_total
           labels:
             engine: vllm-v0
-        - record: modeldoctor:throughput:generation_rate_tps
+        - record: infer:throughput:generation_rate_tps
           expr: sum by (model_name, instance) (rate(vllm:generation_tokens_total[1m]))
           labels:
             engine: vllm-v0
@@ -102,15 +102,15 @@ spec:
     - name: modeldoctor.vllm-v0.cache
       interval: 30s
       rules:
-        - record: modeldoctor:cache:kv_usage_ratio
+        - record: infer:cache:kv_usage_ratio
           expr: vllm:gpu_cache_usage_perc
           labels:
             engine: vllm-v0
-        - record: modeldoctor:cache:prefix_hit_ratio
+        - record: infer:cache:prefix_hit_ratio
           expr: vllm:gpu_prefix_cache_hit_rate
           labels:
             engine: vllm-v0
-        - record: modeldoctor:cache:swap_usage_ratio
+        - record: infer:cache:swap_usage_ratio
           expr: vllm:cpu_cache_usage_perc
           labels:
             engine: vllm-v0

--- a/deploy/k8s/prometheus-rules/recording/engines/vllm-v0.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/vllm-v0.yaml
@@ -1,16 +1,18 @@
 # PrometheusRule: vLLM V0 (0.5.x – 0.6.x legacy) — version-SPECIFIC metrics only
 #
-# Shared metrics (request lifecycle, throughput — same raw name as V1)
-# live in vllm-common.yaml, which attaches the engine label per instance
-# via a discriminator join. This file carries ONLY metrics whose RAW NAME
-# is unique to V0, so a static engine=vllm-v0 label is unambiguous and
-# safe even on a mixed (V0+V1) fleet — V1 pods do not expose these names.
+# Shared metrics (request lifecycle, throughput — same raw name as V1) live
+# in vllm-common.yaml, which attaches the engine label per instance via a
+# discriminator join. This file carries ONLY metrics whose raw name is
+# specific to V0.
 #
-# V0-specific raw names (vs V1):
-# - vllm:gpu_cache_usage_perc        (V1: vllm:kv_cache_usage_perc)
-# - vllm:time_per_output_token_seconds (V1: vllm:inter_token_latency_seconds)
-# - vllm:gpu_prefix_cache_hit_rate   (V1: prefix_cache_hits / _queries pair)
-# - vllm:cpu_cache_usage_perc        (removed in V1 — swap model changed)
+# IMPORTANT — deprecated-alias guard: some vLLM builds emit V0 metric names
+# (gpu_cache_usage_perc, time_per_output_token_seconds, …) as DEPRECATED
+# ALIASES even while running the V1 engine. So "V0 raw name present" does
+# NOT prove a V0 engine. Every rule here is gated with
+# `unless on (instance, model_name) vllm:kv_cache_usage_perc` — i.e. emit
+# only for instances that do NOT also expose the V1 cache metric. This keeps
+# V0 series off dual-emitting V1 instances (which vllm-v1.yaml owns) and
+# matches the engine_id discriminator in vllm-common.yaml (V1 wins).
 #
 # Apply alongside vllm-common.yaml whenever V0 is present.
 
@@ -30,15 +32,21 @@ spec:
       rules:
         # V0: time_per_output_token_seconds (V1 renamed to inter_token_latency)
         - record: infer:request:tpot_seconds:p50
-          expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(vllm:time_per_output_token_seconds_bucket[5m])))
+          expr: |
+            histogram_quantile(0.50, sum by (le, model_name, instance) (rate(vllm:time_per_output_token_seconds_bucket[5m])))
+            unless on (instance, model_name) vllm:kv_cache_usage_perc
           labels:
             engine: vllm-v0
         - record: infer:request:tpot_seconds:p95
-          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:time_per_output_token_seconds_bucket[5m])))
+          expr: |
+            histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:time_per_output_token_seconds_bucket[5m])))
+            unless on (instance, model_name) vllm:kv_cache_usage_perc
           labels:
             engine: vllm-v0
         - record: infer:request:tpot_seconds:p99
-          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:time_per_output_token_seconds_bucket[5m])))
+          expr: |
+            histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:time_per_output_token_seconds_bucket[5m])))
+            unless on (instance, model_name) vllm:kv_cache_usage_perc
           labels:
             engine: vllm-v0
 
@@ -46,14 +54,20 @@ spec:
       interval: 30s
       rules:
         - record: infer:cache:kv_usage_ratio
-          expr: vllm:gpu_cache_usage_perc
+          expr: |
+            vllm:gpu_cache_usage_perc
+            unless on (instance, model_name) vllm:kv_cache_usage_perc
           labels:
             engine: vllm-v0
         - record: infer:cache:prefix_hit_ratio
-          expr: vllm:gpu_prefix_cache_hit_rate
+          expr: |
+            vllm:gpu_prefix_cache_hit_rate
+            unless on (instance, model_name) vllm:kv_cache_usage_perc
           labels:
             engine: vllm-v0
         - record: infer:cache:swap_usage_ratio
-          expr: vllm:cpu_cache_usage_perc
+          expr: |
+            vllm:cpu_cache_usage_perc
+            unless on (instance, model_name) vllm:kv_cache_usage_perc
           labels:
             engine: vllm-v0

--- a/deploy/k8s/prometheus-rules/recording/engines/vllm-v0.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/vllm-v0.yaml
@@ -55,16 +55,16 @@ spec:
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: vllm-v0
-        # ITL (inter-token latency, i.e. TPOT)
-        - record: infer:request:itl_seconds:p50
+        # TPOT (time per output token, a.k.a. ITL)
+        - record: infer:request:tpot_seconds:p50
           expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(vllm:time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: vllm-v0
-        - record: infer:request:itl_seconds:p95
+        - record: infer:request:tpot_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: vllm-v0
-        - record: infer:request:itl_seconds:p99
+        - record: infer:request:tpot_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:time_per_output_token_seconds_bucket[5m])))
           labels:
             engine: vllm-v0

--- a/deploy/k8s/prometheus-rules/recording/engines/vllm-v0.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/vllm-v0.yaml
@@ -1,16 +1,18 @@
-# PrometheusRule: vLLM V0 (0.5.x – 0.6.x legacy engine)
+# PrometheusRule: vLLM V0 (0.5.x – 0.6.x legacy) — version-SPECIFIC metrics only
 #
-# Normalizes vLLM V0 raw metrics into the `infer:*` namespace.
-# Apply ONLY when your inference workload is vLLM 0.5.x or 0.6.x.
-# For vLLM 0.7+ (V1 engine), apply vllm-v1.yaml instead — do not apply both.
+# Shared metrics (request lifecycle, throughput — same raw name as V1)
+# live in vllm-common.yaml, which attaches the engine label per instance
+# via a discriminator join. This file carries ONLY metrics whose RAW NAME
+# is unique to V0, so a static engine=vllm-v0 label is unambiguous and
+# safe even on a mixed (V0+V1) fleet — V1 pods do not expose these names.
 #
-# Hard-coded label `engine="vllm-v0"` is injected on every recorded
-# metric so downstream alert/dashboard queries can select by engine.
+# V0-specific raw names (vs V1):
+# - vllm:gpu_cache_usage_perc        (V1: vllm:kv_cache_usage_perc)
+# - vllm:time_per_output_token_seconds (V1: vllm:inter_token_latency_seconds)
+# - vllm:gpu_prefix_cache_hit_rate   (V1: prefix_cache_hits / _queries pair)
+# - vllm:cpu_cache_usage_perc        (removed in V1 — swap model changed)
 #
-# Source label expectations:
-# - Scrape config must expose `model_name` on all vllm:* metrics
-#   (vLLM exports it by default in V0).
-# - `instance` label distinguishes replicas.
+# Apply alongside vllm-common.yaml whenever V0 is present.
 
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -26,36 +28,7 @@ spec:
     - name: modeldoctor.vllm-v0.request
       interval: 30s
       rules:
-        - record: infer:request:running
-          expr: vllm:num_requests_running
-          labels:
-            engine: vllm-v0
-        - record: infer:request:waiting
-          expr: vllm:num_requests_waiting
-          labels:
-            engine: vllm-v0
-        - record: infer:request:swapped
-          expr: vllm:num_requests_swapped
-          labels:
-            engine: vllm-v0
-        - record: infer:request:preempted_total
-          expr: vllm:num_preemptions_total
-          labels:
-            engine: vllm-v0
-        # TTFT P50 / P95 / P99 over 5m
-        - record: infer:request:ttft_seconds:p50
-          expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
-          labels:
-            engine: vllm-v0
-        - record: infer:request:ttft_seconds:p95
-          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
-          labels:
-            engine: vllm-v0
-        - record: infer:request:ttft_seconds:p99
-          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
-          labels:
-            engine: vllm-v0
-        # TPOT (time per output token, a.k.a. ITL)
+        # V0: time_per_output_token_seconds (V1 renamed to inter_token_latency)
         - record: infer:request:tpot_seconds:p50
           expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(vllm:time_per_output_token_seconds_bucket[5m])))
           labels:
@@ -66,36 +39,6 @@ spec:
             engine: vllm-v0
         - record: infer:request:tpot_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:time_per_output_token_seconds_bucket[5m])))
-          labels:
-            engine: vllm-v0
-        # E2E latency
-        - record: infer:request:e2e_seconds:p95
-          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:e2e_request_latency_seconds_bucket[5m])))
-          labels:
-            engine: vllm-v0
-        - record: infer:request:e2e_seconds:p99
-          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:e2e_request_latency_seconds_bucket[5m])))
-          labels:
-            engine: vllm-v0
-        # Queue time
-        - record: infer:request:queue_seconds:p95
-          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:request_queue_time_seconds_bucket[5m])))
-          labels:
-            engine: vllm-v0
-
-    - name: modeldoctor.vllm-v0.throughput
-      interval: 30s
-      rules:
-        - record: infer:throughput:prompt_tokens_total
-          expr: vllm:prompt_tokens_total
-          labels:
-            engine: vllm-v0
-        - record: infer:throughput:generation_tokens_total
-          expr: vllm:generation_tokens_total
-          labels:
-            engine: vllm-v0
-        - record: infer:throughput:generation_rate_tps
-          expr: sum by (model_name, instance) (rate(vllm:generation_tokens_total[1m]))
           labels:
             engine: vllm-v0
 

--- a/deploy/k8s/prometheus-rules/recording/engines/vllm-v1.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/vllm-v1.yaml
@@ -1,22 +1,17 @@
-# PrometheusRule: vLLM V1 (0.7.x+ default engine)
+# PrometheusRule: vLLM V1 (0.7.x+) — version-SPECIFIC metrics only
 #
-# Normalizes vLLM V1 raw metrics into the `infer:*` namespace.
-# Apply ONLY when your inference workload is vLLM 0.7+ (V1 engine on by
-# default). For vLLM 0.6.x and earlier, apply vllm-v0.yaml instead.
+# Shared metrics (request lifecycle, throughput — same raw name as V0)
+# live in vllm-common.yaml, which attaches the engine label per instance
+# via a discriminator join. This file carries ONLY metrics whose RAW NAME
+# is unique to V1, so a static engine=vllm-v1 label is unambiguous and
+# safe even on a mixed (V0+V1) fleet — V0 pods do not expose these names.
 #
-# Hard-coded label `engine="vllm-v1"` is injected on every recorded
-# metric so downstream alert/dashboard queries can select by engine.
+# V1-specific raw names (vs V0):
+# - vllm:kv_cache_usage_perc          (V0: vllm:gpu_cache_usage_perc)
+# - vllm:inter_token_latency_seconds  (V0: vllm:time_per_output_token_seconds)
+# - vllm:prefix_cache_hits / _queries (V0: vllm:gpu_prefix_cache_hit_rate)
 #
-# Breaking changes from V0 handled here:
-# - vllm:gpu_cache_usage_perc → vllm:kv_cache_usage_perc
-# - vllm:time_per_output_token_seconds → vllm:inter_token_latency_seconds
-# - vllm:gpu_prefix_cache_hit_rate (gauge) → rate(vllm:prefix_cache_hits)
-#   / rate(vllm:prefix_cache_queries) (counter pair)
-#
-# Source label expectations:
-# - V1 metrics natively carry `model_name` and `engine` labels.
-# - This file's hard-coded `engine: vllm-v1` overrides any source `engine`
-#   label so the normalized layer has a single consistent value.
+# Apply alongside vllm-common.yaml whenever V1 is present.
 
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -32,30 +27,6 @@ spec:
     - name: modeldoctor.vllm-v1.request
       interval: 30s
       rules:
-        - record: infer:request:running
-          expr: vllm:num_requests_running
-          labels:
-            engine: vllm-v1
-        - record: infer:request:waiting
-          expr: vllm:num_requests_waiting
-          labels:
-            engine: vllm-v1
-        - record: infer:request:preempted_total
-          expr: vllm:num_preemptions_total
-          labels:
-            engine: vllm-v1
-        - record: infer:request:ttft_seconds:p50
-          expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
-          labels:
-            engine: vllm-v1
-        - record: infer:request:ttft_seconds:p95
-          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
-          labels:
-            engine: vllm-v1
-        - record: infer:request:ttft_seconds:p99
-          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
-          labels:
-            engine: vllm-v1
         # V1: time_per_output_token_seconds renamed to inter_token_latency_seconds
         - record: infer:request:tpot_seconds:p50
           expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(vllm:inter_token_latency_seconds_bucket[5m])))
@@ -69,34 +40,6 @@ spec:
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:inter_token_latency_seconds_bucket[5m])))
           labels:
             engine: vllm-v1
-        - record: infer:request:e2e_seconds:p95
-          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:e2e_request_latency_seconds_bucket[5m])))
-          labels:
-            engine: vllm-v1
-        - record: infer:request:e2e_seconds:p99
-          expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:e2e_request_latency_seconds_bucket[5m])))
-          labels:
-            engine: vllm-v1
-        - record: infer:request:queue_seconds:p95
-          expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:request_queue_time_seconds_bucket[5m])))
-          labels:
-            engine: vllm-v1
-
-    - name: modeldoctor.vllm-v1.throughput
-      interval: 30s
-      rules:
-        - record: infer:throughput:prompt_tokens_total
-          expr: vllm:prompt_tokens_total
-          labels:
-            engine: vllm-v1
-        - record: infer:throughput:generation_tokens_total
-          expr: vllm:generation_tokens_total
-          labels:
-            engine: vllm-v1
-        - record: infer:throughput:generation_rate_tps
-          expr: sum by (model_name, instance) (rate(vllm:generation_tokens_total[1m]))
-          labels:
-            engine: vllm-v1
 
     - name: modeldoctor.vllm-v1.cache
       interval: 30s
@@ -107,7 +50,7 @@ spec:
           labels:
             engine: vllm-v1
         # V1: prefix cache hit rate must be derived from two counters.
-        # Guard against divide-by-zero with a 0 fallback when queries are idle.
+        # Guard against divide-by-zero with a clamp_min fallback when idle.
         - record: infer:cache:prefix_hit_ratio
           expr: |
             sum by (model_name, instance) (rate(vllm:prefix_cache_hits[5m]))

--- a/deploy/k8s/prometheus-rules/recording/engines/vllm-v1.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/vllm-v1.yaml
@@ -57,15 +57,15 @@ spec:
           labels:
             engine: vllm-v1
         # V1: time_per_output_token_seconds renamed to inter_token_latency_seconds
-        - record: infer:request:itl_seconds:p50
+        - record: infer:request:tpot_seconds:p50
           expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(vllm:inter_token_latency_seconds_bucket[5m])))
           labels:
             engine: vllm-v1
-        - record: infer:request:itl_seconds:p95
+        - record: infer:request:tpot_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:inter_token_latency_seconds_bucket[5m])))
           labels:
             engine: vllm-v1
-        - record: infer:request:itl_seconds:p99
+        - record: infer:request:tpot_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:inter_token_latency_seconds_bucket[5m])))
           labels:
             engine: vllm-v1

--- a/deploy/k8s/prometheus-rules/recording/engines/vllm-v1.yaml
+++ b/deploy/k8s/prometheus-rules/recording/engines/vllm-v1.yaml
@@ -1,6 +1,6 @@
 # PrometheusRule: vLLM V1 (0.7.x+ default engine)
 #
-# Normalizes vLLM V1 raw metrics into the `modeldoctor:*` namespace.
+# Normalizes vLLM V1 raw metrics into the `infer:*` namespace.
 # Apply ONLY when your inference workload is vLLM 0.7+ (V1 engine on by
 # default). For vLLM 0.6.x and earlier, apply vllm-v0.yaml instead.
 #
@@ -32,52 +32,52 @@ spec:
     - name: modeldoctor.vllm-v1.request
       interval: 30s
       rules:
-        - record: modeldoctor:request:running
+        - record: infer:request:running
           expr: vllm:num_requests_running
           labels:
             engine: vllm-v1
-        - record: modeldoctor:request:waiting
+        - record: infer:request:waiting
           expr: vllm:num_requests_waiting
           labels:
             engine: vllm-v1
-        - record: modeldoctor:request:preempted_total
+        - record: infer:request:preempted_total
           expr: vllm:num_preemptions_total
           labels:
             engine: vllm-v1
-        - record: modeldoctor:request:ttft_seconds:p50
+        - record: infer:request:ttft_seconds:p50
           expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: vllm-v1
-        - record: modeldoctor:request:ttft_seconds:p95
+        - record: infer:request:ttft_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: vllm-v1
-        - record: modeldoctor:request:ttft_seconds:p99
+        - record: infer:request:ttft_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
           labels:
             engine: vllm-v1
         # V1: time_per_output_token_seconds renamed to inter_token_latency_seconds
-        - record: modeldoctor:request:itl_seconds:p50
+        - record: infer:request:itl_seconds:p50
           expr: histogram_quantile(0.50, sum by (le, model_name, instance) (rate(vllm:inter_token_latency_seconds_bucket[5m])))
           labels:
             engine: vllm-v1
-        - record: modeldoctor:request:itl_seconds:p95
+        - record: infer:request:itl_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:inter_token_latency_seconds_bucket[5m])))
           labels:
             engine: vllm-v1
-        - record: modeldoctor:request:itl_seconds:p99
+        - record: infer:request:itl_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:inter_token_latency_seconds_bucket[5m])))
           labels:
             engine: vllm-v1
-        - record: modeldoctor:request:e2e_seconds:p95
+        - record: infer:request:e2e_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:e2e_request_latency_seconds_bucket[5m])))
           labels:
             engine: vllm-v1
-        - record: modeldoctor:request:e2e_seconds:p99
+        - record: infer:request:e2e_seconds:p99
           expr: histogram_quantile(0.99, sum by (le, model_name, instance) (rate(vllm:e2e_request_latency_seconds_bucket[5m])))
           labels:
             engine: vllm-v1
-        - record: modeldoctor:request:queue_seconds:p95
+        - record: infer:request:queue_seconds:p95
           expr: histogram_quantile(0.95, sum by (le, model_name, instance) (rate(vllm:request_queue_time_seconds_bucket[5m])))
           labels:
             engine: vllm-v1
@@ -85,15 +85,15 @@ spec:
     - name: modeldoctor.vllm-v1.throughput
       interval: 30s
       rules:
-        - record: modeldoctor:throughput:prompt_tokens_total
+        - record: infer:throughput:prompt_tokens_total
           expr: vllm:prompt_tokens_total
           labels:
             engine: vllm-v1
-        - record: modeldoctor:throughput:generation_tokens_total
+        - record: infer:throughput:generation_tokens_total
           expr: vllm:generation_tokens_total
           labels:
             engine: vllm-v1
-        - record: modeldoctor:throughput:generation_rate_tps
+        - record: infer:throughput:generation_rate_tps
           expr: sum by (model_name, instance) (rate(vllm:generation_tokens_total[1m]))
           labels:
             engine: vllm-v1
@@ -102,13 +102,13 @@ spec:
       interval: 30s
       rules:
         # V1: kv_cache_usage_perc replaces gpu_cache_usage_perc (no CPU split)
-        - record: modeldoctor:cache:kv_usage_ratio
+        - record: infer:cache:kv_usage_ratio
           expr: vllm:kv_cache_usage_perc
           labels:
             engine: vllm-v1
         # V1: prefix cache hit rate must be derived from two counters.
         # Guard against divide-by-zero with a 0 fallback when queries are idle.
-        - record: modeldoctor:cache:prefix_hit_ratio
+        - record: infer:cache:prefix_hit_ratio
           expr: |
             sum by (model_name, instance) (rate(vllm:prefix_cache_hits[5m]))
             /

--- a/deploy/k8s/prometheus-rules/recording/gateway/higress.yaml
+++ b/deploy/k8s/prometheus-rules/recording/gateway/higress.yaml
@@ -1,7 +1,7 @@
 # PrometheusRule: Higress AI Statistics gateway
 #
 # Normalizes Higress AI Statistics plugin metrics into the
-# `modeldoctor:gateway:*` namespace. This is the route/consumer dimension
+# `infer:gateway:*` namespace. This is the route/consumer dimension
 # — it does NOT replace engine-side metrics. Apply this in addition to
 # (not instead of) your engine recording rule.
 #
@@ -27,21 +27,21 @@ spec:
     - name: modeldoctor.gateway.higress.tokens
       interval: 30s
       rules:
-        - record: modeldoctor:gateway:input_tokens_total
+        - record: infer:gateway:input_tokens_total
           expr: route_upstream_model_consumer_metric_input_token
           labels:
             source: higress
-        - record: modeldoctor:gateway:output_tokens_total
+        - record: infer:gateway:output_tokens_total
           expr: route_upstream_model_consumer_metric_output_token
           labels:
             source: higress
         # Token rate per consumer — most useful series for spotting a
         # noisy-neighbor tenant.
-        - record: modeldoctor:gateway:input_tokens_rate
+        - record: infer:gateway:input_tokens_rate
           expr: sum by (ai_route, ai_cluster, ai_model, ai_consumer) (rate(route_upstream_model_consumer_metric_input_token[1m]))
           labels:
             source: higress
-        - record: modeldoctor:gateway:output_tokens_rate
+        - record: infer:gateway:output_tokens_rate
           expr: sum by (ai_route, ai_cluster, ai_model, ai_consumer) (rate(route_upstream_model_consumer_metric_output_token[1m]))
           labels:
             source: higress
@@ -51,29 +51,29 @@ spec:
       rules:
         # Cumulative LLM service duration; downstream uses this with
         # llm_duration_count to compute average.
-        - record: modeldoctor:gateway:llm_duration_total_seconds
+        - record: infer:gateway:llm_duration_total_seconds
           # Higress reports microseconds in the source counter; convert to seconds.
           # Verify your plugin build's unit before applying (some legacy
           # builds report milliseconds — divide by 1000 instead).
           expr: route_upstream_model_consumer_metric_llm_service_duration / 1e6
           labels:
             source: higress
-        - record: modeldoctor:gateway:llm_request_count_total
+        - record: infer:gateway:llm_request_count_total
           expr: route_upstream_model_consumer_metric_llm_duration_count
           labels:
             source: higress
-        - record: modeldoctor:gateway:ttft_total_seconds
+        - record: infer:gateway:ttft_total_seconds
           expr: route_upstream_model_consumer_metric_llm_first_token_duration / 1e6
           labels:
             source: higress
-        - record: modeldoctor:gateway:streaming_count_total
+        - record: infer:gateway:streaming_count_total
           expr: route_upstream_model_consumer_metric_llm_stream_duration_count
           labels:
             source: higress
         # Avg latency derived: total_duration / request_count (over 5m).
         # Histogram-quantile is impossible from sum/count alone — for P99
         # query the engine side via ai_model == model_name.
-        - record: modeldoctor:gateway:llm_duration_seconds:avg
+        - record: infer:gateway:llm_duration_seconds:avg
           expr: |
             sum by (ai_route, ai_cluster, ai_model, ai_consumer) (rate(route_upstream_model_consumer_metric_llm_service_duration[5m]))
             /
@@ -81,7 +81,7 @@ spec:
             / 1e6
           labels:
             source: higress
-        - record: modeldoctor:gateway:ttft_seconds:avg
+        - record: infer:gateway:ttft_seconds:avg
           expr: |
             sum by (ai_route, ai_cluster, ai_model, ai_consumer) (rate(route_upstream_model_consumer_metric_llm_first_token_duration[5m]))
             /


### PR DESCRIPTION
## What

Renames the normalized Prometheus recording/alert metric namespace and aligns one leaf to OpenTelemetry GenAI conventions. Two commits:

1. **`modeldoctor:*` → `infer:*`** — the normalized namespace was branded with the product name, coupling vendor identity to what should be an engine-neutral, portable namespace (bad for OSS reuse, semantically empty). Renamed across all 7 recording-rule files, 4 alert-rule files, and the README.
2. **`request:itl_seconds` → `request:tpot_seconds`** — aligns the leaf to OTel `gen_ai.server.time_per_output_token`; `tpot` is consistent with the existing `ttft` abbreviation and matches genai-perf/guidellm usage.

## Scope / safety

- Pure rename: leaf names and units otherwise unchanged; the diff is 1:1 line swaps (138↔138 then 16↔16).
- **No application code references these rules** (`apps/` has zero metric refs), so nothing breaks at runtime — these are deploy-time PrometheusRule artifacts applied manually.
- Upstream engine source metrics (`vllm:*`, `sglang*`, `tgi_*`, `inter_token_latency`/`time_per_output_token`) are untouched — only the normalized *output* names move.

## Intentional non-changes (for reviewers)

- **`e2e_seconds` kept** (not OTel's `request.duration`): engines emit `e2e_request_latency_seconds` and genai-perf/guidellm/MLPerf all say "e2e" — the inference-community term is more standard here than OTel's generic name.
- **Labels `engine`/`model_name` kept** (not `gen_ai_system`/`gen_ai_request_model`): `model_name` is what engines emit and is the cross-layer join key; OTel dotted label names are awkward in Prometheus.

## Follow-ups (not here)

- The archived `2026-05-15-inference-engine-metrics-survey.md` and the positioning report still reference `modeldoctor:*` in prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)