### PR TITLE
fix(benchmark): real run logs — tee runner output to pod log + combined stdout/stderr in UI

### DIFF
--- a/apps/benchmark-runner/runner/main.py
+++ b/apps/benchmark-runner/runner/main.py
@@ -7,6 +7,7 @@ contains zero tool-specific knowledge.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -16,14 +17,15 @@ import threading
 from collections import deque
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TextIO
 
 from runner.s3_writer import S3Writer
 from runner.storage_keys import file_key, keys_for
 
 LOG_LINE_MAX_BYTES = 64 * 1024
 # Bounds the S3 stdout/stderr objects and runner RSS for long-running benchmarks.
-# stdout.log/stderr.log are post-mortem only (/log already streamed
-# everything live), so 64 KB per stream is sufficient for triage.
+# stdout.log/stderr.log are post-mortem only (the live stream is the pod log,
+# which StreamPump tees to), so 64 KB per stream is sufficient for triage.
 LOG_TAIL_MAX_BYTES = 64 * 1024  # per stream
 # S3 enforces its own object size limits; output files stream via put_file
 # (multipart-aware for objects >5 MB), so no in-memory cap is needed here.
@@ -69,14 +71,19 @@ def detect_tool_version(tool: str) -> str | None:
 
 
 class StreamPump:
-    """Drains a subprocess pipe into a bounded tail buffer (LOG_TAIL_MAX_BYTES).
-    Phase 3: API now reads live logs directly via K8s pods/log:get; runner
-    only retains the tail for the post-mortem stdout.log / stderr.log writes
-    to S3 (Phase 2 path)."""
+    """Tees a subprocess pipe to ``sink`` (the runner's own stdout/stderr) AND
+    into a bounded tail buffer (LOG_TAIL_MAX_BYTES).
 
-    def __init__(self, stream, name: str):
+    The tee is what makes the tool's output visible *live*: the API reads the
+    K8s pod log via pods/log:get, and ``kubectl logs`` reads the same stream.
+    Without it the pod log carries only the runner's own ``[runner]`` framing
+    lines and the tool's actual output would surface only post-mortem in the
+    S3 stdout.log / stderr.log objects (the tail buffer below)."""
+
+    def __init__(self, stream, name: str, sink: TextIO):
         self.stream = stream
         self.name = name
+        self.sink = sink
         self.full: deque[str] = deque()
         self.full_bytes: int = 0
 
@@ -90,6 +97,10 @@ class StreamPump:
             except Exception:
                 line = repr(line_bytes)
             line = line.rstrip("\n")[:LOG_LINE_MAX_BYTES]
+            # Tee to the pod log (flush so it streams live). A broken sink must
+            # not kill the pump — the S3 tail is the source of truth post-mortem.
+            with contextlib.suppress(ValueError, OSError):
+                print(line, file=self.sink, flush=True)
             self.full.append(line)
             # +1 accounts for the \n that "\n".join(...) reinserts on read
             self.full_bytes += len(line.encode("utf-8")) + 1
@@ -231,8 +242,8 @@ def main() -> int:
         cwd=os.getcwd(),
     )
 
-    out_pump = StreamPump(proc.stdout, "stdout")
-    err_pump = StreamPump(proc.stderr, "stderr")
+    out_pump = StreamPump(proc.stdout, "stdout", sys.stdout)
+    err_pump = StreamPump(proc.stderr, "stderr", sys.stderr)
     t1 = threading.Thread(target=out_pump.run, daemon=True)
     t2 = threading.Thread(target=err_pump.run, daemon=True)
     t1.start()

--- a/apps/benchmark-runner/runner/main.py
+++ b/apps/benchmark-runner/runner/main.py
@@ -86,6 +86,11 @@ class StreamPump:
         self.sink = sink
         self.full: deque[str] = deque()
         self.full_bytes: int = 0
