### PR TITLE
fix(benchmark): green aiperf/guidellm/evalscope smoke runs + runner Dockerfile optimization

### DIFF
--- a/apps/benchmark-runner/images/aiperf.Dockerfile
+++ b/apps/benchmark-runner/images/aiperf.Dockerfile
@@ -6,10 +6,14 @@
 # tag below and AIPERF_VERSION in build-base-images.sh.
 FROM ghcr.io/weetime/md-base-aiperf:0.7.0
 
-COPY runner runner
+WORKDIR /app
 
-# Pinned to match pyproject.toml's requests>=2.31,<3 declaration.
-RUN pip install --no-cache-dir 'requests>=2.31,<3' 'boto3>=1.34,<2'
+# Runner deps BEFORE `COPY runner` so editing runner/ doesn't bust this layer
+# and reinstall on every image rebuild. boto3 = the wrapper's only declared
+# dep (pyproject.toml); requests is pinned defensively for transitive importers.
+RUN pip install --no-cache-dir --disable-pip-version-check 'requests>=2.31,<3' 'boto3>=1.34,<2'
+
+COPY runner runner
 
 RUN useradd --create-home --shell /sbin/nologin runner \
     && chown -R runner:runner /app

--- a/apps/benchmark-runner/images/evalscope.Dockerfile
+++ b/apps/benchmark-runner/images/evalscope.Dockerfile
@@ -7,10 +7,13 @@
 FROM ghcr.io/weetime/md-base-evalscope:1.7.0
 
 WORKDIR /app
-COPY runner runner
 
-# Pinned to match pyproject.toml's requests>=2.31,<3 declaration.
-RUN pip install --no-cache-dir 'requests>=2.31,<3' 'boto3>=1.34,<2'
+# Runner deps BEFORE `COPY runner` so editing runner/ doesn't bust this layer
+# and reinstall on every image rebuild. boto3 = the wrapper's only declared
+# dep (pyproject.toml); requests is pinned defensively for transitive importers.
+RUN pip install --no-cache-dir --disable-pip-version-check 'requests>=2.31,<3' 'boto3>=1.34,<2'
+
+COPY runner runner
 
 RUN useradd --create-home --shell /sbin/nologin runner \
     && chown -R runner:runner /app /opt/evalscope-datasets

--- a/apps/benchmark-runner/images/evalscope.base.Dockerfile
+++ b/apps/benchmark-runner/images/evalscope.base.Dockerfile
@@ -26,12 +26,37 @@ RUN modelscope download \
         --local_dir /opt/evalscope-datasets/longalpaca
 
 # Bake openqa (HC3-Chinese) for the inf-evalscope-short template + any
-# openqa-driven manual runs. Only open_qa.jsonl is needed.
+# openqa-driven manual runs. Only open_qa.jsonl is needed. evalscope's openqa
+# plugin reads this jsonl directly via --dataset-path (line-by-line + json),
+# so it's served as-is.
 RUN python -c "from modelscope import dataset_snapshot_download; \
     import shutil, os; \
     p = dataset_snapshot_download('AI-ModelScope/HC3-Chinese', allow_patterns=['open_qa.jsonl']); \
     os.makedirs('/opt/evalscope-datasets/openqa', exist_ok=True); \
     shutil.copy(os.path.join(p, 'open_qa.jsonl'), '/opt/evalscope-datasets/openqa/open_qa.jsonl')"
+
+# Flatten LongAlpaca to one prompt per line for evalscope's `line_by_line` reader.
+# Why not serve it natively: the longalpaca plugin's --dataset-path code path does
+# json.loads() of a single JSON-array file, but ModelScope ships LongAlpaca-12k as
+# a CSV (+ metadata stub), and the cluster can't auto-download (pod TLS to
+# modelscope.cn fails). line_by_line streams the file, so the full corpus costs no
+# runtime RAM; each instruction is collapsed to a single line (newlines stripped).
+# Drop the raw CSV download afterwards — the .txt replaces it.
+RUN python3 <<'PY'
+import csv, sys, shutil
+csv.field_size_limit(sys.maxsize)
+src = '/opt/evalscope-datasets/longalpaca/LongAlpaca-12k_.csv'
+dst = '/opt/evalscope-datasets/longalpaca.txt'
+n = 0
+with open(src, encoding='utf-8') as f, open(dst, 'w', encoding='utf-8') as out:
+    for row in csv.DictReader(f):
+        line = ' '.join((row.get('instruction') or '').split())
+        if line:
+            out.write(line + '\n')
+            n += 1
+shutil.rmtree('/opt/evalscope-datasets/longalpaca')
+print('longalpaca.txt lines:', n)
+PY
 
 # evalscope LAST, with the [perf] extra — `evalscope perf` imports uvicorn via
 # evalscope.perf.utils.local_server; without [perf] the runner dies with

