### PR TITLE
feat(charts): static value labels + baseline trend deltas on report bars

### DIFF
--- a/apps/web/src/components/charts/StageBarChart.tsx
+++ b/apps/web/src/components/charts/StageBarChart.tsx
@@ -7,11 +7,34 @@ export interface StageBarSeries {
   key: string;
   label: string;
   color: string;
+  /** Decimal places for the static value label (default: up to 2, trimmed). */
+  decimals?: number;
+  /**
+   * Direction for the per-bar delta vs baseline: `true` = higher is better
+   * (throughput), `false` = lower is better (latency / error rate). When set
+   * together with `baselineIndex`, each non-baseline bar shows a colored
+   * ↑/↓ % annotation. Omit to suppress the trend annotation for this series.
+   */
+  higherIsBetter?: boolean;
 }
 
 export interface StageBarDatum {
   stage: string;
   [seriesKey: string]: string | number | null;
+}
+
+/** Fixed label/trend colors. Pass Primer light values for the always-light
+ * report "paper" so labels stay readable on screen, in PDF, and on export
+ * regardless of the app's dark/light theme. */
+export interface StageBarLabelColors {
+  /** Value text + category (A/B/C) axis labels. */
+  value?: string;
+  /** Delta annotation when the bar is better than baseline. */
+  up?: string;
+  /** Delta annotation when the bar is worse than baseline. */
+  down?: string;
+  /** Baseline marker text, "≈" ties, y-axis ticks, reference line. */
+  baseline?: string;
 }
 
 export interface StageBarChartProps {
@@ -23,49 +46,139 @@ export interface StageBarChartProps {
   ariaLabel?: string;
   loading?: boolean;
   empty?: boolean | string;
+  /** Render static value labels on every bar (PDF/print-safe). Default true. */
+  showValueLabels?: boolean;
+  /**
+   * Index into `data` of the baseline stage. Enables per-bar delta annotations
+   * and (for single-series charts) a dashed reference line at the baseline
+   * value. Omit to render values only.
+   */
+  baselineIndex?: number;
+  /** Fixed label/trend colors (defaults to theme tokens + Primer green/red). */
+  labelColors?: StageBarLabelColors;
+}
+
+type LabelParam = { dataIndex: number; value: unknown };
+
+function fmtValue(v: number, decimals?: number): string {
+  return v.toLocaleString("en-US", {
+    minimumFractionDigits: decimals ?? 0,
+    maximumFractionDigits: decimals ?? 2,
+  });
 }
 
 /**
  * Categorical-X grouped bar chart for stage-aligned metrics
  * (QPS / TTFT percentiles / TPOT / etc. across "stages" = compare buckets).
  *
+ * Values are rendered as static labels on top of every bar (not just on hover)
+ * so the chart reads correctly in print / PDF / HTML export. With a
+ * `baselineIndex`, each non-baseline bar also carries a colored ↑/↓ % delta vs
+ * the baseline stage, and single-series charts draw a dashed reference line at
+ * the baseline value.
+ *
  * Differs from {@link BarChart} which is time-axis (timestamp samples).
- * Built for the SavedCompare report where each row is one stage and columns
- * are user-defined series keyed by `series[*].key`.
  */
 export function StageBarChart({
   title,
   data,
   series,
-  height = 280,
+  height = 300,
   yLabel,
   ariaLabel,
   loading,
   empty,
+  showValueLabels = true,
+  baselineIndex,
+  labelColors,
 }: StageBarChartProps): JSX.Element {
   const tokens = useChartTokens();
   const isEmpty = empty ?? data.length === 0;
   const label = ariaLabel ?? title ?? "stage-bar";
 
   const option = useMemo<EChartsOption>(() => {
+    const lc = {
+      value: labelColors?.value ?? tokens.textColor,
+      up: labelColors?.up ?? "#1a7f37",
+      down: labelColors?.down ?? "#d1242f",
+      baseline: labelColors?.baseline ?? tokens.axisLabelColor,
+    };
     const categories = data.map((d) => d.stage);
-    const ecSeries = series.map((s) => ({
-      name: s.label,
-      type: "bar" as const,
-      data: data.map((d) => {
+
+    const ecSeries = series.map((s) => {
+      const values = data.map((d) => {
         const v = d[s.key];
         return typeof v === "number" ? v : null;
-      }),
-      itemStyle: { color: s.color },
-    }));
+      });
+      const baseVal = baselineIndex != null && baselineIndex >= 0 ? values[baselineIndex] : null;
+
+      const labelFor = (idx: number, value: number): string => {
+        const valueStr = fmtValue(value, s.decimals);
+        // No baseline context, or this series opts out of trend → value only.
+        if (baselineIndex == null || s.higherIsBetter == null) return valueStr;
+        if (idx === baselineIndex) return `${valueStr}\n{base|baseline}`;
+        if (baseVal == null || baseVal === 0) return valueStr;
+        const deltaPct = ((value - baseVal) / Math.abs(baseVal)) * 100;
+        if (Math.abs(deltaPct) < 0.5) return `${valueStr}\n{base|≈}`;
+        const arrow = deltaPct > 0 ? "↑" : "↓";
+        const better = deltaPct > 0 === s.higherIsBetter;
+        const tone = better ? "up" : "down";
+        return `${valueStr}\n{${tone}|${arrow}${Math.abs(deltaPct).toFixed(0)}%}`;
+      };
+
+      return {
+        name: s.label,
+        type: "bar" as const,
+        data: values,
+        itemStyle: { color: s.color },
+        label: showValueLabels
+          ? {
+              show: true,
+              position: "top" as const,
+              color: lc.value,
+              fontSize: 11,
+              fontWeight: 500 as const,
+              lineHeight: 14,
+              formatter: (p: LabelParam) =>
+                typeof p.value === "number" ? labelFor(p.dataIndex, p.value) : "",
+              rich: {
+                up: { color: lc.up, fontSize: 10, fontWeight: 700 as const },
+                down: { color: lc.down, fontSize: 10, fontWeight: 700 as const },
+                base: { color: lc.baseline, fontSize: 10 },
+              },
+            }
+          : undefined,
+        // Dashed reference line at the baseline value — only meaningful for a
+        // single series (multiple series have different baselines).
+        markLine:
+          baselineIndex != null && series.length === 1 && baseVal != null
+            ? {
+                silent: true,
+                symbol: "none" as const,
+                lineStyle: { type: "dashed" as const, color: lc.baseline, width: 1 },
+                label: { show: false },
+                data: [{ yAxis: baseVal }],
+              }
+            : undefined,
+      };
+    });
 
     return themed(
       {
         tooltip: { trigger: "axis" },
         legend: series.length > 1 ? { type: "scroll", top: 0 } : undefined,
-        xAxis: { type: "category", data: categories },
+        xAxis: {
+          type: "category",
+          data: categories,
+          // Category labels (A/B/C) are the key to reading the chart — make
+          // them prominent and readable on the light report paper.
+          axisLabel: { color: lc.value, fontWeight: 600, fontSize: 12 },
+        },
         yAxis: {
           type: "value",
+          // 20% headroom so the top value labels are not clipped.
+          max: (v: { max: number }) => (v.max > 0 ? Math.ceil(v.max * 1.2) : 1),
+          axisLabel: { color: lc.baseline },
           ...(yLabel ? { name: yLabel, nameLocation: "middle", nameGap: 40 } : {}),
         },
         grid: { left: 56, right: 24, top: series.length > 1 ? 56 : 24, bottom: 32 },
@@ -73,7 +186,7 @@ export function StageBarChart({
       },
       tokens,
     );
-  }, [data, series, yLabel, tokens]);
+  }, [data, series, yLabel, tokens, showValueLabels, baselineIndex, labelColors]);
 
   return (
     <div className="rounded-md border border-border p-4">

--- a/apps/web/src/components/charts/StageBarChart.tsx
+++ b/apps/web/src/components/charts/StageBarChart.tsx
@@ -176,8 +176,10 @@ export function StageBarChart({
         },
         yAxis: {
           type: "value",
-          // 20% headroom so the top value labels are not clipped.
-          max: (v: { max: number }) => (v.max > 0 ? Math.ceil(v.max * 1.2) : 1),
+          // 20% headroom so the top value labels are not clipped. Keep it
+          // fractional — `Math.ceil` would round sub-1 maxima (small error
+          // rates / throughputs) up to 1 and squash the bars flat.
+          max: (v: { max: number }) => (v.max > 0 ? v.max * 1.2 : 1),
           axisLabel: { color: lc.baseline },
           ...(yLabel ? { name: yLabel, nameLocation: "middle", nameGap: 40 } : {}),
         },
@@ -186,7 +188,18 @@ export function StageBarChart({
       },
       tokens,
     );
-  }, [data, series, yLabel, tokens, showValueLabels, baselineIndex, labelColors]);
+  }, [
+    data,
+    series,
+    yLabel,
+    tokens,
+    showValueLabels,
+    baselineIndex,
+    labelColors?.value,
+    labelColors?.up,
+    labelColors?.down,
+    labelColors?.baseline,
+  ]);
 
   return (
     <div className="rounded-md border border-border p-4">

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
@@ -1,5 +1,9 @@
 import type { FigureRefId } from "@modeldoctor/contracts";
-import { StageBarChart, type StageBarDatum } from "@/components/charts/StageBarChart";
+import {
+  StageBarChart,
+  type StageBarDatum,
+  type StageBarLabelColors,
+} from "@/components/charts/StageBarChart";
 import { availableFigureRefIds, summarizeForPrompt } from "./client-metrics";
 import type { ReportRun } from "./ReportSections";
 
@@ -8,6 +12,28 @@ export interface FigureRendererProps {
   runs: ReportRun[];
   caption: string;
   figureNumber: number;
+  /** Baseline run id for per-bar delta annotations. */
+  baselineId?: string | null;
+}
+
+/** Fixed Primer light colors — the report "paper" is always light (even in
+ * dark mode / PDF), so chart labels must not follow the app theme. */
+const REPORT_LABEL_COLORS: StageBarLabelColors = {
+  value: "#1f2328",
+  up: "#1a7f37",
+  down: "#d1242f",
+  baseline: "#59636e",
+};
+
+/** Index of the baseline stage within `rows` (preserving their order). Falls
+ * back to the first stage when no baseline is set or it was filtered out. */
+function baselineIndexOf(rows: { r: ReportRun }[], baselineId?: string | null): number | undefined {
+  if (rows.length === 0) return undefined;
+  if (baselineId) {
+    const i = rows.findIndex(({ r }) => r.id === baselineId);
+    if (i >= 0) return i;
+  }
+  return 0;
 }
 
 /**
@@ -15,12 +41,21 @@ export interface FigureRendererProps {
  * picks the refId; the data comes from `runs`. Single source of styling means
  * AI-generated reports look identical regardless of which figure the AI chose.
  *
+ * Bars carry static value labels + a colored ↑/↓ % delta vs the baseline stage
+ * so the chart reads correctly in print / PDF / export (no hover needed).
+ *
  * If the underlying runs do not carry the data this refId needs (e.g. vegeta
  * has no TTFT distribution), we render an inline "data unavailable" placeholder
  * instead of an empty chart. The server-side prompt also receives the same
  * availability set so the LLM can avoid picking the refId in the first place.
  */
-export function FigureRenderer({ refId, runs, caption, figureNumber }: FigureRendererProps) {
+export function FigureRenderer({
+  refId,
+  runs,
+  caption,
+  figureNumber,
+  baselineId,
+}: FigureRendererProps) {
   const summaries = runs
     .filter((r) => r.benchmark !== null)
     .map((r) => ({ r, s: summarizeForPrompt(r.summaryMetrics) }));
@@ -52,8 +87,10 @@ export function FigureRenderer({ refId, runs, caption, figureNumber }: FigureRen
       <StageBarChart
         title="Throughput"
         data={data}
-        series={[{ key: "qps", label: "QPS", color: "#2980b9" }]}
+        series={[{ key: "qps", label: "QPS", color: "#2980b9", decimals: 2, higherIsBetter: true }]}
         yLabel="req/s"
+        baselineIndex={baselineIndexOf(summaries, baselineId)}
+        labelColors={REPORT_LABEL_COLORS}
       />
     );
   } else if (refId === "stage-bars-error-rate") {
@@ -65,56 +102,60 @@ export function FigureRenderer({ refId, runs, caption, figureNumber }: FigureRen
       <StageBarChart
         title="Error rate"
         data={data}
-        series={[{ key: "err", label: "%", color: "#c0392b" }]}
+        series={[{ key: "err", label: "%", color: "#c0392b", decimals: 1, higherIsBetter: false }]}
         yLabel="%"
+        baselineIndex={baselineIndexOf(summaries, baselineId)}
+        labelColors={REPORT_LABEL_COLORS}
       />
     );
   } else if (refId === "stage-bars-ttft-p95") {
-    const data: StageBarDatum[] = summaries
-      .filter(({ s }) => s.ttft)
-      .map(({ r, s }) => ({
-        stage: r.stageLabel,
-        // biome-ignore lint/style/noNonNullAssertion: filtered above
-        p50: s.ttft!.p50 ?? 0,
-        // biome-ignore lint/style/noNonNullAssertion: filtered above
-        p90: s.ttft!.p90 ?? 0,
-        // biome-ignore lint/style/noNonNullAssertion: filtered above
-        p99: s.ttft!.p99 ?? 0,
-      }));
+    const rows = summaries.filter(({ s }) => s.ttft);
+    const data: StageBarDatum[] = rows.map(({ r, s }) => ({
+      stage: r.stageLabel,
+      // biome-ignore lint/style/noNonNullAssertion: filtered above
+      p50: s.ttft!.p50 ?? 0,
+      // biome-ignore lint/style/noNonNullAssertion: filtered above
+      p90: s.ttft!.p90 ?? 0,
+      // biome-ignore lint/style/noNonNullAssertion: filtered above
+      p99: s.ttft!.p99 ?? 0,
+    }));
     chart = (
       <StageBarChart
         title="TTFT percentiles"
         data={data}
         series={[
-          { key: "p50", label: "p50", color: "#27ae60" },
-          { key: "p90", label: "p90", color: "#e67e22" },
-          { key: "p99", label: "p99", color: "#c0392b" },
+          { key: "p50", label: "p50", color: "#27ae60", decimals: 0, higherIsBetter: false },
+          { key: "p90", label: "p90", color: "#e67e22", decimals: 0, higherIsBetter: false },
+          { key: "p99", label: "p99", color: "#c0392b", decimals: 0, higherIsBetter: false },
         ]}
         yLabel="ms"
+        baselineIndex={baselineIndexOf(rows, baselineId)}
+        labelColors={REPORT_LABEL_COLORS}
       />
     );
   } else if (refId === "stage-bars-e2e-p95") {
-    const data: StageBarDatum[] = summaries
-      .filter(({ s }) => s.e2e)
-      .map(({ r, s }) => ({
-        stage: r.stageLabel,
-        // biome-ignore lint/style/noNonNullAssertion: filtered above
-        p50: s.e2e!.p50 ?? 0,
-        // biome-ignore lint/style/noNonNullAssertion: filtered above
-        p90: s.e2e!.p90 ?? 0,
-        // biome-ignore lint/style/noNonNullAssertion: filtered above
-        p99: s.e2e!.p99 ?? 0,
-      }));
+    const rows = summaries.filter(({ s }) => s.e2e);
+    const data: StageBarDatum[] = rows.map(({ r, s }) => ({
+      stage: r.stageLabel,
+      // biome-ignore lint/style/noNonNullAssertion: filtered above
+      p50: s.e2e!.p50 ?? 0,
+      // biome-ignore lint/style/noNonNullAssertion: filtered above
+      p90: s.e2e!.p90 ?? 0,
+      // biome-ignore lint/style/noNonNullAssertion: filtered above
+      p99: s.e2e!.p99 ?? 0,
+    }));
     chart = (
       <StageBarChart
         title="E2E latency percentiles"
         data={data}
         series={[
-          { key: "p50", label: "p50", color: "#27ae60" },
-          { key: "p90", label: "p90", color: "#e67e22" },
-          { key: "p99", label: "p99", color: "#c0392b" },
+          { key: "p50", label: "p50", color: "#27ae60", decimals: 0, higherIsBetter: false },
+          { key: "p90", label: "p90", color: "#e67e22", decimals: 0, higherIsBetter: false },
+          { key: "p99", label: "p99", color: "#c0392b", decimals: 0, higherIsBetter: false },
         ]}
         yLabel="ms"
+        baselineIndex={baselineIndexOf(rows, baselineId)}
+        labelColors={REPORT_LABEL_COLORS}
       />
     );
   } else if (refId === "compare-grid") {

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
@@ -1,4 +1,5 @@
 import type { FigureRefId } from "@modeldoctor/contracts";
+import { memo } from "react";
 import {
   StageBarChart,
   type StageBarDatum,
@@ -48,8 +49,14 @@ function baselineIndexOf(rows: { r: ReportRun }[], baselineId?: string | null): 
  * has no TTFT distribution), we render an inline "data unavailable" placeholder
  * instead of an empty chart. The server-side prompt also receives the same
  * availability set so the LLM can avoid picking the refId in the first place.
+ *
+ * `memo`-wrapped: the host report runs a scroll-spy that re-renders on every
+ * scroll. Its props (refId/runs/caption/figureNumber/baselineId) are stable
+ * across those re-renders, so memoization skips recomputing summaries and
+ * rebuilding chart options — and avoids re-rendering the ECharts canvases — on
+ * scroll.
  */
-export function FigureRenderer({
+export const FigureRenderer = memo(function FigureRenderer({
   refId,
   runs,
   caption,
@@ -170,7 +177,7 @@ export function FigureRenderer({
       </figcaption>
     </figure>
   );
-}
+});
 
 /** Compact 4-metric table for the compare-grid figure refId. */
 function FourMetricTable({ runs }: { runs: ReportRun[] }) {

--- a/apps/web/src/features/benchmarks/compare/ReportDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/compare/ReportDetailPage.tsx
@@ -217,7 +217,13 @@ export function ReportDetailPage() {
             {/* Document-viewer: the light Primer "paper" sits inside a themed
                 bordered card on the (theme-following) page background. */}
             <div className="overflow-hidden rounded-lg border border-border">
-              <SavedCompareReport narrative={narrative} runs={reportRuns} embedded showDataSource />
+              <SavedCompareReport
+                narrative={narrative}
+                runs={reportRuns}
+                baselineId={sc.baselineId}
+                embedded
+                showDataSource
+              />
             </div>
           </>
         ) : (

--- a/apps/web/src/features/benchmarks/compare/ReportPreviewPage.tsx
+++ b/apps/web/src/features/benchmarks/compare/ReportPreviewPage.tsx
@@ -145,6 +145,7 @@ export function ReportPreviewPage() {
         <SavedCompareReport
           narrative={narrative}
           runs={reportRuns}
+          baselineId={sc.baselineId}
           printHeader={`ModelDoctor · ${sc.name}`}
         />
       </div>

--- a/apps/web/src/features/benchmarks/compare/SavedCompareReport.tsx
+++ b/apps/web/src/features/benchmarks/compare/SavedCompareReport.tsx
@@ -20,6 +20,8 @@ export interface SavedCompareReportProps {
    * detail page only — the standalone print/export preview omits it.
    */
   showDataSource?: boolean;
+  /** Baseline run id — drives per-bar ↑/↓ delta annotations in figures. */
+  baselineId?: string | null;
 }
 
 /**
@@ -40,6 +42,7 @@ export function SavedCompareReport({
   printHeader,
   embedded = false,
   showDataSource = false,
+  baselineId,
 }: SavedCompareReportProps) {
   const { t } = useTranslation("benchmarks");
   const sections = narrative.sections;
@@ -184,6 +187,7 @@ export function SavedCompareReport({
                   runs={runs}
                   caption={f.caption}
                   figureNumber={nextFigureNumber()}
+                  baselineId={baselineId}
                 />
               ))}
             </section>


### PR DESCRIPTION
## 背景

报告里的柱状图只在 **hover tooltip** 里显示数值 → 导出 PDF / 打印 / 导出 HTML 时(没有鼠标)是空白的,看不出哪根柱是多少、也看不出涨跌。参考 `~/vllm/repots/reports` 的静态报告规范重做。

## 改动(`StageBarChart` 为主)

- **柱顶静态数值 label**(`series.label`,PDF 安全),`yAxis` 留 20% 顶部空间防裁切。
- **A/B/C 类别标签加粗放大**,不 hover 也能认出每根柱。
- **相对基线的涨跌**:每个数值下方一行带色 ↑/↓ %,按指标方向上色(吞吐高=绿、延迟/错误低=绿,反之红);基线柱标注 `baseline`,单序列图再画一条基线虚线。
- label 用**固定 Primer 浅色**(非主题色)——报告纸张永远浅色,这样屏幕/深色模式/PDF 里都清晰。
- hover tooltip 保留作屏幕加成。

`FigureRenderer` 传每序列 decimals/方向 + 基线 index(取 `baselineId`,未设回退第一个 stage);`baselineId` 从 `ReportDetailPage`/`ReportPreviewPage` → `SavedCompareReport` → `FigureRenderer` 串下去。

## 验证

- ✅ type-check / biome / **160 测试**通过
- ⚠️ **视觉冒烟在作者本地** —— 重点看:① 柱顶数值不被裁切 ② A/B/C 清晰 ③ ↑/↓% 颜色方向对(吞吐涨=绿、延迟涨=红)④ Print/PDF 里 label 都在(无需 hover)⑤ grouped 百分位图 label 不过度拥挤

## 已知/范围外
- 这次只动柱状图(`StageBarChart`,即报告里的 4 类图)。深色模式下报告内图表「轴线/y刻度」用主题色可能偏淡,是既有问题、本次未一并处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)