### PR TITLE
build(aiperf): bump base image 0.7.0 → 0.10.0 + bake Mooncake traces

### DIFF
--- a/apps/benchmark-runner/images/aiperf.Dockerfile
+++ b/apps/benchmark-runner/images/aiperf.Dockerfile
@@ -4,7 +4,7 @@
 # pulled from the registry cache.
 # To bump aiperf: run `./tools/build-base-images.sh aiperf`, then update the
 # tag below and AIPERF_VERSION in build-base-images.sh.
-FROM ghcr.io/weetime/md-base-aiperf:0.7.0
+FROM ghcr.io/weetime/md-base-aiperf:0.10.0
 
 WORKDIR /app
 

--- a/apps/benchmark-runner/images/aiperf.base.Dockerfile
+++ b/apps/benchmark-runner/images/aiperf.base.Dockerfile
@@ -15,9 +15,16 @@ FROM python:3.11-slim
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-ARG AIPERF_VERSION=0.7.0
+ARG AIPERF_VERSION=0.10.0
 
-RUN pip install --no-cache-dir "aiperf==${AIPERF_VERSION}"
+# crick (aiperf dep) ships no aarch64 wheel — needs a C toolchain to build
+# from sdist. Install/purge it in the same layer to keep the slim image slim.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && pip install --no-cache-dir "aiperf==${AIPERF_VERSION}" \
+    && apt-get purge -y build-essential \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 
 # Bake ShareGPT V3 corpus (~672 MB) so --public-dataset sharegpt works on
 # air-gapped clusters. aiperf's ShareGPTLoader resolves

--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -29,7 +29,7 @@ VEGETA_VERSION=12.13.0
 VEGETA_SHA256_AMD64=e8759ce45c14e18374bdccd3ba6068197bc3a9f9b7e484db3837f701b9d12e61
 VEGETA_SHA256_ARM64=950381173a5575e25e8e086f36fc03bf65d61a2433329b48e41e1cb5e4133bba
 EVALSCOPE_VERSION=1.7.0
-AIPERF_VERSION=0.7.0
+AIPERF_VERSION=0.10.0
 SHAREGPT_URL="https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json"
 MOONCAKE_TRACE_BASEURL="https://raw.githubusercontent.com/kvcache-ai/Mooncake/main/FAST25-release/traces"
 


### PR DESCRIPTION
## Summary

Stacked on #278. Addresses the rebake half of #279.

- `AIPERF_VERSION` 0.7.0 → 0.10.0(build 脚本 / base Dockerfile ARG / runner FROM 三处)
- crick(aiperf 依赖)无 aarch64 wheel:同层安装并卸载 `build-essential`,镜像保持 slim
- 基础镜像重烤后 Mooncake FAST25 traces 烤入 `/app/.cache/aiperf/datasets/mooncake/`(#276 的 build 脚本逻辑首次真正生效)

## Why 0.10.0

aiperf 0.7.0 的结果后处理在 ≥600 条多轮 records 时 livelock(导出文件零增长、CPU 0.3 核、event-loop 告警),0.10.0 实测痊愈:

- 冒烟 c20/300req:5 分钟完成,TTFT p99 540.9ms,命中率 92.3%
- 全阶梯 c20→c160 OFF/ON 共 8 次运行全绿,单次最大 2400 records 后处理无卡顿
- 额外解锁 `--record-processors` 与 `--request-rate`(后续开环合成负载的前置条件)

## Verified

完整 OFF/ON 并发阶梯(详见 SavedCompare "Prefix-cache t2 阶梯"):同 SLO(TTFT p99≤2s)容量约 2 倍(OFF 拐点 c20-40,ON 拐点 c40-80),命中率 43% vs 93% 全程稳定。

## 待办(不阻塞本 PR)

- [ ] amd64 + ghcr 多架构 push(本机 buildx 容器 builder 经代理访问 registry 仍 EOF,需网络窗口再试;本地 arm64 镜像已在 k3d 工作)

refs #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)