--- a/apps/benchmark-runner/images/evalscope.base.Dockerfile
+++ b/apps/benchmark-runner/images/evalscope.base.Dockerfile
@@ -14,9 +14,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 ARG EVALSCOPE_VERSION=1.7.0
 
-RUN pip install --no-cache-dir \
-        "evalscope==${EVALSCOPE_VERSION}" \
-        "modelscope==1.36.3"
+# Install modelscope first (stable, rarely bumped) so the baked-dataset layers
+# below stay in the build cache across evalscope version/extra changes — only
+# the much smaller evalscope layer at the end re-runs on a bump.
+RUN pip install --no-cache-dir --disable-pip-version-check "modelscope==1.36.3"
 
 # Bake LongAlpaca-12k. modelscope download's positional `repo_id` defaults
 # to model lookup; LongAlpaca-12k is a dataset, so `--dataset` is required.
@@ -31,3 +32,11 @@ RUN python -c "from modelscope import dataset_snapshot_download; \
     p = dataset_snapshot_download('AI-ModelScope/HC3-Chinese', allow_patterns=['open_qa.jsonl']); \
     os.makedirs('/opt/evalscope-datasets/openqa', exist_ok=True); \
     shutil.copy(os.path.join(p, 'open_qa.jsonl'), '/opt/evalscope-datasets/openqa/open_qa.jsonl')"
+
+# evalscope LAST, with the [perf] extra — `evalscope perf` imports uvicorn via
+# evalscope.perf.utils.local_server; without [perf] the runner dies with
+# `ModuleNotFoundError: No module named 'uvicorn'`. Re-pin modelscope so the
+# extra's dependency resolution can't drift it off the dataset-baking version.
+RUN pip install --no-cache-dir --disable-pip-version-check \
+        "evalscope[perf]==${EVALSCOPE_VERSION}" \
+        "modelscope==1.36.3"

--- a/apps/benchmark-runner/images/guidellm.Dockerfile
+++ b/apps/benchmark-runner/images/guidellm.Dockerfile
@@ -13,13 +13,14 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
+# Runner deps BEFORE `COPY runner` so editing runner/ doesn't bust this layer
+# and reinstall on every image rebuild. boto3 = the wrapper's only declared dep
+# (pyproject.toml); requests is pinned defensively — don't drop the constraint
+# or pip will silently grab requests 3.x when it ships.
+RUN pip install --no-cache-dir --disable-pip-version-check 'requests>=2.31,<3' 'boto3>=1.34,<2'
+
 # Copy the wrapper. Tests are excluded by .dockerignore.
 COPY runner runner
-
-# Pinned to match pyproject.toml's requests>=2.31,<3 declaration. Don't drop
-# the version constraint here — pip install requests is otherwise unconstrained
-# and will silently grab requests 3.x when it ships.
-RUN pip install --no-cache-dir 'requests>=2.31,<3' 'boto3>=1.34,<2'
 
 # Run as a non-root user.
 RUN useradd --create-home --shell /sbin/nologin runner \

--- a/apps/benchmark-runner/images/prefix-cache-probe.Dockerfile
+++ b/apps/benchmark-runner/images/prefix-cache-probe.Dockerfile
@@ -9,8 +9,9 @@ FROM python:3.11-slim
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-# httpx for the probe; requests pinned to match runner wrapper's pyproject.
-RUN pip install --no-cache-dir \
+# Deps BEFORE COPY so editing runner/ doesn't reinstall them. httpx drives the
+# probe; boto3 = the wrapper's declared dep; requests pinned defensively.
+RUN pip install --no-cache-dir --disable-pip-version-check \
         'httpx>=0.27,<1' \
         'requests>=2.31,<3' \
         'boto3>=1.34,<2'

