### PR TITLE
feat(compare): consolidate benchmark compare into 2 pages + inline light report

### DIFF
--- a/apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
+++ b/apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
@@ -49,6 +49,7 @@ export function BenchmarkComparePage() {
   const { t: tSidebar } = useTranslation("sidebar");
   const [searchParams, setSearchParams] = useSearchParams();
   const [saveOpen, setSaveOpen] = useState(false);
+  const [generateAfterSave, setGenerateAfterSave] = useState(false);
   const ids = useMemo(() => parseIds(searchParams), [searchParams]);
   // URL baseline param has three possible meanings:
   //   - missing            → "user hasn't chosen yet, fall back to inferred default"
@@ -217,7 +218,25 @@ export function BenchmarkComparePage() {
               <Button variant="outline" asChild>
                 <Link to="/benchmarks/compare/saved">{t("savedCompare.savedListLink")}</Link>
               </Button>
-              <Button onClick={() => setSaveOpen(true)}>{t("savedCompare.saveButton")}</Button>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    setGenerateAfterSave(false);
+                    setSaveOpen(true);
+                  }}
+                >
+                  {t("savedCompare.compare.saveOnly")}
+                </Button>
+                <Button
+                  onClick={() => {
+                    setGenerateAfterSave(true);
+                    setSaveOpen(true);
+                  }}
+                >
+                  {t("savedCompare.compare.generate")}
+                </Button>
+              </div>
             </div>
             <ReportSections
               runs={reportRuns}
@@ -232,6 +251,7 @@ export function BenchmarkComparePage() {
               runs={successfulBenchmarks.map((r) => ({ id: r.id, name: r.name, tool: r.tool }))}
               baselineId={defaultBaseline}
               context=""
+              generateAfterSave={generateAfterSave}
             />
           </>
         )}

