### PR TITLE
fix(aiperf): make multi-turn prefix-cache runs actually execute

### DIFF
--- a/packages/tool-adapters/src/aiperf/runtime.spec.ts
+++ b/packages/tool-adapters/src/aiperf/runtime.spec.ts
@@ -48,6 +48,10 @@ describe("aiperf.buildCommand", () => {
       "http://10.0.0.5:8000",
       "--endpoint-type",
       "chat",
+      "--api-key",
+      "__MD_OPENAI_API_KEY__",
+      "--workers-max",
+      "4",
       "--streaming",
       "--concurrency",
       "8",
@@ -67,6 +71,16 @@ describe("aiperf.buildCommand", () => {
       "out",
     ]);
     expect(r.secretEnv?.OPENAI_API_KEY).toBe("sk-test");
+    // The raw key must never appear in argv — only the runner-side sentinel.
+    expect(r.argv).not.toContain("sk-test");
+  });
+
+  it("omits --api-key when connection.apiKey is empty", () => {
+    const r = buildCommand({
+      ...plan,
+      connection: { ...plan.connection, apiKey: "" },
+    });
+    expect(r.argv).not.toContain("--api-key");
   });
 
   it("omits --streaming when streaming=false", () => {
@@ -172,7 +186,10 @@ describe("aiperf.buildCommand", () => {
     expect(flat).toContain("--concurrency 20");
     expect(flat).toContain("--conversation-num 30");
     expect(flat).toContain("--conversation-turn-mean 10");
-    expect(flat).toContain("--conversation-type sticky-user-sessions");
+    expect(flat).toContain("--connection-reuse-strategy sticky-user-sessions");
+    expect(flat).not.toContain("--conversation-type");
+    // aiperf forbids --request-count alongside --conversation-num.
+    expect(flat).not.toContain("--request-count");
     expect(flat).not.toContain("--fixed-schedule");
   });
 

--- a/packages/tool-adapters/src/aiperf/runtime.ts
+++ b/packages/tool-adapters/src/aiperf/runtime.ts
@@ -9,6 +9,14 @@ import { type AiperfParams, aiperfReportSchema } from "./schema.js";
 const OUTPUTS_DIR = "out";
 const SUMMARY_FILE = "profile_export_aiperf.json";
 
+// aiperf reads the endpoint API key ONLY from --api-key (no env-var channel;
+// OPENAI_API_KEY in secretEnv alone never reaches the requests — Higress-style
+// authed gateways then 401 every request). Same sentinel contract as
+// evalscope: the runner swaps it for OPENAI_API_KEY right before Popen and
+// masks the value after --api-key in logs.
+// Contract: apps/benchmark-runner/runner/main.py::OPENAI_API_KEY_SENTINEL.
+const OPENAI_API_KEY_SENTINEL = "__MD_OPENAI_API_KEY__";
+
 export function buildCommand(plan: BuildCommandPlan<AiperfParams>): BuildCommandResult {
   const { params, connection } = plan;
   const trimmedBase = connection.baseUrl.replace(/\/+$/, "");
@@ -31,6 +39,16 @@ export function buildCommand(plan: BuildCommandPlan<AiperfParams>): BuildCommand
   // "Failed to load tokenizer '<model>'". Mirrors guidellm's --processor.
   if (connection.tokenizerHfId) argv.push("--tokenizer", connection.tokenizerHfId);
 
+  // Sentinel — runner replaces with OPENAI_API_KEY at exec time (see above).
+  if (connection.apiKey) argv.push("--api-key", OPENAI_API_KEY_SENTINEL);
+
+  // aiperf sizes its worker pool from the HOST cpu count (cgroup-blind), so
+  // inside the 2-CPU runner limit it overspawns and the multiprocess service
+  // registration times out ("Service timing_manager failed to register").
+  // Cap workers to fit the runner cgroup; each worker is async and easily
+  // drives many concurrent streams.
+  argv.push("--workers-max", String(Math.min(params.concurrency, 4)));
+
   // --streaming is a presence-only boolean toggle (no --no-streaming form).
   // Streaming off = simply omit the flag.
   if (params.streaming) argv.push("--streaming");
@@ -48,11 +66,15 @@ export function buildCommand(plan: BuildCommandPlan<AiperfParams>): BuildCommand
     }
   } else {
     // Closed-loop synthetic / sharegpt.
+    argv.push("--concurrency", String(params.concurrency));
+    // aiperf rejects --request-count combined with --conversation-num
+    // (UserConfig validation). In multi-turn mode the workload size is
+    // conversationNum × conversationTurnMean; requestCount only drives
+    // the single-turn path (and our wall-clock estimate).
+    if (params.conversationNum === undefined) {
+      argv.push("--request-count", String(params.requestCount));
+    }
     argv.push(
-      "--concurrency",
-      String(params.concurrency),
-      "--request-count",
-      String(params.requestCount),
       "--synthetic-input-tokens-mean",
       String(params.inputTokensMean),
       "--synthetic-input-tokens-stddev",
@@ -76,7 +98,10 @@ export function buildCommand(plan: BuildCommandPlan<AiperfParams>): BuildCommand
       argv.push("--conversation-turn-stddev", String(params.conversationTurnStddev));
     }
     if (params.conversationType !== undefined) {
-      argv.push("--conversation-type", params.conversationType);
+      // aiperf has no --conversation-type; sticky routing is controlled by the
+      // transport-level --connection-reuse-strategy (pooled | never |
+      // sticky-user-sessions), which is what our conversationType maps to.
+      argv.push("--connection-reuse-strategy", params.conversationType);
     }
     if (params.conversationTurnDelayMeanMs !== undefined) {
       argv.push("--conversation-turn-delay-mean", String(params.conversationTurnDelayMeanMs));


### PR DESCRIPTION
## Summary

Playwright-driven end-to-end verification of #276 against the real Higress gateway (multi-pod `gen-studio_Qwen2.5-3B-Instruct-MOsr`, ai-load-balancer **off**) showed the t2 multi-turn run could never execute — four runtime-only failures, fixed here in `packages/tool-adapters/src/aiperf/runtime.ts`:

1. **`--conversation-type` doesn't exist** in aiperf (verified: zero hits in upstream `ai-dynamo/aiperf`). The sticky-routing knob is `--connection-reuse-strategy` (`pooled | never | sticky-user-sessions`) — exactly our `conversationType` enum. Mapped accordingly.
2. **`--request-count` + `--conversation-num` is rejected** by aiperf's UserConfig validation. Multi-turn mode now omits `--request-count` (workload = conversations × turns).
3. **API key never reached requests** — aiperf has no env-var channel; it only honors `--api-key`. All 300 requests 401'd against the authed gateway. Now passes the existing runner sentinel `__MD_OPENAI_API_KEY__` (same contract as evalscope; key stays out of the Job manifest, runner masks it in logs).
4. **Worker-pool oversubscription** — aiperf sizes workers from host CPUs (cgroup-blind), starving the 2-CPU runner cgroup until `Service timing_manager failed to register within timeout`. Capped via `--workers-max min(concurrency, 4)` (reproduced + validated locally under `docker --cpus 2`).

## Verified run (t2 · 30 conv × 10 turns · sticky-user-sessions)

- Job green in k3d, runner image `md-runner-aiperf:b6a824c` (still content-correct: `runner/` unchanged since that tag)
- 299 requests, 298 success, TTFT p50 352.8ms / p99 1925.6ms, RPS 2.7
- Prometheus annotation populated: **hit rate 45.9%, top-pod share 19.3%** (~1/5 pods — expected uniform baseline with ai-load-balancer off)
- `--api-key` value confirmed `***REDACTED***` in pod logs

## Notes

- `aiperfParamsSchema` field name `conversationType` is kept (UI/i18n/seeded templates untouched) — only the CLI mapping changed. If we want to rename it to `connectionReuseStrategy` for accuracy, that's a follow-up cascade (form, i18n, seeds, existing rows).
- Mooncake trace templates still need the rebuilt base image (`build-base-images.sh aiperf` now bakes the FAST25 traces; the current `md-base-aiperf:0.7.0` in ghcr/local predates that). Synthetic multi-turn (t1–t3) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)