--- a/apps/benchmark-runner/images/vegeta.Dockerfile
+++ b/apps/benchmark-runner/images/vegeta.Dockerfile
@@ -6,10 +6,13 @@
 FROM ghcr.io/weetime/md-base-vegeta:12.13.0
 
 WORKDIR /app
-COPY runner runner
 
-# Pinned to match pyproject.toml's requests>=2.31,<3 declaration.
-RUN pip install --no-cache-dir 'requests>=2.31,<3' 'boto3>=1.34,<2'
+# Runner deps BEFORE `COPY runner` so editing runner/ doesn't bust this layer
+# and reinstall on every image rebuild. boto3 = the wrapper's only declared
+# dep (pyproject.toml); requests is pinned defensively for transitive importers.
+RUN pip install --no-cache-dir --disable-pip-version-check 'requests>=2.31,<3' 'boto3>=1.34,<2'
+
+COPY runner runner
 
 RUN useradd --create-home --shell /sbin/nologin runner \
     && chown -R runner:runner /app

--- a/apps/benchmark-runner/runner/main.py
+++ b/apps/benchmark-runner/runner/main.py
@@ -120,14 +120,43 @@ def _materialize_input_files() -> None:
 
 
 def _redacted(argv: list[str]) -> list[str]:
-    """Mask --backend-kwargs= JSON since it can contain api_key."""
+    """Mask secrets in argv for logging: --backend-kwargs= JSON (may contain
+    api_key) and the value following --api-key (evalscope auth)."""
     out: list[str] = []
+    mask_next = False
     for a in argv:
+        if mask_next:
+            out.append("***REDACTED***")
+            mask_next = False
+            continue
         if a.startswith("--backend-kwargs="):
             out.append("--backend-kwargs=***REDACTED***")
+        elif a == "--api-key":
+            out.append(a)
+            mask_next = True
         else:
             out.append(a)
     return out
+
+
+# Sentinel emitted by adapters that must pass the API key as a CLI flag the
+# tool reads ONLY from argv (e.g. evalscope `--api-key`, which ignores env).
+# The adapter puts this placeholder in argv so the secret never lands in the
+# K8s Job manifest / MD_ARGV; the runner swaps in OPENAI_API_KEY (from the
+# per-run Secret, via secretEnv) immediately before Popen. Mirrors the guidellm
+# api_key handling but for tools without an env-var or backend-kwargs channel.
+# Contract: packages/tool-adapters/src/evalscope/runtime.ts.
+OPENAI_API_KEY_SENTINEL = "__MD_OPENAI_API_KEY__"
+
+
+def _inject_api_key_sentinel(argv: list[str]) -> list[str]:
+    """Replace the OPENAI_API_KEY sentinel token in argv with the real key.
+
+    If OPENAI_API_KEY is unset, the sentinel becomes an empty string (the tool
+    then sees an empty --api-key, equivalent to no auth configured).
+    """
+    api_key = os.environ.get("OPENAI_API_KEY", "")
+    return [api_key if a == OPENAI_API_KEY_SENTINEL else a for a in argv]
 
 
 def _inject_api_key_into_backend_kwargs(argv: list[str]) -> list[str]:
@@ -193,6 +222,7 @@ def main() -> int:
     )
 
     argv = _inject_api_key_into_backend_kwargs(argv)
