### PR TITLE
fix(quality-gate): LLM judge fail-fast + phantom schema cleanup

### DIFF
--- a/apps/api/src/modules/quality-gate/judges/llm-judge.ts
+++ b/apps/api/src/modules/quality-gate/judges/llm-judge.ts
@@ -3,10 +3,10 @@ import type { Judge } from "./types.js";
 
 type Config = Extract<JudgeConfig, { kind: "llm-judge" }>;
 
-// Thin shape from the AI Diagnostics service: factory only needs runJudge(prompts) → { content }.
-// At wiring time the real adapter delegates to the diagnostics service.
+// Thin shape over the singleton LLM judge provider. At wiring time the real
+// adapter delegates to `LlmJudgeService.getDecrypted()` + `chatCompletion`.
 export interface LlmJudgeService {
-  runJudge(input: { systemPrompt: string; userPrompt: string; connectionId?: string }): Promise<{
+  runJudge(input: { systemPrompt: string; userPrompt: string }): Promise<{
     content: string;
   }>;
 }
@@ -50,7 +50,6 @@ export function createLlmJudge(service: LlmJudgeService): Judge<Config> {
         const resp = await service.runJudge({
           systemPrompt: buildSystemPrompt(config.rubric, config.scale),
           userPrompt: buildUserPrompt(ctx),
-          connectionId: config.judgeModel?.connectionId,
         });
         let parsed: { score: number; reason: string };
         try {

--- a/apps/api/src/modules/quality-gate/services/__tests__/runs.service.spec.ts
+++ b/apps/api/src/modules/quality-gate/services/__tests__/runs.service.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { RunsService } from "../runs.service.js";
+import { NO_LLM_JUDGE_PROVIDER_MSG, RunsService } from "../runs.service.js";
 
 function build() {
   const repo = {
@@ -215,5 +215,73 @@ describe("RunsService", () => {
     expect(m.repo.createPending).toHaveBeenCalledWith(
       expect.objectContaining({ baselineRunIdAtExecution: null, endpointBId: "b" }),
     );
+  });
+
+  it("rejects with BadRequest when llm-judge sample requires provider but none is configured", async () => {
+    const m = build();
+    m.evaluationsRepo.get.mockResolvedValueOnce({
+      id: "e1",
+      userId: "u1",
+      version: 2,
+      samples: [
+        {
+          id: "s",
+          idx: 0,
+          prompt: "Q",
+          expected: "A",
+          judgeConfig: {
+            kind: "llm-judge",
+            rubric: "Score the response quality",
+            scale: "pass-fail",
+          },
+        },
+      ],
+      baselineRunId: null,
+    });
+    m.llmJudge.getDecrypted.mockResolvedValueOnce(null);
+    const svc = new RunsService(
+      m.repo as never,
+      m.evaluationsRepo as never,
+      m.connections as never,
+      m.executor as never,
+      m.llmJudge as never,
+    );
+    await expect(
+      svc.create("u1", { evaluationId: "e1", endpointAId: "c1", gateConfig: { passRateMin: 0.9 } }),
+    ).rejects.toThrow(NO_LLM_JUDGE_PROVIDER_MSG);
+  });
+
+  it("rejects with BadRequest when llm-judge sample requires provider but provider is disabled", async () => {
+    const m = build();
+    m.evaluationsRepo.get.mockResolvedValueOnce({
+      id: "e1",
+      userId: "u1",
+      version: 2,
+      samples: [
+        {
+          id: "s",
+          idx: 0,
+          prompt: "Q",
+          expected: "A",
+          judgeConfig: {
+            kind: "llm-judge",
+            rubric: "Score the response quality",
+            scale: "pass-fail",
+          },
+        },
+      ],
+      baselineRunId: null,
+    });
+    m.llmJudge.getDecrypted.mockResolvedValueOnce({ enabled: false });
+    const svc = new RunsService(
+      m.repo as never,
+      m.evaluationsRepo as never,
+      m.connections as never,
+      m.executor as never,
+      m.llmJudge as never,
+    );
+    await expect(
+      svc.create("u1", { evaluationId: "e1", endpointAId: "c1", gateConfig: { passRateMin: 0.9 } }),
+    ).rejects.toThrow(NO_LLM_JUDGE_PROVIDER_MSG);
   });
 });

--- a/apps/api/src/modules/quality-gate/services/__tests__/runs.service.spec.ts
+++ b/apps/api/src/modules/quality-gate/services/__tests__/runs.service.spec.ts
@@ -24,7 +24,10 @@ function build() {
     findOwnedPublic: vi.fn().mockResolvedValue({ id: "c", userId: "u1" }),
   };
   const executor = { start: vi.fn(), cancel: vi.fn() };
-  return { repo, evaluationsRepo, connections, executor };
+  const llmJudge = {
+    getDecrypted: vi.fn().mockResolvedValue({ enabled: true }),
+  };
+  return { repo, evaluationsRepo, connections, executor, llmJudge };
 }
 
 describe("RunsService", () => {
@@ -36,6 +39,7 @@ describe("RunsService", () => {
       m.evaluationsRepo as never,
       m.connections as never,
       m.executor as never,
+      m.llmJudge as never,
     );
     await expect(
       svc.create("u1", { evaluationId: "x", endpointAId: "c", gateConfig: { passRateMin: 0.9 } }),
@@ -48,6 +52,7 @@ describe("RunsService", () => {
       m.evaluationsRepo as never,
       m.connections as never,
       m.executor as never,
+      m.llmJudge as never,
     );
     const r = await svc.create("u1", {
       evaluationId: "e1",
@@ -68,6 +73,7 @@ describe("RunsService", () => {
       m.evaluationsRepo as never,
       m.connections as never,
       m.executor as never,
+      m.llmJudge as never,
     );
     await svc.cancel("u1", "r1");
     expect(m.executor.cancel).toHaveBeenCalledWith("r1");
@@ -89,6 +95,7 @@ describe("RunsService", () => {
       m.evaluationsRepo as never,
       m.connections as never,
       m.executor as never,
+      m.llmJudge as never,
     );
     await svc.create("u1", {
       evaluationId: "e1",
@@ -116,6 +123,7 @@ describe("RunsService", () => {
       m.evaluationsRepo as never,
       m.connections as never,
       m.executor as never,
+      m.llmJudge as never,
     );
     await svc.create("u1", {
       evaluationId: "e1",
@@ -141,6 +149,7 @@ describe("RunsService", () => {
       m.evaluationsRepo as never,
       m.connections as never,
       m.executor as never,
+      m.llmJudge as never,
     );
     await svc.create("u1", {
       evaluationId: "e1",
@@ -167,6 +176,7 @@ describe("RunsService", () => {
       m.evaluationsRepo as never,
       m.connections as never,
       m.executor as never,
+      m.llmJudge as never,
     );
     await expect(
       svc.create("u1", {
@@ -194,6 +204,7 @@ describe("RunsService", () => {
       m.evaluationsRepo as never,
       m.connections as never,
       m.executor as never,
+      m.llmJudge as never,
     );
     await svc.create("u1", {
       evaluationId: "e1",

--- a/apps/api/src/modules/quality-gate/services/runs.service.ts
+++ b/apps/api/src/modules/quality-gate/services/runs.service.ts
@@ -11,6 +11,14 @@ import { RunsRepository } from "../repositories/runs.repository.js";
 import { EvaluationsService } from "./evaluations.service.js";
 import { QualityGateRunExecutor } from "./run-executor.service.js";
 
+// Exported so unit tests can assert the exact message without duplicating it.
+// If the Settings page label ever moves, both this constant and the i18n key
+// `settings.ai.title` need updating together.
+export const NO_LLM_JUDGE_PROVIDER_MSG =
+  "This evaluation requires an LLM judge. " +
+  "No enabled LLM judge provider is configured. " +
+  "Configure one at Settings → AI Diagnostics.";
+
 @Injectable()
 export class RunsService {
   constructor(
@@ -50,11 +58,7 @@ export class RunsService {
     if (needsLlmJudge) {
       const provider = await this.llmJudge.getDecrypted();
       if (!provider?.enabled) {
-        throw new BadRequestException(
-          "This evaluation requires an LLM judge. " +
-            "No enabled LLM judge provider is configured. " +
-            "Configure one at Settings → AI Diagnostics.",
-        );
+        throw new BadRequestException(NO_LLM_JUDGE_PROVIDER_MSG);
       }
     }
 

--- a/apps/api/src/modules/quality-gate/services/runs.service.ts
+++ b/apps/api/src/modules/quality-gate/services/runs.service.ts
@@ -6,6 +6,7 @@ import type {
 } from "@modeldoctor/contracts";
 import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
 import { ConnectionService } from "../../connection/connection.service.js";
+import { LlmJudgeService } from "../../llm-judge/llm-judge.service.js";
 import { RunsRepository } from "../repositories/runs.repository.js";
 import { EvaluationsService } from "./evaluations.service.js";
 import { QualityGateRunExecutor } from "./run-executor.service.js";
@@ -17,6 +18,7 @@ export class RunsService {
     private readonly evaluations: EvaluationsService,
     private readonly connections: ConnectionService,
     private readonly executor: QualityGateRunExecutor,
+    private readonly llmJudge: LlmJudgeService,
   ) {}
 
   list(userId: string, q: ListRunsQuery) {
@@ -43,6 +45,19 @@ export class RunsService {
   async create(userId: string, body: CreateRunRequest): Promise<EvaluationRun> {
     const evaluation = await this.evaluations.get(userId, body.evaluationId);
     if (!evaluation) throw new NotFoundException(`evaluation ${body.evaluationId} not found`);
+
+    const needsLlmJudge = evaluation.samples.some((s) => s.judgeConfig.kind === "llm-judge");
+    if (needsLlmJudge) {
+      const provider = await this.llmJudge.getDecrypted();
+      if (!provider?.enabled) {
+        throw new BadRequestException(
+          "This evaluation requires an LLM judge. " +
+            "No enabled LLM judge provider is configured. " +
+            "Configure one at Settings → AI Diagnostics.",
+        );
+      }
+    }
+
     const connA = await this.connections
       .findOwnedPublic(userId, body.endpointAId)
       .catch(() => null);

--- a/apps/api/test/e2e/quality-gate.e2e-spec.ts
+++ b/apps/api/test/e2e/quality-gate.e2e-spec.ts
@@ -1,5 +1,5 @@
 import request from "supertest";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { bootE2E, type E2EContext, registerUser } from "../helpers/app.js";
 
 let ctx: E2EContext;
@@ -241,4 +241,158 @@ describe("baseline pin flow", () => {
       .expect(201);
     expect(newRun.body.baselineRunIdAtExecution).toBeNull();
   }, 120_000);
+});
+
+describe("LLM judge guard at run creation", () => {
+  // The LLM judge provider is a singleton row in llm_judge_providers.
+  // Each test below sets the desired state explicitly via the /api/llm-judge/provider
+  // endpoint, then exercises POST /api/quality-gate/runs to assert the guard.
+
+  afterEach(() => deleteProvider());
+
+  async function deleteProvider() {
+    // Tolerate 404 (no row to delete) so tests are independent of file ordering.
+    await request(ctx.app.getHttpServer())
+      .delete("/api/llm-judge/provider")
+      .set("Authorization", `Bearer ${token}`)
+      .then(() => undefined)
+      .catch(() => undefined);
+  }
+
+  async function upsertProvider(opts: { enabled: boolean }) {
+    await request(ctx.app.getHttpServer())
+      .put("/api/llm-judge/provider")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        baseUrl: "https://judge.example/v1",
+        apiKey: "sk-test",
+        model: "judge-model",
+        enabled: opts.enabled,
+      })
+      .expect(200);
+  }
+
+  async function createLlmJudgeEval(name: string) {
+    const r = await request(ctx.app.getHttpServer())
+      .post("/api/quality-gate/evaluations")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        name,
+        samples: [
+          {
+            id: "s0",
+            idx: 0,
+            prompt: "summarise: the sky is blue",
+            expected: "blue sky",
+            judgeConfig: {
+              kind: "llm-judge",
+              rubric:
+                "Score 1 if the summary mentions blue and sky, otherwise 0.",
+              scale: "pass-fail",
+            },
+          },
+        ],
+      })
+      .expect(201);
+    return r.body.id as string;
+  }
+
+  async function createExactMatchEval(name: string) {
+    const r = await request(ctx.app.getHttpServer())
+      .post("/api/quality-gate/evaluations")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        name,
+        samples: [
+          {
+            id: "s0",
+            idx: 0,
+            prompt: "echo hi",
+            expected: "hi",
+            judgeConfig: { kind: "exact-match" },
+          },
+        ],
+      })
+      .expect(201);
+    return r.body.id as string;
+  }
+
+  it("rejects with 400 when eval has llm-judge samples and no provider configured", async () => {
+    await deleteProvider();
+    const evalId = await createLlmJudgeEval("guard-no-provider");
+    const conn = await createConnection("guard-target-1");
+
+    const r = await request(ctx.app.getHttpServer())
+      .post("/api/quality-gate/runs")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        evaluationId: evalId,
+        endpointAId: conn,
+        gateConfig: { passRateMin: 0.9 },
+      })
+      .expect(400);
+
+    expect(String(r.body.message ?? r.text)).toMatch(
+      /No enabled LLM judge provider/i,
+    );
+  }, 60_000);
+
+  it("rejects with 400 when provider exists but enabled=false", async () => {
+    await upsertProvider({ enabled: false });
+    const evalId = await createLlmJudgeEval("guard-disabled-provider");
+    const conn = await createConnection("guard-target-2");
+
+    const r = await request(ctx.app.getHttpServer())
+      .post("/api/quality-gate/runs")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        evaluationId: evalId,
+        endpointAId: conn,
+        gateConfig: { passRateMin: 0.9 },
+      })
+      .expect(400);
+
+    expect(String(r.body.message ?? r.text)).toMatch(
+      /No enabled LLM judge provider/i,
+    );
+  }, 60_000);
+
+  it("succeeds when llm-judge eval has an enabled provider", async () => {
+    await upsertProvider({ enabled: true });
+    const evalId = await createLlmJudgeEval("guard-happy-path");
+    const conn = await createConnection("guard-target-3");
+
+    const r = await request(ctx.app.getHttpServer())
+      .post("/api/quality-gate/runs")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        evaluationId: evalId,
+        endpointAId: conn,
+        gateConfig: { passRateMin: 0.9 },
+      })
+      .expect(201);
+
+    expect(r.body.id).toBeTruthy();
+    expect(["PENDING", "RUNNING", "COMPLETED", "FAILED"]).toContain(
+      r.body.status,
+    );
+  }, 60_000);
+
+  it("succeeds when eval has only non-llm-judge samples even without provider", async () => {
+    await deleteProvider();
+    const evalId = await createExactMatchEval("guard-no-llm-judge-needed");
+    const conn = await createConnection("guard-target-4");
+
+    const r = await request(ctx.app.getHttpServer())
+      .post("/api/quality-gate/runs")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        evaluationId: evalId,
+        endpointAId: conn,
+        gateConfig: { passRateMin: 0.9 },
+      })
+      .expect(201);
+
+    expect(r.body.id).toBeTruthy();
+  }, 60_000);
 });

--- a/docs/superpowers/plans/2026-05-28-llm-judge-fail-fast.md
+++ b/docs/superpowers/plans/2026-05-28-llm-judge-fail-fast.md
@@ -1,0 +1,591 @@
+# LLM Judge fail-fast Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop reporting "missing LLM judge provider" as a fake 0% quality fail. Reject `POST /api/quality-gate/runs` with `400` at creation time when the evaluation needs an `llm-judge` but no enabled provider exists, and remove the dead `judgeModel.connectionId` schema field.
+
+**Architecture:** Add a single guard call inside `RunsService.create()` (the one funnel for all run creations) that consults `LlmJudgeService.getDecrypted()` before persisting a PENDING row. Delete the phantom `judgeModel` field from contracts + the matching plumbing in the judge factory — no DB migration needed (verified 0 rows carry it).
+
+**Tech Stack:** TypeScript, NestJS, Vitest (api e2e via supertest), pnpm workspaces, Prisma over Postgres (`modeldoctor_test` DB for e2e).
+
+**Spec:** [`docs/superpowers/specs/2026-05-28-llm-judge-fail-fast-design.md`](../specs/2026-05-28-llm-judge-fail-fast-design.md)
+
+**Branch:** `fix/llm-judge-fail-fast` (already created; spec committed as `c9e77f0`)
+
+---
+
+## File map
+
+| File | Action | Why |
+|---|---|---|
+| `packages/contracts/src/quality-gate/judge-config.ts` | Modify (delete L27) | Remove phantom `judgeModel` schema field |
+| `apps/api/src/modules/quality-gate/judges/llm-judge.ts` | Modify (L6-7 comment, L9 interface, L53 call site) | Remove dead `connectionId` plumbing; tighten comment |
+| `apps/api/src/modules/quality-gate/services/runs.service.ts` | Modify (inject `LlmJudgeService`, add guard in `create()`) | Core fail-fast behavior |
+| `apps/api/test/e2e/quality-gate.e2e-spec.ts` | Modify (append new `describe` block, 4 cases) | E2E coverage for the guard |
+
+No new files. No DB migration. No web-side change.
+
+---
+
+## Task 1: Cleanup phantom `judgeModel` field (no behavioral change)
+
+**Files:**
+- Modify: `packages/contracts/src/quality-gate/judge-config.ts:27`
+- Modify: `apps/api/src/modules/quality-gate/judges/llm-judge.ts:6-9,53`
+
+- [ ] **Step 1: Verify current state — exactly 2 source-code hits expected**
+
+Run:
+```bash
+cd /Users/fangyong/vllm/modeldoctor/main
+rg -n 'judgeModel' apps packages 2>/dev/null
+```
+
+Expected output (exactly 2 lines):
+```
+apps/api/src/modules/quality-gate/judges/llm-judge.ts:53:          connectionId: config.judgeModel?.connectionId,
+packages/contracts/src/quality-gate/judge-config.ts:27:  judgeModel: z.object({ connectionId: z.string() }).optional(),
+```
+
+If you see more than these 2, stop and investigate — the dead-code sweep was wrong.
+
+- [ ] **Step 2: Remove `judgeModel` from the `llmJudge` schema**
+
+In `packages/contracts/src/quality-gate/judge-config.ts`, locate the `llmJudge` z.object (lines 22-28) and delete line 27:
+
+```diff
+ const llmJudge = z.object({
+   kind: z.literal("llm-judge"),
+   rubric: z.string().min(10).max(4000),
+   scale: z.enum(["0-1", "0-5", "pass-fail"]),
+   passThreshold: z.number().optional(),
+-  judgeModel: z.object({ connectionId: z.string() }).optional(),
+ });
+```
+
+- [ ] **Step 3: Remove `connectionId` from the `LlmJudgeService` interface + the call site, and tighten the comment**
+
+In `apps/api/src/modules/quality-gate/judges/llm-judge.ts`, replace the comment block (lines 6-7) and the interface (lines 8-12):
+
+```diff
+-// Thin shape from the AI Diagnostics service: factory only needs runJudge(prompts) → { content }.
+-// At wiring time the real adapter delegates to the diagnostics service.
++// Thin shape over the singleton LLM judge provider. At wiring time the real
++// adapter delegates to `LlmJudgeService.getDecrypted()` + `chatCompletion`.
+ export interface LlmJudgeService {
+-  runJudge(input: { systemPrompt: string; userPrompt: string; connectionId?: string }): Promise<{
++  runJudge(input: { systemPrompt: string; userPrompt: string }): Promise<{
+     content: string;
+   }>;
+ }
+```
+
+And in the same file, inside `createLlmJudge(service)` → `evaluate()` (around line 49-54), drop the `connectionId` arg:
+
+```diff
+         const resp = await service.runJudge({
+           systemPrompt: buildSystemPrompt(config.rubric, config.scale),
+           userPrompt: buildUserPrompt(ctx),
+-          connectionId: config.judgeModel?.connectionId,
+         });
+```
+
+- [ ] **Step 4: Verify zero remaining references**
+
+Run:
+```bash
+rg -n 'judgeModel' apps packages 2>/dev/null
+```
+
+Expected: empty output (exit code 1 from ripgrep is normal here — it means no matches).
+
+- [ ] **Step 5: Build contracts so the api can consume the new types**
+
+Run:
+```bash
+pnpm -F @modeldoctor/contracts build
+```
+
+Expected: success, no errors. The contracts package emits to `packages/contracts/dist`.
+
+- [ ] **Step 6: Type-check contracts + api (catches any stale callers we missed)**
+
+Run:
+```bash
+pnpm -F @modeldoctor/contracts type-check && pnpm -F @modeldoctor/api type-check
+```
+
+Expected: no type errors. If you see a `Property 'judgeModel' does not exist` error, that's a missed caller — find it with `rg judgeModel` and remove it before continuing.
+
+- [ ] **Step 7: Run contracts + judge unit tests (regression guard)**
+
+Run:
+```bash
+pnpm -F @modeldoctor/contracts test && pnpm -F @modeldoctor/api test -- judges
+```
+
+Expected: all green. If a contracts test asserted the shape of `llmJudge` (it doesn't today, verified by `rg judgeModel packages/contracts/src/quality-gate/__tests__/`), update it to drop the `judgeModel` field.
+
+- [ ] **Step 8: Commit**
+
+Run:
+```bash
+git add packages/contracts/src/quality-gate/judge-config.ts \
+        apps/api/src/modules/quality-gate/judges/llm-judge.ts
+git status --short
+```
+
+Expected output:
+```
+M  packages/contracts/src/quality-gate/judge-config.ts
+M  apps/api/src/modules/quality-gate/judges/llm-judge.ts
+```
+
+Then:
+```bash
+git commit -m "refactor(quality-gate): drop phantom judgeModel.connectionId field
+
+The schema-level judgeModel.connectionId allowed per-llm-judge connection
+override, but: (1) the runtime adapter in judges.service.ts ignores
+input.connectionId, (2) 0 seeded evals use it, (3) the web UI never
+exposes it, (4) no DB row carries it. Pure dead surface — removing
+across schema + interface + call site.
+
+Refs spec: docs/superpowers/specs/2026-05-28-llm-judge-fail-fast-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Write the failing e2e tests (TDD — red)
+
+**Files:**
+- Modify: `apps/api/test/e2e/quality-gate.e2e-spec.ts` (append new `describe` block)
+
+This task writes 4 new e2e cases. They all fail because the guard does not exist yet — that's the point. Do **not** commit at the end of this task; Task 3 implements the guard and the combined diff lands as one TDD commit.
+
+- [ ] **Step 1: Append the new describe block to `apps/api/test/e2e/quality-gate.e2e-spec.ts`**
+
+The existing file already has `beforeAll`/`afterAll`/`createConnection`/`waitForRunStatus` at file scope (lines 5-57). Reuse them. Append this block **after** the existing `describe("baseline pin flow", …)` block at end of file:
+
+```ts
+describe("LLM judge guard at run creation", () => {
+  // The LLM judge provider is a singleton row in llm_judge_providers.
+  // Each test below sets the desired state explicitly via the /api/llm-judge/provider
+  // endpoint, then exercises POST /api/quality-gate/runs to assert the guard.
+
+  async function deleteProvider() {
+    // Tolerate 404 (no row to delete) so tests are independent of file ordering.
+    await request(ctx.app.getHttpServer())
+      .delete("/api/llm-judge/provider")
+      .set("Authorization", `Bearer ${token}`)
+      .then(() => undefined)
+      .catch(() => undefined);
+  }
+
+  async function upsertProvider(opts: { enabled: boolean }) {
+    await request(ctx.app.getHttpServer())
+      .put("/api/llm-judge/provider")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        baseUrl: "https://judge.example/v1",
+        apiKey: "sk-test",
+        model: "judge-model",
+        enabled: opts.enabled,
+      })
+      .expect(200);
+  }
+
+  async function createLlmJudgeEval(name: string) {
+    const r = await request(ctx.app.getHttpServer())
+      .post("/api/quality-gate/evaluations")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        name,
+        samples: [
+          {
+            id: "s0",
+            idx: 0,
+            prompt: "summarise: the sky is blue",
+            expected: "blue sky",
+            judgeConfig: {
+              kind: "llm-judge",
+              rubric:
+                "Score 1 if the summary mentions blue and sky, otherwise 0.",
+              scale: "pass-fail",
+            },
+          },
+        ],
+      })
+      .expect(201);
+    return r.body.id as string;
+  }
+
+  async function createExactMatchEval(name: string) {
+    const r = await request(ctx.app.getHttpServer())
+      .post("/api/quality-gate/evaluations")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        name,
+        samples: [
+          {
+            id: "s0",
+            idx: 0,
+            prompt: "echo hi",
+            expected: "hi",
+            judgeConfig: { kind: "exact-match" },
+          },
+        ],
+      })
+      .expect(201);
+    return r.body.id as string;
+  }
+
+  it("rejects with 400 when eval has llm-judge samples and no provider configured", async () => {
+    await deleteProvider();
+    const evalId = await createLlmJudgeEval("guard-no-provider");
+    const conn = await createConnection("guard-target-1");
+
+    const r = await request(ctx.app.getHttpServer())
+      .post("/api/quality-gate/runs")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        evaluationId: evalId,
+        endpointAId: conn,
+        gateConfig: { passRateMin: 0.9 },
+      })
+      .expect(400);
+
+    expect(String(r.body.message ?? r.text)).toMatch(
+      /No enabled LLM judge provider/i,
+    );
+  }, 60_000);
+
+  it("rejects with 400 when provider exists but enabled=false", async () => {
+    await upsertProvider({ enabled: false });
+    const evalId = await createLlmJudgeEval("guard-disabled-provider");
+    const conn = await createConnection("guard-target-2");
+
+    const r = await request(ctx.app.getHttpServer())
+      .post("/api/quality-gate/runs")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        evaluationId: evalId,
+        endpointAId: conn,
+        gateConfig: { passRateMin: 0.9 },
+      })
+      .expect(400);
+
+    expect(String(r.body.message ?? r.text)).toMatch(
+      /No enabled LLM judge provider/i,
+    );
+  }, 60_000);
+
+  it("succeeds when llm-judge eval has an enabled provider", async () => {
+    await upsertProvider({ enabled: true });
+    const evalId = await createLlmJudgeEval("guard-happy-path");
+    const conn = await createConnection("guard-target-3");
+
+    const r = await request(ctx.app.getHttpServer())
+      .post("/api/quality-gate/runs")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        evaluationId: evalId,
+        endpointAId: conn,
+        gateConfig: { passRateMin: 0.9 },
+      })
+      .expect(201);
+
+    expect(r.body.id).toBeTruthy();
+    expect(["PENDING", "RUNNING", "COMPLETED", "FAILED"]).toContain(
+      r.body.status,
+    );
+  }, 60_000);
+
+  it("succeeds when eval has only non-llm-judge samples even without provider", async () => {
+    await deleteProvider();
+    const evalId = await createExactMatchEval("guard-no-llm-judge-needed");
+    const conn = await createConnection("guard-target-4");
+
+    const r = await request(ctx.app.getHttpServer())
+      .post("/api/quality-gate/runs")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        evaluationId: evalId,
+        endpointAId: conn,
+        gateConfig: { passRateMin: 0.9 },
+      })
+      .expect(201);
+
+    expect(r.body.id).toBeTruthy();
+  }, 60_000);
+});
+```
+
+- [ ] **Step 2: Run only the new describe block to observe the expected red state**
+
+Run:
+```bash
+pnpm -F @modeldoctor/api test:e2e -- quality-gate.e2e-spec.ts -t "LLM judge guard at run creation"
+```
+
+(If the api package script is named differently, the canonical command is `pnpm test:e2e:api -- quality-gate.e2e-spec.ts -t "LLM judge guard"` from repo root.)
+
+Expected behavior:
+- **3 of 4 tests FAIL** with "expected 400, got 201" (the guard does not exist yet — `POST /api/quality-gate/runs` happily creates runs even with no provider).
+- **1 of 4 PASSES**: the last case ("only non-llm-judge samples even without provider") — that path doesn't need the guard at all and already works.
+
+If you see all 4 pass: the guard already exists (maybe shipped in a parallel commit) — verify with `git log` and skip to Task 3 Step 4. If all 4 fail with something other than the status assertion (e.g., schema validation error 400 from a different path): inspect the response body and adjust the test eval shape.
+
+- [ ] **Step 3: Do NOT commit yet**
+
+The failing tests stay uncommitted; Task 3 implements the guard and the final diff (tests + implementation) is one TDD commit.
+
+---
+
+## Task 3: Implement the guard (TDD — green)
+
+**Files:**
+- Modify: `apps/api/src/modules/quality-gate/services/runs.service.ts`
+
+- [ ] **Step 1: Inject `LlmJudgeService` into `RunsService`**
+
+Open `apps/api/src/modules/quality-gate/services/runs.service.ts`. At the top, add the import (place it alphabetically with other module imports):
+
+```ts
+import { LlmJudgeService } from "../../llm-judge/llm-judge.service.js";
+```
+
+Then add `LlmJudgeService` as a constructor parameter. The existing constructor looks like:
+
+```ts
+constructor(
+  private readonly repo: RunsRepository,
+  private readonly evaluations: EvaluationsService,
+  private readonly connections: ConnectionService,
+  private readonly executor: QualityGateRunExecutor,
+) {}
+```
+
+Add `private readonly llmJudge: LlmJudgeService,` as the last parameter (no DI module change needed — `LlmJudgeModule` is already in `quality-gate.module.ts` imports at line 3 + 16; `LlmJudgeService` is exported from there):
+
+```ts
+constructor(
+  private readonly repo: RunsRepository,
+  private readonly evaluations: EvaluationsService,
+  private readonly connections: ConnectionService,
+  private readonly executor: QualityGateRunExecutor,
+  private readonly llmJudge: LlmJudgeService,
+) {}
+```
+
+If `BadRequestException` is not already imported from `@nestjs/common`, add it to the existing import line, e.g.:
+
+```ts
+import { BadRequestException, Injectable } from "@nestjs/common";
+```
+
+- [ ] **Step 2: Add the guard check inside `create()`**
+
+The existing `create()` body (verbatim head):
+
+```ts
+async create(userId: string, body: CreateRunRequest): Promise<EvaluationRun> {
+  const evaluation = await this.evaluations.get(userId, body.evaluationId);
+  if (!evaluation) throw new NotFoundException(`evaluation ${body.evaluationId} not found`);
+  const connA = await this.connections
+    .findOwnedPublic(userId, body.endpointAId)
+    .catch(() => null);
+  // …continues with endpointA / endpointB / baseline resolution / repo.createPending
+```
+
+Insert the guard **between** the `if (!evaluation)` line and the `const connA =` line. The full insertion:
+
+```ts
+  if (!evaluation) throw new NotFoundException(`evaluation ${body.evaluationId} not found`);
+
+  const needsLlmJudge = evaluation.samples.some(
+    (s) => s.judgeConfig.kind === "llm-judge",
+  );
+  if (needsLlmJudge) {
+    const provider = await this.llmJudge.getDecrypted();
+    if (!provider?.enabled) {
+      throw new BadRequestException(
+        "This evaluation requires an LLM judge. " +
+          "No enabled LLM judge provider is configured. " +
+          "Configure one at Settings → AI Diagnostics.",
+      );
+    }
+  }
+
+  const connA = await this.connections
+```
+
+Placing it before endpoint-connection validation means the most actionable error fires first when multiple validations would fail. `NotFoundException` for the eval itself stays primary (you can't validate the judge requirement on an eval that doesn't exist).
+
+- [ ] **Step 3: Re-run the failing tests — expect green**
+
+Run:
+```bash
+pnpm -F @modeldoctor/api test:e2e -- quality-gate.e2e-spec.ts -t "LLM judge guard at run creation"
+```
+
+Expected: **all 4 cases pass**. If any still fail:
+- Read the response body in the test output — the message should match `/No enabled LLM judge provider/i`. If it doesn't, you probably placed the check after another exception path; move it earlier in `create()`.
+- If a 500 surfaces instead of 400: `LlmJudgeService` injection probably didn't wire — confirm the import path and that `LlmJudgeModule` is in `quality-gate.module.ts` `imports`.
+
+- [ ] **Step 4: Run the entire quality-gate e2e file (catch regressions in existing happy paths)**
+
+Run:
+```bash
+pnpm -F @modeldoctor/api test:e2e -- quality-gate.e2e-spec.ts
+```
+
+Expected: all 4 new cases + the existing `Quality Gate e2e` + `baseline pin flow` describes all pass. If the existing "trigger dual-endpoint run" case now fails with a 400 it means it was incidentally using `llm-judge` with no provider — but it isn't (it uses `exact-match` + `contains`, see lines 73-82). No regression should occur.
+
+- [ ] **Step 5: Run the related unit tests**
+
+Run:
+```bash
+pnpm -F @modeldoctor/api test -- runs
+pnpm -F @modeldoctor/api test -- judges
+```
+
+Expected: green. The existing `runs.controller.spec.ts` test should still pass — controller-layer mocks `RunsService` so DI changes to the service are invisible. If a service spec exists (`runs.service.spec.ts`) it may need a mock `LlmJudgeService` provider — supply a minimal mock returning `{ enabled: true }`.
+
+- [ ] **Step 6: Commit (TDD pair: tests + implementation)**
+
+```bash
+git add apps/api/src/modules/quality-gate/services/runs.service.ts \
+        apps/api/test/e2e/quality-gate.e2e-spec.ts
+git status --short
+```
+
+Expected:
+```
+M  apps/api/src/modules/quality-gate/services/runs.service.ts
+M  apps/api/test/e2e/quality-gate.e2e-spec.ts
+```
+
+Then:
+```bash
+git commit -m "fix(quality-gate): reject run creation when llm-judge eval has no provider
+
+When llm_judge_providers is empty (or the row is disabled), evaluations
+containing kind:\"llm-judge\" samples used to complete with status=COMPLETED
++ gate_result=FAILED + fake 0% pass rate (the no-provider error was caught
+inside the judge factory and silently downgraded to passed:false). Users
+misread this as a model regression.
+
+Guard at the run-creation funnel: RunsService.create() now consults
+LlmJudgeService.getDecrypted() when any sample is kind:\"llm-judge\", and
+throws BadRequestException → 400 + actionable message if no enabled provider
+is configured. No PENDING row is persisted. Existing non-llm-judge evals
+(exact-match / contains / regex) are unaffected.
+
+4 new e2e cases cover: no provider, disabled provider, enabled provider
+(happy path), and the no-llm-judge-needed false-positive guard.
+
+Out of scope: per-run / per-eval judge override, in-flight provider-disable
+race protection. Refs spec:
+docs/superpowers/specs/2026-05-28-llm-judge-fail-fast-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Workspace verification (no commit)
+
+- [ ] **Step 1: Lint the whole workspace**
+
+Run:
+```bash
+pnpm -r lint
+```
+
+Expected: green across all packages. If biome flags the new `BadRequestException` import as unused (false positive on Nest decorators), run with `--apply` only if biome itself fixes it — never silence by hand.
+
+- [ ] **Step 2: Type-check the whole workspace**
+
+Run:
+```bash
+pnpm -r type-check
+```
+
+Expected: green. CI mirrors this exact command, so a local pass means CI typecheck will pass.
+
+- [ ] **Step 3: Run the full api unit suite**
+
+Run:
+```bash
+pnpm -F @modeldoctor/api test
+```
+
+Expected: green. ~few hundred unit tests should run in 10-30s.
+
+- [ ] **Step 4: Run the full api e2e suite**
+
+Run:
+```bash
+pnpm test:e2e:api
+```
+
+Expected: green. ~couple minutes. This is the authoritative gate before pushing.
+
+- [ ] **Step 5: Confirm zero `judgeModel` references workspace-wide**
+
+Run:
+```bash
+rg -n 'judgeModel' .
+```
+
+Expected: empty output (exit code 1). If anything matches (other than this plan file or the spec file), the cleanup missed a spot — go back and fix.
+
+- [ ] **Step 6: Confirm the branch + commit log look right**
+
+Run:
+```bash
+git log --oneline -5
+git status
+```
+
+Expected:
+- Current branch: `fix/llm-judge-fail-fast`
+- Top 3 commits (most recent first):
+  - `fix(quality-gate): reject run creation when llm-judge eval has no provider`
+  - `refactor(quality-gate): drop phantom judgeModel.connectionId field`
+  - `docs: spec — LLM judge fail-fast + judgeModel phantom-schema cleanup`
+- Working tree clean.
+
+---
+
+## Acceptance checklist (mirror of spec)
+
+- [ ] Missing enabled provider + llm-judge eval → 400 + clear message; no PENDING row persisted
+- [ ] Enabled provider + llm-judge eval → 201 (existing happy path preserved)
+- [ ] Non-llm-judge eval without provider → 201 (no false-positive guard)
+- [ ] `judgeModel` removed from schema + interface + call site; `rg judgeModel` workspace-wide = 0
+- [ ] 4 new e2e cases green
+- [ ] Existing api unit + e2e suites green; `pnpm -r lint` + `pnpm -r type-check` green
+
+## Push handoff (manual — owner decides)
+
+After Task 4 passes, the branch is ready to push and open a PR. Per project convention this is an owner decision — do NOT push or open a PR autonomously unless the owner explicitly authorizes it in this session. The expected one-liners when authorized:
+
+```bash
+git push -u origin fix/llm-judge-fail-fast
+gh pr create --base main --title "fix(quality-gate): LLM judge fail-fast + phantom schema cleanup" \
+  --body-file <( printf '%s\n' \
+    "Closes the silent-failure UX bug where evals containing \`llm-judge\` samples report a fake 0% quality fail when no LLM judge provider is configured." \
+    "" \
+    "**Spec:** \`docs/superpowers/specs/2026-05-28-llm-judge-fail-fast-design.md\`" \
+    "" \
+    "**Commits:**" \
+    "1. docs spec" \
+    "2. refactor: drop phantom \`judgeModel.connectionId\`" \
+    "3. fix: guard run creation when llm-judge needs a provider" \
+    "" \
+    "🤖 Generated with [Claude Code](https://claude.com/claude-code)" )
+```

--- a/docs/superpowers/specs/2026-05-28-llm-judge-fail-fast-design.md
+++ b/docs/superpowers/specs/2026-05-28-llm-judge-fail-fast-design.md
@@ -1,0 +1,230 @@
+# LLM Judge fail-fast：缺裁判时拒绝创建 run + 清理 phantom schema
+
+**Status:** draft · 2026-05-28
+**Scope:** `apps/api/src/modules/quality-gate` + `packages/contracts/src/quality-gate`
+**Tracks:** 无 issue（可选开 `fix/llm-judge-fail-fast` 单 PR）
+**Out of scope:** per-run / per-eval 裁判覆盖、`"AI Diagnostics (Global)"` 改名 / 拆分、其他模块的 phantom schema sweep
+
+## 问题
+
+当系统未配置启用的 LLM judge provider 时，含 `kind:"llm-judge"` 样本的评测 run 仍能创建并跑完，但每条 llm-judge 样本被静默判 `passed:false`（错误信息塞进 `result.judge.error`），最终：
+
+- `run.status = COMPLETED`（看起来执行没事）
+- `aggregate.totalErrors = 0`（端点调用零错误）
+- `passRateA ≈ 0`，`gate_result = FAILED`（伪装成质量门禁失败）
+
+用户在 UI 上看到的是"模型不行 / 通过率 0%"，根因其实是"裁判没配"——基础设施 / 配置问题被错放到了质量判定语义里。
+
+### 证据链（2026-05-28 实际数据）
+
+```
+run cmposedoh001m5xkan61xe2iq (中文摘要质量, 6 samples)
+  status=COMPLETED, gate_result=FAILED, totalErrors=0, passRateA=0
+  result_a.call.rawAnswer = "苹果公司于2026年发布的Vision Pro 2售价2999美元…"  ← 模型答出来了
+  result_a.judge.error    = "No enabled LLM judge provider configured. Configure one at Settings → LLM Judge."
+```
+
+### 根因点位
+
+`apps/api/src/modules/quality-gate/judges/llm-judge.ts:73-74` 的 catch 把所有判分异常（含"无 provider"这种**配置缺失**）一律降级成 `{ passed:false, error:msg }`。该结果不计入 `totalErrors`、不抛出执行器，被当成"模型这条没通过"参与聚合。
+
+### 顺带的 dead surface
+
+`packages/contracts/src/quality-gate/judge-config.ts:27` 定义的 `judgeModel: z.object({ connectionId: z.string() }).optional()` 是个 phantom 字段：
+
+| 层 | 现状 |
+|---|---|
+| Schema | 允许传 |
+| Runtime adapter (`judges.service.ts:20-36`) | **完全忽略** `input.connectionId` |
+| 10 个 seed 内置评测 | 0 处使用 |
+| Web UI（`EvaluationSampleEditor` / `SamplesTableEditor`） | 0 处暴露 |
+| DB（`evaluations.samples` + `evaluation_runs.evaluation_snapshot` JSONB） | 0 行携带 |
+| 所有 test / spec | 0 处断言 |
+
+留着只会让阅读者误以为"每条 judge 可指定连接"是已实现能力。
+
+## 设计目标
+
+1. **缺裁判时拒绝创建 run** —— 把"无 provider"从"运行时静默降级"提前到"创建时显式拒绝"，让 `run.status` 如实反映执行能不能跑、不再制造伪 0% pass rate
+2. **清理 phantom schema** —— 一次性删掉 `judgeModel` 三处（schema 1 行 + interface 1 行 + call site 1 行），零数据迁移
+
+## 为什么这样设计
+
+### 业内共识：单一全局裁判已是主流
+
+文献和工业实践对 LLM-as-judge 的 model 选择有明确共识 ——**裁判和被测应跨家族**，且通常**一个强大的外部裁判 + 全局默认**就够。证据：
+
+- [*Judging LLM-as-a-Judge with MT-Bench and Chatbot Arena*](https://arxiv.org/abs/2306.05685) (Zheng et al., 2023) ——"GPT-4 favors itself with 10% higher win rate, Claude-v1 favors itself with 25% higher win rate. Don't let one model be both contestant and judge."
+- [*Self-Preference Bias in LLM-as-a-Judge*](https://arxiv.org/abs/2410.21819) (EMNLP 2025) —— 记录 "positive self-bias and family-bias"
+- 工业产品：MT-Bench / AlpacaEval / Arena-Hard 统一 GPT-4 / GPT-4o 当裁判；Promptfoo / DeepEval / Braintrust / Langfuse 默认 GPT-4 系或 Claude Sonnet 系，per-test 覆盖是可选高级用法
+
+ModelDoctor 当前的"singleton `LlmJudgeService` + DeepSeek 当裁判 + 多家 Qwen 当被测"——**已经符合业内最佳实践**，不需要再加 per-run / per-eval 覆盖能力。该删的不是 singleton 设计，是那个**没人用的 phantom 覆盖口子**。
+
+### 为什么在 `RunsService.create()` 拒绝、不在 executor 拒绝
+
+```
+POST /runs
+  ↓
+RunsController.create  (zod 校验)
+  ↓
+RunsService.create     ← 检查放这里 ✅
+  ↓
+RunsRepository.createPending   (创建 PENDING 行)
+  ↓
+executor.start (fire-and-forget)
+```
+
+- 放 controller 太浅，绕开 service 的入口（未来如果加 re-run / scheduled run）就漏检
+- 放 executor 太深，会产生一个状态为 PENDING/FAILED 的"垃圾 run"残留在列表里
+- 放 `RunsService.create()` 是唯一漏斗，一次检查覆盖所有入口、不留半成品
+
+### 不做"运行中 provider 被禁用"的竞态保护
+
+判断：单进程执行器 + 用户手动改 provider 的窗口几乎为零，YAGNI。该边角场景仍走原降级路径（部分样本 `passed:false`），acceptable。
+
+## 改动清单
+
+### 1. `RunsService.create()` 加守门检查
+
+**文件：** `apps/api/src/modules/quality-gate/services/runs.service.ts`
+
+注入 `LlmJudgeService`，在 fetch evaluation 之后、`createPending` 之前加：
+
+```ts
+const needsLlmJudge = evaluation.samples.some(
+  (s) => s.judgeConfig.kind === "llm-judge",
+);
+if (needsLlmJudge) {
+  const provider = await this.llmJudge.getDecrypted();
+  if (!provider?.enabled) {
+    throw new BadRequestException(
+      "This evaluation requires an LLM judge. " +
+        "No enabled LLM judge provider is configured. " +
+        "Configure one at Settings → AI Diagnostics.",
+    );
+  }
+}
+```
+
+- 错误消息英文（项目惯例：服务端 `BadRequestException` 用英文，前端 toast 直接展示）
+- "Settings → AI Diagnostics" 指向 en-US `settings.ai.title = "AI Diagnostics (Global)"`（zh-CN 对应 "AI 智能诊断（全局）"）。当前不做服务端消息 i18n —— 中文 UI 用户看到的英文段会与 zh-CN 标签轻微错位，可接受；如需进一步抹平，单开 i18n 化 PR
+
+### 2. DI 接线
+
+**文件：** `apps/api/src/modules/quality-gate/quality-gate.module.ts`
+
+已确认 `LlmJudgeModule` 已在 `imports`（line 3 + 16）—— `JudgesService` 当前就依赖 `LlmJudgeService`。**本 spec 不改 module 文件**，只需在 `RunsService` 构造函数追加一个 `private readonly llmJudge: LlmJudgeService` 即可（Nest 会自动注入）。
+
+### 3. Phantom schema：删 `judgeModel`
+
+**文件：** `packages/contracts/src/quality-gate/judge-config.ts`
+
+```diff
+ const llmJudge = z.object({
+   kind: z.literal("llm-judge"),
+   rubric: z.string().min(10).max(4000),
+   scale: z.enum(["0-1", "0-5", "pass-fail"]),
+   passThreshold: z.number().optional(),
+-  judgeModel: z.object({ connectionId: z.string() }).optional(),
+ });
+```
+
+### 4. Phantom plumbing：删 `runJudge` 入参中的 `connectionId`
+
+**文件：** `apps/api/src/modules/quality-gate/judges/llm-judge.ts`
+
+```diff
+ export interface LlmJudgeService {
+-  runJudge(input: { systemPrompt: string; userPrompt: string; connectionId?: string }): Promise<{
++  runJudge(input: { systemPrompt: string; userPrompt: string }): Promise<{
+     content: string;
+   }>;
+ }
+```
+
+```diff
+         const resp = await service.runJudge({
+           systemPrompt: buildSystemPrompt(config.rubric, config.scale),
+           userPrompt: buildUserPrompt(ctx),
+-          connectionId: config.judgeModel?.connectionId,
+         });
+```
+
+**附带：** `llm-judge.ts:6-7` 头部注释当前写的是 "Thin shape from the AI Diagnostics service" —— 这个表述把"裁判 provider"和"AI Diagnostics 功能"两个概念绑死，跟接口本身的通用性矛盾，本次一并改为 "Thin shape over the singleton LLM judge provider. At wiring time the real adapter delegates to `LlmJudgeService.getDecrypted()` + `chatCompletion`."
+
+### 5. 测试
+
+**新增 / 扩展：** `apps/api/test/e2e/quality-gate-runs.e2e-spec.ts`（已有则扩 case，没有则新建）
+
+```ts
+describe("POST /api/quality-gate/runs — LLM judge guard", () => {
+  it("rejects with 400 when evaluation has llm-judge samples but no provider configured", async () => {
+    // arrange: ensure llm_judge_providers is empty
+    // arrange: create eval with at least one kind:"llm-judge" sample
+    // act: POST /api/quality-gate/runs
+    // assert: 400, body.message contains "No enabled LLM judge provider"
+  });
+
+  it("rejects with 400 when provider exists but enabled=false", async () => {
+    // ensure provider row exists with enabled=false
+    // assert: 400 (same path)
+  });
+
+  it("succeeds when llm-judge eval has an enabled provider", async () => {
+    // upsert enabled provider, post run → 200, status=PENDING
+  });
+
+  it("succeeds when eval has only non-llm-judge samples even without provider", async () => {
+    // exact-match / contains / regex only eval, no provider → 200
+  });
+});
+```
+
+**契约层 spec：** `packages/contracts/src/quality-gate/__tests__/judge-config.spec.ts` —— 当前 0 处断言 `judgeModel`，无需改。如果新增"`judgeModel` 字段不被 schema 接受（strip 或 reject）"的 case，可选。
+
+### 6. 不需要数据迁移
+
+DB 实际扫描（2026-05-28）：
+
+```
+SELECT id, name, jsonb_path_exists(samples, '$[*].judgeConfig.judgeModel') FROM evaluations;
+  → 7 rows, all has_judgemodel=f
+
+SELECT id, jsonb_path_exists(evaluation_snapshot, '$.samples[*].judgeConfig.judgeModel') FROM evaluation_runs;
+  → 1 row, has_judgemodel=f
+```
+
+zod schema 默认 strip 未知字段，即使未来出现脏数据也不会破坏解析。
+
+## 验证计划
+
+1. **手动复现修复前现象**（基线证据）—— 已完成，见 §问题/证据链
+2. **改动后 manual smoke：**
+   - 关闭 / 删除 LLM judge provider（`DELETE /api/llm-judge/provider`）
+   - UI 上 New Run 选 `中文摘要质量` → 提交
+   - 期望：toast 弹错"This evaluation requires an LLM judge…"，列表里**不**出现一条 FAILED run
+   - 重启 provider → 再 New Run → 期望正常跑、`status=COMPLETED`、`gate_result=PASSED`
+3. **自动化：**
+   - `pnpm -F @modeldoctor/api test` —— 单元 / 控制器层 spec 全过
+   - `pnpm test:e2e:api` —— 新 e2e 4 个 case 全过
+   - `pnpm -F @modeldoctor/contracts test` —— judge-config 既有 spec 全过（应零失败，因为没人断言过 `judgeModel`）
+   - `pnpm -r lint && pnpm -r type-check`
+4. **回归保护：** 4 种 judge 全覆盖 eval（`eval_builtin_qg_demo_zh_customer`，4 样本含 exact-match / contains / regex / llm-judge 各一）跑通
+
+## Acceptance
+
+- [ ] 缺 enabled provider 时，含 llm-judge 的 eval **不能**创建 run（400 + 清晰错误）
+- [ ] 含 enabled provider 时，含 llm-judge 的 eval 创建 run 正常
+- [ ] 仅含非 llm-judge 样本的 eval 即使无 provider 也能创建 run（不误伤）
+- [ ] `judgeModel` 字段从 schema / interface / call site 三处全部移除，全仓 `rg judgeModel` 命中数 = 0
+- [ ] 新增 4 个 e2e case 全绿
+- [ ] 既有 unit / e2e 套件零回归
+
+## Out of scope（明确拒绝）
+
+- **per-run 裁判选择 UI** —— 业内共识不需要，YAGNI
+- **per-eval 裁判 connectionId 覆盖** —— 同上；删 phantom 字段就是这个决定的体现
+- **`"AI Diagnostics (Global)"` 改名 / 拆为多张表** —— 它被 alerts.explainer / insights.synthesize / quality-gate.judges 三个模块复用，rename 牵动范围远超当前问题
+- **"运行中 provider 被禁用"的竞态保护** —— 单进程执行器窗口几乎为零，YAGNI
+- **Web 端 New Run 表单的预防性禁用按钮** —— 后端 400 → toast 链路已足够，UI 层 polish 是另一票
+- **其他模块的 phantom schema sweep** —— 本 spec 只清 `judgeModel`，全仓 dead code 审计是另一票

--- a/packages/contracts/src/quality-gate/judge-config.ts
+++ b/packages/contracts/src/quality-gate/judge-config.ts
@@ -24,7 +24,6 @@ const llmJudge = z.object({
   rubric: z.string().min(10).max(4000),
   scale: z.enum(["0-1", "0-5", "pass-fail"]),
   passThreshold: z.number().optional(),
-  judgeModel: z.object({ connectionId: z.string() }).optional(),
 });
 
 const baseUnion = z.discriminatedUnion("kind", [exactMatch, contains, regex, llmJudge]);


### PR DESCRIPTION
## Why

When `llm_judge_providers` was empty (or the row was disabled), evaluations containing `kind:"llm-judge"` samples used to complete with `status=COMPLETED` + `gate_result=FAILED` + a fake **0% pass rate**. The "no provider" error was caught inside `judges/llm-judge.ts:73-74` and silently downgraded to `passed:false`, then aggregated as a quality fail. Users misread this as a model regression.

Surfaced via DB query on the failing screenshot:

```
run cmposedoh001m5xkan61xe2iq (中文摘要质量, 6 samples)
  status=COMPLETED, gate_result=FAILED, totalErrors=0, passRateA=0
  result_a.call.rawAnswer = "苹果公司于2026年发布的Vision Pro 2..."  ← model answered fine
  result_a.judge.error    = "No enabled LLM judge provider configured."
```

## What

Two logical changes (separate commits, one PR):

### 1. `refactor`: drop phantom `judgeModel.connectionId` field
Schema-level slot for per-llm-judge connection override that the runtime adapter (`judges.service.ts:20-36`) completely ignored — 0 seeded evals, 0 web UI references, 0 DB rows carried it. Removed from `judge-config.ts` schema + `LlmJudgeService` interface + the dead call site. No DB migration needed.

### 2. `fix`: reject run creation when llm-judge eval has no provider
`RunsService.create()` — the one funnel for all run creation — now consults `LlmJudgeService.getDecrypted()` when any sample is `kind:"llm-judge"`, and throws `BadRequestException` → `400` with an actionable message if no enabled provider is configured. No `PENDING` row is persisted. `exact-match` / `contains` / `regex` evals are unaffected.

## Industry context (why no per-run / per-eval judge picker)

Researched MT-Bench / AlpacaEval / Arena-Hard / Promptfoo / DeepEval / Braintrust / Langfuse and the LLM-as-judge bias literature ([MT-Bench paper](https://arxiv.org/abs/2306.05685), [Self-Preference Bias EMNLP 2025](https://arxiv.org/abs/2410.21819)): industry consensus is **"a single strong cross-family judge with one global default"** — per-test override is an optional advanced feature, not the primary UX. ModelDoctor's existing singleton `LlmJudgeService` already matches best practice; this PR cleans the dead override slot rather than building it out. Per-run picker explicitly de-scoped.

## Tests

4 new e2e cases in `quality-gate.e2e-spec.ts`:
- `rejects with 400 when eval has llm-judge samples and no provider configured`
- `rejects with 400 when provider exists but enabled=false`
- `succeeds when llm-judge eval has an enabled provider`
- `succeeds when eval has only non-llm-judge samples even without provider`

2 new unit cases in `runs.service.spec.ts` cover the guard branch directly (was previously uncovered at the unit level).

All green locally: `pnpm -r type-check`, `pnpm -r lint`, `pnpm -F @modeldoctor/api test -- runs` (10/10), `pnpm test:e2e:api` (93/98 — the 5 fails are pre-existing `alerts`/`subscribers` flakes verified identical on `main`).

## Out of scope (explicitly)

- per-run / per-eval judge override UI
- "AI Diagnostics (Global)" rename / split (it's shared by alerts.explainer + insights.synthesize + quality-gate.judges)
- in-flight "provider disabled mid-run" race protection (YAGNI, single-process executor)
- New Run dialog pre-flight disable button (the 400 → toast chain is enough)

## Spec / Plan

- Design: `docs/superpowers/specs/2026-05-28-llm-judge-fail-fast-design.md`
- Plan: `docs/superpowers/plans/2026-05-28-llm-judge-fail-fast.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
