### PR TITLE
feat(web): duration column + zero-collapse number formatting on benchmark list

### DIFF
--- a/apps/web/src/features/benchmarks/BenchmarkDetailMetadata.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailMetadata.tsx
@@ -1,21 +1,17 @@
 import type { Benchmark } from "@modeldoctor/contracts";
-import { format, formatDistanceStrict } from "date-fns";
+import { format } from "date-fns";
 import { Copy } from "lucide-react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { copyToClipboard } from "@/lib/clipboard";
+import { fmtDurationMs, runDurationMs } from "./duration";
 import { StatusBadge } from "./status-display";
 
 function fmtDate(iso: string | null): string {
   if (!iso) return "—";
   return format(new Date(iso), "yyyy-MM-dd HH:mm:ss");
-}
-
-function fmtDuration(start: string | null, end: string | null): string {
-  if (!start || !end) return "—";
-  return formatDistanceStrict(new Date(end), new Date(start));
 }
 
 export function BenchmarkDetailMetadata({ benchmark }: { benchmark: Benchmark }) {
@@ -43,7 +39,11 @@ export function BenchmarkDetailMetadata({ benchmark }: { benchmark: Benchmark })
       <Row label={t("detail.metadata.startedAt")}>{fmtDate(benchmark.startedAt)}</Row>
       <Row label={t("detail.metadata.completedAt")}>{fmtDate(benchmark.completedAt)}</Row>
       <Row label={t("detail.metadata.duration")}>
-        {fmtDuration(benchmark.startedAt, benchmark.completedAt)}
+        <span className="tabular-nums">
+          {fmtDurationMs(
+            runDurationMs(benchmark.startedAt, benchmark.completedAt, benchmark.status),
+          )}
+        </span>
       </Row>
       {benchmark.driverHandle && <JobRow handle={benchmark.driverHandle} />}
     </dl>

--- a/apps/web/src/features/benchmarks/BenchmarkListShell.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkListShell.tsx
@@ -5,7 +5,7 @@ import type {
   ListBenchmarksQuery,
 } from "@modeldoctor/contracts";
 import { migrateVegetaParams } from "@modeldoctor/tool-adapters/schemas";
-import { format, formatDistanceToNow } from "date-fns";
+import { formatDistanceToNow } from "date-fns";
 import { enUS, zhCN } from "date-fns/locale";
 import {
   ArrowRight,
@@ -53,6 +53,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useLocaleStore } from "@/stores/locale-store";
 import { BenchmarkListFilters } from "./BenchmarkListFilters";
 import { readErrorRate, readP95Latency } from "./compare/metrics";
+import { fmtDurationMs, fmtTimeRange, runDurationMs } from "./duration";
 import { useBenchmarkList, useCreateBenchmark, useDeleteBenchmark } from "./queries";
 import { SaveAsTemplateDialog } from "./SaveAsTemplateDialog";
 import { SCENARIOS, type ScenarioId } from "./scenarios";
@@ -63,26 +64,6 @@ function fmtNum(n: number | null | undefined, digits = 1): string {
   const s = n.toFixed(digits);
   // All-zero strings like "0.0000" (and "-0.0") read better as plain "0".
   return Number(s) === 0 ? "0" : s;
-}
-
-function fmtDurationMs(ms: number): string {
-  if (!Number.isFinite(ms) || ms < 0) return "—";
-  const totalSec = Math.round(ms / 1000);
-  const h = Math.floor(totalSec / 3600);
-  const m = Math.floor((totalSec % 3600) / 60);
-  const s = totalSec % 60;
-  if (h > 0) return `${h}h ${m}m ${s}s`;
-  if (m > 0) return `${m}m ${s}s`;
-  return `${s}s`;
-}
-
-function fmtTimeRange(startIso: string, endIso: string | null): string {
-  const start = new Date(startIso);
-  const startStr = format(start, "MM-dd HH:mm:ss");
-  if (!endIso) return `${startStr} →`;
-  const end = new Date(endIso);
-  const sameDay = format(start, "yyyy-MM-dd") === format(end, "yyyy-MM-dd");
-  return `${startStr} → ${format(end, sameDay ? "HH:mm:ss" : "MM-dd HH:mm:ss")}`;
 }
 
 interface BenchmarkListShellProps {
@@ -354,9 +335,11 @@ export function BenchmarkListShell({ scenario }: BenchmarkListShellProps) {
                         <div className="flex flex-col gap-0.5">
                           <span className="tabular-nums text-foreground">
                             {fmtDurationMs(
-                              (benchmark.completedAt
-                                ? new Date(benchmark.completedAt).getTime()
-                                : Date.now()) - new Date(benchmark.startedAt).getTime(),
+                              runDurationMs(
+                                benchmark.startedAt,
+                                benchmark.completedAt,
+                                benchmark.status,
+                              ),
                             )}
                           </span>
                           <span className="text-xs tabular-nums text-muted-foreground/70">

--- a/apps/web/src/features/benchmarks/BenchmarkListShell.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkListShell.tsx
@@ -5,7 +5,7 @@ import type {
   ListBenchmarksQuery,
 } from "@modeldoctor/contracts";
 import { migrateVegetaParams } from "@modeldoctor/tool-adapters/schemas";
-import { formatDistanceToNow } from "date-fns";
+import { format, formatDistanceToNow } from "date-fns";
 import { enUS, zhCN } from "date-fns/locale";
 import {
   ArrowRight,
@@ -60,7 +60,29 @@ import { StatusBadge } from "./status-display";
 
 function fmtNum(n: number | null | undefined, digits = 1): string {
   if (n == null) return "—";
-  return n.toFixed(digits);
+  const s = n.toFixed(digits);
+  // All-zero strings like "0.0000" (and "-0.0") read better as plain "0".
+  return Number(s) === 0 ? "0" : s;
+}
+
+function fmtDurationMs(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  const totalSec = Math.round(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  if (h > 0) return `${h}h ${m}m ${s}s`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+function fmtTimeRange(startIso: string, endIso: string | null): string {
+  const start = new Date(startIso);
+  const startStr = format(start, "MM-dd HH:mm:ss");
+  if (!endIso) return `${startStr} →`;
+  const end = new Date(endIso);
+  const sameDay = format(start, "yyyy-MM-dd") === format(end, "yyyy-MM-dd");
+  return `${startStr} → ${format(end, sameDay ? "HH:mm:ss" : "MM-dd HH:mm:ss")}`;
 }
 
 interface BenchmarkListShellProps {
@@ -294,6 +316,7 @@ export function BenchmarkListShell({ scenario }: BenchmarkListShellProps) {
                   <TableHead className="w-10" />
                   <TableHead>{t("columns.name")}</TableHead>
                   <TableHead>{t("columns.createdAt")}</TableHead>
+                  <TableHead>{t("columns.duration")}</TableHead>
                   <TableHead>{t("columns.tool")}</TableHead>
                   <TableHead>{t("columns.connection")}</TableHead>
                   <TableHead>{t("columns.status")}</TableHead>
@@ -325,6 +348,24 @@ export function BenchmarkListShell({ scenario }: BenchmarkListShellProps) {
                         addSuffix: true,
                         locale: dateFnsLocale,
                       })}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap text-muted-foreground">
+                      {benchmark.startedAt ? (
+                        <div className="flex flex-col gap-0.5">
+                          <span className="tabular-nums text-foreground">
+                            {fmtDurationMs(
+                              (benchmark.completedAt
+                                ? new Date(benchmark.completedAt).getTime()
+                                : Date.now()) - new Date(benchmark.startedAt).getTime(),
+                            )}
+                          </span>
+                          <span className="text-xs tabular-nums text-muted-foreground/70">
+                            {fmtTimeRange(benchmark.startedAt, benchmark.completedAt)}
+                          </span>
+                        </div>
+                      ) : (
+                        "—"
+                      )}
                     </TableCell>
                     <TableCell>
                       <Badge variant="default">{benchmark.tool}</Badge>

--- a/apps/web/src/features/benchmarks/__tests__/BenchmarkListShell.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/BenchmarkListShell.test.tsx
@@ -163,6 +163,36 @@ describe("BenchmarkListShell", () => {
     expect(cells[cells.length - 3].textContent).toBe("—");
   });
 
+  it("renders duration with start → end range from startedAt/completedAt", async () => {
+    vi.mocked(api.get).mockResolvedValue(ONE_BENCHMARK);
+    render(<BenchmarkListShell scenario="inference" />, { wrapper: Wrapper });
+    // startedAt 12:00:01Z → completedAt 12:00:30Z = 29s
+    expect(await screen.findByText("29s")).toBeInTheDocument();
+    // Clock values render in local time — assert the shape, not exact times.
+    expect(
+      screen.getByText(/\d{2}-\d{2} \d{2}:\d{2}:\d{2} → \d{2}:\d{2}:\d{2}/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an all-zero error rate as '0' instead of '0.0000'", async () => {
+    const zeroErrorMetrics = {
+      tool: "guidellm",
+      data: {
+        e2eLatency: { p95: 491.2 },
+        requests: { total: 10, success: 10, error: 0, incomplete: 0 },
+      },
+    };
+    vi.mocked(api.get).mockResolvedValue({
+      items: [makeBenchmark("r1", "guidellm", "completed", zeroErrorMetrics)],
+      nextCursor: null,
+    } satisfies ListBenchmarksResponse);
+    render(<BenchmarkListShell scenario="inference" />, { wrapper: Wrapper });
+    await screen.findByText("guidellm");
+    const cells = screen.getAllByRole("cell");
+    // last cell is actions; -2 = errorRate
+    expect(cells[cells.length - 2].textContent).toBe("0");
+  });
+
   it("compare button is disabled by default", async () => {
     vi.mocked(api.get).mockResolvedValue(ONE_BENCHMARK);
     render(<BenchmarkListShell scenario="inference" />, { wrapper: Wrapper });

--- a/apps/web/src/features/benchmarks/__tests__/duration.test.ts
+++ b/apps/web/src/features/benchmarks/__tests__/duration.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fmtDurationMs, fmtTimeRange, runDurationMs } from "../duration";
+
+describe("runDurationMs", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns completedAt - startedAt for finished runs", () => {
+    expect(runDurationMs("2026-04-30T12:00:01.000Z", "2026-04-30T12:00:30.000Z", "completed")).toBe(
+      29_000,
+    );
+  });
+
+  it("returns null when the run never started", () => {
+    expect(runDurationMs(null, null, "pending")).toBeNull();
+  });
+
+  it("returns a live now-based delta for running runs without completedAt", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-30T12:01:01.000Z"));
+    expect(runDurationMs("2026-04-30T12:00:01.000Z", null, "running")).toBe(60_000);
+  });
+
+  it("returns null for terminal runs missing completedAt (no ever-growing delta)", () => {
+    expect(runDurationMs("2026-04-30T12:00:01.000Z", null, "failed")).toBeNull();
+    expect(runDurationMs("2026-04-30T12:00:01.000Z", null, "canceled")).toBeNull();
+  });
+});
+
+describe("fmtDurationMs", () => {
+  it("formats seconds / minutes / hours GitHub-Actions style", () => {
+    expect(fmtDurationMs(29_000)).toBe("29s");
+    expect(fmtDurationMs(272_000)).toBe("4m 32s");
+    expect(fmtDurationMs(3_785_000)).toBe("1h 3m 5s");
+  });
+
+  it("renders null and negative values as em dash", () => {
+    expect(fmtDurationMs(null)).toBe("—");
+    expect(fmtDurationMs(-1)).toBe("—");
+  });
+});
+
+describe("fmtTimeRange", () => {
+  it("is open-ended without an end timestamp", () => {
+    expect(fmtTimeRange("2026-04-30T12:00:01.000Z", null)).toMatch(
+      /^\d{2}-\d{2} \d{2}:\d{2}:\d{2} →$/,
+    );
+  });
+
+  it("repeats the date on the end only when the run crosses midnight", () => {
+    const sameDay = fmtTimeRange("2026-04-30T12:00:01.000Z", "2026-04-30T12:00:30.000Z");
+    expect(sameDay).toMatch(/^\d{2}-\d{2} \d{2}:\d{2}:\d{2} → \d{2}:\d{2}:\d{2}$/);
+    const crossDay = fmtTimeRange("2026-04-30T12:00:01.000Z", "2026-05-02T12:00:30.000Z");
+    expect(crossDay).toMatch(/^\d{2}-\d{2} \d{2}:\d{2}:\d{2} → \d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+  });
+});

--- a/apps/web/src/features/benchmarks/duration.ts
+++ b/apps/web/src/features/benchmarks/duration.ts
@@ -1,0 +1,42 @@
+import type { BenchmarkStatus } from "@modeldoctor/contracts";
+import { format } from "date-fns";
+
+const TERMINAL_STATUSES = new Set<BenchmarkStatus>(["completed", "failed", "canceled"]);
+
+/** Elapsed run time in ms, or null when it can't be known. Active runs
+ *  (pending/submitted/running) fall back to a live now-startedAt delta;
+ *  terminal runs missing completedAt (e.g. failed before the runner reported
+ *  back) return null — a live delta there would grow forever. */
+export function runDurationMs(
+  startedAt: string | null,
+  completedAt: string | null,
+  status: BenchmarkStatus,
+): number | null {
+  if (!startedAt) return null;
+  if (completedAt) return new Date(completedAt).getTime() - new Date(startedAt).getTime();
+  if (TERMINAL_STATUSES.has(status)) return null;
+  return Date.now() - new Date(startedAt).getTime();
+}
+
+/** GitHub-Actions-style compact duration: "29s", "4m 32s", "1h 3m 5s". */
+export function fmtDurationMs(ms: number | null): string {
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return "—";
+  const totalSec = Math.round(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  if (h > 0) return `${h}h ${m}m ${s}s`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+/** "06-12 10:21:05 → 10:25:37" (end repeats the date only across midnight);
+ *  open-ended "06-12 10:21:05 →" while the run has no end yet. */
+export function fmtTimeRange(startIso: string, endIso: string | null): string {
+  const start = new Date(startIso);
+  const startStr = format(start, "MM-dd HH:mm:ss");
+  if (!endIso) return `${startStr} →`;
+  const end = new Date(endIso);
+  const sameDay = format(start, "yyyy-MM-dd") === format(end, "yyyy-MM-dd");
+  return `${startStr} → ${format(end, sameDay ? "HH:mm:ss" : "MM-dd HH:mm:ss")}`;
+}

--- a/apps/web/src/locales/en-US/benchmarks.json
+++ b/apps/web/src/locales/en-US/benchmarks.json
@@ -99,6 +99,7 @@
   "columns": {
     "name": "Name",
     "createdAt": "Created",
+    "duration": "Duration",
     "tool": "Tool",
     "connection": "Connection",
     "status": "Status",

--- a/apps/web/src/locales/zh-CN/benchmarks.json
+++ b/apps/web/src/locales/zh-CN/benchmarks.json
@@ -99,6 +99,7 @@
   "columns": {
     "name": "名称",
     "createdAt": "创建时间",
+    "duration": "运行时长",
     "tool": "工具",
     "connection": "Connection",
     "status": "状态",


### PR DESCRIPTION
## Summary

List + detail polish for benchmark runs (all five scenario lists share `BenchmarkListShell`):

1. **运行时长 (Duration) column on the list** — new column after Created.
   - Primary line: elapsed run time in GitHub-Actions style (`29s`, `4m 32s`, `1h 3m 5s`), computed from `startedAt` → `completedAt` (already in the list response; no API change).
   - Secondary line (small, muted): start → end clock range, e.g. `06-12 10:21:05 → 10:25:37` (end repeats the date only when it crosses midnight).
   - Running rows show elapsed-so-far with an open-ended `start →` range; rows that never started show `—`; terminal runs (failed/canceled) missing `completedAt` show `—` instead of an ever-growing live delta (review feedback).
2. **Detail page Duration row** — now uses the same compact format via the shared `features/benchmarks/duration.ts` module (was `formatDistanceStrict`'s coarse "4 minutes"), and shows elapsed-so-far while running instead of `—`.
3. **Zero-collapse number formatting** — `fmtNum` renders all-zero formatted values (`0.0000`, `-0.0`) as plain `0`, so zero error rates stop reading as four-decimal noise. Non-zero values keep their precision (`0.0033` unchanged).

## Testing

- New `duration.test.ts` unit tests (8) for `runDurationMs` / `fmtDurationMs` / `fmtTimeRange`, incl. the terminal-without-completedAt case; 2 new `BenchmarkListShell` tests (duration cell + `0` error-rate collapse), 21/21 pass.
- `pnpm -F @modeldoctor/web type-check` + `lint` (incl. i18n-parity) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)