### PR TITLE
build(aiperf): bump base image 0.7.0 → 0.10.0 (re-land #282)

### DIFF
--- a/apps/benchmark-runner/images/aiperf.Dockerfile
+++ b/apps/benchmark-runner/images/aiperf.Dockerfile
@@ -4,7 +4,7 @@
 # pulled from the registry cache.
 # To bump aiperf: run `./tools/build-base-images.sh aiperf`, then update the
 # tag below and AIPERF_VERSION in build-base-images.sh.
-FROM ghcr.io/weetime/md-base-aiperf:0.7.0
+FROM ghcr.io/weetime/md-base-aiperf:0.10.0
 
 WORKDIR /app
 

--- a/apps/benchmark-runner/images/aiperf.base.Dockerfile
+++ b/apps/benchmark-runner/images/aiperf.base.Dockerfile
@@ -15,9 +15,16 @@ FROM python:3.11-slim
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-ARG AIPERF_VERSION=0.7.0
+ARG AIPERF_VERSION=0.10.0
 
-RUN pip install --no-cache-dir "aiperf==${AIPERF_VERSION}"
+# crick (aiperf dep) ships no aarch64 wheel — needs a C toolchain to build
+# from sdist. Install/purge it in the same layer to keep the slim image slim.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && pip install --no-cache-dir "aiperf==${AIPERF_VERSION}" \
+    && apt-get purge -y build-essential \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 
 # Bake ShareGPT V3 corpus (~672 MB) so --public-dataset sharegpt works on
 # air-gapped clusters. aiperf's ShareGPTLoader resolves

--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -29,7 +29,7 @@ VEGETA_VERSION=12.13.0
 VEGETA_SHA256_AMD64=e8759ce45c14e18374bdccd3ba6068197bc3a9f9b7e484db3837f701b9d12e61
 VEGETA_SHA256_ARM64=950381173a5575e25e8e086f36fc03bf65d61a2433329b48e41e1cb5e4133bba
 EVALSCOPE_VERSION=1.7.0
-AIPERF_VERSION=0.7.0
+AIPERF_VERSION=0.10.0
 SHAREGPT_URL="https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json"
 MOONCAKE_TRACE_BASEURL="https://raw.githubusercontent.com/kvcache-ai/Mooncake/main/FAST25-release/traces"
 


### PR DESCRIPTION
Re-land of #282 — the original was based on the feat branch and its squash never reached main (stacked merge-order trap; see #282 discussion). Identical content, cherry-picked onto main:

- AIPERF_VERSION 0.7.0 → 0.10.0(build 脚本 / base Dockerfile ARG / runner FROM)
- crick 无 aarch64 wheel:同层装/卸 build-essential
- 重烤后 Mooncake traces 烤入基础镜像(refs #279)

🤖 Generated with [Claude Code](https://claude.com/claude-code)