+        # Guards full/full_bytes. The pump runs on a daemon thread while main()
+        # snapshots the tail after join(timeout=5), which may elapse with the
+        # thread still alive under unusual EOF behavior — iterating the deque
+        # mid-append would raise "deque mutated during iteration".
+        self._lock = threading.Lock()
 
     def run(self) -> None:
         while True:
@@ -99,14 +104,22 @@ class StreamPump:
             line = line.rstrip("\n")[:LOG_LINE_MAX_BYTES]
             # Tee to the pod log (flush so it streams live). A broken sink must
             # not kill the pump — the S3 tail is the source of truth post-mortem.
+            # Kept outside the lock so a slow flush never blocks snapshot().
             with contextlib.suppress(ValueError, OSError):
                 print(line, file=self.sink, flush=True)
-            self.full.append(line)
-            # +1 accounts for the \n that "\n".join(...) reinserts on read
-            self.full_bytes += len(line.encode("utf-8")) + 1
-            while self.full_bytes > LOG_TAIL_MAX_BYTES and self.full:
-                evicted = self.full.popleft()
-                self.full_bytes -= len(evicted.encode("utf-8")) + 1
+            with self._lock:
+                self.full.append(line)
+                # +1 accounts for the \n that "\n".join(...) reinserts on read
+                self.full_bytes += len(line.encode("utf-8")) + 1
+                while self.full_bytes > LOG_TAIL_MAX_BYTES and self.full:
+                    evicted = self.full.popleft()
+                    self.full_bytes -= len(evicted.encode("utf-8")) + 1
+
+    def snapshot(self) -> list[str]:
+        """Copy the tail buffer under the lock so a still-running pump thread
+        can't trigger a 'deque mutated during iteration' RuntimeError."""
+        with self._lock:
+            return list(self.full)
 
 
 def _materialize_input_files() -> None:
@@ -263,12 +276,12 @@ def main() -> int:
         s3.put_file(file_key(benchmark_id, alias), str(full))
         files_map[alias] = rel
 
