### PR TITLE
feat(compare): hide data-source table in printed/PDF report

### DIFF
--- a/apps/web/src/features/benchmarks/compare/SavedCompareReport.tsx
+++ b/apps/web/src/features/benchmarks/compare/SavedCompareReport.tsx
@@ -186,7 +186,7 @@ export function SavedCompareReport({
               columns only (no metrics); names deep-link to the benchmark detail.
               Sits before the footer so the footer truly closes the document. */}
           {runs.length > 0 ? (
-            <section className="pr-sec">
+            <section className="pr-sec pr-source">
               <h3>{t("savedCompare.report.sourceTitle")}</h3>
               <table>
                 <thead>

--- a/apps/web/src/styles/primer-report.css
+++ b/apps/web/src/styles/primer-report.css
@@ -438,6 +438,11 @@
   .pr-toc {
     display: none !important;
   }
+  /* The "data source · associated benchmarks" table is an on-screen navigation
+     aid (links to each benchmark); a printed/PDF report doesn't need it. */
+  .primer-report .pr-source {
+    display: none !important;
+  }
   .primer-report {
     background: #fff !important;
     font-size: 10.5px;

--- a/apps/web/src/styles/primer-report.css
+++ b/apps/web/src/styles/primer-report.css
@@ -439,8 +439,10 @@
     display: none !important;
   }
   /* The "data source · associated benchmarks" table is an on-screen navigation
-     aid (links to each benchmark); a printed/PDF report doesn't need it. */
-  .primer-report .pr-source {
+     aid (links to each benchmark); a printed/PDF report doesn't need it. Bare
+     single-class selector to match the `.pr-app-bar` / `.pr-toc` hide cluster
+     above and avoid a descending-specificity warning. */
+  .pr-source {
     display: none !important;
   }
   .primer-report {


### PR DESCRIPTION
## 背景

上一个 PR(#270)在报告 footer 之前加了「数据来源 · 关联 Benchmark」表,名称深链到各 benchmark 详情。它本质是**屏幕上的导航辅助**;打印/导出 PDF 的报告里这些链接没意义。

## 改动

- 给该 `<section>` 加 `.pr-source` 类
- 在 `primer-report.css` 的 `@media print` 块里、紧挨现有 `.pr-app-bar` / `.pr-toc` 隐藏簇,加 `.primer-report .pr-source { display: none !important; }`

屏幕显示不变,打印/PDF 时整段消失。导出的静态 HTML 在屏幕上仍显示该表,但用户打印那份 HTML 时同样会隐藏(stylesheet 一并带出)。

## 验证

- ✅ type-check / 75 compare 测试通过
- ℹ️ biome 的 `noDescendingSpecificity` warning 是 `.pr-toc` 上的**既有**告警(pristine main 同样 1 条),非本次引入、不致 CI 失败

🤖 Generated with [Claude Code](https://claude.com/claude-code)