### PR TITLE
chore: v1 contract polish — vegeta multimodal defaults + complete OpenAPI decorators

### DIFF
--- a/apps/api/src/modules/alerts/alerts.controller.ts
+++ b/apps/api/src/modules/alerts/alerts.controller.ts
@@ -13,6 +13,7 @@ import {
   UnauthorizedException,
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
 import { Public } from "../../common/decorators/public.decorator.js";
 import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
@@ -27,6 +28,7 @@ import {
 import { AlertsService } from "./alerts.service.js";
 import { AlertExplainerService } from "./explainer.service.js";
 
+@ApiTags("alerts")
 @Controller("alerts")
 export class AlertsController {
   private readonly log = new Logger(AlertsController.name);
@@ -52,6 +54,9 @@ export class AlertsController {
    *               type: Bearer
    *               credentials: <shared-secret matching ALERTMANAGER_WEBHOOK_SECRET>
    */
+  @ApiOperation({
+    summary: "Alertmanager webhook ingest (Bearer-token authenticated, not JWT)",
+  })
   @Public()
   @Post("webhook")
   @HttpCode(202)
@@ -86,6 +91,8 @@ export class AlertsController {
     }
   }
 
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "List alerts for the current user, optionally filtered by connection" })
   @Get()
   list(
     @CurrentUser() user: JwtPayload,
@@ -94,6 +101,8 @@ export class AlertsController {
     return this.alerts.listForUser(user.sub, query);
   }
 
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "Get a single alert event with its AI explanation" })
   @Get(":id")
   async get(@CurrentUser() user: JwtPayload, @Param("id") id: string) {
     const row = await this.alerts.getForUser(user.sub, id);

--- a/apps/api/src/modules/alerts/subscribers.controller.ts
+++ b/apps/api/src/modules/alerts/subscribers.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Delete, Get, HttpCode, Param, Patch, Post } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
 import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
 import type { JwtPayload } from "../auth/jwt.strategy.js";
@@ -10,15 +11,19 @@ import {
 } from "./subscribers.dto.js";
 import { SubscribersService } from "./subscribers.service.js";
 
