### PR TITLE
feat(compare): show data-source table on detail only, not preview

### DIFF
--- a/apps/web/src/features/benchmarks/compare/ReportDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/compare/ReportDetailPage.tsx
@@ -217,7 +217,7 @@ export function ReportDetailPage() {
             {/* Document-viewer: the light Primer "paper" sits inside a themed
                 bordered card on the (theme-following) page background. */}
             <div className="overflow-hidden rounded-lg border border-border">
-              <SavedCompareReport narrative={narrative} runs={reportRuns} embedded />
+              <SavedCompareReport narrative={narrative} runs={reportRuns} embedded showDataSource />
             </div>
           </>
         ) : (

--- a/apps/web/src/features/benchmarks/compare/SavedCompareReport.tsx
+++ b/apps/web/src/features/benchmarks/compare/SavedCompareReport.tsx
@@ -14,6 +14,12 @@ export interface SavedCompareReportProps {
   printHeader?: string;
   /** Inline on the compare page: no TOC, no scroll-spy, no data-report-root. */
   embedded?: boolean;
+  /**
+   * Render the "data source · associated benchmarks" table (with benchmark
+   * deep-links) before the footer. On-screen navigation aid for the in-app
+   * detail page only — the standalone print/export preview omits it.
+   */
+  showDataSource?: boolean;
 }
 
 /**
@@ -33,6 +39,7 @@ export function SavedCompareReport({
   runs,
   printHeader,
   embedded = false,
+  showDataSource = false,
 }: SavedCompareReportProps) {
   const { t } = useTranslation("benchmarks");
   const sections = narrative.sections;
@@ -184,8 +191,10 @@ export function SavedCompareReport({
 
           {/* Data source — which benchmarks this report is built from. Identity
               columns only (no metrics); names deep-link to the benchmark detail.
-              Sits before the footer so the footer truly closes the document. */}
-          {runs.length > 0 ? (
+              Detail page only (showDataSource): a print/export preview is a
+              finished artifact and shouldn't carry the in-app nav table. Sits
+              before the footer so the footer truly closes the document. */}
+          {showDataSource && runs.length > 0 ? (
             <section className="pr-sec pr-source">
               <h3>{t("savedCompare.report.sourceTitle")}</h3>
               <table>


### PR DESCRIPTION
## 背景

「数据来源 · 关联 Benchmark」表是**详情页的导航辅助**(benchmark 深链)。但它由 `SavedCompareReport` 无条件渲染,导致**预览页 / 导出的 HTML 里也出现了**(见图)。预览是「打印/分享成品」,不该带 in-app 的导航表。

## 改动

- `SavedCompareReport` 加 `showDataSource` prop(默认 false),数据来源表 gated 在它后面。
- 只有 `ReportDetailPage` 传 `showDataSource`;`ReportPreviewPage` 不传 → 预览/导出不再显示该表。

行为:
- **详情页** → 显示关联 Benchmark 表(可点跳转)
- **预览页 / 导出 HTML / 打印** → 不显示

## 验证

- ✅ type-check / biome / 75 compare 测试通过(`SavedCompareReport.test` 用 `runs={[]}`,不受影响)

🤖 Generated with [Claude Code](https://claude.com/claude-code)