### PR TITLE
feat(quality-gate): per-run generation params (thinking/max_tokens/temperature) + strip <think>

### DIFF
--- a/apps/api/prisma/migrations/20260529070049_add_gen_config/migration.sql
+++ b/apps/api/prisma/migrations/20260529070049_add_gen_config/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "evaluation_runs" ADD COLUMN     "gen_config" JSONB;
+
+-- AlterTable
+ALTER TABLE "evaluations" ADD COLUMN     "gen_config" JSONB;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -377,6 +377,7 @@ model Evaluation {
   version       Int      @default(1)
   samples       Json
   totalSamples  Int      @default(0) @map("total_samples")
+  genConfig     Json?    @map("gen_config")
   isOfficial    Boolean  @default(false) @map("is_official")
   createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt     DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
@@ -398,6 +399,7 @@ model EvaluationRun {
   endpointAId              String                @map("endpoint_a_id")
   endpointBId              String?               @map("endpoint_b_id")
   gateConfig               Json                  @map("gate_config")
+  genConfig                Json?                 @map("gen_config")
   status                   EvaluationRunStatus   @default(PENDING)
   gateResult               EvaluationGateResult? @map("gate_result")
   aggregateMetrics         Json?                 @map("aggregate_metrics")

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -905,6 +905,10 @@ interface BuiltInEvaluationSeed {
     judgeConfig: unknown;
     tags?: string[];
   }>;
+  // Eval-level default generation params (run-create pre-fills these). MCQ sets
+  // ship thinking:"off" so reasoning models (Qwen3 etc.) answer directly instead
+  // of burning the token budget on <think> and getting truncated.
+  genConfig?: { maxTokens?: number; temperature?: number; thinking?: "auto" | "on" | "off" };
 }
 
 const BUILT_IN_EVALUATIONS: BuiltInEvaluationSeed[] = [
@@ -1523,6 +1527,9 @@ const BUILT_IN_EVALUATIONS: BuiltInEvaluationSeed[] = [
     description:
       "从 C-Eval 抽样的 60 道中文单项选择题，覆盖 12 个学科（数学/物理/化学/计算机/经济/法学/历史/文学等），使用 multiple-choice 判分器检测模型对中文学科知识的准确性。数据源 C-Eval（CC-BY-NC-SA-4.0，非商用），仅供自用评测。",
     samples: cevalSamples,
+    // Short-answer MCQ: disable thinking so reasoning models (Qwen3 etc.) emit
+    // the answer letter directly instead of being truncated mid-<think>.
+    genConfig: { thinking: "off" },
   },
 ];
 
@@ -1536,6 +1543,7 @@ async function seedBuiltInEvaluations(): Promise<void> {
         description: ev.description,
         samples: validatedSamples,
         totalSamples: validatedSamples.length,
+        genConfig: ev.genConfig ?? Prisma.JsonNull,
         isOfficial: true,
       },
       create: {
@@ -1545,6 +1553,7 @@ async function seedBuiltInEvaluations(): Promise<void> {
         description: ev.description,
         samples: validatedSamples,
         totalSamples: validatedSamples.length,
+        genConfig: ev.genConfig ?? Prisma.JsonNull,
         isOfficial: true,
       },
     });

--- a/apps/api/src/modules/quality-gate/__tests__/endpoint-caller.body.spec.ts
+++ b/apps/api/src/modules/quality-gate/__tests__/endpoint-caller.body.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { buildRequestBody } from "../endpoint-caller.js";
+
+const gen = (over: Partial<Parameters<typeof buildRequestBody>[2]> = {}) =>
+  ({ maxTokens: 2048, temperature: 0, thinking: "auto", ...over }) as Parameters<
+    typeof buildRequestBody
+  >[2];
+
+describe("buildRequestBody", () => {
+  it("maps maxTokens/temperature and omits chat_template_kwargs on auto", () => {
+    const b = buildRequestBody("m", "hi", gen()) as Record<string, unknown>;
+    expect(b).toMatchObject({ model: "m", max_tokens: 2048, temperature: 0 });
+    expect(b.chat_template_kwargs).toBeUndefined();
+  });
+  it("thinking=off sends enable_thinking:false", () => {
+    const b = buildRequestBody("m", "hi", gen({ thinking: "off" })) as Record<string, unknown>;
+    expect(b.chat_template_kwargs).toEqual({ enable_thinking: false });
+  });
+  it("thinking=on sends enable_thinking:true", () => {
+    const b = buildRequestBody("m", "hi", gen({ thinking: "on" })) as Record<string, unknown>;
+    expect(b.chat_template_kwargs).toEqual({ enable_thinking: true });
+  });
+  it("includes stop only when non-empty", () => {
+    expect((buildRequestBody("m", "hi", gen()) as Record<string, unknown>).stop).toBeUndefined();
+    expect(
+      (buildRequestBody("m", "hi", gen({ stop: ["\n\n"] })) as Record<string, unknown>).stop,
+    ).toEqual(["\n\n"]);
+  });
+});

--- a/apps/api/src/modules/quality-gate/endpoint-caller.ts
+++ b/apps/api/src/modules/quality-gate/endpoint-caller.ts
@@ -1,4 +1,8 @@
-import { DEFAULT_GEN_CONFIG, type EndpointCallResult, type GenConfig } from "@modeldoctor/contracts";
+import {
+  DEFAULT_GEN_CONFIG,
+  type EndpointCallResult,
+  type GenConfig,
+} from "@modeldoctor/contracts";
 import { Injectable } from "@nestjs/common";
 import { ConnectionService } from "../connection/connection.service.js";
 