-    # 3. Upload stdout/stderr (tailed buffer from StreamPump)
-    # Snapshot deques into lists in case a daemon pump thread is still
-    # alive after join(timeout=5) — protects against "deque mutated
-    # during iteration" RuntimeError under unusual EOF behavior.
-    s3.put_text(keys.stdout, "\n".join(list(out_pump.full)))
-    s3.put_text(keys.stderr, "\n".join(list(err_pump.full)))
+    # 3. Upload stdout/stderr (tailed buffer from StreamPump).
+    # snapshot() copies under the pump's lock so a daemon pump thread still
+    # alive after join(timeout=5) (unusual EOF behavior) can't trigger a
+    # "deque mutated during iteration" RuntimeError mid-read.
+    s3.put_text(keys.stdout, "\n".join(out_pump.snapshot()))
+    s3.put_text(keys.stderr, "\n".join(err_pump.snapshot()))
 
     # 4. Sentinel — result.json LAST. API uses this to determine "storage complete".
     s3.put_json(

--- a/apps/benchmark-runner/tests/test_main.py
+++ b/apps/benchmark-runner/tests/test_main.py
@@ -336,6 +336,37 @@ def test_stdout_written_to_s3_with_all_lines(
     assert "line three" in text_calls["b-test/stdout.log"]
 
 
+def test_subprocess_output_teed_to_pod_log(
+    md_env_minimal: dict[str, str],
+    mocker: MockerFixture,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """StreamPump tees the tool's stdout/stderr to the runner's own
+    stdout/stderr so the lines land in the K8s pod log for live streaming
+    (API pods/log + kubectl logs), not only in the post-mortem S3 objects."""
+    mocker.patch.dict("os.environ", _s3_env(md_env_minimal), clear=True)
+    mocker.patch("runner.main.Path.cwd", return_value=tmp_path)
+    mocker.patch("runner.main.os.getcwd", return_value=str(tmp_path))
+    proc = _fake_proc(
+        stdout=b"tool-stdout-line\n",
+        stderr=b"tool-stderr-line\n",
+        returncode=0,
+    )
+    mocker.patch("runner.main.subprocess.Popen", return_value=proc)
+    mocker.patch("runner.main.detect_tool_version", return_value=None)
+
+    writer = MagicMock()
+    with patch("runner.main.S3Writer") as MockS3:
+        MockS3.from_env.return_value = writer
+        rc = main_mod.main()
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "tool-stdout-line" in captured.out
+    assert "tool-stderr-line" in captured.err
+
+
 def test_stdout_tail_caps_at_64kb(
     md_env_minimal: dict[str, str],
     mocker: MockerFixture,

--- a/apps/benchmark-runner/tests/test_main.py
+++ b/apps/benchmark-runner/tests/test_main.py
@@ -367,6 +367,13 @@ def test_subprocess_output_teed_to_pod_log(
     assert "tool-stderr-line" in captured.err
 
 
+def test_streampump_snapshot_returns_buffered_lines() -> None:
+    """snapshot() returns a stable copy of the tail buffer (locked read)."""
+    pump = main_mod.StreamPump(io.BytesIO(b"a\nb\nc\n"), "stdout", io.StringIO())
+    pump.run()
+    assert pump.snapshot() == ["a", "b", "c"]
+
+
 def test_stdout_tail_caps_at_64kb(
     md_env_minimal: dict[str, str],
     mocker: MockerFixture,

--- a/apps/web/src/features/benchmarks/BenchmarkDetailMetadata.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailMetadata.tsx
@@ -1,7 +1,10 @@
 import type { Benchmark } from "@modeldoctor/contracts";
 import { format, formatDistanceStrict } from "date-fns";
+import { Copy } from "lucide-react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
 import { StatusBadge } from "./status-display";
 
 function fmtDate(iso: string | null): string {
@@ -41,7 +44,46 @@ export function BenchmarkDetailMetadata({ benchmark }: { benchmark: Benchmark })
       <Row label={t("detail.metadata.duration")}>
         {fmtDuration(benchmark.startedAt, benchmark.completedAt)}
       </Row>
+      {benchmark.driverHandle && <JobRow handle={benchmark.driverHandle} />}
     </dl>
+  );
+}
+
+/** Surfaces the K8s job that ran this benchmark so operators can pull pod logs
+ *  directly (`driverHandle` is "<namespace>/<jobName>"). The copy button yields
+ *  a ready-to-run `kubectl logs` command. */
+function JobRow({ handle }: { handle: string }) {
+  const { t } = useTranslation("benchmarks");
+  const slash = handle.indexOf("/");
+  const namespace = slash >= 0 ? handle.slice(0, slash) : null;
+  const jobName = slash >= 0 ? handle.slice(slash + 1) : handle;
+  const kubectlCmd = namespace
+    ? `kubectl logs -n ${namespace} job/${jobName}`
+    : `kubectl logs job/${jobName}`;
+  return (
+    <Row label={t("detail.metadata.job")}>
+      <div className="flex flex-col">
+        <span className="flex items-center gap-1.5">
+          <code className="font-mono text-xs break-all">{jobName}</code>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-5 w-5 shrink-0"
+            title={kubectlCmd}
+            onClick={() => {
+              void navigator.clipboard.writeText(kubectlCmd);
+              toast.success(t("detail.metadata.jobCopied"));
+            }}
+          >
+            <Copy className="h-3 w-3" />
+          </Button>
+        </span>
+        {namespace && (
+          <span className="text-xs font-normal text-muted-foreground">{namespace}</span>
+        )}
+      </div>
+    </Row>
   );
 }
 

--- a/apps/web/src/features/benchmarks/BenchmarkDetailMetadata.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailMetadata.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { copyToClipboard } from "@/lib/clipboard";
 import { StatusBadge } from "./status-display";
 
 function fmtDate(iso: string | null): string {
@@ -72,8 +73,11 @@ function JobRow({ handle }: { handle: string }) {
             className="h-5 w-5 shrink-0"
             title={kubectlCmd}
             onClick={() => {
-              void navigator.clipboard.writeText(kubectlCmd);
-              toast.success(t("detail.metadata.jobCopied"));
+              void copyToClipboard(kubectlCmd).then((ok) => {
+                toast[ok ? "success" : "error"](
+                  t(ok ? "detail.metadata.jobCopied" : "detail.metadata.jobCopyFailed"),
+                );
+              });
             }}
           >
             <Copy className="h-3 w-3" />

--- a/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
@@ -83,31 +83,49 @@ function RunningSection({ benchmark }: { benchmark: Benchmark }) {
   );
 }
 
-/** Dark terminal-style log panel. Shows live SSE lines during run; stdout
- *  from rawOutput after completion. Survives page refresh via DB fallback. */
-function LogPanel({ logLines, stdout }: { logLines: LogEvent[]; stdout: string }) {
+/** Dark terminal-style log panel. Shows live SSE lines during a run; the
+ *  combined stdout+stderr from rawOutput after completion. Survives page
+ *  refresh via the DB fallback. */
+function LogPanel({
+  logLines,
+  stdout,
+  stderr,
+}: {
+  logLines: LogEvent[];
+  stdout: string;
+  stderr: string;
+}) {
   const { t } = useTranslation("benchmarks");
   const logEndRef = useRef<HTMLDivElement>(null);
 
+  // Post-mortem the runner stores stdout and stderr as separate S3 objects, so
+  // chronological interleaving is lost — show stdout then stderr. Many tools
+  // log entirely to one stream (guidellm/evalscope write to stderr), so the
+  // panel must render both or a successful run looks empty.
+  const stored = [stdout, stderr]
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .join("\n");
+
   useEffect(() => {
     logEndRef.current?.scrollIntoView({ behavior: "auto" });
-  }, [logLines, stdout]);
+  }, [logLines, stored]);
 
   const hasLive = logLines.length > 0;
-  const hasStdout = stdout.trim().length > 0;
+  const hasStored = stored.length > 0;
 
-  if (!hasLive && !hasStdout) {
+  if (!hasLive && !hasStored) {
     return (
-      <div className="flex h-48 items-center justify-center rounded-md border border-border bg-zinc-950 text-xs text-zinc-500">
+      <div className="flex h-48 items-center justify-center rounded-md border border-border bg-zinc-950 px-6 text-center text-xs text-zinc-500">
         {t("detail.logs.empty")}
       </div>
     );
   }
 
-  if (hasStdout) {
+  if (hasStored) {
     return (
       <pre className="max-h-[60vh] min-h-48 overflow-auto rounded-md bg-zinc-950 p-4 font-mono text-xs leading-relaxed text-zinc-200 whitespace-pre-wrap break-all">
-        {stdout}
+        {stored}
         <div ref={logEndRef} />
       </pre>
     );
@@ -188,7 +206,9 @@ function BenchmarkDetailTabs({
   );
   const [active, setActive] = useState<string>("overview");
 
-  const stdout = (benchmark.rawOutput as { stdout?: string } | null)?.stdout ?? "";
+  const rawLogs = benchmark.rawOutput as { stdout?: string; stderr?: string } | null;
+  const stdout = rawLogs?.stdout ?? "";
+  const stderr = rawLogs?.stderr ?? "";
 
   return (
     <Tabs value={active} onValueChange={setActive} className="w-full">
@@ -235,7 +255,7 @@ function BenchmarkDetailTabs({
       )}
 
       <TabsContent value="logs">
-        <LogPanel logLines={logLines} stdout={stdout} />
+        <LogPanel logLines={logLines} stdout={stdout} stderr={stderr} />
       </TabsContent>
 
       {isTerminal && (

--- a/apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
@@ -635,6 +635,33 @@ describe("BenchmarkDetailPage", () => {
     expect(screen.getByText(/No stderr captured|没有捕获到 stderr 输出/i)).toBeInTheDocument();
   });
 
+  it("shows stderr in the Run Logs tab for a completed run that logged only to stderr", async () => {
+    // Regression: guidellm --disable-console writes nothing to stdout; its
+    // output lands in stderr. The Run Logs tab used to render stdout only and
+    // showed "No logs available" for such successful runs.
+    vi.mocked(api.get).mockResolvedValueOnce(
+      makeBenchmark({
+        status: "completed",
+        rawOutput: { stdout: "", stderr: "Warning: unauthenticated HF Hub request", files: {} },
+      }),
+    );
+    const user = userEvent.setup();
+    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
+    await screen.findByRole("heading", { name: "smoke" });
+    await user.click(screen.getByRole("tab", { name: /Run Logs|运行日志/i }));
+    expect(await screen.findByText(/unauthenticated HF Hub request/)).toBeInTheDocument();
+    expect(screen.queryByText(/No console output|没有控制台输出/i)).not.toBeInTheDocument();
+  });
+
+  it("surfaces the K8s job name when driverHandle is set", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(
+      makeBenchmark({ driverHandle: "modeldoctor-benchmarks/run-abc123" }),
+    );
+    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
+    expect(await screen.findByText("run-abc123")).toBeInTheDocument();
+    expect(screen.getByText("modeldoctor-benchmarks")).toBeInTheDocument();
+  });
+
   it("renders Save-as-Template button when status is completed", async () => {
     vi.mocked(api.get).mockResolvedValueOnce(makeBenchmark({ status: "completed" }));
     render(<BenchmarkDetailPage />, { wrapper: Wrapper });

--- a/apps/web/src/lib/clipboard.ts
+++ b/apps/web/src/lib/clipboard.ts
@@ -1,0 +1,35 @@
+/**
+ * Copy text to the clipboard, with a fallback for non-secure (HTTP) contexts.
+ *
+ * `navigator.clipboard` is only defined in secure contexts (HTTPS or
+ * localhost). Self-hosted ModelDoctor dashboards are frequently served over
+ * plain HTTP on an internal IP, where `navigator.clipboard` is `undefined` and
+ * calling `.writeText` would throw. Fall back to a hidden `<textarea>` +
+ * `document.execCommand("copy")` so copy works everywhere.
+ *
+ * @returns true if the copy succeeded.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Permission denied / blocked — fall through to the legacy path.
+    }
+  }
+  try {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(textarea);
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/locales/en-US/benchmarks.json
+++ b/apps/web/src/locales/en-US/benchmarks.json
@@ -154,7 +154,8 @@
       "completedAt": "Completed",
       "duration": "Duration",
       "job": "Run (K8s Job)",
-      "jobCopied": "kubectl logs command copied"
+      "jobCopied": "kubectl logs command copied",
+      "jobCopyFailed": "Copy failed"
     },
     "statusMessage": {
       "title": "Failure reason"

--- a/apps/web/src/locales/en-US/benchmarks.json
+++ b/apps/web/src/locales/en-US/benchmarks.json
@@ -152,7 +152,9 @@
       "createdAt": "Created",
       "startedAt": "Started",
       "completedAt": "Completed",
-      "duration": "Duration"
+      "duration": "Duration",
+      "job": "Run (K8s Job)",
+      "jobCopied": "kubectl logs command copied"
     },
     "statusMessage": {
       "title": "Failure reason"
@@ -172,7 +174,7 @@
       "toggle": "Logs",
       "stdout": "stdout",
       "stderr": "stderr",
-      "empty": "No logs available"
+      "empty": "This run produced no console output (see the Overview / Distributions tabs for results)"
     },
     "baseline": {
       "setButton": "Set as baseline",

--- a/apps/web/src/locales/zh-CN/benchmarks.json
+++ b/apps/web/src/locales/zh-CN/benchmarks.json
@@ -152,7 +152,9 @@
       "createdAt": "创建于",
       "startedAt": "开始于",
       "completedAt": "结束于",
-      "duration": "时长"
+      "duration": "时长",
+      "job": "运行实例（K8s Job）",
+      "jobCopied": "已复制 kubectl logs 命令"
     },
     "statusMessage": {
       "title": "失败原因"
@@ -172,7 +174,7 @@
       "toggle": "日志",
       "stdout": "标准输出（stdout）",
       "stderr": "标准错误（stderr）",
-      "empty": "暂无日志"
+      "empty": "此次运行没有控制台输出（结果见「概览」「分布」标签页）"
     },
     "baseline": {
       "setButton": "设为基线",

--- a/apps/web/src/locales/zh-CN/benchmarks.json
+++ b/apps/web/src/locales/zh-CN/benchmarks.json
@@ -154,7 +154,8 @@
       "completedAt": "结束于",
       "duration": "时长",
       "job": "运行实例（K8s Job）",
-      "jobCopied": "已复制 kubectl logs 命令"
+      "jobCopied": "已复制 kubectl logs 命令",
+      "jobCopyFailed": "复制失败"
     },
     "statusMessage": {
       "title": "失败原因"


### PR DESCRIPTION
## Problem

Completed benchmarks showed **"No logs available"** in the detail page's *Run Logs* tab, and `kubectl logs <pod>` on a finished benchmark pod showed only the runner's own `[runner] …` framing lines — never the benchmark tool's output. Two independent causes:

1. **Runner never echoed tool output to the pod log.** `StreamPump` drained the subprocess pipes into an in-memory tail buffer (for the post-mortem S3 `stdout.log`/`stderr.log`) but never wrote them to its own stdout/stderr. Since the API's live log stream reads the pod log via `pods/log:get`, a running benchmark showed no real output live and progress parsing had nothing to read; the tool output surfaced only post-mortem in S3.
2. **The UI rendered `stdout` only.** `LogPanel` showed `rawOutput.stdout`; `stderr` appeared only in the failure section and only for *failed* runs. Tools that log to stderr (`guidellm --disable-console`, evalscope) therefore displayed "No logs available" on a *successful* run even though their output was captured (e.g. guidellm: stdout=0B, stderr=137B; evalscope: 12KB of logs in stderr).

## Changes

**`apps/benchmark-runner` (runner)**
- `StreamPump` now tees each line to the runner's own stdout/stderr (flushed) alongside the tail buffer, so the pod log carries the full live stream. S3 keeps stdout/stderr as separate objects — `parseFinalReport(stdout)` stays clean and the failure stderr-tail is intact.

**`apps/web` (detail page)**
- *Run Logs* tab renders the **combined stdout+stderr** post-mortem (was stdout-only).
- Empty state reworded to point at the Overview/Distributions tabs for tools that emit no console output (e.g. vegeta → results live in report files).
- New **Run (K8s Job)** metadata row surfaces `driverHandle` (`<ns>/run-<id>`) with one-click copy of a ready-to-run `kubectl logs -n … job/…` command.

## Effect (two layers, different timing)

- **Web fix is retroactive** for existing completed runs — it reads `rawOutput.stderr` already persisted in the DB. The guidellm run that showed "No logs available" will now show its stderr.
- **Runner tee** only takes effect for new runs once the runner image is **rebuilt + redeployed**; it fixes the *live* SSE stream and `kubectl logs`.

## Test plan

- Runner: `uv run --extra dev pytest` → 38 passed (incl. new `test_subprocess_output_teed_to_pod_log`); `ruff check` clean.
- Web: `vitest run BenchmarkDetailPage.test.tsx` → 40 passed (incl. new "shows stderr in Run Logs for a completed stderr-only run" + "surfaces the K8s job name"); `type-check` clean; `lint` clean (i18n zh/en parity + no-hardcoded-CJK + component checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)