+@ApiTags("subscribers")
+@ApiBearerAuth()
 @Controller("connections/:connectionId/subscribers")
 export class SubscribersController {
   constructor(private readonly service: SubscribersService) {}
 
+  @ApiOperation({ summary: "List alert subscribers for a connection" })
   @Get()
   list(@CurrentUser() user: JwtPayload, @Param("connectionId") connectionId: string) {
     return this.service.list(user.sub, connectionId);
   }
 
+  @ApiOperation({ summary: "Subscribe a notification channel to alerts for this connection" })
   @Post()
   create(
     @CurrentUser() user: JwtPayload,
@@ -28,6 +33,7 @@ export class SubscribersController {
     return this.service.create(user.sub, connectionId, body);
   }
 
+  @ApiOperation({ summary: "Update a subscriber's severity filter or channel binding" })
   @Patch(":id")
   update(
     @CurrentUser() user: JwtPayload,
@@ -38,6 +44,7 @@ export class SubscribersController {
     return this.service.update(user.sub, connectionId, id, body);
   }
 
+  @ApiOperation({ summary: "Unsubscribe a channel from this connection's alerts" })
   @Delete(":id")
   @HttpCode(204)
   async remove(

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -16,6 +16,7 @@ import {
   UseGuards,
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { Throttle } from "@nestjs/throttler";
 import type { Request, Response } from "express";
 import { Public } from "../../common/decorators/public.decorator.js";
@@ -63,6 +64,7 @@ function clearAuthCookies(res: Response): void {
   res.clearCookie(SESSION_COOKIE, { path: "/" });
 }
 
+@ApiTags("auth")
 @Controller("auth")
 export class AuthController {
   constructor(
@@ -71,6 +73,7 @@ export class AuthController {
     private readonly config: ConfigService<Env, true>,
   ) {}
 
+  @ApiOperation({ summary: "Register a new user (issues access + refresh tokens)" })
   @Public()
   @Post("register")
   async register(
@@ -96,6 +99,7 @@ export class AuthController {
     };
   }
 
+  @ApiOperation({ summary: "Log in with email + password" })
   @Throttle({ default: { limit: 10, ttl: 60_000 } })
   @Public()
   @Post("login")
@@ -122,6 +126,7 @@ export class AuthController {
     };
   }
 
+  @ApiOperation({ summary: "Rotate the access token via the refresh cookie" })
   @Public()
   @Post("refresh")
   async refresh(
@@ -153,6 +158,8 @@ export class AuthController {
     };
   }
 
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "Revoke the current refresh token and clear cookies" })
   @Post("logout")
   async logout(
     @Req() req: Request,
@@ -164,6 +171,8 @@ export class AuthController {
     return { ok: true };
   }
 
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "Return the authenticated user's profile" })
   @UseGuards(JwtAuthGuard)
   @Get("me")
   async me(@Req() req: Request & { user: JwtPayload }): Promise<PublicUser> {

--- a/apps/api/src/modules/baseline/baseline.controller.ts
+++ b/apps/api/src/modules/baseline/baseline.controller.ts
@@ -15,22 +15,27 @@ import {
   Post,
   UseGuards,
 } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
 import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
 import type { JwtPayload } from "../auth/jwt.strategy.js";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
 import { BaselineService } from "./baseline.service.js";
 
+@ApiTags("baselines")
+@ApiBearerAuth()
 @Controller("baselines")
 @UseGuards(JwtAuthGuard)
 export class BaselineController {
   constructor(private readonly service: BaselineService) {}
 
+  @ApiOperation({ summary: "List baselines owned by the current user" })
   @Get()
   list(@CurrentUser() user: JwtPayload): Promise<ListBaselinesResponse> {
     return this.service.list(user.sub);
   }
 
+  @ApiOperation({ summary: "Save a benchmark snapshot as a baseline" })
   @Post()
   create(
     @CurrentUser() user: JwtPayload,
@@ -39,6 +44,7 @@ export class BaselineController {
     return this.service.create(user.sub, body);
   }
 
+  @ApiOperation({ summary: "Delete a baseline" })
   @Delete(":id")
   @HttpCode(HttpStatus.NO_CONTENT)
   async remove(@CurrentUser() user: JwtPayload, @Param("id") id: string): Promise<void> {

--- a/apps/api/src/modules/benchmark-template/benchmark-template.controller.ts
+++ b/apps/api/src/modules/benchmark-template/benchmark-template.controller.ts
@@ -20,6 +20,7 @@ import {
   Query,
   UseGuards,
 } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
 import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
 import type { JwtPayload } from "../auth/jwt.strategy.js";
@@ -34,11 +35,14 @@ function actorFrom(user: JwtPayload): TemplateActor {
   return { sub: user.sub, isAdmin: user.roles.includes("admin") };
 }
 
+@ApiTags("benchmark-templates")
+@ApiBearerAuth()
 @Controller("benchmark-templates")
 @UseGuards(JwtAuthGuard)
 export class BenchmarkTemplateController {
   constructor(private readonly service: BenchmarkTemplateService) {}
 
+  @ApiOperation({ summary: "List official + user benchmark templates with optional filters" })
   @Get()
   list(
     @Query(new ZodValidationPipe(listBenchmarkTemplatesQuerySchema))
@@ -47,11 +51,13 @@ export class BenchmarkTemplateController {
     return this.service.list(query);
   }
 
+  @ApiOperation({ summary: "Get a benchmark template by ID" })
   @Get(":id")
   detail(@Param("id") id: string): Promise<BenchmarkTemplate> {
     return this.service.findByIdOrFail(id);
   }
 
+  @ApiOperation({ summary: "Create a new benchmark template (admins may flag as official)" })
   @Post()
   create(
     @CurrentUser() user: JwtPayload,
@@ -61,6 +67,7 @@ export class BenchmarkTemplateController {
     return this.service.create(actorFrom(user), body);
   }
 
+  @ApiOperation({ summary: "Patch a benchmark template (owner or admin only)" })
   @Patch(":id")
   update(
     @CurrentUser() user: JwtPayload,
@@ -70,6 +77,7 @@ export class BenchmarkTemplateController {
     return this.service.update(actorFrom(user), id, body);
   }
 
+  @ApiOperation({ summary: "Delete a benchmark template (owner or admin only)" })
   @Delete(":id")
   @HttpCode(HttpStatus.NO_CONTENT)
   async delete(@CurrentUser() user: JwtPayload, @Param("id") id: string): Promise<void> {

--- a/apps/api/src/modules/benchmark/benchmark.controller.ts
+++ b/apps/api/src/modules/benchmark/benchmark.controller.ts
@@ -25,6 +25,7 @@ import {
   Sse,
   UseGuards,
 } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { EMPTY, from, type Observable } from "rxjs";
 import { map, switchMap } from "rxjs/operators";
 import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
@@ -38,6 +39,8 @@ import { BenchmarkChartsService } from "./benchmark-charts.service.js";
 import { isInProgressStatus } from "./constants.js";
 import { SseHub } from "./sse/sse-hub.service.js";
 
+@ApiTags("benchmarks")
+@ApiBearerAuth()
 @Controller("benchmarks")
 @UseGuards(JwtAuthGuard)
 export class BenchmarkController {
@@ -47,6 +50,7 @@ export class BenchmarkController {
     private readonly sse: SseHub,
   ) {}
 
+  @ApiOperation({ summary: "List benchmarks (scope=mine by default; scope=all is admin-only)" })
   @Get()
   async list(
     @CurrentUser() user: JwtPayload,
@@ -61,6 +65,7 @@ export class BenchmarkController {
     return this.service.list(query, query.scope === "all" ? undefined : user.sub);
   }
 
+  @ApiOperation({ summary: "Aggregated benchmark reports grouped by connection over a date range" })
   @Get("reports/by-connection")
   reportsByConnection(
     @CurrentUser() user: JwtPayload,
@@ -70,11 +75,13 @@ export class BenchmarkController {
     return this.service.getByConnectionReports(user.sub, range ?? "30d");
   }
 
+  @ApiOperation({ summary: "Get a benchmark by ID (owner or admin)" })
   @Get(":id")
   detail(@CurrentUser() user: JwtPayload, @Param("id") id: string): Promise<Benchmark> {
     return this.service.findByIdOrFail(id, user.roles.includes("admin") ? undefined : user.sub);
   }
 
+  @ApiOperation({ summary: "Submit a new benchmark run" })
   @Post()
   create(
     @CurrentUser() user: JwtPayload,
@@ -83,11 +90,13 @@ export class BenchmarkController {
     return this.service.create(user.sub, body);
   }
 
+  @ApiOperation({ summary: "Cancel an in-flight benchmark" })
   @Post(":id/cancel")
   cancel(@CurrentUser() user: JwtPayload, @Param("id") id: string): Promise<Benchmark> {
     return this.service.cancel(id, user.roles.includes("admin") ? undefined : user.sub);
   }
 
+  @ApiOperation({ summary: "Delete a benchmark and its artifacts" })
   @Delete(":id")
   @HttpCode(204)
   async delete(@CurrentUser() user: JwtPayload, @Param("id") id: string): Promise<void> {
@@ -98,6 +107,9 @@ export class BenchmarkController {
    *  @Public() bypasses the class-level JwtAuthGuard; SseJwtAuthGuard then
    *  validates the JWT via Authorization header OR `?token=` query param,
    *  which EventSource requires since it cannot set custom headers. */
+  @ApiOperation({
+    summary: "Server-Sent Events stream for a running benchmark (token via Bearer or ?token=)",
+  })
   @Public()
   @UseGuards(SseJwtAuthGuard)
   @Sse(":id/events")
@@ -109,6 +121,7 @@ export class BenchmarkController {
     );
   }
 
+  @ApiOperation({ summary: "Extracted chart-ready data series from a benchmark's raw output" })
   @Get(":id/charts")
   @Header("Cache-Control", "private, max-age=86400")
   async getCharts(

--- a/apps/api/src/modules/connection/connection.controller.ts
+++ b/apps/api/src/modules/connection/connection.controller.ts
@@ -23,6 +23,7 @@ import {
   Post,
   UseGuards,
 } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { Throttle } from "@nestjs/throttler";
 import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
 import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
@@ -31,6 +32,8 @@ import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
 import { ConnectionService } from "./connection.service.js";
 import { DiscoveryService } from "./discovery/discovery.service.js";
 
+@ApiTags("connections")
+@ApiBearerAuth()
 @Controller("connections")
 @UseGuards(JwtAuthGuard)
 export class ConnectionController {
@@ -39,11 +42,13 @@ export class ConnectionController {
     private readonly discoveryService: DiscoveryService,
   ) {}
 
+  @ApiOperation({ summary: "List connections (model endpoints + gateways) owned by the user" })
   @Get()
   list(@CurrentUser() user: JwtPayload): Promise<ListConnectionsResponse> {
     return this.service.list(user.sub);
   }
 
+  @ApiOperation({ summary: "Create a new connection (the response carries the api key once)" })
   @Post()
   create(
     @CurrentUser() user: JwtPayload,
@@ -52,11 +57,13 @@ export class ConnectionController {
     return this.service.create(user.sub, body);
   }
 
+  @ApiOperation({ summary: "Get a connection by ID (key is omitted from the response)" })
   @Get(":id")
   detail(@CurrentUser() user: JwtPayload, @Param("id") id: string): Promise<ConnectionPublic> {
     return this.service.findOwnedPublic(user.sub, id);
   }
 
+  @ApiOperation({ summary: "Reveal the decrypted api key for the connection (rate-limited)" })
   @Throttle({ default: { limit: 10, ttl: 60_000 } })
   @Get(":id/reveal-key")
   revealKey(
@@ -66,6 +73,7 @@ export class ConnectionController {
     return this.service.revealApiKey(user.sub, id);
   }
 
+  @ApiOperation({ summary: "Probe an endpoint and infer its capabilities (kind, model list)" })
   @Throttle({ default: { limit: 10, ttl: 60_000 } })
   @Post("discover")
   discover(
@@ -74,6 +82,7 @@ export class ConnectionController {
     return this.discoveryService.discover(body);
   }
 
+  @ApiOperation({ summary: "Patch a connection (re-encrypts the key when supplied)" })
   @Patch(":id")
   update(
     @CurrentUser() user: JwtPayload,
@@ -83,6 +92,7 @@ export class ConnectionController {
     return this.service.update(user.sub, id, body);
   }
 
+  @ApiOperation({ summary: "Delete a connection (cascades to its benchmarks and subscribers)" })
   @Delete(":id")
   @HttpCode(HttpStatus.NO_CONTENT)
   async remove(@CurrentUser() user: JwtPayload, @Param("id") id: string): Promise<void> {

--- a/apps/api/src/modules/insights/comparison.controller.ts
+++ b/apps/api/src/modules/insights/comparison.controller.ts
@@ -1,15 +1,19 @@
 // apps/api/src/modules/insights/comparison.controller.ts
 import { Controller, Get, Param, Query, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
 import type { JwtPayload } from "../auth/jwt.strategy.js";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
 import { ComparisonService } from "./comparison.service.js";
 
+@ApiTags("insights")
+@ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller("insights/:connectionId")
 export class ComparisonController {
   constructor(private readonly svc: ComparisonService) {}
 
+  @ApiOperation({ summary: "Compare recent benchmarks for this connection against its baseline" })
   @Get("baseline-comparison")
   async baseline(
     @CurrentUser() user: JwtPayload,
@@ -19,6 +23,7 @@ export class ComparisonController {
     return { items: await this.svc.baseline(user.sub, connectionId, fromISO) };
   }
 
+  @ApiOperation({ summary: "Compare this connection's benchmarks against other connections" })
   @Get("fleet-comparison")
   async fleet(
     @CurrentUser() user: JwtPayload,

--- a/apps/api/src/modules/insights/evaluation-profile.controller.ts
+++ b/apps/api/src/modules/insights/evaluation-profile.controller.ts
@@ -1,18 +1,23 @@
 // apps/api/src/modules/insights/evaluation-profile.controller.ts
 import { listEvaluationProfilesResponseSchema } from "@modeldoctor/contracts";
 import { Controller, Get, Param } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { EvaluationProfileService } from "./evaluation-profile.service.js";
 
+@ApiTags("insights")
+@ApiBearerAuth()
 @Controller("insights/profiles")
 export class EvaluationProfileController {
   constructor(private readonly svc: EvaluationProfileService) {}
 
+  @ApiOperation({ summary: "List built-in evaluation profiles (read-only seed data)" })
   @Get()
   async list() {
     const items = await this.svc.list();
     return listEvaluationProfilesResponseSchema.parse({ items });
   }
 
+  @ApiOperation({ summary: "Get an evaluation profile by slug" })
   @Get(":slug")
   async get(@Param("slug") slug: string) {
     return this.svc.getBySlug(slug);

--- a/apps/api/src/modules/insights/synthesize.controller.ts
+++ b/apps/api/src/modules/insights/synthesize.controller.ts
@@ -1,17 +1,23 @@
 // apps/api/src/modules/insights/synthesize.controller.ts
 import { type SynthesizeRequest, synthesizeRequestSchema } from "@modeldoctor/contracts";
 import { Body, Controller, Param, Post, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
 import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
 import type { JwtPayload } from "../auth/jwt.strategy.js";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
 import { SynthesizeService } from "./synthesize.service.js";
 
+@ApiTags("insights")
+@ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller("insights/:connectionId")
 export class SynthesizeController {
   constructor(private readonly svc: SynthesizeService) {}
 
+  @ApiOperation({
+    summary: "Synthesize an AI narrative report from recent benchmarks (synchronous, 5-30s)",
+  })
   @Post("synthesize")
   async synthesize(
     @CurrentUser() user: JwtPayload,

--- a/apps/api/src/modules/llm-judge/llm-judge.controller.ts
+++ b/apps/api/src/modules/llm-judge/llm-judge.controller.ts
@@ -9,22 +9,27 @@ import {
   upsertLlmJudgeProviderSchema,
 } from "@modeldoctor/contracts";
 import { Body, Controller, Delete, Get, HttpCode, Post, Put, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
 import { chatCompletion } from "../insights/llm-client.js";
 import { LlmJudgeService } from "./llm-judge.service.js";
 
+@ApiTags("llm-judge")
+@ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller("llm-judge")
 export class LlmJudgeController {
   constructor(private readonly svc: LlmJudgeService) {}
 
+  @ApiOperation({ summary: "Return the LLM-judge provider config (api key omitted)" })
   @Get("provider")
   async get() {
     const p = await this.svc.getPublic();
     return p ? llmJudgeProviderPublicSchema.parse(p) : null;
   }
 
+  @ApiOperation({ summary: "Create or replace the LLM-judge provider config" })
   @Put("provider")
   async put(
     @Body(new ZodValidationPipe(upsertLlmJudgeProviderSchema)) body: UpsertLlmJudgeProvider,
@@ -32,12 +37,14 @@ export class LlmJudgeController {
     return this.svc.upsert(body);
   }
 
+  @ApiOperation({ summary: "Clear the LLM-judge provider config" })
   @Delete("provider")
   @HttpCode(204)
   async del() {
     await this.svc.delete();
   }
 
+  @ApiOperation({ summary: "Send a one-shot ping to verify the provider config works" })
   @Post("test")
   async test(
     @Body(new ZodValidationPipe(testLlmJudgeRequestSchema)) body: TestLlmJudgeRequest,

--- a/apps/api/src/modules/mcp/mcp.controller.ts
+++ b/apps/api/src/modules/mcp/mcp.controller.ts
@@ -1,4 +1,5 @@
 import { All, Controller, InternalServerErrorException, Req, Res, UseGuards } from "@nestjs/common";
+import { ApiExcludeController } from "@nestjs/swagger";
 import type { Request, Response } from "express";
 import { Public } from "../../common/decorators/public.decorator.js";
 import { McpAuthGuard } from "./mcp.guard.js";
@@ -14,6 +15,9 @@ import { McpService } from "./mcp.service.js";
  * McpAuthGuard (fixed env-pinned bearer token) — totally separate from the
  * web app's rotating JWT, see mcp.guard.ts for rationale.
  */
+// Excluded from OpenAPI: this is the JSON-RPC transport for the MCP server,
+// not a REST endpoint. Its protocol is described by the MCP spec, not OpenAPI.
+@ApiExcludeController()
 @Controller("mcp")
 @Public()
 @UseGuards(McpAuthGuard)

--- a/apps/api/src/modules/notifications/notifications.controller.ts
+++ b/apps/api/src/modules/notifications/notifications.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Delete, Get, HttpCode, Param, Patch, Post } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
 import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
 import type { JwtPayload } from "../auth/jwt.strategy.js";
@@ -14,6 +15,8 @@ import {
 } from "./notifications.dto.js";
 import { SubscriptionsService } from "./subscriptions.service.js";
 
+@ApiTags("notifications")
+@ApiBearerAuth()
 @Controller("notifications")
 export class NotificationsController {
   constructor(
@@ -22,11 +25,13 @@ export class NotificationsController {
     private readonly dispatcher: DispatcherService,
   ) {}
 
+  @ApiOperation({ summary: "List notification channels (Slack / Feishu / DingTalk webhooks)" })
   @Get("channels")
   list(@CurrentUser() user: JwtPayload) {
     return this.channels.list(user.sub);
   }
 
+  @ApiOperation({ summary: "Create a notification channel" })
   @Post("channels")
   create(
     @CurrentUser() user: JwtPayload,
@@ -35,6 +40,7 @@ export class NotificationsController {
     return this.channels.create(user.sub, body);
   }
 
+  @ApiOperation({ summary: "Update a notification channel" })
   @Patch("channels/:id")
   update(
     @CurrentUser() user: JwtPayload,
@@ -44,12 +50,14 @@ export class NotificationsController {
     return this.channels.update(user.sub, id, body);
   }
 
+  @ApiOperation({ summary: "Delete a notification channel" })
   @Delete("channels/:id")
   @HttpCode(204)
   async remove(@CurrentUser() user: JwtPayload, @Param("id") id: string): Promise<void> {
     await this.channels.delete(user.sub, id);
   }
 
+  @ApiOperation({ summary: "Send a test notification through the channel" })
   @Post("channels/:id/test")
   async test(@CurrentUser() user: JwtPayload, @Param("id") id: string) {
     try {
@@ -64,11 +72,13 @@ export class NotificationsController {
     }
   }
 
+  @ApiOperation({ summary: "List notification subscriptions" })
   @Get("subscriptions")
   listSubs(@CurrentUser() user: JwtPayload) {
     return this.subscriptions.list(user.sub);
   }
 
+  @ApiOperation({ summary: "Create a notification subscription" })
   @Post("subscriptions")
   createSub(
     @CurrentUser() user: JwtPayload,
@@ -77,6 +87,7 @@ export class NotificationsController {
     return this.subscriptions.create(user.sub, body);
   }
 
+  @ApiOperation({ summary: "Delete a notification subscription" })
   @Delete("subscriptions/:id")
   @HttpCode(204)
   async removeSub(@CurrentUser() user: JwtPayload, @Param("id") id: string): Promise<void> {

--- a/apps/api/src/modules/prometheus-datasource/prometheus-datasource.controller.ts
+++ b/apps/api/src/modules/prometheus-datasource/prometheus-datasource.controller.ts
@@ -23,6 +23,7 @@ import {
   Post,
   UseGuards,
 } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { Throttle } from "@nestjs/throttler";
 import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
 import { parseCustomHeaders } from "../../common/http/parse-custom-headers.js";
@@ -39,16 +40,20 @@ function actorFrom(user: JwtPayload): PrometheusDatasourceActor {
   return { sub: user.sub, isAdmin: user.roles.includes("admin") };
 }
 
+@ApiTags("prometheus-datasources")
+@ApiBearerAuth()
 @Controller("prometheus-datasources")
 @UseGuards(JwtAuthGuard)
 export class PrometheusDatasourceController {
   constructor(private readonly svc: PrometheusDatasourceService) {}
 
+  @ApiOperation({ summary: "List configured Prometheus datasources" })
   @Get()
   list(@CurrentUser() user: JwtPayload): Promise<ListPrometheusDatasourcesResponse> {
     return this.svc.list(actorFrom(user));
   }
 
+  @ApiOperation({ summary: "Get a Prometheus datasource by ID" })
   @Get(":id")
   getOne(
     @CurrentUser() user: JwtPayload,
@@ -57,6 +62,7 @@ export class PrometheusDatasourceController {
     return this.svc.getOne(actorFrom(user), id);
   }
 
+  @ApiOperation({ summary: "Create a Prometheus datasource (admin-only)" })
   @Post()
   create(
     @CurrentUser() user: JwtPayload,
@@ -66,6 +72,7 @@ export class PrometheusDatasourceController {
     return this.svc.create(actorFrom(user), body);
   }
 
+  @ApiOperation({ summary: "Patch a Prometheus datasource" })
   @Patch(":id")
   update(
     @CurrentUser() user: JwtPayload,
@@ -76,6 +83,7 @@ export class PrometheusDatasourceController {
     return this.svc.update(actorFrom(user), id, body);
   }
 
+  @ApiOperation({ summary: "Delete a Prometheus datasource" })
   @Delete(":id")
   remove(
     @CurrentUser() user: JwtPayload,
@@ -84,6 +92,7 @@ export class PrometheusDatasourceController {
     return this.svc.remove(actorFrom(user), id);
   }
 
+  @ApiOperation({ summary: "Promote a Prometheus datasource to the default" })
   @Post(":id/set-default")
   setDefault(
     @CurrentUser() user: JwtPayload,
@@ -92,9 +101,7 @@ export class PrometheusDatasourceController {
     return this.svc.setDefault(actorFrom(user), id);
   }
 
-  // Shallow probe — reuses the verifyPrometheus helper that powered the old
-  // `kind=prometheus` verify-kind branch. Admin-only because this would let
-  // an unauthenticated user use the api as an outbound HTTP proxy otherwise.
+  @ApiOperation({ summary: "Probe a Prometheus URL for buildinfo + version (admin-only)" })
   @Throttle({ default: { limit: 20, ttl: 60_000 } })
   @Post("verify")
   async verify(

--- a/apps/api/src/modules/quality-gate/controllers/evaluations.controller.ts
+++ b/apps/api/src/modules/quality-gate/controllers/evaluations.controller.ts
@@ -17,6 +17,7 @@ import {
   Post,
   UseGuards,
 } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { z } from "zod";
 import { CurrentUser } from "../../../common/decorators/current-user.decorator.js";
 import { ZodValidationPipe } from "../../../common/pipes/zod-validation.pipe.js";
@@ -29,16 +30,20 @@ const importBodySchema = z.object({
   import: importEvaluationRequestSchema,
 });
 
+@ApiTags("quality-gate")
+@ApiBearerAuth()
 @Controller("quality-gate/evaluations")
 @UseGuards(JwtAuthGuard)
 export class EvaluationsController {
   constructor(private readonly svc: EvaluationsService) {}
 
+  @ApiOperation({ summary: "List Quality-Gate evaluation sets owned by the user" })
   @Get()
   async list(@CurrentUser() user: JwtPayload) {
     return { items: await this.svc.list(user.sub) };
   }
 
+  @ApiOperation({ summary: "Create a Quality-Gate evaluation set" })
   @Post()
   create(
     @CurrentUser() user: JwtPayload,
@@ -47,6 +52,7 @@ export class EvaluationsController {
     return this.svc.create(user.sub, body);
   }
 
+  @ApiOperation({ summary: "Get a Quality-Gate evaluation set by ID" })
   @Get(":id")
   async findOne(@CurrentUser() user: JwtPayload, @Param("id") id: string) {
     const r = await this.svc.get(user.sub, id);
@@ -54,6 +60,7 @@ export class EvaluationsController {
     return r;
   }
 
+  @ApiOperation({ summary: "Patch a Quality-Gate evaluation set" })
   @Patch(":id")
   update(
     @CurrentUser() user: JwtPayload,
@@ -63,12 +70,14 @@ export class EvaluationsController {
     return this.svc.update(user.sub, id, body);
   }
 
+  @ApiOperation({ summary: "Delete a Quality-Gate evaluation set" })
   @Delete(":id")
   @HttpCode(204)
   remove(@CurrentUser() user: JwtPayload, @Param("id") id: string) {
     return this.svc.delete(user.sub, id);
   }
 
+  @ApiOperation({ summary: "Import an evaluation set from an external source" })
   @Post("import")
   importSet(
     @CurrentUser() user: JwtPayload,
@@ -77,6 +86,7 @@ export class EvaluationsController {
     return this.svc.import(user.sub, body.name, body.import);
   }
 
+  @ApiOperation({ summary: "Duplicate an evaluation set" })
   @Post(":id/duplicate")
   duplicate(@CurrentUser() user: JwtPayload, @Param("id") id: string) {
     return this.svc.duplicate(user.sub, id);

--- a/apps/api/src/modules/quality-gate/controllers/runs.controller.ts
+++ b/apps/api/src/modules/quality-gate/controllers/runs.controller.ts
@@ -17,17 +17,21 @@ import {
   Query,
   UseGuards,
 } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { CurrentUser } from "../../../common/decorators/current-user.decorator.js";
 import { ZodValidationPipe } from "../../../common/pipes/zod-validation.pipe.js";
 import type { JwtPayload } from "../../auth/jwt.strategy.js";
 import { JwtAuthGuard } from "../../auth/jwt-auth.guard.js";
 import { RunsService } from "../services/runs.service.js";
 
+@ApiTags("quality-gate")
+@ApiBearerAuth()
 @Controller("quality-gate/runs")
 @UseGuards(JwtAuthGuard)
 export class RunsController {
   constructor(private readonly svc: RunsService) {}
 
+  @ApiOperation({ summary: "List Quality-Gate smoke-test runs" })
   @Get()
   list(
     @CurrentUser() user: JwtPayload,
@@ -36,6 +40,7 @@ export class RunsController {
     return this.svc.list(user.sub, q);
   }
 
+  @ApiOperation({ summary: "Submit a new Quality-Gate run" })
   @Post()
   create(
     @CurrentUser() user: JwtPayload,
@@ -44,23 +49,27 @@ export class RunsController {
     return this.svc.create(user.sub, body);
   }
 
+  @ApiOperation({ summary: "Get a Quality-Gate run by ID" })
   @Get(":id")
   get(@CurrentUser() user: JwtPayload, @Param("id") id: string) {
     return this.svc.get(user.sub, id);
   }
 
+  @ApiOperation({ summary: "Cancel an in-flight Quality-Gate run" })
   @Post(":id/cancel")
   async cancel(@CurrentUser() user: JwtPayload, @Param("id") id: string) {
     await this.svc.cancel(user.sub, id);
     return { ok: true };
   }
 
+  @ApiOperation({ summary: "Delete a Quality-Gate run and its samples" })
   @Delete(":id")
   @HttpCode(204)
   remove(@CurrentUser() user: JwtPayload, @Param("id") id: string) {
     return this.svc.delete(user.sub, id);
   }
 
+  @ApiOperation({ summary: "List per-sample results for a Quality-Gate run" })
   @Get(":id/samples")
   samples(
     @CurrentUser() user: JwtPayload,

--- a/apps/api/src/modules/saved-compares/saved-compares.controller.ts
+++ b/apps/api/src/modules/saved-compares/saved-compares.controller.ts
@@ -18,6 +18,7 @@ import {
   Post,
   UseGuards,
 } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
 import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
 import type { JwtPayload } from "../auth/jwt.strategy.js";
@@ -25,6 +26,8 @@ import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
 import { CompareSynthesizeService } from "./compare-synthesize.service.js";
 import { SavedComparesService } from "./saved-compares.service.js";
 
+@ApiTags("saved-compares")
+@ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller("saved-compares")
 export class SavedComparesController {
@@ -33,11 +36,13 @@ export class SavedComparesController {
     private readonly synth: CompareSynthesizeService,
   ) {}
 
+  @ApiOperation({ summary: "List saved benchmark comparisons" })
   @Get()
   async list(@CurrentUser() user: JwtPayload) {
     return { items: await this.svc.list(user.sub) };
   }
 
+  @ApiOperation({ summary: "Get a saved comparison with hydrated benchmark data" })
   @Get(":id")
   async get(@CurrentUser() user: JwtPayload, @Param("id") id: string) {
     const sc = await this.svc.getHydrated(user.sub, id);
@@ -45,6 +50,7 @@ export class SavedComparesController {
     return sc;
   }
 
+  @ApiOperation({ summary: "Save a benchmark comparison" })
   @Post()
   async create(
     @CurrentUser() user: JwtPayload,
@@ -53,6 +59,7 @@ export class SavedComparesController {
     return this.svc.create(user.sub, body);
   }
 
+  @ApiOperation({ summary: "Patch a saved comparison" })
   @Patch(":id")
   async update(
     @CurrentUser() user: JwtPayload,
@@ -62,12 +69,14 @@ export class SavedComparesController {
     return this.svc.update(user.sub, id, body);
   }
 
+  @ApiOperation({ summary: "Delete a saved comparison" })
   @Delete(":id")
   @HttpCode(204)
   async delete(@CurrentUser() user: JwtPayload, @Param("id") id: string) {
     await this.svc.delete(user.sub, id);
   }
 
+  @ApiOperation({ summary: "Generate an AI narrative report for the saved comparison" })
   @Post(":id/synthesize")
   async synthesize(
     @CurrentUser() user: JwtPayload,

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -6,6 +6,7 @@ import {
   UpdateProfileRequestSchema,
 } from "@modeldoctor/contracts";
 import { Body, Controller, Get, HttpCode, Patch, Post, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { Throttle } from "@nestjs/throttler";
 import { CurrentUser } from "../../common/decorators/current-user.decorator.js";
 import { ZodValidationPipe } from "../../common/pipes/zod-validation.pipe.js";
@@ -13,17 +14,21 @@ import type { JwtPayload } from "../auth/jwt.strategy.js";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard.js";
 import { UsersService } from "./users.service.js";
 
+@ApiTags("me")
+@ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller("me")
 export class UsersController {
   constructor(private readonly users: UsersService) {}
 
+  @ApiOperation({ summary: "Return the authenticated user's profile" })
   @Get()
   async me(@CurrentUser() user: JwtPayload): Promise<PublicUser> {
     const u = await this.users.findById(user.sub);
     return this.users.toPublic(u);
   }
 
+  @ApiOperation({ summary: "Patch the authenticated user's profile" })
   @Patch()
   async patch(
     @CurrentUser() user: JwtPayload,
@@ -32,6 +37,7 @@ export class UsersController {
     return this.users.updateProfile(user.sub, body);
   }
 
+  @ApiOperation({ summary: "Change the authenticated user's password" })
   @Throttle({ default: { limit: 5, ttl: 60_000 } })
   @Post("password")
   @HttpCode(204)

--- a/packages/tool-adapters/src/vegeta/body-templates.spec.ts
+++ b/packages/tool-adapters/src/vegeta/body-templates.spec.ts
@@ -1,0 +1,81 @@
+import { ChatMessageContentPartSchema, ChatMessageSchema } from "@modeldoctor/contracts";
+import { describe, expect, it } from "vitest";
+import { MODALITY_BODY_TEMPLATES } from "./body-templates.js";
+
+const MODEL = "Qwen2.5-0.5B-Instruct";
+
+describe("MODALITY_BODY_TEMPLATES — JSON validity", () => {
+  it.each(["chat", "chat-vision", "chat-audio", "embeddings", "rerank", "images"] as const)(
+    "%s default body parses as JSON with the requested model",
+    (apiType) => {
+      const raw = MODALITY_BODY_TEMPLATES[apiType](MODEL);
+      const parsed = JSON.parse(raw);
+      expect(parsed.model).toBe(MODEL);
+    },
+  );
+});
+
+describe("MODALITY_BODY_TEMPLATES — chat-vision shape", () => {
+  it("emits a content-parts array with one image_url part", () => {
+    const body = JSON.parse(MODALITY_BODY_TEMPLATES["chat-vision"](MODEL));
+    const message = body.messages[0];
+    expect(Array.isArray(message.content)).toBe(true);
+    const imageParts = message.content.filter(
+      (p: { type: string }) => p.type === "image_url",
+    );
+    expect(imageParts).toHaveLength(1);
+    expect(imageParts[0].image_url.url).toMatch(/^data:image\/png;base64,/);
+  });
+
+  it("validates against ChatMessageSchema (OpenAI-compatible)", () => {
+    const body = JSON.parse(MODALITY_BODY_TEMPLATES["chat-vision"](MODEL));
+    for (const m of body.messages) {
+      expect(() => ChatMessageSchema.parse(m)).not.toThrow();
+    }
+  });
+});
+
+describe("MODALITY_BODY_TEMPLATES — chat-audio shape", () => {
+  it("emits a content-parts array with one input_audio part", () => {
+    const body = JSON.parse(MODALITY_BODY_TEMPLATES["chat-audio"](MODEL));
+    const message = body.messages[0];
+    expect(Array.isArray(message.content)).toBe(true);
+    const audioParts = message.content.filter(
+      (p: { type: string }) => p.type === "input_audio",
+    );
+    expect(audioParts).toHaveLength(1);
+    expect(audioParts[0].input_audio.format).toBe("wav");
+    expect(typeof audioParts[0].input_audio.data).toBe("string");
+    expect(audioParts[0].input_audio.data.length).toBeGreaterThan(0);
+  });
+
+  it("each part validates against ChatMessageContentPartSchema", () => {
+    const body = JSON.parse(MODALITY_BODY_TEMPLATES["chat-audio"](MODEL));
+    for (const part of body.messages[0].content) {
+      expect(() => ChatMessageContentPartSchema.parse(part)).not.toThrow();
+    }
+  });
+});
+
+describe("MODALITY_BODY_TEMPLATES — non-chat shapes unchanged", () => {
+  it("embeddings keeps { model, input } shape", () => {
+    const body = JSON.parse(MODALITY_BODY_TEMPLATES.embeddings(MODEL));
+    expect(body).toEqual({ model: MODEL, input: "hello" });
+  });
+
+  it("rerank keeps { model, query, documents } shape", () => {
+    const body = JSON.parse(MODALITY_BODY_TEMPLATES.rerank(MODEL));
+    expect(body.query).toBe("what is 2+2");
+    expect(body.documents).toEqual(["four", "five"]);
+  });
+
+  it("images keeps { model, prompt } shape", () => {
+    const body = JSON.parse(MODALITY_BODY_TEMPLATES.images(MODEL));
+    expect(body.prompt).toBe("a cat");
+  });
+
+  it("plain chat keeps single user message", () => {
+    const body = JSON.parse(MODALITY_BODY_TEMPLATES.chat(MODEL));
+    expect(body.messages).toEqual([{ role: "user", content: "hello" }]);
+  });
+});

--- a/packages/tool-adapters/src/vegeta/body-templates.spec.ts
+++ b/packages/tool-adapters/src/vegeta/body-templates.spec.ts
@@ -5,14 +5,18 @@ import { MODALITY_BODY_TEMPLATES } from "./body-templates.js";
 const MODEL = "Qwen2.5-0.5B-Instruct";
 
 describe("MODALITY_BODY_TEMPLATES — JSON validity", () => {
-  it.each(["chat", "chat-vision", "chat-audio", "embeddings", "rerank", "images"] as const)(
-    "%s default body parses as JSON with the requested model",
-    (apiType) => {
-      const raw = MODALITY_BODY_TEMPLATES[apiType](MODEL);
-      const parsed = JSON.parse(raw);
-      expect(parsed.model).toBe(MODEL);
-    },
-  );
+  it.each([
+    "chat",
+    "chat-vision",
+    "chat-audio",
+    "embeddings",
+    "rerank",
+    "images",
+  ] as const)("%s default body parses as JSON with the requested model", (apiType) => {
+    const raw = MODALITY_BODY_TEMPLATES[apiType](MODEL);
+    const parsed = JSON.parse(raw);
+    expect(parsed.model).toBe(MODEL);
+  });
 });
 
 describe("MODALITY_BODY_TEMPLATES — chat-vision shape", () => {
@@ -20,9 +24,7 @@ describe("MODALITY_BODY_TEMPLATES — chat-vision shape", () => {
     const body = JSON.parse(MODALITY_BODY_TEMPLATES["chat-vision"](MODEL));
     const message = body.messages[0];
     expect(Array.isArray(message.content)).toBe(true);
-    const imageParts = message.content.filter(
-      (p: { type: string }) => p.type === "image_url",
-    );
+    const imageParts = message.content.filter((p: { type: string }) => p.type === "image_url");
     expect(imageParts).toHaveLength(1);
     expect(imageParts[0].image_url.url).toMatch(/^data:image\/png;base64,/);
   });
@@ -40,9 +42,7 @@ describe("MODALITY_BODY_TEMPLATES — chat-audio shape", () => {
     const body = JSON.parse(MODALITY_BODY_TEMPLATES["chat-audio"](MODEL));
     const message = body.messages[0];
     expect(Array.isArray(message.content)).toBe(true);
-    const audioParts = message.content.filter(
-      (p: { type: string }) => p.type === "input_audio",
-    );
+    const audioParts = message.content.filter((p: { type: string }) => p.type === "input_audio");
     expect(audioParts).toHaveLength(1);
     expect(audioParts[0].input_audio.format).toBe("wav");
     expect(typeof audioParts[0].input_audio.data).toBe("string");

--- a/packages/tool-adapters/src/vegeta/body-templates.ts
+++ b/packages/tool-adapters/src/vegeta/body-templates.ts
@@ -1,0 +1,54 @@
+import type { VegetaParams } from "./schema.js";
+
+// 1×1 transparent PNG — 67 bytes, smallest universally-decodable PNG. Lets
+// real vision endpoints pass image-decode validation without depending on
+// outbound network access from the runner pod.
+const SAMPLE_IMAGE_PNG_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+
+// 44-byte silent mono 8 kHz 8-bit WAV (RIFF header + zero-length data chunk).
+// Real audio endpoints accept this for shape-validation; they may 4xx later
+// on empty samples, which is per-issue acceptance ("not 'missing input_audio'").
+const SAMPLE_AUDIO_WAV_BASE64 = "UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=";
+
+/**
+ * Canonical seed bodies for each `apiType`. Shapes mirror the OpenAI-compatible
+ * payloads built by `apps/web/src/features/playground/chat/attachments.ts` and
+ * validated by `ChatMessageContentPartSchema` in `@modeldoctor/contracts`.
+ *
+ * Used as:
+ *   - vegeta default body (this package's `API_TYPE_TO_BODY`)
+ *   - reference for any future tool that needs a "what does a real request look like" seed
+ */
+export const MODALITY_BODY_TEMPLATES: Record<VegetaParams["apiType"], (model: string) => string> = {
+  chat: (m) => JSON.stringify({ model: m, messages: [{ role: "user", content: "hello" }] }),
+  "chat-vision": (m) =>
+    JSON.stringify({
+      model: m,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "What is in this image?" },
+            { type: "image_url", image_url: { url: SAMPLE_IMAGE_PNG_DATA_URL } },
+          ],
+        },
+      ],
+    }),
+  "chat-audio": (m) =>
+    JSON.stringify({
+      model: m,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Transcribe this audio." },
+            { type: "input_audio", input_audio: { data: SAMPLE_AUDIO_WAV_BASE64, format: "wav" } },
+          ],
+        },
+      ],
+    }),
+  embeddings: (m) => JSON.stringify({ model: m, input: "hello" }),
+  rerank: (m) => JSON.stringify({ model: m, query: "what is 2+2", documents: ["four", "five"] }),
+  images: (m) => JSON.stringify({ model: m, prompt: "a cat" }),
+};

--- a/packages/tool-adapters/src/vegeta/runtime.ts
+++ b/packages/tool-adapters/src/vegeta/runtime.ts
@@ -4,6 +4,7 @@ import type {
   ProgressEvent,
   ToolReport,
 } from "../core/interface.js";
+import { MODALITY_BODY_TEMPLATES } from "./body-templates.js";
 import { type VegetaParams, type VegetaReport, vegetaReportSchema } from "./schema.js";
 
 export const API_TYPE_TO_PATH: Record<VegetaParams["apiType"], string> = {
@@ -15,15 +16,7 @@ export const API_TYPE_TO_PATH: Record<VegetaParams["apiType"], string> = {
   images: "/v1/images/generations",
 };
 
-export const API_TYPE_TO_BODY: Record<VegetaParams["apiType"], (model: string) => string> = {
-  chat: (m) => JSON.stringify({ model: m, messages: [{ role: "user", content: "hello" }] }),
-  "chat-vision": (m) =>
-    JSON.stringify({ model: m, messages: [{ role: "user", content: "hello" }] }),
-  "chat-audio": (m) => JSON.stringify({ model: m, messages: [{ role: "user", content: "hello" }] }),
-  embeddings: (m) => JSON.stringify({ model: m, input: "hello" }),
-  rerank: (m) => JSON.stringify({ model: m, query: "what is 2+2", documents: ["four", "five"] }),
-  images: (m) => JSON.stringify({ model: m, prompt: "a cat" }),
-};
+export const API_TYPE_TO_BODY = MODALITY_BODY_TEMPLATES;
 
 export function buildCommand(plan: BuildCommandPlan<VegetaParams>): BuildCommandResult {
   const { params, connection } = plan;


### PR DESCRIPTION
## Summary

P2 quality fixes from roadmap [#189](https://github.com/weetime/modeldoctor/issues/189). Two phase-per-commit changes:

- **`fix(vegeta)`** — vegeta `chat-vision` / `chat-audio` default bodies were the same as plain `chat` (single user message, string content), so benchmarks against a real multimodal endpoint failed 4xx out of the box. Extracted `MODALITY_BODY_TEMPLATES` as the SSOT for "what a real X request looks like" — shapes mirror the OpenAI-compatible parts the playground builds in `apps/web/src/features/playground/chat/attachments.ts` and `ChatMessageContentPartSchema` in `@modeldoctor/contracts`. Vision uses an inline 1×1 PNG; audio uses a 44-byte silent WAV. Closes #136 scope.

- **`docs(api)`** — completed `@ApiTags` / `@ApiOperation` / `@ApiBearerAuth` across the 18 remaining controllers (was 10/28; now full). The `/mcp` JSON-RPC transport is `@ApiExcludeController()` since its protocol is MCP, not OpenAPI. Goal: `/api/docs-json` becomes a usable v1 contract for external SDKs / openapi-typescript / partner integrations.

## Why

The OpenAPI doc is the second contract ModelDoctor ships (alongside the MCP tool catalog). Roadmap #189 positions ModelDoctor as a private-cloud LLM-stack assistant whose capabilities are reachable from Claude Code / Cursor — that needs both contracts complete. The multimodal default-body bug was a first-run rake step that directly contradicts the "supports chat-vision/chat-audio benchmarks" claim.

## Verification

- `pnpm -F @modeldoctor/tool-adapters test` — 229 pass (14 new tests for `MODALITY_BODY_TEMPLATES` shape + `ChatMessageContentPartSchema` validation).
- `pnpm -F @modeldoctor/api build` — clean.
- `pnpm -F @modeldoctor/api type-check` — clean.
- `pnpm -F @modeldoctor/api test` — 838 pass; the 6 unrelated Prisma client errors in `saved-compares` + `insights/synthesize` service specs also fail on unmodified `main` (verified via direct comparison).
- `pnpm exec biome check apps/api/src/modules/ packages/tool-adapters/src/vegeta/` — 0 errors, 17 pre-existing warnings.

## Test plan

- [ ] Run a vegeta benchmark against a chat-vision endpoint with default body — should not 4xx with "missing image_url".
- [ ] Run a vegeta benchmark against a chat-audio endpoint with default body — should not 4xx with "missing input_audio".
- [ ] Open `http://localhost:3000/api/docs` after rebuild and confirm all 27 documented controllers list at least one tag + operation summary (`/mcp` deliberately hidden).

Refs #189. Closes #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)