--- a/apps/web/src/features/benchmarks/compare/ReportSections.tsx
+++ b/apps/web/src/features/benchmarks/compare/ReportSections.tsx
@@ -24,8 +24,8 @@ export interface ReportSectionsProps {
 /**
  * Pre-narrative "raw matrix" preview. Renders the per-run table + the metric
  * grid + the four bar charts. Used by:
- *   - BenchmarkComparePage (ad-hoc compare, no narrative yet)
- *   - SavedCompareDetailPage when the saved compare has no narrative yet
+ *   - BenchmarkComparePage (ad-hoc compare, no narrative)
+ *   - SavedComparePage (raw matrix below the inline AI narrative)
  *
  * The narrative deep report (Hero + summary cards + 6 sections + figures)
  * is rendered by `<SavedCompareReport>`, not here.

--- a/apps/web/src/features/benchmarks/compare/SaveCompareDialog.test.tsx
+++ b/apps/web/src/features/benchmarks/compare/SaveCompareDialog.test.tsx
@@ -1,49 +1,107 @@
-import "@/lib/i18n";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import "@/lib/i18n";
 import { SaveCompareDialog } from "./SaveCompareDialog";
 
-function wrap(ui: React.ReactElement) {
+vi.mock("@/lib/api-client", () => ({
+  api: { post: vi.fn(async () => ({ id: "scNEW" })), get: vi.fn(), patch: vi.fn(), del: vi.fn() },
+}));
+
+function Loc() {
+  const l = useLocation();
+  return <div data-testid="loc">{l.pathname + l.search}</div>;
+}
+
+function renderDialog(generateAfterSave: boolean) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return (
-    <MemoryRouter>
-      <QueryClientProvider client={qc}>{ui}</QueryClientProvider>
-    </MemoryRouter>
+  render(
+    <MemoryRouter initialEntries={["/benchmarks/compare?ids=b1,b2"]}>
+      <QueryClientProvider client={qc}>
+        <Routes>
+          <Route
+            path="/benchmarks/compare"
+            element={
+              <SaveCompareDialog
+                open
+                onOpenChange={() => {}}
+                runs={[
+                  { id: "b1", name: "r1", tool: "guidellm" },
+                  { id: "b2", name: "r2", tool: "guidellm" },
+                ]}
+                baselineId="b1"
+                context=""
+                generateAfterSave={generateAfterSave}
+              />
+            }
+          />
+          <Route path="/benchmarks/compare/saved/:id" element={<Loc />} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>,
   );
 }
 
-describe("SaveCompareDialog", () => {
-  const runs = [
-    { id: "r1", name: "run-a", tool: "guidellm" },
-    { id: "r2", name: "run-b", tool: "guidellm" },
-  ];
+// NOTE: test env uses en-US fallback locale; labels/buttons are in English.
+// - Name label: "Name" (savedCompare.dialog.nameLabel)
+// - Submit button (saveOnly): "Save and view" (savedCompare.dialog.submit)
+// - Submit button (generate): "Save & generate" (savedCompare.dialog.submitGenerate)
+// Per-run inputs have aria-label={r.name ?? r.id} so getByLabelText("r1") works.
 
-  it("renders one stage-label input per run", () => {
-    render(
-      wrap(
-        <SaveCompareDialog open onOpenChange={() => {}} runs={runs} baselineId="r1" context="" />,
-      ),
+// Matches exactly "Save and view" OR "Save & generate" (en-US fallback values).
+const submitButton = () =>
+  screen.getByRole("button", { name: /^(?:Save and view|Save & generate)$/ });
+
+async function fillAndSubmit() {
+  fireEvent.change(screen.getByLabelText("Name", { selector: "#sc-name" }), {
+    target: { value: "X" },
+  });
+  fireEvent.change(screen.getByLabelText("r1"), { target: { value: "A" } });
+  fireEvent.change(screen.getByLabelText("r2"), { target: { value: "B" } });
+  fireEvent.click(submitButton());
+}
+
+describe("SaveCompareDialog navigation", () => {
+  it("navigates to the saved page without generate flag when generateAfterSave is false", async () => {
+    renderDialog(false);
+    await fillAndSubmit();
+    await waitFor(() =>
+      expect(screen.getByTestId("loc")).toHaveTextContent("/benchmarks/compare/saved/scNEW"),
     );
-    expect(screen.getByLabelText(/run-a/)).toBeInTheDocument();
-    expect(screen.getByLabelText(/run-b/)).toBeInTheDocument();
+    expect(screen.getByTestId("loc")).not.toHaveTextContent("generate=1");
   });
 
-  it("submit is disabled until name and all labels provided", async () => {
-    const u = userEvent.setup();
-    render(
-      wrap(
-        <SaveCompareDialog open onOpenChange={() => {}} runs={runs} baselineId="r1" context="" />,
+  it("appends ?generate=1 when generateAfterSave is true", async () => {
+    renderDialog(true);
+    await fillAndSubmit();
+    await waitFor(() =>
+      expect(screen.getByTestId("loc")).toHaveTextContent(
+        "/benchmarks/compare/saved/scNEW?generate=1",
       ),
     );
-    const submit = screen.getByRole("button", { name: /保存|save/i });
-    expect(submit).toBeDisabled();
+  });
+});
 
-    await u.type(screen.getByPlaceholderText(/Qwen3|横评/i), "Study A");
-    await u.type(screen.getByLabelText(/run-a/), "A");
-    await u.type(screen.getByLabelText(/run-b/), "B");
-    expect(submit).not.toBeDisabled();
+describe("SaveCompareDialog validation", () => {
+  it("submit is disabled until name and all labels provided", async () => {
+    const u = userEvent.setup();
+    renderDialog(false);
+
+    // Initially disabled — no name, no run labels filled
+    expect(submitButton()).toBeDisabled();
+
+    // Fill name only — still disabled
+    await u.type(screen.getByLabelText("Name", { selector: "#sc-name" }), "Study A");
+    expect(submitButton()).toBeDisabled();
+
+    // Fill run-a label — still disabled (run-b missing)
+    await u.type(screen.getByLabelText("r1"), "A");
+    expect(submitButton()).toBeDisabled();
+
+    // Fill run-b label — now all three fields have values, submit should be enabled
+    await u.type(screen.getByLabelText("r2"), "B");
+    expect(submitButton()).not.toBeDisabled();
   });
 });

--- a/apps/web/src/features/benchmarks/compare/SaveCompareDialog.tsx
+++ b/apps/web/src/features/benchmarks/compare/SaveCompareDialog.tsx
@@ -34,6 +34,8 @@ export interface SaveCompareDialogProps {
   runs: SaveCompareDialogRun[];
   baselineId: string | null;
   context: string;
+  /** When true, navigate to the saved page with ?generate=1 so it auto-synthesizes. */
+  generateAfterSave?: boolean;
 }
 
 export function SaveCompareDialog({
@@ -42,6 +44,7 @@ export function SaveCompareDialog({
   runs,
   baselineId,
   context,
+  generateAfterSave = false,
 }: SaveCompareDialogProps) {
   const { t } = useTranslation("benchmarks");
   const navigate = useNavigate();
@@ -67,7 +70,8 @@ export function SaveCompareDialog({
       clientName: clientName.trim() || undefined,
     });
     onOpenChange(false);
-    navigate(`/benchmarks/compare/saved/${sc.id}`);
+    const suffix = generateAfterSave ? "?generate=1" : "";
+    navigate(`/benchmarks/compare/saved/${sc.id}${suffix}`);
   }
 
   return (
@@ -168,7 +172,9 @@ export function SaveCompareDialog({
             {t("savedCompare.dialog.cancel")}
           </Button>
           <Button onClick={submit} disabled={!canSubmit}>
-            {t("savedCompare.dialog.submit")}
+            {generateAfterSave
+              ? t("savedCompare.dialog.submitGenerate")
+              : t("savedCompare.dialog.submit")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/src/features/benchmarks/compare/SavedComparePage.test.tsx
+++ b/apps/web/src/features/benchmarks/compare/SavedComparePage.test.tsx
@@ -1,9 +1,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@/lib/i18n";
-import { SavedCompareDetailPage } from "./SavedCompareDetailPage";
+import { SavedComparePage } from "./SavedComparePage";
+
+const state = vi.hoisted(() => ({ narrative: null as unknown }));
 
 vi.mock("@/lib/api-client", () => ({
   api: {
@@ -17,8 +19,8 @@ vi.mock("@/lib/api-client", () => ({
           stageLabels: { b1: "A", b2: "B" },
           baselineId: "b1",
           context: "8x NPU",
-          narrative: null,
-          narrativeAt: null,
+          narrative: state.narrative,
+          narrativeAt: state.narrative ? "2026-05-12T00:00:00.000Z" : null,
           createdAt: "2026-05-12T00:00:00.000Z",
           updatedAt: "2026-05-12T00:00:00.000Z",
           benchmarks: [
@@ -44,15 +46,16 @@ vi.mock("@/lib/api-client", () => ({
               tool: "guidellm",
               scenario: "inference",
               params: {},
-              summaryMetrics: { tool: "guidellm", data: { ttft: { p50: 80, p90: 160, p99: 400 } } },
+              summaryMetrics: {
+                tool: "guidellm",
+                data: { ttft: { p50: 80, p90: 160, p99: 400 } },
+              },
               createdAt: "2026-05-12T00:00:00.000Z",
             },
           ],
         };
       }
-      if (path === "/api/llm-judge-providers/active") {
-        return { id: "p", enabled: true };
-      }
+      if (path === "/api/llm-judge/provider") return { id: "p", enabled: true };
       throw new Error(`unmocked: ${path}`);
     }),
     post: vi.fn(),
@@ -61,21 +64,45 @@ vi.mock("@/lib/api-client", () => ({
   },
 }));
 
-describe("SavedCompareDetailPage", () => {
-  it("renders the report once data loads", async () => {
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    render(
-      <MemoryRouter initialEntries={["/benchmarks/compare/saved/sc1"]}>
-        <QueryClientProvider client={qc}>
-          <Routes>
-            <Route path="/benchmarks/compare/saved/:id" element={<SavedCompareDetailPage />} />
-          </Routes>
-        </QueryClientProvider>
-      </MemoryRouter>,
-    );
+beforeEach(() => {
+  state.narrative = null;
+});
+
+function renderAt(entry: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <QueryClientProvider client={qc}>
+        <Routes>
+          <Route path="/benchmarks/compare/saved/:id" element={<SavedComparePage />} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("SavedComparePage", () => {
+  it("renders the raw data once loaded", async () => {
+    renderAt("/benchmarks/compare/saved/sc1");
     await waitFor(() =>
       expect(screen.getByRole("heading", { level: 1, name: "Study A" })).toBeInTheDocument(),
     );
     expect(screen.getByText(/8x NPU/)).toBeInTheDocument();
+  });
+
+  it("renders the AI narrative inline when present", async () => {
+    state.narrative = {
+      schemaVersion: 2,
+      locale: "zh-CN",
+      hero: { eyebrow: "EB", title: "Inline Hero", subtitle: "S", metaItems: [] },
+      summaryCards: [],
+      sections: [{ id: "summary", num: "01", title: "Summary", bodyMarkdown: "x" }],
+      figures: [],
+      lintWarnings: [],
+    };
+    renderAt("/benchmarks/compare/saved/sc1");
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Inline Hero" })).toBeInTheDocument(),
+    );
   });
 });

--- a/apps/web/src/features/benchmarks/compare/SavedComparePage.tsx
+++ b/apps/web/src/features/benchmarks/compare/SavedComparePage.tsx
@@ -1,8 +1,8 @@
 import type { Benchmark, CompareNarrative } from "@modeldoctor/contracts";
 import { ExternalLink, RefreshCw, Sparkles } from "lucide-react";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { PageHeader } from "@/components/common/page-header";
 import {
   AlertDialog,
@@ -21,6 +21,7 @@ import { exportPageAsHtml } from "./exportHtml";
 import { useDeleteSavedCompare, useSavedCompare, useSynthesizeSavedCompare } from "./queries";
 import { ReportProgress } from "./ReportProgress";
 import { type ReportRun, ReportSections } from "./ReportSections";
+import { SavedCompareReport } from "./SavedCompareReport";
 
 function extractParamsSummary(params: unknown): {
   workload?: string;
@@ -36,7 +37,7 @@ function extractParamsSummary(params: unknown): {
   };
 }
 
-export function SavedCompareDetailPage() {
+export function SavedComparePage() {
   const { id = "" } = useParams<{ id: string }>();
   const { t } = useTranslation("benchmarks");
   const { t: tSidebar } = useTranslation("sidebar");
@@ -46,6 +47,39 @@ export function SavedCompareDetailPage() {
   const synth = useSynthesizeSavedCompare(id);
   const del = useDeleteSavedCompare();
   const [narrativeOverride, setNarrativeOverride] = useState<CompareNarrative | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const autoGenFired = useRef(false);
+
+  const generate = useCallback(async () => {
+    const r = await synth.mutateAsync({ locale: "zh-CN" });
+    setNarrativeOverride(r.narrative);
+  }, [synth.mutateAsync]);
+
+  // Ad-hoc -> generate bridge: the compare page navigates here with ?generate=1
+  // after a save-and-generate. Fire synthesize once, then strip the flag.
+  useEffect(() => {
+    if (autoGenFired.current) return;
+    if (searchParams.get("generate") !== "1") return;
+    const sc = query.data;
+    if (!sc || sc.narrative) {
+      if (sc?.narrative) {
+        autoGenFired.current = true;
+        setSearchParams({}, { replace: true });
+      }
+      return;
+    }
+    if (!provider.data?.enabled || synth.isPending) return;
+    autoGenFired.current = true;
+    setSearchParams({}, { replace: true });
+    void generate();
+  }, [
+    searchParams,
+    query.data,
+    provider.data?.enabled,
+    synth.isPending,
+    setSearchParams,
+    generate,
+  ]);
 
   if (query.isLoading) {
     return (
@@ -82,11 +116,6 @@ export function SavedCompareDetailPage() {
   );
   const narrative = narrativeOverride ?? (sc.narrative as CompareNarrative | null);
 
-  async function generate() {
-    const r = await synth.mutateAsync({ locale: "zh-CN" });
-    setNarrativeOverride(r.narrative);
-  }
-
   async function onDelete() {
     await del.mutateAsync(id);
     navigate("/benchmarks/compare/saved");
@@ -114,7 +143,7 @@ export function SavedCompareDetailPage() {
               <Button asChild>
                 <Link to={`/reports/${sc.id}`}>
                   <ExternalLink className="mr-1.5 h-4 w-4" />
-                  {t("savedCompare.detail.openReport", { defaultValue: "Open report" })}
+                  {t("savedCompare.report.openPrint")}
                 </Link>
               </Button>
             ) : null}
@@ -182,7 +211,7 @@ export function SavedCompareDetailPage() {
               <Button asChild>
                 <Link to={`/reports/${sc.id}`}>
                   <ExternalLink className="mr-1.5 h-4 w-4" />
-                  {t("savedCompare.detail.openReport", { defaultValue: "Open report" })}
+                  {t("savedCompare.report.openPrint")}
                 </Link>
               </Button>
             </div>
@@ -217,6 +246,15 @@ export function SavedCompareDetailPage() {
             </Button>
           </div>
         )}
+
+        {narrative ? (
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold">{t("savedCompare.report.inlineHeading")}</h2>
+            <div className="overflow-hidden rounded-md border border-border">
+              <SavedCompareReport narrative={narrative} runs={reportRuns} embedded />
+            </div>
+          </section>
+        ) : null}
 
         <ReportSections
           runs={reportRuns}

--- a/apps/web/src/features/benchmarks/compare/SavedComparePage.tsx
+++ b/apps/web/src/features/benchmarks/compare/SavedComparePage.tsx
@@ -48,6 +48,7 @@ export function SavedComparePage() {
   const del = useDeleteSavedCompare();
   const [narrativeOverride, setNarrativeOverride] = useState<CompareNarrative | null>(null);
   const [searchParams, setSearchParams] = useSearchParams();
+  const generateParam = searchParams.get("generate");
   const autoGenFired = useRef(false);
 
   const generate = useCallback(async () => {
@@ -55,17 +56,20 @@ export function SavedComparePage() {
     setNarrativeOverride(r.narrative);
   }, [synth.mutateAsync]);
 
+  // Depend on primitives, not the whole query.data / searchParams objects, so
+  // background refetches and unrelated URL changes don't re-run this effect.
+  const scId = query.data?.id;
+  const hasNarrative = !!query.data?.narrative;
+
   // Ad-hoc -> generate bridge: the compare page navigates here with ?generate=1
   // after a save-and-generate. Fire synthesize once, then strip the flag.
   useEffect(() => {
     if (autoGenFired.current) return;
-    if (searchParams.get("generate") !== "1") return;
-    const sc = query.data;
-    if (!sc || sc.narrative) {
-      if (sc?.narrative) {
-        autoGenFired.current = true;
-        setSearchParams({}, { replace: true });
-      }
+    if (generateParam !== "1") return;
+    if (!scId) return; // data not loaded yet — wait, don't strip
+    if (hasNarrative) {
+      autoGenFired.current = true;
+      setSearchParams({}, { replace: true });
       return;
     }
     if (!provider.data?.enabled || synth.isPending) return;
@@ -73,8 +77,9 @@ export function SavedComparePage() {
     setSearchParams({}, { replace: true });
     void generate();
   }, [
-    searchParams,
-    query.data,
+    generateParam,
+    scId,
+    hasNarrative,
     provider.data?.enabled,
     synth.isPending,
     setSearchParams,

--- a/apps/web/src/features/benchmarks/compare/SavedCompareReport.test.tsx
+++ b/apps/web/src/features/benchmarks/compare/SavedCompareReport.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import "@/lib/i18n";
+import type { CompareNarrative } from "@modeldoctor/contracts";
+import { SavedCompareReport } from "./SavedCompareReport";
+
+const narrative: CompareNarrative = {
+  schemaVersion: 2,
+  locale: "zh-CN",
+  hero: { eyebrow: "EB", title: "Hero Title", subtitle: "Sub", metaItems: [] },
+  summaryCards: [],
+  sections: [
+    { id: "summary", num: "01", title: "Summary", bodyMarkdown: "body one" },
+    { id: "advice", num: "06", title: "Advice", bodyMarkdown: "body six" },
+  ],
+  figures: [],
+  lintWarnings: [],
+};
+
+describe("SavedCompareReport", () => {
+  it("renders the TOC nav in standalone mode", () => {
+    const { container } = render(<SavedCompareReport narrative={narrative} runs={[]} />);
+    expect(container.querySelector(".pr-toc")).not.toBeNull();
+    expect(container.querySelector("[data-report-root]")).not.toBeNull();
+  });
+
+  it("drops the TOC nav and data-report-root in embedded mode", () => {
+    const { container } = render(<SavedCompareReport narrative={narrative} runs={[]} embedded />);
+    expect(container.querySelector(".pr-toc")).toBeNull();
+    expect(container.querySelector(".pr-layout-embedded")).not.toBeNull();
+    expect(container.querySelector("[data-report-root]")).toBeNull();
+    expect(screen.getByRole("heading", { name: "Hero Title" })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/benchmarks/compare/SavedCompareReport.test.tsx
+++ b/apps/web/src/features/benchmarks/compare/SavedCompareReport.test.tsx
@@ -20,13 +20,13 @@ const narrative: CompareNarrative = {
 describe("SavedCompareReport", () => {
   it("renders the TOC nav in standalone mode", () => {
     const { container } = render(<SavedCompareReport narrative={narrative} runs={[]} />);
-    expect(container.querySelector(".pr-toc")).not.toBeNull();
+    expect(screen.getByRole("navigation", { name: /contents/i })).toBeInTheDocument();
     expect(container.querySelector("[data-report-root]")).not.toBeNull();
   });
 
   it("drops the TOC nav and data-report-root in embedded mode", () => {
     const { container } = render(<SavedCompareReport narrative={narrative} runs={[]} embedded />);
-    expect(container.querySelector(".pr-toc")).toBeNull();
+    expect(screen.queryByRole("navigation", { name: /contents/i })).not.toBeInTheDocument();
     expect(container.querySelector(".pr-layout-embedded")).not.toBeNull();
     expect(container.querySelector("[data-report-root]")).toBeNull();
     expect(screen.getByRole("heading", { name: "Hero Title" })).toBeInTheDocument();

--- a/apps/web/src/features/benchmarks/compare/SavedCompareReport.tsx
+++ b/apps/web/src/features/benchmarks/compare/SavedCompareReport.tsx
@@ -27,7 +27,12 @@ export interface SavedCompareReportProps {
  *   - Lint-warning callout (when present)
  *   - Sticky left-rail TOC with scroll-spy
  */
-export function SavedCompareReport({ narrative, runs, printHeader, embedded = false }: SavedCompareReportProps) {
+export function SavedCompareReport({
+  narrative,
+  runs,
+  printHeader,
+  embedded = false,
+}: SavedCompareReportProps) {
   const { t } = useTranslation("benchmarks");
   const sections = narrative.sections;
   const figuresBySection = useMemo(() => {
@@ -68,7 +73,11 @@ export function SavedCompareReport({ narrative, runs, printHeader, embedded = fa
   }
 
   return (
-    <div className="primer-report" {...(embedded ? {} : { "data-report-root": true })} data-print-header={printHeader ?? ""}>
+    <div
+      className="primer-report"
+      {...(embedded ? {} : { "data-report-root": true })}
+      data-print-header={printHeader ?? ""}
+    >
       <div className={`pr-layout${embedded ? " pr-layout-embedded" : ""}`}>
         {embedded ? null : (
           <nav

--- a/apps/web/src/features/benchmarks/compare/SavedCompareReport.tsx
+++ b/apps/web/src/features/benchmarks/compare/SavedCompareReport.tsx
@@ -11,6 +11,8 @@ export interface SavedCompareReportProps {
   runs: ReportRun[];
   /** Optional print-time header text (one-line, gray). */
   printHeader?: string;
+  /** Inline on the compare page: no TOC, no scroll-spy, no data-report-root. */
+  embedded?: boolean;
 }
 
 /**
@@ -25,7 +27,7 @@ export interface SavedCompareReportProps {
  *   - Lint-warning callout (when present)
  *   - Sticky left-rail TOC with scroll-spy
  */
-export function SavedCompareReport({ narrative, runs, printHeader }: SavedCompareReportProps) {
+export function SavedCompareReport({ narrative, runs, printHeader, embedded = false }: SavedCompareReportProps) {
   const { t } = useTranslation("benchmarks");
   const sections = narrative.sections;
   const figuresBySection = useMemo(() => {
@@ -42,6 +44,7 @@ export function SavedCompareReport({ narrative, runs, printHeader }: SavedCompar
   // Scroll-spy: highlight TOC entry for the section currently in view.
   const [activeId, setActiveId] = useState<string>(sections[0]?.id ?? "");
   useEffect(() => {
+    if (embedded) return;
     function onScroll() {
       let nearest: string = sections[0]?.id ?? "";
       for (const s of sections) {
@@ -56,7 +59,7 @@ export function SavedCompareReport({ narrative, runs, printHeader }: SavedCompar
     document.addEventListener("scroll", onScroll, { passive: true });
     onScroll();
     return () => document.removeEventListener("scroll", onScroll);
-  }, [sections]);
+  }, [sections, embedded]);
 
   let figureCounter = 0;
   function nextFigureNumber(): number {
@@ -65,28 +68,30 @@ export function SavedCompareReport({ narrative, runs, printHeader }: SavedCompar
   }
 
   return (
-    <div className="primer-report" data-report-root data-print-header={printHeader ?? ""}>
-      <div className="pr-layout">
-        <nav
-          className="pr-toc"
-          aria-label={t("savedCompare.report.toc", { defaultValue: "Contents" })}
-        >
-          <div className="pr-toc-title">
-            {t("savedCompare.report.toc", { defaultValue: "Contents" })}
-          </div>
-          <ul>
-            {sections.map((s) => (
-              <li key={s.id}>
-                <a
-                  href={`#pr-section-${s.id}`}
-                  className={activeId === s.id ? "active" : undefined}
-                >
-                  {s.num} {s.title}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </nav>
+    <div className="primer-report" {...(embedded ? {} : { "data-report-root": true })} data-print-header={printHeader ?? ""}>
+      <div className={`pr-layout${embedded ? " pr-layout-embedded" : ""}`}>
+        {embedded ? null : (
+          <nav
+            className="pr-toc"
+            aria-label={t("savedCompare.report.toc", { defaultValue: "Contents" })}
+          >
+            <div className="pr-toc-title">
+              {t("savedCompare.report.toc", { defaultValue: "Contents" })}
+            </div>
+            <ul>
+              {sections.map((s) => (
+                <li key={s.id}>
+                  <a
+                    href={`#pr-section-${s.id}`}
+                    className={activeId === s.id ? "active" : undefined}
+                  >
+                    {s.num} {s.title}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        )}
 
         <main className="pr-canvas">
           {/* Hero */}

--- a/apps/web/src/locales/en-US/benchmarks.json
+++ b/apps/web/src/locales/en-US/benchmarks.json
@@ -354,6 +354,10 @@
   "savedCompare": {
     "saveButton": "Save comparison",
     "savedListLink": "Saved comparisons",
+    "compare": {
+      "generate": "Generate AI report",
+      "saveOnly": "Save only"
+    },
     "dialog": {
       "title": "Save as a shareable report",
       "nameLabel": "Name",
@@ -363,6 +367,7 @@
       "contextLabel": "Test environment & context (optional)",
       "contextPlaceholder": "Hardware, image tags, motivation, known issues…",
       "submit": "Save and view",
+      "submitGenerate": "Save & generate",
       "cancel": "Cancel"
     },
     "list": {
@@ -380,7 +385,8 @@
       "editContext": "Edit context",
       "deleteTitle": "Delete this report",
       "deleteBody": "This cannot be undone.",
-      "missingBenchmark": "Data deleted"
+      "missingBenchmark": "Data deleted",
+      "openReport": "Open report"
     },
     "report": {
       "sectionTldr": "Overview / TL;DR",
@@ -397,6 +403,8 @@
       "chartExtraTitle": "Cache hit / extra metrics",
       "narrativeMissing": "AI analysis not generated yet.",
       "generateButton": "Generate AI analysis",
+      "openPrint": "Open print view",
+      "inlineHeading": "AI analysis",
       "toc": "Contents"
     },
     "reportPage": {

--- a/apps/web/src/locales/en-US/benchmarks.json
+++ b/apps/web/src/locales/en-US/benchmarks.json
@@ -352,7 +352,6 @@
     }
   },
   "savedCompare": {
-    "saveButton": "Save comparison",
     "savedListLink": "Saved comparisons",
     "compare": {
       "generate": "Generate AI report",
@@ -385,8 +384,7 @@
       "editContext": "Edit context",
       "deleteTitle": "Delete this report",
       "deleteBody": "This cannot be undone.",
-      "missingBenchmark": "Data deleted",
-      "openReport": "Open report"
+      "missingBenchmark": "Data deleted"
     },
     "report": {
       "sectionTldr": "Overview / TL;DR",

--- a/apps/web/src/locales/zh-CN/benchmarks.json
+++ b/apps/web/src/locales/zh-CN/benchmarks.json
@@ -352,7 +352,6 @@
     }
   },
   "savedCompare": {
-    "saveButton": "保存对比",
     "savedListLink": "历史对比",
     "compare": {
       "generate": "生成 AI 解读",
@@ -385,8 +384,7 @@
       "editContext": "编辑上下文",
       "deleteTitle": "删除该对比报告",
       "deleteBody": "此操作不可撤销。",
-      "missingBenchmark": "数据已删除",
-      "openReport": "打开报告"
+      "missingBenchmark": "数据已删除"
     },
     "report": {
       "sectionTldr": "概述 / TL;DR",

--- a/apps/web/src/locales/zh-CN/benchmarks.json
+++ b/apps/web/src/locales/zh-CN/benchmarks.json
@@ -354,6 +354,10 @@
   "savedCompare": {
     "saveButton": "保存对比",
     "savedListLink": "历史对比",
+    "compare": {
+      "generate": "生成 AI 解读",
+      "saveOnly": "仅保存"
+    },
     "dialog": {
       "title": "保存为可分享对比报告",
       "nameLabel": "名称",
@@ -363,6 +367,7 @@
       "contextLabel": "测试环境与上下文（可选）",
       "contextPlaceholder": "硬件、镜像版本、为什么对比、已知踩坑……",
       "submit": "保存并跳转",
+      "submitGenerate": "保存并生成",
       "cancel": "取消"
     },
     "list": {
@@ -380,7 +385,8 @@
       "editContext": "编辑上下文",
       "deleteTitle": "删除该对比报告",
       "deleteBody": "此操作不可撤销。",
-      "missingBenchmark": "数据已删除"
+      "missingBenchmark": "数据已删除",
+      "openReport": "打开报告"
     },
     "report": {
       "sectionTldr": "概述 / TL;DR",
@@ -397,6 +403,8 @@
       "chartExtraTitle": "缓存命中 / 额外指标",
       "narrativeMissing": "尚未生成 AI 分析。",
       "generateButton": "生成 AI 分析",
+      "openPrint": "打开打印视图",
+      "inlineHeading": "AI 解读",
       "toc": "目录"
     },
     "reportPage": {

--- a/apps/web/src/router/index.tsx
+++ b/apps/web/src/router/index.tsx
@@ -15,7 +15,7 @@ import { BenchmarkKvCacheStressPage } from "@/features/benchmarks/BenchmarkKvCac
 import { BenchmarkPrefixCachePage } from "@/features/benchmarks/BenchmarkPrefixCachePage";
 import { BenchmarkCompareGate } from "@/features/benchmarks/compare/BenchmarkCompareGate";
 import { ReportPage } from "@/features/benchmarks/compare/ReportPage";
-import { SavedCompareDetailPage } from "@/features/benchmarks/compare/SavedCompareDetailPage";
+import { SavedComparePage } from "@/features/benchmarks/compare/SavedComparePage";
 import { SavedComparesListPage } from "@/features/benchmarks/compare/SavedComparesListPage";
 import { EndpointReportsPage } from "@/features/benchmarks/EndpointReportsPage";
 import { ConnectionsPage } from "@/features/connections/ConnectionsPage";
@@ -87,7 +87,7 @@ export const routes: RouteObject[] = [
           },
           { path: "benchmarks/compare", element: <BenchmarkCompareGate /> },
           { path: "benchmarks/compare/saved", element: <SavedComparesListPage /> },
-          { path: "benchmarks/compare/saved/:id", element: <SavedCompareDetailPage /> },
+          { path: "benchmarks/compare/saved/:id", element: <SavedComparePage /> },
           { path: "benchmarks/reports", element: <EndpointReportsPage /> },
           { path: "benchmarks/reports/:connectionId", element: <RedirectToInsights /> },
           { path: "insights/:connectionId", element: <InsightsDetailPage /> },

--- a/apps/web/src/styles/primer-report.css
+++ b/apps/web/src/styles/primer-report.css
@@ -50,21 +50,6 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-.dark .primer-report {
-  --pr-bg-canvas: #0d1117;
-  --pr-bg-subtle: #161b22;
-  --pr-bg-muted: #21262d;
-  --pr-fg-default: #e6edf3;
-  --pr-fg-muted: #8d96a0;
-  --pr-fg-subtle: #6e7681;
-  --pr-border-default: #30363d;
-  --pr-border-muted: #21262d;
-  --pr-accent-subtle: #0e2a52;
-  --pr-success-subtle: #033a16;
-  --pr-danger-subtle: #5a0c0c;
-  --pr-attention-subtle: #4e3d0e;
-}
-
 .primer-report a {
   color: var(--pr-accent-fg);
   text-decoration: none;
@@ -95,6 +80,11 @@
   grid-template-columns: 240px minmax(0, 1fr);
   gap: 32px;
   align-items: start;
+}
+/* Embedded mode (inline on the compare page): drop the TOC column so the
+ * canvas flows full-width. Overrides the grid set on .pr-layout. */
+.primer-report .pr-layout-embedded {
+  display: block;
 }
 .primer-report .pr-toc {
   position: sticky;

--- a/docs/superpowers/plans/2026-06-03-benchmark-compare-consolidation.md
+++ b/docs/superpowers/plans/2026-06-03-benchmark-compare-consolidation.md
@@ -1,0 +1,728 @@
+# Benchmark Compare Consolidation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Collapse the benchmark-compare surfaces from 4 routes / 3 views into a 2-page model — one compare workbench (raw data always + AI narrative inline) and one print/share report page — by deleting the redundant `SavedCompareDetailPage` middle layer and locking the AI narrative to light "paper".
+
+**Architecture:** The saved-compare detail page becomes the destination (renamed `SavedComparePage`): it renders the AI narrative **inline** via the existing `<SavedCompareReport>` (in a new `embedded` mode) above the raw `<ReportSections>`. The ad-hoc compare page's primary CTA becomes "生成 AI 解读" = save + auto-synthesize (bridged by a `?generate=1` URL flag the saved page consumes). `/reports/:id` stays as the full-screen print mode. The narrative is locked to light by removing the single `.dark .primer-report` CSS override, so it renders as light paper whether inline on a dark compare page or full-screen.
+
+**Tech Stack:** React 18 + react-router-dom v6, TanStack Query v5, react-i18next, Tailwind + shadcn/ui, Vitest 2 (component) + Playwright (browser e2e), Biome (lint). Worktree: `/Users/fangyong/vllm/modeldoctor/compare-consolidation` on branch `feat/compare-consolidation`.
+
+**Pre-flight (run once before Task 1):** This is a fresh worktree — `packages/*/dist` is empty, so web typecheck and browser-e2e will fail until built.
+
+```bash
+cd /Users/fangyong/vllm/modeldoctor/compare-consolidation && pnpm install && pnpm -r build
+```
+Expected: all packages build; `packages/contracts/dist` now exists.
+
+---
+
+### Task 1: Add i18n keys for the new two-CTA + inline-report wording
+
+**Files:**
+- Modify: `apps/web/src/locales/zh-CN/benchmarks.json` (the `savedCompare` object)
+- Modify: `apps/web/src/locales/en-US/benchmarks.json` (the `savedCompare` object)
+
+No test (pure data); validated by lint + the component tests in later tasks that reference these keys.
+
+- [ ] **Step 1: Add zh-CN keys**
+
+In `apps/web/src/locales/zh-CN/benchmarks.json`, inside `savedCompare`:
+
+Add a new `compare` block (sibling of `dialog`):
+```json
+"compare": {
+  "generate": "生成 AI 解读",
+  "saveOnly": "仅保存"
+},
+```
+Add to the existing `savedCompare.dialog` block:
+```json
+"submitGenerate": "保存并生成",
+```
+Add to the existing `savedCompare.detail` block:
+```json
+"openReport": "打开报告",
+```
+Add to the existing `savedCompare.report` block:
+```json
+"openPrint": "打开打印视图",
+"inlineHeading": "AI 解读"
+```
+
+- [ ] **Step 2: Add en-US keys (mirror)**
+
+In `apps/web/src/locales/en-US/benchmarks.json`, inside `savedCompare`, add the parallel keys:
+```json
+"compare": { "generate": "Generate AI report", "saveOnly": "Save only" },
+```
+`dialog.submitGenerate`: `"Save & generate"`; `detail.openReport`: `"Open report"`; `report.openPrint`: `"Open print view"`; `report.inlineHeading`: `"AI analysis"`.
+
+- [ ] **Step 3: Verify JSON parses**
+
+Run: `cd apps/web && node -e "require('./src/locales/zh-CN/benchmarks.json');require('./src/locales/en-US/benchmarks.json');console.log('ok')"`
+Expected: prints `ok` (no JSON syntax error).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/fangyong/vllm/modeldoctor/compare-consolidation
+git add apps/web/src/locales/zh-CN/benchmarks.json apps/web/src/locales/en-US/benchmarks.json
+git commit -m "feat(compare): i18n keys for two-CTA compare + inline report
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Lock the AI narrative to light ("paper") + embedded layout CSS
+
+**Files:**
+- Modify: `apps/web/src/styles/primer-report.css:53-66` (delete the `.dark .primer-report` block); add `.pr-layout-embedded` rule.
+
+The narrative must render light regardless of app theme. The ONLY thing flipping it dark today is the `.dark .primer-report` token override at lines 53–66. Removing it makes `.primer-report` permanently light. Also add a block-layout variant for embedded (no-TOC) rendering used in Task 3.
+
+- [ ] **Step 1: Delete the dark override block**
+
+Remove lines 53–66 exactly (the whole `.dark .primer-report { … }` rule plus the blank line after it):
+```css
+.dark .primer-report {
+  --pr-bg-canvas: #0d1117;
+  --pr-bg-subtle: #161b22;
+  --pr-bg-muted: #21262d;
+  --pr-fg-default: #e6edf3;
+  --pr-fg-muted: #8d96a0;
+  --pr-fg-subtle: #6e7681;
+  --pr-border-default: #30363d;
+  --pr-border-muted: #21262d;
+  --pr-accent-subtle: #0e2a52;
+  --pr-success-subtle: #033a16;
+  --pr-danger-subtle: #5a0c0c;
+  --pr-attention-subtle: #4e3d0e;
+}
+```
+
+- [ ] **Step 2: Add embedded single-column layout rule**
+
+Immediately after the `.primer-report .pr-layout { … }` rule (around line 90, the `max-width: 1760px` block), append:
+```css
+/* Embedded mode (inline on the compare page): drop the TOC column so the
+ * canvas flows full-width. Overrides the grid set on .pr-layout. */
+.primer-report .pr-layout-embedded {
+  display: block;
+}
+```
+
+- [ ] **Step 3: Verify no `.dark` rules remain in the file**
+
+Run: `cd apps/web && grep -c "\.dark" src/styles/primer-report.css`
+Expected: `0`
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/fangyong/vllm/modeldoctor/compare-consolidation
+git add apps/web/src/styles/primer-report.css
+git commit -m "feat(compare): lock AI narrative to light paper, add embedded layout
+
+Remove the .dark .primer-report override so the report renders light
+regardless of app theme (paper-on-canvas). Add .pr-layout-embedded for
+inline rendering without the TOC column.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Add `embedded` prop to `SavedCompareReport`
+
+**Files:**
+- Modify: `apps/web/src/features/benchmarks/compare/SavedCompareReport.tsx`
+- Test: `apps/web/src/features/benchmarks/compare/SavedCompareReport.test.tsx` (create)
+
+In embedded mode the report renders inline on the compare page: no sticky left-rail TOC, no document scroll-spy, and no `data-report-root` (the page's `<ReportSections>` already owns that attribute for the HTML export).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/features/benchmarks/compare/SavedCompareReport.test.tsx`:
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import "@/lib/i18n";
+import type { CompareNarrative } from "@modeldoctor/contracts";
+import { SavedCompareReport } from "./SavedCompareReport";
+
+const narrative: CompareNarrative = {
+  schemaVersion: 2,
+  locale: "zh-CN",
+  hero: { eyebrow: "EB", title: "Hero Title", subtitle: "Sub", metaItems: [] },
+  summaryCards: [],
+  sections: [
+    { id: "summary", num: "01", title: "Summary", bodyMarkdown: "body one" },
+    { id: "advice", num: "06", title: "Advice", bodyMarkdown: "body six" },
+  ],
+  figures: [],
+  lintWarnings: [],
+};
+
+describe("SavedCompareReport", () => {
+  it("renders the TOC nav in standalone mode", () => {
+    const { container } = render(<SavedCompareReport narrative={narrative} runs={[]} />);
+    expect(container.querySelector(".pr-toc")).not.toBeNull();
+    expect(container.querySelector("[data-report-root]")).not.toBeNull();
+  });
+
+  it("drops the TOC nav and data-report-root in embedded mode", () => {
+    const { container } = render(<SavedCompareReport narrative={narrative} runs={[]} embedded />);
+    expect(container.querySelector(".pr-toc")).toBeNull();
+    expect(container.querySelector(".pr-layout-embedded")).not.toBeNull();
+    expect(container.querySelector("[data-report-root]")).toBeNull();
+    // Section content still renders.
+    expect(screen.getByRole("heading", { name: "Hero Title" })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `cd apps/web && pnpm exec vitest run src/features/benchmarks/compare/SavedCompareReport.test.tsx`
+Expected: FAIL — `embedded` prop not yet supported (TOC still present / `data-report-root` still present).
+
+- [ ] **Step 3: Implement the `embedded` prop**
+
+In `SavedCompareReport.tsx`:
+
+Update the props interface (after line 13):
+```tsx
+export interface SavedCompareReportProps {
+  narrative: CompareNarrative;
+  runs: ReportRun[];
+  /** Optional print-time header text (one-line, gray). */
+  printHeader?: string;
+  /** Inline on the compare page: no TOC, no scroll-spy, no data-report-root. */
+  embedded?: boolean;
+}
+```
+
+Update the signature (line 28):
+```tsx
+export function SavedCompareReport({ narrative, runs, printHeader, embedded = false }: SavedCompareReportProps) {
+```
+
+Guard the scroll-spy effect (top of the `useEffect` body, line 44):
+```tsx
+  useEffect(() => {
+    if (embedded) return;
+    function onScroll() {
+```
+and add `embedded` to its dependency array (line 59): `}, [sections, embedded]);`
+
+Update the outer wrapper (line 68) to conditionally drop `data-report-root`:
+```tsx
+    <div
+      className="primer-report"
+      {...(embedded ? {} : { "data-report-root": true })}
+      data-print-header={printHeader ?? ""}
+    >
+      <div className={embedded ? "pr-layout pr-layout-embedded" : "pr-layout"}>
+        {embedded ? null : (
+          <nav
+            className="pr-toc"
+            aria-label={t("savedCompare.report.toc", { defaultValue: "Contents" })}
+          >
+```
+Close the conditional after the existing `</nav>` (line 89): change `</nav>` to `</nav>\n        )}`.
+
+(The `<main className="pr-canvas">…</main>` block and everything inside it is unchanged.)
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `cd apps/web && pnpm exec vitest run src/features/benchmarks/compare/SavedCompareReport.test.tsx`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/fangyong/vllm/modeldoctor/compare-consolidation
+git add apps/web/src/features/benchmarks/compare/SavedCompareReport.tsx apps/web/src/features/benchmarks/compare/SavedCompareReport.test.tsx
+git commit -m "feat(compare): embedded mode for SavedCompareReport (no TOC/scroll-spy)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Rename detail page → `SavedComparePage`, render narrative inline, auto-generate on `?generate=1`
+
+**Files:**
+- Create: `apps/web/src/features/benchmarks/compare/SavedComparePage.tsx` (from `SavedCompareDetailPage.tsx`)
+- Delete: `apps/web/src/features/benchmarks/compare/SavedCompareDetailPage.tsx`
+- Create: `apps/web/src/features/benchmarks/compare/SavedComparePage.test.tsx` (from the old `.test.tsx`)
+- Delete: `apps/web/src/features/benchmarks/compare/SavedCompareDetailPage.test.tsx`
+- Modify: `apps/web/src/router/index.tsx:18,90` (import + element)
+
+The page now (a) renders `<SavedCompareReport embedded>` above `<ReportSections>` when a narrative exists, (b) relabels the strip's "open report" link via `detail.openReport` / `report.openPrint`, and (c) auto-runs generate once when the URL carries `?generate=1` (the ad-hoc → generate bridge) and no narrative exists.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web/src/features/benchmarks/compare/SavedComparePage.test.tsx` by copying the existing `SavedCompareDetailPage.test.tsx` content, then changing the import + describe + the rendered element to `SavedComparePage`, and adding a narrative-inline test. Full file:
+
+```tsx
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import "@/lib/i18n";
+import { SavedComparePage } from "./SavedComparePage";
+
+function makeApi(narrative: unknown) {
+  return {
+    get: vi.fn(async (path: string) => {
+      if (path.startsWith("/api/saved-compares/")) {
+        return {
+          id: "sc1",
+          userId: "u",
+          name: "Study A",
+          benchmarkIds: ["b1", "b2"],
+          stageLabels: { b1: "A", b2: "B" },
+          baselineId: "b1",
+          context: "8x NPU",
+          narrative,
+          narrativeAt: narrative ? "2026-05-12T00:00:00.000Z" : null,
+          createdAt: "2026-05-12T00:00:00.000Z",
+          updatedAt: "2026-05-12T00:00:00.000Z",
+          benchmarks: [
+            {
+              id: "b1",
+              stageLabel: "A",
+              missing: false,
+              name: "r1",
+              tool: "guidellm",
+              scenario: "inference",
+              params: {},
+              summaryMetrics: { tool: "guidellm", data: { ttft: { p50: 100, p90: 200, p99: 500 } } },
+              createdAt: "2026-05-12T00:00:00.000Z",
+            },
+            {
+              id: "b2",
+              stageLabel: "B",
+              missing: false,
+              name: "r2",
+              tool: "guidellm",
+              scenario: "inference",
+              params: {},
+              summaryMetrics: { tool: "guidellm", data: { ttft: { p50: 80, p90: 160, p99: 400 } } },
+              createdAt: "2026-05-12T00:00:00.000Z",
+            },
+          ],
+        };
+      }
+      if (path === "/api/llm-judge-providers/active") return { id: "p", enabled: true };
+      throw new Error(`unmocked: ${path}`);
+    }),
+    post: vi.fn(),
+    patch: vi.fn(),
+    del: vi.fn(),
+  };
+}
+
+const apiMock = makeApi(null);
+vi.mock("@/lib/api-client", () => ({ api: apiMock }));
+
+function renderAt(entry: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <QueryClientProvider client={qc}>
+        <Routes>
+          <Route path="/benchmarks/compare/saved/:id" element={<SavedComparePage />} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("SavedComparePage", () => {
+  it("renders the raw data once loaded", async () => {
+    renderAt("/benchmarks/compare/saved/sc1");
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { level: 1, name: "Study A" })).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/8x NPU/)).toBeInTheDocument();
+  });
+
+  it("renders the AI narrative inline when present", async () => {
+    apiMock.get.mockImplementationOnce(makeApi({
+      schemaVersion: 2,
+      locale: "zh-CN",
+      hero: { eyebrow: "EB", title: "Inline Hero", subtitle: "S", metaItems: [] },
+      summaryCards: [],
+      sections: [{ id: "summary", num: "01", title: "Summary", bodyMarkdown: "x" }],
+      figures: [],
+      lintWarnings: [],
+    }).get);
+    renderAt("/benchmarks/compare/saved/sc1");
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Inline Hero" })).toBeInTheDocument(),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests, verify they fail**
+
+Run: `cd apps/web && pnpm exec vitest run src/features/benchmarks/compare/SavedComparePage.test.tsx`
+Expected: FAIL — module `./SavedComparePage` does not exist.
+
+- [ ] **Step 3: Create `SavedComparePage.tsx`**
+
+Create `apps/web/src/features/benchmarks/compare/SavedComparePage.tsx` from the current `SavedCompareDetailPage.tsx`, with these changes:
+
+1. Rename the function: `export function SavedComparePage() {`
+2. Add imports: `useEffect, useRef` from react (alongside `useState`); `useSearchParams` from react-router-dom; `SavedCompareReport` from `./SavedCompareReport`.
+3. Read the generate flag and add a one-shot auto-generate. After the existing `const [narrativeOverride, setNarrativeOverride] = useState<…>(null);` line and BEFORE the `if (query.isLoading)` early return, add:
+```tsx
+  const [searchParams, setSearchParams] = useSearchParams();
+  const autoGenFired = useRef(false);
+```
+4. Move the `generate` function definition above the effect (it currently sits after the early returns — hoist the `async function generate()` so the effect can call it; keep its body identical). Then add the effect (must run before early returns, so place it right after `autoGenFired`):
+```tsx
+  // Ad-hoc → generate bridge: the compare page navigates here with ?generate=1
+  // after a save-and-generate. Fire synthesize once, then strip the flag.
+  useEffect(() => {
+    if (autoGenFired.current) return;
+    if (searchParams.get("generate") !== "1") return;
+    const sc = query.data;
+    if (!sc || sc.narrative) {
+      // Nothing to generate (still loading or already has a narrative): clear flag.
+      if (sc?.narrative) {
+        autoGenFired.current = true;
+        setSearchParams({}, { replace: true });
+      }
+      return;
+    }
+    if (!provider.data?.enabled || synth.isPending) return;
+    autoGenFired.current = true;
+    setSearchParams({}, { replace: true });
+    void generate();
+  }, [searchParams, query.data, provider.data?.enabled, synth.isPending, setSearchParams]);
+```
+   Note: `generate`, `provider`, `synth` are already defined in the component; ensure `generate` is hoisted above this effect. Because hooks must precede the early `return null`, keep all of `useState/useSearchParams/useRef/useEffect` above the `if (query.isLoading)` block. The `generate` function references `synth` and `setNarrativeOverride`, both defined above — keep it as a function declaration (hoisted) so order is not an issue.
+5. Update breadcrumbs middle crumb label to the list (unchanged target): keep `{ label: t("compare.title"), to: "/benchmarks/compare/saved" }`.
+6. Relabel the strip's "open report" buttons to point at the print view and add proper i18n. Both `<Link to={`/reports/${sc.id}`}>` buttons currently use `t("savedCompare.detail.openReport", { defaultValue: "Open report" })`; change their label to `t("savedCompare.report.openPrint")` (keeps the same `/reports/:id` target — now explicitly "print view").
+7. Render the inline narrative ABOVE `<ReportSections>`. Replace the final body block:
+```tsx
+      <div className="space-y-6 px-8 py-6">
+        {/* Report status / generate strip */}
+        { /* …existing strip unchanged… */ }
+
+        {narrative ? (
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold">{t("savedCompare.report.inlineHeading")}</h2>
+            <div className="overflow-hidden rounded-md border border-border">
+              <SavedCompareReport narrative={narrative} runs={reportRuns} embedded />
+            </div>
+          </section>
+        ) : null}
+
+        <ReportSections
+          runs={reportRuns}
+          baselineId={sc.baselineId}
+          narrative={null}
+          context={sc.context}
+          environmentLines={environmentLines}
+        />
+      </div>
+```
+   (`narrative` and `reportRuns` are already computed above. `narrative` is `narrativeOverride ?? sc.narrative` — so a freshly generated report renders inline immediately.)
+
+- [ ] **Step 4: Delete the old page + its test**
+
+```bash
+cd /Users/fangyong/vllm/modeldoctor/compare-consolidation
+git rm apps/web/src/features/benchmarks/compare/SavedCompareDetailPage.tsx apps/web/src/features/benchmarks/compare/SavedCompareDetailPage.test.tsx
+```
+
+- [ ] **Step 5: Update the router**
+
+In `apps/web/src/router/index.tsx`:
+- Line 18: change import to `import { SavedComparePage } from "@/features/benchmarks/compare/SavedComparePage";`
+- Line 90: change element to `{ path: "benchmarks/compare/saved/:id", element: <SavedComparePage /> },`
+
+- [ ] **Step 6: Run the tests, verify they pass**
+
+Run: `cd apps/web && pnpm exec vitest run src/features/benchmarks/compare/SavedComparePage.test.tsx`
+Expected: PASS (both tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/fangyong/vllm/modeldoctor/compare-consolidation
+git add apps/web/src/features/benchmarks/compare/SavedComparePage.tsx apps/web/src/features/benchmarks/compare/SavedComparePage.test.tsx apps/web/src/router/index.tsx
+git commit -m "feat(compare): inline AI narrative on saved compare page + auto-generate
+
+Rename SavedCompareDetailPage -> SavedComparePage. Render the narrative
+inline (embedded, light paper) above the raw matrix instead of forcing a
+jump to /reports/:id, which is now just the print view. Auto-run
+synthesize once when arriving with ?generate=1.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Ad-hoc compare page — two CTAs ("生成 AI 解读" + "仅保存") + dialog bridge
+
+**Files:**
+- Modify: `apps/web/src/features/benchmarks/compare/SaveCompareDialog.tsx` (add `generateAfterSave` prop, branch navigate + submit label)
+- Modify: `apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx` (two buttons + state)
+- Test: `apps/web/src/features/benchmarks/compare/SaveCompareDialog.test.tsx` (create)
+
+- [ ] **Step 1: Write the failing test for the dialog navigation target**
+
+Create `apps/web/src/features/benchmarks/compare/SaveCompareDialog.test.tsx`:
+```tsx
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import "@/lib/i18n";
+import { SaveCompareDialog } from "./SaveCompareDialog";
+
+vi.mock("@/lib/api-client", () => ({
+  api: { post: vi.fn(async () => ({ id: "scNEW" })), get: vi.fn(), patch: vi.fn(), del: vi.fn() },
+}));
+
+function Loc() {
+  const l = useLocation();
+  return <div data-testid="loc">{l.pathname + l.search}</div>;
+}
+
+function renderDialog(generateAfterSave: boolean) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <MemoryRouter initialEntries={["/benchmarks/compare?ids=b1,b2"]}>
+      <QueryClientProvider client={qc}>
+        <Routes>
+          <Route
+            path="/benchmarks/compare"
+            element={
+              <SaveCompareDialog
+                open
+                onOpenChange={() => {}}
+                runs={[{ id: "b1", name: "r1", tool: "guidellm" }, { id: "b2", name: "r2", tool: "guidellm" }]}
+                baselineId="b1"
+                context=""
+                generateAfterSave={generateAfterSave}
+              />
+            }
+          />
+          <Route path="/benchmarks/compare/saved/:id" element={<Loc />} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+async function fillAndSubmit() {
+  fireEvent.change(screen.getByLabelText("名称", { selector: "#sc-name" }), { target: { value: "X" } });
+  fireEvent.change(screen.getByLabelText("r1"), { target: { value: "A" } });
+  fireEvent.change(screen.getByLabelText("r2"), { target: { value: "B" } });
+  fireEvent.click(screen.getByRole("button", { name: /保存/ }));
+}
+
+describe("SaveCompareDialog navigation", () => {
+  it("navigates to the saved page without generate flag when generateAfterSave is false", async () => {
+    renderDialog(false);
+    await fillAndSubmit();
+    await waitFor(() =>
+      expect(screen.getByTestId("loc")).toHaveTextContent("/benchmarks/compare/saved/scNEW"),
+    );
+    expect(screen.getByTestId("loc")).not.toHaveTextContent("generate=1");
+  });
+
+  it("appends ?generate=1 when generateAfterSave is true", async () => {
+    renderDialog(true);
+    await fillAndSubmit();
+    await waitFor(() =>
+      expect(screen.getByTestId("loc")).toHaveTextContent("/benchmarks/compare/saved/scNEW?generate=1"),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `cd apps/web && pnpm exec vitest run src/features/benchmarks/compare/SaveCompareDialog.test.tsx`
+Expected: FAIL — `generateAfterSave` prop unknown / no `?generate=1` appended.
+
+- [ ] **Step 3: Add `generateAfterSave` to the dialog**
+
+In `SaveCompareDialog.tsx`:
+
+Extend the props interface (after `context: string;`, line 36):
+```tsx
+  /** When true, navigate to the saved page with ?generate=1 so it auto-synthesizes. */
+  generateAfterSave?: boolean;
+```
+Add to the destructured params (line 45): add `generateAfterSave = false,`.
+
+Update the navigate call (line 70):
+```tsx
+    onOpenChange(false);
+    const suffix = generateAfterSave ? "?generate=1" : "";
+    navigate(`/benchmarks/compare/saved/${sc.id}${suffix}`);
+```
+
+Update the submit button label (line 170-172) to reflect the mode:
+```tsx
+          <Button onClick={submit} disabled={!canSubmit}>
+            {generateAfterSave
+              ? t("savedCompare.dialog.submitGenerate")
+              : t("savedCompare.dialog.submit")}
+          </Button>
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `cd apps/web && pnpm exec vitest run src/features/benchmarks/compare/SaveCompareDialog.test.tsx`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Wire the two CTAs into the ad-hoc compare page**
+
+In `BenchmarkComparePage.tsx`:
+
+Add a state alongside `saveOpen` (line 51):
+```tsx
+  const [saveOpen, setSaveOpen] = useState(false);
+  const [generateAfterSave, setGenerateAfterSave] = useState(false);
+```
+
+Replace the action row (lines 216-221) — the `<Button variant="outline" asChild>…历史对比…</Button>` + the single Save button — with:
+```tsx
+            <div className="flex items-center justify-between">
+              <Button variant="outline" asChild>
+                <Link to="/benchmarks/compare/saved">{t("savedCompare.savedListLink")}</Link>
+              </Button>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    setGenerateAfterSave(false);
+                    setSaveOpen(true);
+                  }}
+                >
+                  {t("savedCompare.compare.saveOnly")}
+                </Button>
+                <Button
+                  onClick={() => {
+                    setGenerateAfterSave(true);
+                    setSaveOpen(true);
+                  }}
+                >
+                  {t("savedCompare.compare.generate")}
+                </Button>
+              </div>
+            </div>
+```
+
+Pass the flag to the dialog (the existing `<SaveCompareDialog … />` at line 229-235): add `generateAfterSave={generateAfterSave}` to its props.
+
+- [ ] **Step 6: Run the compare-folder component tests**
+
+Run: `cd apps/web && pnpm exec vitest run src/features/benchmarks/compare`
+Expected: PASS — all tests in the compare folder (SavedCompareReport, SavedComparePage, SaveCompareDialog).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/fangyong/vllm/modeldoctor/compare-consolidation
+git add apps/web/src/features/benchmarks/compare/SaveCompareDialog.tsx apps/web/src/features/benchmarks/compare/SaveCompareDialog.test.tsx apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
+git commit -m "feat(compare): ad-hoc compare page two-CTA (generate vs save-only)
+
+Primary CTA saves and auto-generates the AI report (bridged via
+?generate=1); secondary CTA saves only. Fulfills select-runs -> report
+in one step while landing on the data-backed saved page.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Cleanup, full verification, and e2e
+
+**Files:**
+- Modify: `apps/web/src/features/benchmarks/compare/ReportSections.tsx:24-33` (doc comment: it's no longer rendered by a separate detail page)
+- Verify only: `apps/web/src/features/benchmarks/compare/ReportPage.tsx` (its `/benchmarks/compare/saved/:id` links now resolve to `SavedComparePage` — no code change needed)
+- Verify only: `e2e/saved-compares.spec.ts` (only touches the list route + auth gate, both unchanged)
+
+- [ ] **Step 1: Update the stale ReportSections doc comment**
+
+In `ReportSections.tsx`, the block comment (lines 24-33) says it's "Used by … SavedCompareDetailPage when the saved compare has no narrative yet." Replace that bullet with:
+```tsx
+ *   - BenchmarkComparePage (ad-hoc compare, no narrative)
+ *   - SavedComparePage (raw matrix below the inline AI narrative)
+```
+
+- [ ] **Step 2: Confirm no dangling references to the old page**
+
+Run: `cd /Users/fangyong/vllm/modeldoctor/compare-consolidation && grep -rn "SavedCompareDetailPage" apps/web/src; echo "exit:$?"`
+Expected: no matches (grep exit 1 → prints `exit:1`).
+
+- [ ] **Step 3: Typecheck the web package**
+
+Run: `cd /Users/fangyong/vllm/modeldoctor/compare-consolidation && pnpm -F @modeldoctor/web type-check`
+Expected: no type errors. (If the script name differs, use `pnpm -F @modeldoctor/web exec tsc --noEmit`.)
+
+- [ ] **Step 4: Lint (Biome)**
+
+Run: `cd /Users/fangyong/vllm/modeldoctor/compare-consolidation && pnpm -F @modeldoctor/web lint`
+Expected: clean. Fix any import-order / formatting findings Biome reports, then re-run.
+
+- [ ] **Step 5: Full web unit/component test run**
+
+Run: `cd /Users/fangyong/vllm/modeldoctor/compare-consolidation/apps/web && pnpm exec vitest run`
+Expected: PASS — whole web suite green (no test still imports the deleted page).
+
+- [ ] **Step 6: Browser e2e for saved compares**
+
+Run: `cd /Users/fangyong/vllm/modeldoctor/compare-consolidation && pnpm test:e2e:browser -- saved-compares`
+Expected: both tests pass (list empty-state renders, anonymous redirects to /login). The routes they touch (`/benchmarks/compare/saved`) are unchanged.
+
+- [ ] **Step 7: Manual visual check (dark-mode paper)**
+
+Run the app, switch the app to dark theme, open a saved compare that has a generated narrative.
+Expected: page chrome + raw tables/charts are dark; the inline AI narrative renders as a light "paper" card (not dark). Open `/reports/:id` → still light.
+(If no narrative exists locally, generate one from the ad-hoc "生成 AI 解读" CTA first.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/fangyong/vllm/modeldoctor/compare-consolidation
+git add apps/web/src/features/benchmarks/compare/ReportSections.tsx
+git commit -m "docs(compare): refresh ReportSections usage comment after consolidation
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- 2 content pages + list index → Tasks 4 (saved page inline), 5 (ad-hoc page), ReportPage untouched, list page untouched. ✅
+- Delete `SavedCompareDetailPage` middle layer → Task 4 Step 4. ✅
+- AI narrative inline on the compare page → Task 4 Step 3 (renders `<SavedCompareReport embedded>`). ✅
+- "select runs → directly AI report" bridge → Tasks 5 (two-CTA + dialog flag) + 4 (auto-generate on `?generate=1`). ✅
+- Narrative locked to light paper-on-canvas → Task 2 (delete `.dark .primer-report`) + Task 3 (embedded). ✅
+- No backend/schema/contract changes, no data migration → confirmed; no task touches `apps/api` or Prisma. ✅
+- e2e link updated → Task 6 confirms the only e2e routes are unchanged. ✅
+
+**Placeholder scan:** No TBD/TODO; every code step shows concrete code. ✅
+
+**Type consistency:** `embedded?: boolean` (Task 3) consumed in Task 4; `generateAfterSave?: boolean` (Task 5 dialog) set by Task 5 page; `?generate=1` written by Task 5 dialog, read by Task 4 page; i18n keys added in Task 1 are all referenced (`compare.generate`, `compare.saveOnly`, `dialog.submitGenerate`, `report.openPrint`, `report.inlineHeading`, `detail.openReport`). ✅
+
+**Risks called out for the implementer:**
+- The `generate` function in `SavedComparePage` must be hoisted (function declaration) above the auto-generate `useEffect`, and all hooks must stay above the `if (query.isLoading)` early return — React's rules-of-hooks.
+- If `pnpm -F @modeldoctor/web type-check` script name differs, fall back to `tsc --noEmit` (noted inline).
+- Biome may reorder the new imports in `SavedComparePage.tsx` / `BenchmarkComparePage.tsx`; run lint and accept its fixes.

--- a/docs/superpowers/specs/2026-06-03-benchmark-compare-consolidation-design.md
+++ b/docs/superpowers/specs/2026-06-03-benchmark-compare-consolidation-design.md
@@ -1,0 +1,119 @@
+# Benchmark Compare 收敛重构设计
+
+- 日期:2026-06-03
+- 状态:已批准方向,待 spec review
+- 分支:`feat/compare-consolidation`
+- 相关:`2026-05-12-saved-compares-ai-report-design.md`(本功能首版)、`2026-05-07-multi-palette-theme-design.md`(多调色板主题)
+
+## 背景与问题
+
+当前同一个"对比"对象散落在 4 条路由 / 3 个视图上:
+
+| 路由 | 组件 | 职责 |
+|---|---|---|
+| `/benchmarks/compare?ids=` | `BenchmarkComparePage` | 临时对比:矩阵表 + 指标网格 + 柱状图,无 AI |
+| `/benchmarks/compare/saved` | `SavedComparesListPage` | 已保存对比列表 |
+| `/benchmarks/compare/saved/:id` | `SavedCompareDetailPage` | **又一遍原始数据** + "生成报告"按钮 |
+| `/reports/:id` | `ReportPage` | 全屏 AI 叙述报告 + 打印 |
+
+问题:
+
+1. **冗余视图** —— 原始数据(`ReportSections`)在临时对比页和已保存详情页渲染了两遍。
+2. **多余的中间层** —— `SavedCompareDetailPage` 既不是探索工作台也不是成品报告,只是个"看一眼数据 + 点按钮去生成"的中转站。
+3. **流程过长** —— 从"想对比"到"拿到报告"要 5 跳:临时对比 → 弹窗保存 → 落详情页 → 点生成 → 跳报告页。
+
+## 目标
+
+收敛为 **2 个内容页 + 1 个列表索引**,删除中间层,AI 解读 inline 化:
+
+- **对比页**(唯一工作台,临时态与已保存态共用一个组件):原始数据永远在 + AI 解读作为可选层叠在上面。
+- **报告页**(`/reports/:id`):全屏、浅色、可打印的成品呈现态,对外/分享用。
+- **列表**(`/benchmarks/compare/saved`):保留为索引,翻历史保存的对比。
+
+设计依据:对标 W&B(Workspace 随手比 run → 一键沉淀为 Report)、Grafana(Dashboard → Snapshot)。两层结构是行业标准,要砍的是多余的第三层。
+
+## 非目标(YAGNI)
+
+- 不改 `SavedCompare` 后端模型 / `synthesize` 接口 / contracts。
+- 不做数据迁移 —— 当前为开发阶段,无历史 reports、未对外分享,现有 `saved_compares` 数据可直接清空。
+- 不新增打印/PDF 能力(`ReportPage` 现有 Primer print CSS 保留即可,不扩展)。
+- 不做深色版报告主题(见下)。
+
+## 设计
+
+### 页面 1 ·对比页 `/benchmarks/compare`
+
+升级现有 `BenchmarkComparePage`,**吸收 `SavedCompareDetailPage` 的全部职责**。同一组件支持两种来源:
+
+- **临时态**:`/benchmarks/compare?ids=run1,run2`,从 `benchmarkApi.get` 逐个水合(现状)。
+- **已保存态**:`/benchmarks/compare/saved/:id`,走 `useSavedCompare(id)` 水合(原详情页逻辑)。
+
+URL 方案:**保留 `/benchmarks/compare/saved/:id`** 表示已保存态(语义清楚、列表链接不用改、可分享)。
+
+自上而下布局:
+
+1. **工具栏** —— 基线选择(`CompareToolbar`);右侧主操作:
+   - 临时态:主按钮「生成 AI 解读」(= 保存 + synthesize,见下),次要项「仅保存」。
+   - 已保存态:管理操作(重命名 / 改分类 / 导出 / 删除);AI 区有「重新生成」「打开打印态」。
+2. **AI 解读层(可选,叠在数据上面)** —— 未生成时为生成入口;已生成时 `narrative` 的摘要卡 + 6 段 inline 渲染在此(浅色"纸",见主题决策),带「重新生成」「打开打印态(`/reports/:id`)」。
+3. **原始数据(永远在、免费、即时)** —— `ReportSections`(测试矩阵 + 指标网格 + 柱状图)原样复用。
+
+### 关键衔接:临时态「生成 AI 解读」
+
+后端 `synthesize` 挂在已保存对比上,**生成 AI 必须先有保存记录**。所以临时态点「生成 AI 解读」时:
+
+```
+弹 SaveCompareDialog 收元数据(name / stageLabels / context / classification / clientName)
+  → POST /api/saved-compares
+  → POST /api/saved-compares/:id/synthesize
+  → 切到已保存态 URL,narrative inline 长在当前页(下面就是原始数据)
+```
+
+兑现"选多个 benchmark 直接出 AI 报告"的诉求,但落点是带原始数据的同一页,而非新目的地。
+
+### 页面 2 ·报告页 `/reports/:id`
+
+`ReportPage` 基本不动:全屏、无 AppShell、浅色、可打印的成品呈现态。唯一入口 = 对比页 AI 层的「打开/打印」。
+
+### 列表 `/benchmarks/compare/saved`
+
+`SavedComparesListPage` 保留为索引。点行 → 进对比页已保存态。
+
+### 主题决策:Narrative 锁定浅色(paper-on-canvas)
+
+- **应用外壳 + 原始数据(表格/图表)跟随多调色板主题**(深色照常)。
+- **AI narrative 永远渲染成浅色"纸"**,无论 inline 在对比页还是全屏在 `/reports/:id`。深色画布 + 白色纸张是成熟模式(PDF 阅读器 / 打印预览)。
+- 全站只有**一个 narrative 渲染器、只有浅色一种**,不做深色叙述皮。
+
+依据:可打印 / 对外交付的报告业内一律浅色(W&B Reports、Grafana snapshot、Datadog notebook、Stripe 发票);打印本就强制白底,做深色屏显版印出来还是白的,纯属重复 + 困惑。
+
+实现要点:`SavedCompareReport`(及其 figure 渲染)在被对比页 inline 引用时,用一个固定浅色 token 作用域包裹("paper" wrapper),不继承当前调色板的深色变量;`/reports/:id` 已在 AppShell 外、已是浅色,无需改。
+
+## 删除 / 改动清单
+
+- **删** `SavedCompareDetailPage.tsx`,职责并入 `BenchmarkComparePage`。
+- 路由 `/benchmarks/compare/saved/:id` 指向升级后的对比页;移除对 `SavedCompareDetailPage` 的引用。
+- 原始数据视图不再渲染两遍(`ReportSections` 仅在对比页一处)。
+- 临时态「仅保存」成功后**留在对比页**(切到已保存态 URL),不再强制跳转到独立详情页。
+- `SavedCompareReport` 增加浅色"纸" wrapper,供对比页 inline 复用。
+
+## 数据
+
+开发阶段,无历史 reports、未对外分享。现有 `saved_compares` 行可直接清空(用户已确认)。**预期无 Prisma schema 变更**,因此无需 migration、无需 DB reset。
+
+## 实施(单 PR,phase-per-commit)
+
+1. **对比页吸收已保存态** —— `BenchmarkComparePage` 增加 `saved/:id` 分支(`useSavedCompare` 水合),搬入 AI 解读面板 + 管理操作。
+2. **narrative inline + 浅色 paper wrapper** —— `SavedCompareReport` 浅色作用域;对比页 AI 层渲染摘要 + 6 段 + 「打开打印态」。
+3. **临时态「生成 AI 解读」衔接** —— 主按钮串起 save + synthesize,落回已保存态。
+4. **删中间层 + 路由清理** —— 删 `SavedCompareDetailPage`,改路由,清列表页 / `ReportPage` 入口链接。
+
+## 测试
+
+- 更新 `e2e/saved-compares.spec.ts`:覆盖 临时对比 →「生成 AI 解读」→ inline narrative →「打开打印态」→ 列表 → 回到已保存态 的新链路;移除对独立详情页的断言。
+- 验证深色主题下:对比页外壳/表格为深色,inline narrative 为浅色"纸"。
+
+## 待确认 / 风险
+
+- 已解决:URL 保留 `/saved/:id`;报告未对外分享,打印态不扩展;narrative 锁浅色;现有数据可清空。
+- 风险:`SavedCompareReport` 的样式此前可能依赖 `ReportPage` 的全屏/浅色上下文;inline 复用时需确认 figure / Primer 样式在受限容器内不串色、不溢出。


### PR DESCRIPTION
## Summary

Collapses the benchmark **compare** experience from 4 routes / 3 views into **2 content pages + a list index**, after a design discussion concluded the middle "detail" layer was redundant and the AI report shouldn't be a separate destination.

- **Compare workbench is the destination.** `SavedCompareDetailPage` is deleted and replaced by `SavedComparePage`, which renders the AI narrative **inline** (`<SavedCompareReport embedded>`) *above* the raw matrix/charts — no more forced jump to `/reports/:id` just to read the report.
- **Select runs → report in one step.** The ad-hoc compare page gets two CTAs: **生成 AI 解读** (save + auto-generate, bridged via `?generate=1`) and **仅保存** (save only). `SavedComparePage` auto-runs synthesize once when it arrives with `?generate=1`.
- **`/reports/:id` kept as the print view** (full-screen, light, printable) — now the only thing the "open print view" button targets.
- **AI narrative locked to light "paper".** Deleted the sole `.dark .primer-report` override so the report renders light regardless of app theme (paper-on-canvas); added an `embedded` mode to `SavedCompareReport` (drops the TOC / scroll-spy / `data-report-root` so the inline copy doesn't collide with the export selector).
- **No backend / Prisma / contract changes.** Frontend + one CSS deletion only.

Spec: `docs/superpowers/specs/2026-06-03-benchmark-compare-consolidation-design.md`
Plan: `docs/superpowers/plans/2026-06-03-benchmark-compare-consolidation.md`

## Test Plan

- [x] `pnpm -F @modeldoctor/web type-check` — clean
- [x] `pnpm -F @modeldoctor/web lint` — 0 errors (66 pre-existing warnings in unrelated files)
- [x] Full web unit/component suite — 851 passing; compare folder 74/74
- [x] Browser e2e `saved-compares` — 2/2 passing
- [ ] Manual: in **dark** app theme, open a saved compare with a generated narrative → page chrome/tables are dark, the inline AI report renders as a light paper card; `/reports/:id` still light & printable

🤖 Generated with [Claude Code](https://claude.com/claude-code)