+    argv = _inject_api_key_sentinel(argv)
     log.info("running: %s", " ".join(_redacted(argv)))
     proc = subprocess.Popen(  # noqa: S603
         argv,

--- a/apps/benchmark-runner/tests/test_main.py
+++ b/apps/benchmark-runner/tests/test_main.py
@@ -34,6 +34,46 @@ def _fake_proc(
     return proc
 
 
+class TestInjectApiKeySentinel:
+    """Adapters that pass the key as a CLI flag (evalscope --api-key) emit a
+    sentinel so the secret stays out of MD_ARGV; the runner swaps in the real
+    OPENAI_API_KEY at exec time.
+    """
+
+    SENT = main_mod.OPENAI_API_KEY_SENTINEL
+
+    def test_replaces_sentinel_with_env_key(self, mocker: MockerFixture) -> None:
+        mocker.patch.dict("os.environ", {"OPENAI_API_KEY": "sk-secret"}, clear=False)
+        argv = ["evalscope", "perf", "--api-key", self.SENT, "--parallel", "8"]
+        out = main_mod._inject_api_key_sentinel(argv)
+        assert out == ["evalscope", "perf", "--api-key", "sk-secret", "--parallel", "8"]
+
+    def test_no_op_when_no_sentinel(self, mocker: MockerFixture) -> None:
+        mocker.patch.dict("os.environ", {"OPENAI_API_KEY": "sk-secret"}, clear=False)
+        argv = ["aiperf", "profile", "--tokenizer", "Qwen/Qwen2.5-0.5B-Instruct"]
+        assert main_mod._inject_api_key_sentinel(argv) == argv
+
+    def test_empty_string_when_env_unset(self, mocker: MockerFixture) -> None:
+        mocker.patch.dict("os.environ", {}, clear=True)
+        argv = ["evalscope", "perf", "--api-key", self.SENT]
+        assert main_mod._inject_api_key_sentinel(argv) == ["evalscope", "perf", "--api-key", ""]
+
+
+class TestRedacted:
+    """The 'running:' log line must not leak secrets."""
+
+    def test_masks_api_key_value(self) -> None:
+        argv = ["evalscope", "perf", "--api-key", "sk-secret", "--parallel", "8"]
+        out = main_mod._redacted(argv)
+        assert out == ["evalscope", "perf", "--api-key", "***REDACTED***", "--parallel", "8"]
+        assert "sk-secret" not in out
+
+    def test_masks_backend_kwargs(self) -> None:
+        argv = ["guidellm", '--backend-kwargs={"api_key": "sk-secret"}']
+        out = main_mod._redacted(argv)
+        assert out == ["guidellm", "--backend-kwargs=***REDACTED***"]
+
+
 class TestInjectApiKeyIntoBackendKwargs:
     """The wrapper merges OPENAI_API_KEY into any --backend-kwargs= JSON
     so guidellm receives api_key. genai-perf and vegeta don't use this

--- a/apps/web/src/locales/en-US/connections.json
+++ b/apps/web/src/locales/en-US/connections.json
@@ -41,7 +41,7 @@
       "queryParamsPlaceholder": "key=value",
       "tokenizerHfId": "Tokenizer (HuggingFace id, optional)",
       "tokenizerHfIdPlaceholder": "e.g. Qwen/Qwen2.5-0.5B-Instruct",
-      "tokenizerHfIdHelp": "Set when the connection's model name is not a HuggingFace identifier (e.g. local served names like gen-studio_*). Used by guidellm benchmarks.",
+      "tokenizerHfIdHelp": "Set when the connection's model name is not a HuggingFace identifier (e.g. local served names like gen-studio_*). Used by guidellm and aiperf benchmarks for synthetic data generation and tokenization.",
       "serverKind": "Engine",
       "serverKindPlaceholder": "Select…",
       "serverKindHelp": "Engine type determines the Prometheus metric namespace and powers the Engine Metrics dashboard.",

--- a/apps/web/src/locales/zh-CN/connections.json
+++ b/apps/web/src/locales/zh-CN/connections.json
@@ -41,7 +41,7 @@
       "queryParamsPlaceholder": "key=value",
       "tokenizerHfId": "Tokenizer（HuggingFace 模型 ID，可选）",
       "tokenizerHfIdPlaceholder": "例如 Qwen/Qwen2.5-0.5B-Instruct",
-      "tokenizerHfIdHelp": "当连接的模型名称不是 HuggingFace 标识符时设置（如 gen-studio_* 等本地服务名称）。用于 guidellm 基准测试。",
+      "tokenizerHfIdHelp": "当连接的模型名称不是 HuggingFace 标识符时设置（如 gen-studio_* 等本地服务名称）。用于 guidellm 和 aiperf 基准测试的合成数据生成与分词。",
       "serverKind": "推理引擎",
       "serverKindPlaceholder": "选择…",
       "serverKindHelp": "推理引擎类型决定 Prometheus 指标的命名空间，关联 Engine Metrics 看板。",

--- a/packages/tool-adapters/src/aiperf/runtime.spec.ts
+++ b/packages/tool-adapters/src/aiperf/runtime.spec.ts
@@ -91,6 +91,21 @@ describe("aiperf.buildCommand", () => {
     expect(r.argv).not.toContain("--public-dataset");
   });
 
+  it("emits --tokenizer when connection.tokenizerHfId is set", () => {
+    const r = buildCommand({
+      ...plan,
+      connection: { ...plan.connection, tokenizerHfId: "Qwen/Qwen2.5-0.5B-Instruct" },
+    });
+    const idx = r.argv.indexOf("--tokenizer");
+    expect(idx).toBeGreaterThan(-1);
+    expect(r.argv[idx + 1]).toBe("Qwen/Qwen2.5-0.5B-Instruct");
+  });
+
+  it("omits --tokenizer when connection.tokenizerHfId is null", () => {
+    const r = buildCommand(plan);
+    expect(r.argv).not.toContain("--tokenizer");
+  });
+
   it("omits --random-seed when seed is not set", () => {
     const r = buildCommand({
       ...plan,

--- a/packages/tool-adapters/src/aiperf/runtime.ts
+++ b/packages/tool-adapters/src/aiperf/runtime.ts
@@ -24,6 +24,15 @@ export function buildCommand(plan: BuildCommandPlan<AiperfParams>): BuildCommand
     params.endpointType,
   ];
 
+  // AIPerf needs a real HF tokenizer for synthetic prompt generation AND
+  // client-side token counting. connection.model is frequently a served name
+  // (e.g. gen-studio_*) that 401s against huggingface.co, so pass the
+  // connection-level tokenizerHfId when set. Without it AIPerf aborts with
+  // "Failed to load tokenizer '<model>'". Mirrors guidellm's --processor.
+  if (connection.tokenizerHfId) {
+    argv.push("--tokenizer", connection.tokenizerHfId);
+  }
+
   // --streaming is a presence-only boolean toggle (no --no-streaming form).
   // Streaming off = simply omit the flag.
   if (params.streaming) argv.push("--streaming");

--- a/packages/tool-adapters/src/evalscope/runtime.spec.ts
+++ b/packages/tool-adapters/src/evalscope/runtime.spec.ts
@@ -55,9 +55,9 @@ describe("evalscope.buildCommand", () => {
       "--number",
       "128",
       "--dataset",
-      "longalpaca",
+      "line_by_line",
       "--dataset-path",
-      "/opt/evalscope-datasets/longalpaca",
+      "/opt/evalscope-datasets/longalpaca.txt",
       "--min-prompt-length",
       "11000",
       "--max-prompt-length",
@@ -96,16 +96,27 @@ describe("evalscope.buildCommand", () => {
     expect(result.argv).toContain("http://10.0.0.5:8000/v1/completions");
   });
 
-  it("passes --dataset-path for openqa (baked HC3-Chinese open_qa.jsonl)", () => {
-    const result = buildCommand({ ...plan, params: { ...baseParams, dataset: "openqa" } });
-    const idx = result.argv.indexOf("--dataset-path");
-    expect(idx).toBeGreaterThan(-1);
-    expect(result.argv[idx + 1]).toBe("/opt/evalscope-datasets/openqa/open_qa.jsonl");
+  it("longalpaca → line_by_line reader with the baked flattened prompt file", () => {
+    const r = buildCommand({ ...plan, params: { ...baseParams, dataset: "longalpaca" } });
+    const di = r.argv.indexOf("--dataset");
+    expect(r.argv[di + 1]).toBe("line_by_line");
+    const pi = r.argv.indexOf("--dataset-path");
+    expect(r.argv[pi + 1]).toBe("/opt/evalscope-datasets/longalpaca.txt");
   });
 
-  it("does not pass --dataset-path for random (synthetic dataset)", () => {
-    const result = buildCommand({ ...plan, params: { ...baseParams, dataset: "random" } });
-    expect(result.argv).not.toContain("--dataset-path");
+  it("openqa → native openqa reader with the baked jsonl", () => {
+    const r = buildCommand({ ...plan, params: { ...baseParams, dataset: "openqa" } });
+    const di = r.argv.indexOf("--dataset");
+    expect(r.argv[di + 1]).toBe("openqa");
+    const pi = r.argv.indexOf("--dataset-path");
+    expect(r.argv[pi + 1]).toBe("/opt/evalscope-datasets/openqa/open_qa.jsonl");
+  });
+
+  it("random → synthetic, no --dataset-path", () => {
+    const r = buildCommand({ ...plan, params: { ...baseParams, dataset: "random" } });
+    const di = r.argv.indexOf("--dataset");
+    expect(r.argv[di + 1]).toBe("random");
+    expect(r.argv).not.toContain("--dataset-path");
   });
 
   it("omits --seed when not provided", () => {

--- a/packages/tool-adapters/src/evalscope/runtime.spec.ts
+++ b/packages/tool-adapters/src/evalscope/runtime.spec.ts
@@ -136,11 +136,11 @@ describe("evalscope.buildCommand", () => {
     expect(result.argv).not.toContain("--stream");
   });
 
-  it("declares both output files (summary + percentile)", () => {
-    const result = buildCommand(plan);
+  it("declares both output files under the parallel_<P>_number_<N> run subdir", () => {
+    const result = buildCommand(plan); // baseParams: parallel 16, number 128
     expect(result.outputFiles).toEqual({
-      summary: "out/evalscope-run/benchmark_summary.json",
-      percentile: "out/evalscope-run/benchmark_percentile.json",
+      summary: "out/evalscope-run/parallel_16_number_128/benchmark_summary.json",
+      percentile: "out/evalscope-run/parallel_16_number_128/benchmark_percentile.json",
     });
   });
 

--- a/packages/tool-adapters/src/evalscope/runtime.spec.ts
+++ b/packages/tool-adapters/src/evalscope/runtime.spec.ts
@@ -48,6 +48,8 @@ describe("evalscope.buildCommand", () => {
       "openai",
       "--model",
       "gen-studio_Qwen3-32B-rJIp",
+      "--api-key",
+      "__MD_OPENAI_API_KEY__",
       "--parallel",
       "16",
       "--number",
@@ -73,6 +75,16 @@ describe("evalscope.buildCommand", () => {
       "--name",
       "evalscope-run",
     ]);
+    expect(result.secretEnv?.OPENAI_API_KEY).toBe("sk-test");
+  });
+
+  it("passes --api-key as a sentinel (real key stays out of argv, only in secretEnv)", () => {
+    const result = buildCommand(plan);
+    const idx = result.argv.indexOf("--api-key");
+    expect(idx).toBeGreaterThan(-1);
+    expect(result.argv[idx + 1]).toBe("__MD_OPENAI_API_KEY__");
+    // The real key must never appear in argv (it would leak into MD_ARGV).
+    expect(result.argv).not.toContain("sk-test");
     expect(result.secretEnv?.OPENAI_API_KEY).toBe("sk-test");
   });
 

--- a/packages/tool-adapters/src/evalscope/runtime.ts
+++ b/packages/tool-adapters/src/evalscope/runtime.ts
@@ -80,19 +80,22 @@ export function buildCommand(plan: BuildCommandPlan<EvalscopeParams>): BuildComm
   // Always emit one or the other so the runtime is explicit about which mode.
   argv.push(params.stream ? "--stream" : "--no-stream");
 
-  // --outputs-dir + --no-timestamp + --name pin a stable output path:
-  //   <OUTPUTS_DIR>/<RUN_NAME>/benchmark_summary.json
-  //   <OUTPUTS_DIR>/<RUN_NAME>/benchmark_percentile.json
-  // Without --no-timestamp, evalscope inserts a YYYYMMDD_HHMMSS directory.
+  // --outputs-dir + --no-timestamp + --name pin the output path. evalscope runs
+  // as a multi-benchmark sweep (even for a single parallel/number), writing each
+  // combo into a `parallel_<P>_number_<N>` subdir, so the reports land at:
+  //   <OUTPUTS_DIR>/<RUN_NAME>/parallel_<P>_number_<N>/benchmark_{summary,percentile}.json
+  // (--no-timestamp drops the YYYYMMDD_HHMMSS dir; closed-loop ⇒ "parallel_" prefix.)
   argv.push("--outputs-dir", OUTPUTS_DIR, "--no-timestamp", "--name", RUN_NAME);
+
+  const runDir = `${OUTPUTS_DIR}/${RUN_NAME}/parallel_${params.parallel}_number_${params.number}`;
 
   return {
     argv,
     env: {},
     secretEnv: { OPENAI_API_KEY: connection.apiKey },
     outputFiles: {
-      summary: `${OUTPUTS_DIR}/${RUN_NAME}/benchmark_summary.json`,
-      percentile: `${OUTPUTS_DIR}/${RUN_NAME}/benchmark_percentile.json`,
+      summary: `${runDir}/benchmark_summary.json`,
+      percentile: `${runDir}/benchmark_percentile.json`,
     },
   };
 }

--- a/packages/tool-adapters/src/evalscope/runtime.ts
+++ b/packages/tool-adapters/src/evalscope/runtime.ts
@@ -6,14 +6,17 @@ import type {
 } from "../core/interface.js";
 import { type EvalscopeParams, evalscopeReportSchema } from "./schema.js";
 
-// LongAlpaca-12k + HC3-Chinese (openqa) are baked into the evalscope runner
-// image at build time (apps/benchmark-runner/images/evalscope.Dockerfile)
-// so air-gapped clusters never hit modelscope.cn at run time. `random` is
-// fully synthetic and needs no dataset path.
-const BAKED_DATASET_PATHS: Record<string, string> = {
-  longalpaca: "/opt/evalscope-datasets/longalpaca",
-  openqa: "/opt/evalscope-datasets/openqa/open_qa.jsonl",
-};
+// Datasets are baked into the runner image and read locally via --dataset-path
+// (the cluster can't reach modelscope.cn — pod TLS to it fails — so evalscope's
+// default auto-download is not an option). Per evalscope's source:
+//   - longalpaca: its native plugin's --dataset-path reader does json.loads() of a
+//     single JSON-array file, which doesn't fit ModelScope's CSV layout. We instead
+//     bake a flattened one-prompt-per-line file and use the streaming `line_by_line`
+//     reader (see evalscope.base.Dockerfile). `--min/max-prompt-length` is in chars.
+//   - openqa: its native plugin reads a jsonl via --dataset-path directly.
+//   - random: fully synthetic, no dataset file.
+const LONGALPACA_PROMPTS = "/opt/evalscope-datasets/longalpaca.txt";
+const OPENQA_JSONL = "/opt/evalscope-datasets/openqa/open_qa.jsonl";
 
 const OUTPUTS_DIR = "out";
 const RUN_NAME = "evalscope-run";
@@ -49,12 +52,16 @@ export function buildCommand(plan: BuildCommandPlan<EvalscopeParams>): BuildComm
     String(params.parallel),
     "--number",
     String(params.number),
-    "--dataset",
-    params.dataset,
   ];
 
-  const datasetPath = BAKED_DATASET_PATHS[params.dataset];
-  if (datasetPath) argv.push("--dataset-path", datasetPath);
+  // Map the logical dataset to evalscope's reader + the baked local file.
+  if (params.dataset === "longalpaca") {
+    argv.push("--dataset", "line_by_line", "--dataset-path", LONGALPACA_PROMPTS);
+  } else if (params.dataset === "openqa") {
+    argv.push("--dataset", "openqa", "--dataset-path", OPENQA_JSONL);
+  } else {
+    argv.push("--dataset", params.dataset); // random — synthetic, no file
+  }
 
   argv.push(
     "--min-prompt-length",

--- a/packages/tool-adapters/src/evalscope/runtime.ts
+++ b/packages/tool-adapters/src/evalscope/runtime.ts
@@ -18,6 +18,13 @@ const BAKED_DATASET_PATHS: Record<string, string> = {
 const OUTPUTS_DIR = "out";
 const RUN_NAME = "evalscope-run";
 
+// evalscope `perf` reads the API key ONLY from --api-key (it ignores env vars),
+// so unlike aiperf (env) / guidellm (--backend-kwargs) the key must travel in
+// argv. To keep the secret out of the K8s Job manifest / MD_ARGV we emit this
+// sentinel; the runner swaps in OPENAI_API_KEY (secretEnv, per-run Secret) at
+// exec time. Contract: apps/benchmark-runner/runner/main.py::OPENAI_API_KEY_SENTINEL.
+const OPENAI_API_KEY_SENTINEL = "__MD_OPENAI_API_KEY__";
+
 export function buildCommand(plan: BuildCommandPlan<EvalscopeParams>): BuildCommandResult {
   const { params, connection } = plan;
   const trimmedBase = connection.baseUrl.replace(/\/+$/, "");
@@ -35,6 +42,9 @@ export function buildCommand(plan: BuildCommandPlan<EvalscopeParams>): BuildComm
     "openai",
     "--model",
     connection.model,
+    // Sentinel — runner replaces with OPENAI_API_KEY at exec time (see above).
+    "--api-key",
+    OPENAI_API_KEY_SENTINEL,
     "--parallel",
     String(params.parallel),
     "--number",


### PR DESCRIPTION
## What & why

Smoke-testing the benchmark feature (`kubectl get pods -n modeldoctor-benchmarks`), 3 of 5 tools were failing. Each had a distinct, previously-latent root cause; this PR fixes all three to green and tightens the runner image builds.

> Note: the `urllib3 HeaderParsingError: MissingHeaderBodySeparatorDefect` traceback in the pod logs is **benign** (MinIO `Content-Length: 0` PUT response; upload succeeds, urllib3 only `log.warning`s it). The real per-tool errors were in each run's MinIO `stderr.log`; the runner exits with the inner tool's exit code.

## Fixes

| Tool | Root cause | Fix |
|---|---|---|
| **aiperf** | Served model name (`gen-studio_*`) isn't an HF repo id → tokenizer load 401 → abort | Adapter emits `--tokenizer <connection.tokenizerHfId>` (mirrors guidellm's `--processor`) |
| **guidellm** | Synthetic data needs a processor; none configured | Connection-level `tokenizerHfId` → `--processor` (adapter already supported it) |
| **evalscope** | Chain of 4 latent bugs (see below) | `[perf]` extra + exec-time `--api-key` injection + offline `line_by_line` dataset + correct report subdir |

### evalscope, layer by layer
1. `evalscope==1.7.0` without the `[perf]` extra → `ModuleNotFoundError: No module named 'uvicorn'`. Base image now installs `evalscope[perf]`.
2. `evalscope perf` reads the API key **only** from `--api-key` (ignores env). Against an auth-required gateway it 401'd. The adapter emits a sentinel (`__MD_OPENAI_API_KEY__`); the runner swaps in `OPENAI_API_KEY` (per-run Secret) at `Popen` time, so the key never lands in the K8s Job manifest. `_redacted` masks it in the `running:` log.
3. Dataset: runner pods can't reach `modelscope.cn` (pod TLS → SSL EOF), so auto-download is out; and `--dataset-path` to ModelScope's CSV layout broke the longalpaca reader. Now the base flattens LongAlpaca to one prompt/line and serves it via the streaming `line_by_line` reader; openqa keeps its native jsonl reader.
4. evalscope writes reports into a `parallel_<P>_number_<N>` sweep subdir — the adapter's `outputFiles` now points there.

### Runner Dockerfile optimization (all 6 images)
- `pip install` moved **before** `COPY runner` so editing `runner/` no longer reinstalls boto3/requests on every rebuild
- `--disable-pip-version-check`, consistent `WORKDIR /app`
- evalscope base reordered (modelscope + datasets before evalscope) so the dataset layers stay cached across evalscope bumps

## Verification (k3d, via UI)
- **aiperf, guidellm, evalscope** reruns all reach **Completed**; evalscope detail page renders metrics (64/64 requests, 0 errors, TTFT/ITL/E2E/throughput).
- Unit tests: `@modeldoctor/tool-adapters` vitest green; runner pytest (sentinel injection + redaction) green.

## Notes
- Requires the connection's `tokenizerHfId` to be set when the served model name isn't an HF id (UI field already exists; help text updated to mention aiperf).
- Follow-up (non-blocking): kv-cache-stress filters `8000–9000` **chars**, which only ~10 LongAlpaca samples hit (cycled to fill `number`). Widen the range or attach a local `--tokenizer-path` for token-based filtering if more unique prompts are wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)