--- a/apps/api/src/modules/quality-gate/endpoint-caller.ts
+++ b/apps/api/src/modules/quality-gate/endpoint-caller.ts
@@ -1,10 +1,28 @@
-import type { EndpointCallResult } from "@modeldoctor/contracts";
+import { DEFAULT_GEN_CONFIG, type EndpointCallResult, type GenConfig } from "@modeldoctor/contracts";
 import { Injectable } from "@nestjs/common";
 import { ConnectionService } from "../connection/connection.service.js";
 
 const REQUEST_TIMEOUT_MS = 30_000;
 const RETRY_DELAY_MS = 500;
-const MAX_TOKENS = 2048;
+
+/**
+ * Build the /v1/chat/completions request body from a resolved GenConfig.
+ * `thinking` maps to vLLM's `chat_template_kwargs.enable_thinking` — only sent
+ * for "on"/"off"; "auto" omits it so non-vLLM endpoints don't 400 on the field.
+ * Exported for unit testing the three-state mapping.
+ */
+export function buildRequestBody(model: string, prompt: string, gen: GenConfig): object {
+  const body: Record<string, unknown> = {
+    model,
+    messages: [{ role: "user", content: prompt }],
+    temperature: gen.temperature,
+    max_tokens: gen.maxTokens,
+  };
+  if (gen.stop?.length) body.stop = gen.stop;
+  if (gen.thinking === "off") body.chat_template_kwargs = { enable_thinking: false };
+  else if (gen.thinking === "on") body.chat_template_kwargs = { enable_thinking: true };
+  return body;
+}
 
 @Injectable()
 export class EndpointCaller {
@@ -15,6 +33,7 @@ export class EndpointCaller {
     userId: string,
     prompt: string,
     outerSignal: AbortSignal,
+    gen: GenConfig = DEFAULT_GEN_CONFIG,
   ): Promise<EndpointCallResult> {
     const conn = await this.connections.getOwnedDecrypted(userId, connectionId).catch(() => null);
     if (!conn) {
@@ -23,12 +42,7 @@ export class EndpointCaller {
     const url = `${conn.baseUrl.replace(/\/$/, "")}/v1/chat/completions`;
     const headers: Record<string, string> = { "Content-Type": "application/json" };
     if (conn.apiKey) headers.Authorization = `Bearer ${conn.apiKey}`;
-    const body = JSON.stringify({
-      model: conn.model,
-      messages: [{ role: "user", content: prompt }],
-      temperature: 0,
-      max_tokens: MAX_TOKENS,
-    });
+    const body = JSON.stringify(buildRequestBody(conn.model, prompt, gen));
     return this.attempt(url, headers, body, outerSignal);
   }
 
@@ -51,6 +65,9 @@ export class EndpointCaller {
       try {
         const resp = await fetch(url, { method: "POST", headers, body, signal: ctrl.signal });
         if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${(await resp.text()).slice(0, 256)}`);
+        // Some vLLM builds with --reasoning-parser split thinking into
+        // `reasoning_content` and leave `content` clean; we read `content`
+        // (and stripThink() handles deployments that inline <think> instead).
         const data = (await resp.json()) as {
           choices?: Array<{ message?: { content?: string } }>;
           usage?: { prompt_tokens?: number; completion_tokens?: number };

--- a/apps/api/src/modules/quality-gate/judges/__tests__/strip-think.spec.ts
+++ b/apps/api/src/modules/quality-gate/judges/__tests__/strip-think.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { stripThink } from "../strip-think.js";
+
+describe("stripThink", () => {
+  it("removes a leading think block and trims", () => {
+    expect(stripThink("<think>\n嗯，让我想想…\n</think>\n\nB")).toBe("B");
+  });
+  it("is a no-op when there is no think block (parser-separated content)", () => {
+    expect(stripThink("C. 北京")).toBe("C. 北京");
+  });
+  it("removes multiple think blocks", () => {
+    expect(stripThink("<think>a</think>X<think>b</think>Y")).toBe("XY");
+  });
+  it("is case-insensitive on the tag", () => {
+    expect(stripThink("<THINK>r</THINK>D")).toBe("D");
+  });
+  it("leaves an unclosed (truncated) think intact", () => {
+    const truncated = "<think>嗯，这道题我需要先分析积分的结构，然后";
+    expect(stripThink(truncated)).toBe(truncated);
+  });
+});

--- a/apps/api/src/modules/quality-gate/judges/strip-think.ts
+++ b/apps/api/src/modules/quality-gate/judges/strip-think.ts
@@ -1,0 +1,16 @@
+const THINK_BLOCK = /<think>[\s\S]*?<\/think>/gi;
+
+/**
+ * Strip closed `<think>…</think>` reasoning blocks from a model answer before
+ * judging. Server-agnostic safety net for reasoning models (Qwen3, DeepSeek-R1)
+ * on vLLM deployments that DON'T run a `--reasoning-parser` (so thinking leaks
+ * into `content`). When the deployment DOES separate reasoning into a distinct
+ * field, `content` has no think tags and this is a no-op.
+ *
+ * Unclosed `<think>` (e.g. thinking truncated by max_tokens before the answer)
+ * is left intact — there's no final answer to recover, and keeping the text
+ * makes the failure visible rather than silently blanking it.
+ */
+export function stripThink(text: string): string {
+  return text.replace(THINK_BLOCK, "").trim();
+}

--- a/apps/api/src/modules/quality-gate/repositories/__tests__/runs.repository.spec.ts
+++ b/apps/api/src/modules/quality-gate/repositories/__tests__/runs.repository.spec.ts
@@ -79,9 +79,11 @@ describe("RunsRepository", () => {
       endpointAId: connA,
       endpointBId: connB,
       gateConfig: { passRateMin: 0.9 },
+      genConfig: { maxTokens: 2048, temperature: 0, thinking: "auto" },
     });
     expect(r.status).toBe("PENDING");
     expect(r.totalSamples).toBe(1);
+    expect(r.genConfig).toMatchObject({ thinking: "auto", maxTokens: 2048 });
   });
 
   it("transitions PENDING → RUNNING → COMPLETED with gate result", async () => {
@@ -92,6 +94,7 @@ describe("RunsRepository", () => {
       evaluationSnapshot: { samples: [] },
       endpointAId: connA,
       gateConfig: { passRateMin: 0.9 },
+      genConfig: { maxTokens: 2048, temperature: 0, thinking: "auto" },
     });
     await repo.markRunning(r.id);
     const updated = await repo.markCompleted(
@@ -119,6 +122,7 @@ describe("RunsRepository", () => {
       endpointAId: connA,
       endpointBId: connB,
       gateConfig: { passRateMin: 0.9 },
+      genConfig: { maxTokens: 2048, temperature: 0, thinking: "auto" },
     });
     await repo.saveSample({
       runId: r.id,
@@ -146,6 +150,7 @@ describe("RunsRepository", () => {
       evaluationSnapshot: { samples: [] },
       endpointAId: connA,
       gateConfig: { passRateMin: 0.9 },
+      genConfig: { maxTokens: 2048, temperature: 0, thinking: "auto" },
     });
     await repo.markRunning(r.id);
     const count = await repo.sweepRunningOnBoot();

--- a/apps/api/src/modules/quality-gate/repositories/evaluations.repository.ts
+++ b/apps/api/src/modules/quality-gate/repositories/evaluations.repository.ts
@@ -2,6 +2,7 @@ import type {
   CreateEvaluationRequest,
   Evaluation,
   EvaluationSample,
+  GenConfig,
   UpdateEvaluationRequest,
 } from "@modeldoctor/contracts";
 import { Injectable, NotFoundException } from "@nestjs/common";
@@ -39,6 +40,7 @@ export class EvaluationsRepository {
         description: body.description ?? null,
         samples: body.samples as unknown as object,
         totalSamples: body.samples.length,
+        genConfig: (body.genConfig ?? undefined) as Prisma.InputJsonValue | undefined,
       },
     });
     return this.toDto(row);
@@ -58,6 +60,10 @@ export class EvaluationsRepository {
       data.samples = body.samples as unknown as Prisma.InputJsonValue;
       data.version = existing.version + 1;
       data.totalSamples = body.samples.length;
+    }
+    if (body.genConfig !== undefined) {
+      data.genConfig =
+        body.genConfig === null ? Prisma.JsonNull : (body.genConfig as Prisma.InputJsonValue);
     }
 
     const row = await this.prisma.evaluation.update({ where: { id }, data });
@@ -81,6 +87,7 @@ export class EvaluationsRepository {
     version: number;
     samples: unknown;
     totalSamples: number;
+    genConfig: unknown;
     isOfficial: boolean;
     createdAt: Date;
     updatedAt: Date;
@@ -92,6 +99,7 @@ export class EvaluationsRepository {
     version: row.version,
     samples: row.samples as EvaluationSample[],
     totalSamples: row.totalSamples,
+    genConfig: (row.genConfig as Partial<GenConfig> | null) ?? null,
     isOfficial: row.isOfficial,
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),

--- a/apps/api/src/modules/quality-gate/repositories/runs.repository.ts
+++ b/apps/api/src/modules/quality-gate/repositories/runs.repository.ts
@@ -2,11 +2,13 @@ import type {
   AggregateMetrics,
   EvaluationRun,
   GateResult,
+  GenConfig,
   ListRunSamplesQuery,
   ListRunSamplesResponse,
   ListRunsQuery,
   RunSample,
 } from "@modeldoctor/contracts";
+import { DEFAULT_GEN_CONFIG } from "@modeldoctor/contracts";
 import { Injectable } from "@nestjs/common";
 import type { EvaluationRunStatus } from "@prisma/client";
 import { Prisma } from "@prisma/client";
@@ -21,6 +23,7 @@ export interface CreatePendingInput {
   endpointAId: string;
   endpointBId?: string | null;
   gateConfig: object;
+  genConfig: GenConfig;
   baselineRunIdAtExecution?: string | null;
 }
 
@@ -48,6 +51,7 @@ export class RunsRepository {
         endpointAId: input.endpointAId,
         endpointBId: input.endpointBId ?? null,
         gateConfig: input.gateConfig,
+        genConfig: input.genConfig,
         totalSamples: total,
         baselineRunIdAtExecution: input.baselineRunIdAtExecution ?? null,
       },
@@ -251,6 +255,7 @@ export class RunsRepository {
         endpointBId: true,
         evaluationSnapshot: true,
         gateConfig: true,
+        genConfig: true,
         baselineRunIdAtExecution: true,
       },
     });
@@ -260,6 +265,7 @@ export class RunsRepository {
       userId: row.userId,
       endpointAId: row.endpointAId,
       endpointBId: row.endpointBId,
+      genConfig: (row.genConfig as GenConfig | null) ?? null,
       evaluationSnapshot: row.evaluationSnapshot as {
         samples: Array<{
           id: string;
@@ -302,6 +308,7 @@ export class RunsRepository {
     endpointA: row.endpointA ? toConnectionRef(row.endpointA) : null,
     endpointB: row.endpointB ? toConnectionRef(row.endpointB) : null,
     gateConfig: row.gateConfig as EvaluationRun["gateConfig"],
+    genConfig: (row.genConfig as GenConfig | null) ?? DEFAULT_GEN_CONFIG,
     status: row.status as EvaluationRun["status"],
     gateResult: row.gateResult,
     aggregateMetrics: row.aggregateMetrics as EvaluationRun["aggregateMetrics"],
@@ -335,6 +342,7 @@ type RunRowWithEndpoints = {
   endpointA: ConnectionRow | null;
   endpointB: ConnectionRow | null;
   gateConfig: unknown;
+  genConfig: unknown;
   status: EvaluationRunStatus;
   gateResult: GateResult | null;
   aggregateMetrics: unknown;

--- a/apps/api/src/modules/quality-gate/services/run-executor.service.ts
+++ b/apps/api/src/modules/quality-gate/services/run-executor.service.ts
@@ -1,10 +1,12 @@
-import type { JudgeConfig } from "@modeldoctor/contracts";
+import type { GenConfig, JudgeConfig } from "@modeldoctor/contracts";
+import { DEFAULT_GEN_CONFIG } from "@modeldoctor/contracts";
 import { Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
 import pLimit from "p-limit";
 import { EndpointCaller } from "../endpoint-caller.js";
 import { computeGateResult } from "../gate/compute-gate-result.js";
 import { aggregateMetrics, computeDelta } from "../gate/sample-aggregation.js";
 import { JudgesService } from "../judges/judges.service.js";
+import { stripThink } from "../judges/strip-think.js";
 import { RunsRepository } from "../repositories/runs.repository.js";
 
 const SAMPLE_CONCURRENCY = 4;
@@ -26,6 +28,7 @@ interface FullRun {
     }>;
   };
   gateConfig: import("@modeldoctor/contracts").GateConfig;
+  genConfig?: GenConfig | null;
   baselineRunIdAtExecution?: string | null;
 }
 
@@ -79,6 +82,7 @@ export class QualityGateRunExecutor implements OnModuleInit, OnModuleDestroy {
       const baselineMode = run.baselineRunIdAtExecution != null;
 
       const samples = run.evaluationSnapshot.samples;
+      const gen = run.genConfig ?? DEFAULT_GEN_CONFIG;
       await Promise.all(
         samples.map((s) =>
           sampleLimit(async () => {
@@ -90,13 +94,14 @@ export class QualityGateRunExecutor implements OnModuleInit, OnModuleDestroy {
               run.userId,
               s.prompt,
               ac.signal,
+              gen,
             );
             if (ac.signal.aborted) return;
             const judgedA = await judgeLimit(() =>
               this.judges.apply(s.judgeConfig, {
                 question: s.prompt,
                 expected: s.expected,
-                answer: callA.rawAnswer,
+                answer: stripThink(callA.rawAnswer),
               }),
             );
             if (s.judgeConfig.kind === "llm-judge") judgeCalls++;
@@ -121,6 +126,7 @@ export class QualityGateRunExecutor implements OnModuleInit, OnModuleDestroy {
                 run.userId,
                 s.prompt,
                 ac.signal,
+                gen,
               );
               callB = result;
               if (!ac.signal.aborted) {
@@ -128,7 +134,7 @@ export class QualityGateRunExecutor implements OnModuleInit, OnModuleDestroy {
                   this.judges.apply(s.judgeConfig, {
                     question: s.prompt,
                     expected: s.expected,
-                    answer: result.rawAnswer,
+                    answer: stripThink(result.rawAnswer),
                   }),
                 );
                 if (s.judgeConfig.kind === "llm-judge") judgeCalls++;

--- a/apps/api/src/modules/quality-gate/services/runs.service.ts
+++ b/apps/api/src/modules/quality-gate/services/runs.service.ts
@@ -4,6 +4,7 @@ import type {
   ListRunSamplesQuery,
   ListRunsQuery,
 } from "@modeldoctor/contracts";
+import { resolveGenConfig } from "@modeldoctor/contracts";
 import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
 import { ConnectionService } from "../../connection/connection.service.js";
 import { LlmJudgeService } from "../../llm-judge/llm-judge.service.js";
@@ -96,6 +97,10 @@ export class RunsService {
       baselineRunIdAtExecution = override.id;
     }
 
+    // Layer: schema defaults < eval-level default < per-run override. Snapshot
+    // the resolved config onto the run for reproducibility.
+    const genConfig = resolveGenConfig(evaluation.genConfig, body.genConfig);
+
     const pending = await this.repo.createPending({
       userId,
       evaluationId: evaluation.id,
@@ -104,6 +109,7 @@ export class RunsService {
       endpointAId: body.endpointAId,
       endpointBId: body.endpointBId ?? null,
       gateConfig: body.gateConfig,
+      genConfig,
       baselineRunIdAtExecution,
     });
 

--- a/apps/web/src/features/quality-gate/RunCreatePage.tsx
+++ b/apps/web/src/features/quality-gate/RunCreatePage.tsx
@@ -98,6 +98,9 @@ export function RunCreatePage() {
 
   // Pre-fill gen params from the selected evaluation's default (built-in MCQ
   // sets ship thinking:"off"); schema defaults fill the rest. User can override.
+  // Depend ONLY on evaluationId (primitive), not evaluations.data — a background
+  // refetch hands back a new array reference and would otherwise re-run this and
+  // clobber the user's manual gen-param edits.
   useEffect(() => {
     const ev = evaluations.data?.find((e) => e.id === evaluationId);
     if (!ev) return;
@@ -106,8 +109,8 @@ export function RunCreatePage() {
       { thinking: "auto", maxTokens: 2048, temperature: 0, ...(ev.genConfig ?? {}) },
       { shouldValidate: true },
     );
-    // biome-ignore lint/correctness/useExhaustiveDependencies: react to eval switch
-  }, [evaluationId, evaluations.data]);
+    // biome-ignore lint/correctness/useExhaustiveDependencies: pre-fill only on eval switch
+  }, [evaluationId]);
 
   const [pickerOpen, setPickerOpen] = useState(false);
 

--- a/apps/web/src/features/quality-gate/RunCreatePage.tsx
+++ b/apps/web/src/features/quality-gate/RunCreatePage.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/select";
 import { BaselinePickerDialog } from "./components/BaselinePickerDialog";
 import { GateConfigForm } from "./components/GateConfigForm";
+import { GenConfigForm } from "./components/GenConfigForm";
 import { useCreateRun, useEvaluations } from "./queries";
 
 export function RunCreatePage() {
@@ -46,6 +47,7 @@ export function RunCreatePage() {
       endpointBId: undefined,
       baselineRunIdOverride: null,
       gateConfig: { passRateMin: 0.9 },
+      genConfig: { thinking: "auto", maxTokens: 2048, temperature: 0 },
     },
   });
 
@@ -93,6 +95,19 @@ export function RunCreatePage() {
     }
     // biome-ignore lint/correctness/useExhaustiveDependencies: only react to evaluationId switch
   }, [evaluationId]);
+
+  // Pre-fill gen params from the selected evaluation's default (built-in MCQ
+  // sets ship thinking:"off"); schema defaults fill the rest. User can override.
+  useEffect(() => {
+    const ev = evaluations.data?.find((e) => e.id === evaluationId);
+    if (!ev) return;
+    form.setValue(
+      "genConfig",
+      { thinking: "auto", maxTokens: 2048, temperature: 0, ...(ev.genConfig ?? {}) },
+      { shouldValidate: true },
+    );
+    // biome-ignore lint/correctness/useExhaustiveDependencies: react to eval switch
+  }, [evaluationId, evaluations.data]);
 
   const [pickerOpen, setPickerOpen] = useState(false);
 
@@ -283,6 +298,10 @@ export function RunCreatePage() {
                     : undefined
                 }
               />
+            </FormSection>
+
+            <FormSection title={t("gen.sectionTitle")} description={t("gen.sectionDescription")}>
+              <GenConfigForm namePrefix="genConfig" />
             </FormSection>
 
             <FormActions

--- a/apps/web/src/features/quality-gate/__tests__/RunReportPage.test.tsx
+++ b/apps/web/src/features/quality-gate/__tests__/RunReportPage.test.tsx
@@ -15,6 +15,7 @@ const mockRun = {
   endpointAId: "a",
   endpointBId: null,
   gateConfig: { passRateMin: 0.9 },
+  genConfig: { maxTokens: 2048, temperature: 0, thinking: "auto" as const },
   status: "COMPLETED" as const,
   gateResult: "PASSED" as const,
   aggregateMetrics: {

--- a/apps/web/src/features/quality-gate/components/GenConfigForm.tsx
+++ b/apps/web/src/features/quality-gate/components/GenConfigForm.tsx
@@ -1,0 +1,99 @@
+import { useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface Props {
+  /** Dot path of the GenConfig object in the parent form (e.g. `genConfig`). */
+  namePrefix: string;
+}
+
+/**
+ * Per-run generation parameters. `thinking` is the key control for reasoning
+ * models: "off" disables vLLM thinking so they answer short-form directly
+ * instead of burning the token budget mid-<think>.
+ */
+export function GenConfigForm({ namePrefix }: Props) {
+  const { t } = useTranslation("quality-gate");
+  const { control } = useFormContext();
+  return (
+    <div className="space-y-3 max-w-md">
+      <FormField
+        control={control}
+        name={`${namePrefix}.thinking`}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>{t("gen.thinkingLabel")}</FormLabel>
+            <FormControl>
+              <Select value={field.value ?? "auto"} onValueChange={field.onChange}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="auto">{t("gen.thinkingAuto")}</SelectItem>
+                  <SelectItem value="off">{t("gen.thinkingOff")}</SelectItem>
+                  <SelectItem value="on">{t("gen.thinkingOn")}</SelectItem>
+                </SelectContent>
+              </Select>
+            </FormControl>
+            <p className="text-xs text-muted-foreground">{t("gen.thinkingHint")}</p>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      <div className="grid grid-cols-2 gap-4">
+        <FormField
+          control={control}
+          name={`${namePrefix}.maxTokens`}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("gen.maxTokensLabel")}</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  min={1}
+                  max={32768}
+                  step={256}
+                  value={field.value ?? ""}
+                  onChange={(e) =>
+                    field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
+                  }
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={control}
+          name={`${namePrefix}.temperature`}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("gen.temperatureLabel")}</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  min={0}
+                  max={2}
+                  step={0.1}
+                  value={field.value ?? ""}
+                  onChange={(e) =>
+                    field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
+                  }
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/quality-gate/components/RunOverview.tsx
+++ b/apps/web/src/features/quality-gate/components/RunOverview.tsx
@@ -53,6 +53,12 @@ export function RunOverview({ run }: { run: EvaluationRun }) {
 
       <GateRulesSection gateConfig={run.gateConfig} metrics={m} />
 
+      <div className="text-xs text-muted-foreground">
+        {t("gen.summaryLabel")}: thinking {run.genConfig.thinking} · max_tokens{" "}
+        {run.genConfig.maxTokens} · temp {run.genConfig.temperature}
+        {run.genConfig.stop?.length ? ` · stop ${run.genConfig.stop.length}` : ""}
+      </div>
+
       {m && (
         <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
           <div>

--- a/apps/web/src/locales/en-US/quality-gate.json
+++ b/apps/web/src/locales/en-US/quality-gate.json
@@ -1,11 +1,17 @@
 {
-  "nav": { "title": "Quality Gate" },
+  "nav": {
+    "title": "Quality Gate"
+  },
   "evaluations": {
     "title": "Evaluation Sets",
     "subtitle": "Manage evaluation samples and judge rules; every run references a snapshot of one set.",
     "create": "New Evaluation Set",
     "empty": "No evaluation sets yet",
-    "col": { "name": "Name", "samples": "Samples", "updatedAt": "Updated" },
+    "col": {
+      "name": "Name",
+      "samples": "Samples",
+      "updatedAt": "Updated"
+    },
     "runsCol": {
       "id": "Run ID",
       "evaluation": "Evaluation",
@@ -163,7 +169,11 @@
       "failed": "Failed",
       "cancelled": "Cancelled"
     },
-    "gateResult": { "passed": "Passed", "warning": "Warning", "failed": "Failed" },
+    "gateResult": {
+      "passed": "Passed",
+      "warning": "Warning",
+      "failed": "Failed"
+    },
     "filters": {
       "any": "Any",
       "status": "Status",
@@ -210,15 +220,32 @@
       "prevPage": "Previous",
       "nextPage": "Next"
     },
-    "sampleDrawer": { "title": "Sample", "detail": "Details" }
+    "sampleDrawer": {
+      "title": "Sample",
+      "detail": "Details"
+    }
   },
   "gate": {
     "passRateMin": "Min Pass Rate",
     "regressionMax": "Max Regressions",
     "judgeScoreMin": "Min Judge Score"
   },
+  "gen": {
+    "sectionTitle": "Generation parameters",
+    "sectionDescription": "Model-call params for this run; snapshotted onto the run for reproducibility.",
+    "thinkingLabel": "Thinking",
+    "thinkingAuto": "Auto (model default)",
+    "thinkingOff": "Off (reasoning models answer directly)",
+    "thinkingOn": "On (needs larger max_tokens)",
+    "thinkingHint": "Recommended Off for MCQ / short-answer evals: stops reasoning models (Qwen3 etc.) from spending the token budget on thinking and truncating the answer. vLLM-style endpoints only.",
+    "maxTokensLabel": "Max tokens",
+    "temperatureLabel": "Temperature",
+    "summaryLabel": "Generation params"
+  },
   "detail": {
-    "actions": { "detail": "Details" },
+    "actions": {
+      "detail": "Details"
+    },
     "delete": {
       "button": "Delete",
       "title": "Delete {{name}}?",

--- a/apps/web/src/locales/zh-CN/quality-gate.json
+++ b/apps/web/src/locales/zh-CN/quality-gate.json
@@ -1,11 +1,17 @@
 {
-  "nav": { "title": "质量门" },
+  "nav": {
+    "title": "质量门"
+  },
   "evaluations": {
     "title": "评测集",
     "subtitle": "管理评测样本与判分规则；任意运行都引用某一个评测集快照。",
     "create": "新建评测集",
     "empty": "还没有评测集",
-    "col": { "name": "名称", "samples": "样本数", "updatedAt": "更新时间" },
+    "col": {
+      "name": "名称",
+      "samples": "样本数",
+      "updatedAt": "更新时间"
+    },
     "runsCol": {
       "id": "运行 ID",
       "evaluation": "评测集",
@@ -163,7 +169,11 @@
       "failed": "失败",
       "cancelled": "已取消"
     },
-    "gateResult": { "passed": "通过", "warning": "警告", "failed": "未通过" },
+    "gateResult": {
+      "passed": "通过",
+      "warning": "警告",
+      "failed": "未通过"
+    },
     "filters": {
       "any": "全部",
       "status": "状态",
@@ -210,15 +220,32 @@
       "prevPage": "上一页",
       "nextPage": "下一页"
     },
-    "sampleDrawer": { "title": "样本", "detail": "详情" }
+    "sampleDrawer": {
+      "title": "样本",
+      "detail": "详情"
+    }
   },
   "gate": {
     "passRateMin": "通过率下限 / passRateMin",
     "regressionMax": "回归数上限 / regressionMax",
     "judgeScoreMin": "Judge 均分下限 / judgeScoreMin"
   },
+  "gen": {
+    "sectionTitle": "生成参数",
+    "sectionDescription": "控制本次 run 的模型调用参数；会随 run 快照记录，便于复现。",
+    "thinkingLabel": "思考模式 (thinking)",
+    "thinkingAuto": "自动（用模型默认）",
+    "thinkingOff": "关闭（推理模型直接作答）",
+    "thinkingOn": "开启（需更大 max_tokens）",
+    "thinkingHint": "选择题/短答评测建议关闭：避免 Qwen3 等推理模型把 token 预算耗在思考上、导致答案被截断。仅对 vLLM 类端点生效。",
+    "maxTokensLabel": "最大 token 数",
+    "temperatureLabel": "温度",
+    "summaryLabel": "生成参数"
+  },
   "detail": {
-    "actions": { "detail": "详情" },
+    "actions": {
+      "detail": "详情"
+    },
     "delete": {
       "button": "删除",
       "title": "删除 {{name}}？",

--- a/packages/contracts/src/quality-gate/__tests__/gen-config.spec.ts
+++ b/packages/contracts/src/quality-gate/__tests__/gen-config.spec.ts
@@ -28,10 +28,15 @@ describe("resolveGenConfig (defaults < eval < run)", () => {
     expect(resolveGenConfig()).toEqual(DEFAULT_GEN_CONFIG);
   });
   it("eval default overrides schema default", () => {
-    expect(resolveGenConfig({ thinking: "off" })).toMatchObject({ thinking: "off", maxTokens: 2048 });
+    expect(resolveGenConfig({ thinking: "off" })).toMatchObject({
+      thinking: "off",
+      maxTokens: 2048,
+    });
   });
   it("run override beats eval default", () => {
-    expect(resolveGenConfig({ thinking: "off", maxTokens: 512 }, { maxTokens: 4096 })).toMatchObject({
+    expect(
+      resolveGenConfig({ thinking: "off", maxTokens: 512 }, { maxTokens: 4096 }),
+    ).toMatchObject({
       thinking: "off",
       maxTokens: 4096,
     });

--- a/packages/contracts/src/quality-gate/__tests__/gen-config.spec.ts
+++ b/packages/contracts/src/quality-gate/__tests__/gen-config.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_GEN_CONFIG, genConfigSchema, resolveGenConfig } from "../gen-config.js";
+
+describe("genConfigSchema", () => {
+  it("applies defaults", () => {
+    expect(genConfigSchema.parse({})).toEqual({
+      maxTokens: 2048,
+      temperature: 0,
+      thinking: "auto",
+    });
+  });
+  it("rejects out-of-range temperature", () => {
+    expect(() => genConfigSchema.parse({ temperature: 3 })).toThrow();
+  });
+  it("rejects maxTokens over cap", () => {
+    expect(() => genConfigSchema.parse({ maxTokens: 99999 })).toThrow();
+  });
+  it("accepts thinking enum + stop", () => {
+    expect(genConfigSchema.parse({ thinking: "off", stop: ["\n\n"] })).toMatchObject({
+      thinking: "off",
+      stop: ["\n\n"],
+    });
+  });
+});
+
+describe("resolveGenConfig (defaults < eval < run)", () => {
+  it("returns DEFAULT when nothing provided", () => {
+    expect(resolveGenConfig()).toEqual(DEFAULT_GEN_CONFIG);
+  });
+  it("eval default overrides schema default", () => {
+    expect(resolveGenConfig({ thinking: "off" })).toMatchObject({ thinking: "off", maxTokens: 2048 });
+  });
+  it("run override beats eval default", () => {
+    expect(resolveGenConfig({ thinking: "off", maxTokens: 512 }, { maxTokens: 4096 })).toMatchObject({
+      thinking: "off",
+      maxTokens: 4096,
+    });
+  });
+  it("null layers are ignored", () => {
+    expect(resolveGenConfig(null, null)).toEqual(DEFAULT_GEN_CONFIG);
+  });
+});

--- a/packages/contracts/src/quality-gate/evaluations.ts
+++ b/packages/contracts/src/quality-gate/evaluations.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { genConfigSchema } from "./gen-config.js";
 import { judgeConfigSchema } from "./judge-config.js";
 
 export const evaluationSampleSchema = z.object({
@@ -29,6 +30,10 @@ export const evaluationSchema = z.object({
   version: z.number().int().positive(),
   samples: z.array(evaluationSampleSchema),
   totalSamples: z.number().int().nonnegative(),
+  // Eval-level default generation params (e.g. built-in MCQ sets ship
+  // thinking:"off"). Used as the run-create form's initial values; per-run
+  // overrides win. Null → fall back to schema defaults.
+  genConfig: genConfigSchema.partial().nullable(),
   // Official built-in evaluations (seeded by the platform). Read-only — users
   // cannot modify name/description/samples or delete; they can run against
   // them and duplicate them as a starting point for their own evaluations.
@@ -42,6 +47,7 @@ export const createEvaluationRequestSchema = z.object({
   name: z.string().min(1).max(200),
   description: z.string().max(2000).nullable().optional(),
   samples: z.array(evaluationSampleInputSchema).min(1).max(500),
+  genConfig: genConfigSchema.partial().nullable().optional(),
 });
 export type CreateEvaluationRequest = z.infer<typeof createEvaluationRequestSchema>;
 
@@ -49,6 +55,7 @@ export const updateEvaluationRequestSchema = z.object({
   name: z.string().min(1).max(200).optional(),
   description: z.string().max(2000).nullable().optional(),
   samples: z.array(evaluationSampleInputSchema).min(1).max(500).optional(),
+  genConfig: genConfigSchema.partial().nullable().optional(),
 });
 export type UpdateEvaluationRequest = z.infer<typeof updateEvaluationRequestSchema>;
 

--- a/packages/contracts/src/quality-gate/evaluations.ts
+++ b/packages/contracts/src/quality-gate/evaluations.ts
@@ -32,8 +32,8 @@ export const evaluationSchema = z.object({
   totalSamples: z.number().int().nonnegative(),
   // Eval-level default generation params (e.g. built-in MCQ sets ship
   // thinking:"off"). Used as the run-create form's initial values; per-run
-  // overrides win. Null → fall back to schema defaults.
-  genConfig: genConfigSchema.partial().nullable(),
+  // overrides win. Absent/null → fall back to schema defaults.
+  genConfig: genConfigSchema.partial().nullable().optional(),
   // Official built-in evaluations (seeded by the platform). Read-only — users
   // cannot modify name/description/samples or delete; they can run against
   // them and duplicate them as a starting point for their own evaluations.

--- a/packages/contracts/src/quality-gate/gen-config.ts
+++ b/packages/contracts/src/quality-gate/gen-config.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+/**
+ * Generation parameters for an evaluation run's model calls.
+ *
+ * Eval ≠ Playground: these are recorded config, snapshotted onto the run for
+ * reproducibility and cross-run comparison — not ephemeral playground knobs.
+ * Layering: eval-level default → run-level override → snapshot on the run.
+ *
+ * `thinking`:
+ *   - "auto": send nothing — use the model/server default (safe for every
+ *             OpenAI-compatible endpoint).
+ *   - "off":  send `chat_template_kwargs: { enable_thinking: false }` (vLLM /
+ *             Qwen3 etc.) so reasoning models answer directly. Do NOT make this
+ *             a global default — non-vLLM endpoints reject the extra field.
+ *   - "on":   send `enable_thinking: true`; callers should also raise maxTokens.
+ */
+export const genConfigSchema = z.object({
+  maxTokens: z.number().int().min(1).max(32768).default(2048),
+  temperature: z.number().min(0).max(2).default(0),
+  thinking: z.enum(["auto", "on", "off"]).default("auto"),
+  stop: z.array(z.string().min(1).max(64)).max(4).optional(),
+});
+export type GenConfig = z.infer<typeof genConfigSchema>;
+
+/** Greedy, no thinking override, 2048-token budget — the gate-friendly default. */
+export const DEFAULT_GEN_CONFIG: GenConfig = {
+  maxTokens: 2048,
+  temperature: 0,
+  thinking: "auto",
+};
+
+/**
+ * Resolve the effective gen config for a run: schema defaults < eval-level
+ * default < per-run override. Each layer may be partial; later layers win.
+ */
+export function resolveGenConfig(
+  evalDefault?: Partial<GenConfig> | null,
+  runOverride?: Partial<GenConfig> | null,
+): GenConfig {
+  return genConfigSchema.parse({
+    ...DEFAULT_GEN_CONFIG,
+    ...(evalDefault ?? {}),
+    ...(runOverride ?? {}),
+  });
+}

--- a/packages/contracts/src/quality-gate/index.ts
+++ b/packages/contracts/src/quality-gate/index.ts
@@ -1,4 +1,5 @@
 export * from "./evaluations.js";
+export * from "./gen-config.js";
 export * from "./judge-config.js";
 export * from "./run-samples.js";
 export * from "./runs.js";

--- a/packages/contracts/src/quality-gate/runs.ts
+++ b/packages/contracts/src/quality-gate/runs.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { evaluationSampleSchema } from "./evaluations.js";
+import { genConfigSchema } from "./gen-config.js";
 
 export const runStatusSchema = z.enum(["PENDING", "RUNNING", "COMPLETED", "FAILED", "CANCELLED"]);
 export type RunStatus = z.infer<typeof runStatusSchema>;
@@ -67,6 +68,7 @@ export const evaluationRunSchema = z.object({
   endpointA: connectionRefSchema.nullable(),
   endpointB: connectionRefSchema.nullable(),
   gateConfig: gateConfigSchema,
+  genConfig: genConfigSchema,
   status: runStatusSchema,
   gateResult: gateResultSchema.nullable(),
   aggregateMetrics: aggregateMetricsSchema.nullable(),
@@ -87,6 +89,9 @@ export const createRunRequestSchema = z
     endpointBId: z.string().optional(),
     baselineRunIdOverride: z.string().nullable().optional(),
     gateConfig: gateConfigSchema,
+    // Per-run override of generation params. Partial — merged over the
+    // evaluation's default and the schema defaults at run creation.
+    genConfig: genConfigSchema.partial().optional(),
   })
   .refine((r) => r.endpointBId == null || r.endpointBId !== r.endpointAId, {
     message: "validation.endpointABMustDiffer",


### PR DESCRIPTION
## What

Per-run **generation parameters** for Quality Gate eval runs: a `thinking` toggle (auto/on/off), `max_tokens`, `temperature`, optional `stop` — layered (eval default → run override → snapshot) and applied to model calls, plus a server-agnostic `<think>` stripper before judging.

Implements the design in #259.

## Why

Validating C-Eval (#257) on **Qwen3-32B** failed: EndpointCaller didn't control thinking (Qwen3 defaults it ON) and `max_tokens` was hardcoded 2048 → the `<think>` trace ate the whole budget, the answer was truncated before any letter, judge got a tag soup. Not a judge bug, not a timeout (curl with `enable_thinking:false` → clean `D. …`). ModelDoctor needs first-class control to evaluate reasoning models — core for the multi-engine self-hosted positioning.

## Governing principle

Eval ≠ Playground: gen params are **recorded config snapshotted onto the run** for reproducibility & cross-run comparison, not ephemeral knobs.

## Changes (phase-per-commit)

1. `feat(contracts)`: `genConfigSchema` + `DEFAULT_GEN_CONFIG` + `resolveGenConfig` (defaults < eval < run); wired into run DTO / create-run / evaluation entity.
2. `feat(api)` migration: nullable `gen_config` JSONB on `evaluations` + `evaluation_runs` (no backfill; null → defaults).
3. `feat(api)`: `buildRequestBody` (thinking→`chat_template_kwargs.enable_thinking`, only on/off so non-vLLM endpoints don't 400 on "auto"); `stripThink()` before judging (rawAnswer kept raw); executor threads genConfig + strips think; runs.service resolves+snapshots; repos persist/return; **C-Eval seed ships `thinking:"off"`**.
4. `feat(web)`: gen-params panel on run-create (pre-filled from eval default, per-run editable) + run-detail display + zh/en i18n.

## thinking three-state

- `auto` — send nothing (safe for every OpenAI-compatible endpoint)
- `off` — `chat_template_kwargs:{enable_thinking:false}` (vLLM/Qwen3 → direct answer)
- `on` — `enable_thinking:true` (raise max_tokens)

## Verification

| Check | Result |
|---|---|
| contracts tests | 8 (gen-config) ✓ |
| api quality-gate tests | 121 ✓ (incl. buildRequestBody 3-state, stripThink, genConfig persist) |
| web quality-gate tests | 20 ✓ |
| api / web typecheck | exit 0 |
| migration | applied; `eval_builtin_qg_ceval_zh.gen_config = {"thinking":"off"}` verified in DB |
| root cause | proven via curl: think-on → 2048-token truncation; `enable_thinking:false` → clean `D. …` |

## Out of scope

- Cluster-side `--reasoning-parser` (deployment config) — separate feedback.
- Streaming (eval doesn't need it; not exposed).
- per-sample param overrides (run-level is enough).

refs #259, #257