### PR TITLE
fix(saved-compare): bold-density lint ignores bulleted lists

### DIFF
--- a/apps/api/src/modules/saved-compares/narrative-lint.spec.ts
+++ b/apps/api/src/modules/saved-compares/narrative-lint.spec.ts
@@ -171,6 +171,48 @@ describe("narrative-lint — bold density", () => {
     );
     expect(out.some((w) => w.code === "bold-density")).toBe(false);
   });
+
+  it("does NOT flag a bulleted list with one **label** per item", () => {
+    const out = lintNarrative(
+      replaceSection(baseNarrative(), "advice", {
+        bodyMarkdown:
+          "- **场景**:对话、RAG 等存在重复前缀的请求。\n- **配置**:开启 prefix-cache + flashattn。\n- **监控**:关注 p90/p99 延迟。",
+      }),
+      [],
+    );
+    expect(out.some((w) => w.code === "bold-density")).toBe(false);
+  });
+
+  it("does NOT flag a numbered list with one **label** per item", () => {
+    const out = lintNarrative(
+      replaceSection(baseNarrative(), "caveats", {
+        bodyMarkdown:
+          "1. **单次运行**:每个配置仅运行一次,未提供方差。\n2. **p90/p99 持平**:TTFT 和 E2E 的尾部分位在 Baseline 和 Optimized 中相同。\n3. **数据有限**:仅 3 个 stage 对比。",
+      }),
+      [],
+    );
+    expect(out.some((w) => w.code === "bold-density")).toBe(false);
+  });
+
+  it("still flags ≥3 bold inside a single non-list paragraph", () => {
+    const out = lintNarrative(
+      replaceSection(baseNarrative(), "results", {
+        bodyMarkdown: "在 **par=32** 高压档下,**vLLM** 吞吐 **12.4 req/s** 领先 SGLang。",
+      }),
+      [],
+    );
+    expect(out.some((w) => w.code === "bold-density")).toBe(true);
+  });
+
+  it("still flags ≥3 bold within a single bullet line", () => {
+    const out = lintNarrative(
+      replaceSection(baseNarrative(), "advice", {
+        bodyMarkdown: "- **vLLM** 吞吐 **12.4 req/s** 比 SGLang **9.0 req/s** 高 38%。",
+      }),
+      [],
+    );
+    expect(out.some((w) => w.code === "bold-density")).toBe(true);
+  });
 });
 
 describe("narrative-lint — decimal precision", () => {

--- a/apps/api/src/modules/saved-compares/narrative-lint.ts
+++ b/apps/api/src/modules/saved-compares/narrative-lint.ts
@@ -108,8 +108,11 @@ const LIST_ITEM_LINE_RE = /^(?:[-*+]|\d+\.)\s+/;
  */
 function paragraphsForBoldDensity(paragraph: string): string[] {
   const lines = paragraph.split("\n");
+  // Single-line paragraphs are by far the common case in prose. Skip the
+  // every() + regex tests on the hot path.
+  if (lines.length <= 1) return [paragraph];
   const isAllListLines = lines.every((l) => l.trim() === "" || LIST_ITEM_LINE_RE.test(l.trim()));
-  if (isAllListLines && lines.length > 1) {
+  if (isAllListLines) {
     return lines.map((l) => l.trim()).filter((l) => l.length > 0);
   }
   return [paragraph];

--- a/apps/api/src/modules/saved-compares/narrative-lint.ts
+++ b/apps/api/src/modules/saved-compares/narrative-lint.ts
@@ -98,6 +98,23 @@ function countBoldSpans(paragraph: string): number {
   return mdBold + htmlBold;
 }
 
+const LIST_ITEM_LINE_RE = /^(?:[-*+]|\d+\.)\s+/;
+
+/**
+ * For bold-density only: split paragraphs further by treating each markdown
+ * list item as its own scope. Bulleted / numbered lists with a leading
+ * `**label**:` per item are legitimate writing — they should not trip the
+ * per-paragraph density rule just because the list has ≥3 items.
+ */
+function paragraphsForBoldDensity(paragraph: string): string[] {
+  const lines = paragraph.split("\n");
+  const isAllListLines = lines.every((l) => l.trim() === "" || LIST_ITEM_LINE_RE.test(l.trim()));
+  if (isAllListLines && lines.length > 1) {
+    return lines.map((l) => l.trim()).filter((l) => l.length > 0);
+  }
+  return [paragraph];
+}
+
 // ─── Main entry ──────────────────────────────────────────────────────────
 
 /**
@@ -157,13 +174,17 @@ export function lintNarrative(narrative: CompareNarrative, _inputNumbers: number
     const paragraphs = paragraphsExcludingCode(body);
 
     for (const para of paragraphs) {
-      // Bold density per paragraph.
-      if (countBoldSpans(para) >= 3) {
-        warnings.push({
-          code: "bold-density",
-          sectionId: section.id,
-          sample: para.slice(0, 120),
-        });
+      // Bold density — list items are each their own scope (4 bullets ×
+      // 1 **label** each ≠ "over-bolded paragraph").
+      for (const scope of paragraphsForBoldDensity(para)) {
+        if (countBoldSpans(scope) >= 3) {
+          warnings.push({
+            code: "bold-density",
+            sectionId: section.id,
+            sample: scope.slice(0, 120),
+          });
+          break;
+        }
       }
 
       // Decimal precision ≥3.


### PR DESCRIPTION
## Summary

Real-LLM smoke test against PR #258's deep-report flow surfaced one false-positive lint rule: bulleted/numbered lists with one `**label**:` per item tripped `bold-density` even though each item carries only one bold span.

Concrete sample DeepSeek produced:

```markdown
- **场景**:对话、RAG 等存在重复前缀的请求。
- **配置**:开启 prefix-cache + flashattn。
- **监控**:关注 p90/p99 延迟。
```

That's legitimate report-writing style, not AI-tic over-bolding. The rule was counting bold spans per blank-line-separated block; a 3-item list has 3 bold spans in one "block" which trips the ≥3 threshold.

## Fix

`paragraphsForBoldDensity()` splits a paragraph further when **every** line is a markdown list item (`-`, `*`, `+`, or `\d+.`). Each list item then gets its own scope for the density check. Mixed content (some prose + some list lines in one paragraph) and multi-bold-spans inside a single list line still trip the rule.

## Verification

- 4 new unit tests cover the regression: 2 positive (clean bullet / numbered lists), 2 negative (real over-bolding still flagged, including inside a single bullet)
- `pnpm -F @modeldoctor/api test -- narrative-lint.spec` → 47 / 47 pass (was 43 + 4 new)
- **Real-LLM regression**: cleared the demo SavedCompare's narrative, regenerated against DeepSeek with this fix in place; `lintWarnings` dropped from 2 → 0. Same prompt + same input data, just the relaxed rule.

Follow-up to #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)