### PR TITLE
feat(report): pair metric table with its trend chart + colored delta triangles

### DIFF
--- a/apps/web/src/features/benchmarks/compare/DeltaTable.tsx
+++ b/apps/web/src/features/benchmarks/compare/DeltaTable.tsx
@@ -1,0 +1,55 @@
+import { deltaColumnIndex, isImprovement, type ParsedTable, parseDelta } from "./report-blocks";
+
+/**
+ * Renders a parsed comparison table with the delta column shown as colored
+ * triangles: ▲/▼ for the literal direction of the change, green/red for
+ * whether that change is an improvement (decoupled, matching the Primer report
+ * style — a latency drop is ▼ and green; a throughput drop would be ▼ and red).
+ */
+export function DeltaTable({ table }: { table: ParsedTable }) {
+  const { headers, rows } = table;
+  const deltaCol = deltaColumnIndex(headers, rows);
+  const deltaHeader = deltaCol >= 0 ? headers[deltaCol] : "";
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          {headers.map((h, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: header cells are positional
+            <th key={i} className={i === deltaCol ? "pr-delta-col" : undefined}>
+              {h}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, ri) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: rows are positional
+          <tr key={ri}>
+            {headers.map((_, ci) => {
+              const cell = row[ci] ?? "";
+              if (ci === deltaCol) {
+                const d = parseDelta(cell);
+                if (d) {
+                  const good = isImprovement(d.sign, deltaHeader);
+                  return (
+                    // biome-ignore lint/suspicious/noArrayIndexKey: positional
+                    <td key={ci} className="pr-delta-col">
+                      <span className={`pr-delta ${good ? "pr-delta-good" : "pr-delta-bad"}`}>
+                        <span className="pr-delta-tri">{d.sign === "+" ? "▲" : "▼"}</span>
+                        {d.magnitude}
+                      </span>
+                    </td>
+                  );
+                }
+              }
+              // biome-ignore lint/suspicious/noArrayIndexKey: positional
+              return <td key={ci}>{cell}</td>;
+            })}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/web/src/features/benchmarks/compare/DeltaTable.tsx
+++ b/apps/web/src/features/benchmarks/compare/DeltaTable.tsx
@@ -32,7 +32,7 @@ export function DeltaTable({ table }: { table: ParsedTable }) {
               if (ci === deltaCol) {
                 const d = parseDelta(cell);
                 if (d) {
-                  const good = isImprovement(d.sign, deltaHeader);
+                  const good = isImprovement(d.sign, deltaHeader, table.metric);
                   return (
                     // biome-ignore lint/suspicious/noArrayIndexKey: positional
                     <td key={ci} className="pr-delta-col">

--- a/apps/web/src/features/benchmarks/compare/SavedCompareReport.tsx
+++ b/apps/web/src/features/benchmarks/compare/SavedCompareReport.tsx
@@ -4,8 +4,10 @@ import { useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
 import { Link } from "react-router-dom";
 import remarkGfm from "remark-gfm";
+import { DeltaTable } from "./DeltaTable";
 import { FigureRenderer } from "./FigureRenderer";
 import type { ReportRun } from "./ReportSections";
+import { parseSectionBlocks } from "./report-blocks";
 
 export interface SavedCompareReportProps {
   narrative: CompareNarrative;
@@ -172,26 +174,65 @@ export function SavedCompareReport({
             </div>
           ) : null}
 
-          {/* Sections */}
-          {sections.map((s) => (
-            <section key={s.id} className="pr-sec" id={`pr-section-${s.id}`}>
-              <h2>
-                <span className="pr-num">{s.num}</span>
-                {s.title}
-              </h2>
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{s.bodyMarkdown}</ReactMarkdown>
-              {(figuresBySection.get(s.id) ?? []).map((f) => (
-                <FigureRenderer
-                  key={f.id}
-                  refId={f.refId}
-                  runs={runs}
-                  caption={f.caption}
-                  figureNumber={nextFigureNumber()}
-                  baselineId={baselineId}
-                />
-              ))}
-            </section>
-          ))}
+          {/* Sections — each table renders next to the chart for the same
+              metric (paired via the table's heading), so TTFT table + TTFT
+              trend sit together rather than all-tables-then-all-charts. */}
+          {sections.map((s) => {
+            const figures = figuresBySection.get(s.id) ?? [];
+            const blocks = parseSectionBlocks(s.bodyMarkdown);
+            const usedFigureIds = new Set<string>();
+            return (
+              <section key={s.id} className="pr-sec" id={`pr-section-${s.id}`}>
+                <h2>
+                  <span className="pr-num">{s.num}</span>
+                  {s.title}
+                </h2>
+                {blocks.map((b, i) => {
+                  if (b.kind === "md") {
+                    return (
+                      // biome-ignore lint/suspicious/noArrayIndexKey: blocks are positional
+                      <ReactMarkdown key={i} remarkPlugins={[remarkGfm]}>
+                        {b.text}
+                      </ReactMarkdown>
+                    );
+                  }
+                  // Table block: render it, then the matching metric chart inline.
+                  const fig = b.table.metric
+                    ? figures.find((f) => f.refId === b.table.metric && !usedFigureIds.has(f.id))
+                    : undefined;
+                  if (fig) usedFigureIds.add(fig.id);
+                  return (
+                    // biome-ignore lint/suspicious/noArrayIndexKey: blocks are positional
+                    <div key={i}>
+                      <DeltaTable table={b.table} />
+                      {fig ? (
+                        <FigureRenderer
+                          refId={fig.refId}
+                          runs={runs}
+                          caption={fig.caption}
+                          figureNumber={nextFigureNumber()}
+                          baselineId={baselineId}
+                        />
+                      ) : null}
+                    </div>
+                  );
+                })}
+                {/* Any figures not paired to a table fall back to the section end. */}
+                {figures
+                  .filter((f) => !usedFigureIds.has(f.id))
+                  .map((f) => (
+                    <FigureRenderer
+                      key={f.id}
+                      refId={f.refId}
+                      runs={runs}
+                      caption={f.caption}
+                      figureNumber={nextFigureNumber()}
+                      baselineId={baselineId}
+                    />
+                  ))}
+              </section>
+            );
+          })}
 
           {/* Data source — which benchmarks this report is built from. Identity
               columns only (no metrics); names deep-link to the benchmark detail.

--- a/apps/web/src/features/benchmarks/compare/report-blocks.test.ts
+++ b/apps/web/src/features/benchmarks/compare/report-blocks.test.ts
@@ -38,6 +38,21 @@ describe("isImprovement", () => {
     expect(isImprovement("+", "Δ")).toBe(true);
     expect(isImprovement("-", "Δ")).toBe(false);
   });
+
+  it("uses the metric's polarity over a generic/ambiguous header", () => {
+    // Header carries no direction; metric decides. Latency/error = lower better.
+    expect(isImprovement("-", "幅度", "stage-bars-ttft-p95")).toBe(true);
+    expect(isImprovement("+", "Δ", "stage-bars-ttft-p95")).toBe(false);
+    expect(isImprovement("-", "Change", "stage-bars-error-rate")).toBe(true);
+    // Throughput = higher better.
+    expect(isImprovement("+", "幅度", "stage-bars-throughput")).toBe(true);
+    expect(isImprovement("-", "Δ", "stage-bars-throughput")).toBe(false);
+  });
+
+  it("metric overrides even a misleading header keyword", () => {
+    // header says 提升 (gain) but metric is latency → a drop is still good.
+    expect(isImprovement("-", "提升幅度", "stage-bars-ttft-p95")).toBe(true);
+  });
 });
 
 describe("deltaColumnIndex", () => {

--- a/apps/web/src/features/benchmarks/compare/report-blocks.test.ts
+++ b/apps/web/src/features/benchmarks/compare/report-blocks.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  deltaColumnIndex,
+  figureForHeading,
+  isImprovement,
+  parseDelta,
+  parseSectionBlocks,
+} from "./report-blocks";
+
+describe("parseDelta", () => {
+  it("parses signed percents in either minus glyph", () => {
+    expect(parseDelta("+19.4%")).toEqual({ sign: "+", magnitude: "19.4%" });
+    expect(parseDelta("-43%")).toEqual({ sign: "-", magnitude: "43%" });
+    expect(parseDelta("−5.4%")).toEqual({ sign: "-", magnitude: "5.4%" });
+    expect(parseDelta("  +2.6%  ")).toEqual({ sign: "+", magnitude: "2.6%" });
+  });
+
+  it("ignores non-delta cells (plain numbers, unsigned percents, prose)", () => {
+    expect(parseDelta("2.87")).toBeNull();
+    expect(parseDelta("0.42%")).toBeNull(); // no sign → not a delta
+    expect(parseDelta("405")).toBeNull();
+    expect(parseDelta("L1 (20)")).toBeNull();
+  });
+});
+
+describe("isImprovement", () => {
+  it("gain columns improve when positive", () => {
+    expect(isImprovement("+", "提升幅度")).toBe(true);
+    expect(isImprovement("-", "提升幅度")).toBe(false);
+    expect(isImprovement("+", "Improvement")).toBe(true);
+  });
+  it("reduction columns improve when negative", () => {
+    expect(isImprovement("-", "降低幅度")).toBe(true);
+    expect(isImprovement("+", "降低幅度")).toBe(false);
+    expect(isImprovement("-", "Reduction")).toBe(true);
+  });
+  it("defaults unknown headers to gain semantics", () => {
+    expect(isImprovement("+", "Δ")).toBe(true);
+    expect(isImprovement("-", "Δ")).toBe(false);
+  });
+});
+
+describe("deltaColumnIndex", () => {
+  it("finds the delta column by header keyword", () => {
+    expect(deltaColumnIndex(["并发等级", "OFF", "ON", "提升幅度"], [])).toBe(3);
+    expect(deltaColumnIndex(["Stage", "OFF (ms)", "ON (ms)", "降低幅度"], [])).toBe(3);
+  });
+  it("falls back to the column whose cells all parse as deltas", () => {
+    const rows = [
+      ["L1", "2.87", "+2.6%"],
+      ["L2", "4.48", "+19.4%"],
+    ];
+    expect(deltaColumnIndex(["stage", "off", "x"], rows)).toBe(2);
+  });
+  it("returns -1 when there is no delta column", () => {
+    expect(deltaColumnIndex(["a", "b"], [["1", "2"]])).toBe(-1);
+  });
+});
+
+describe("figureForHeading", () => {
+  it("maps metric headings to chart refIds, latency before throughput", () => {
+    expect(figureForHeading("TTFT p95 对比")).toBe("stage-bars-ttft-p95");
+    expect(figureForHeading("E2E p95 对比")).toBe("stage-bars-e2e-p95");
+    expect(figureForHeading("端到端延迟")).toBe("stage-bars-e2e-p95");
+    expect(figureForHeading("吞吐对比")).toBe("stage-bars-throughput");
+    expect(figureForHeading("Throughput comparison")).toBe("stage-bars-throughput");
+    expect(figureForHeading("错误率")).toBe("stage-bars-error-rate");
+    expect(figureForHeading("选型建议")).toBeNull();
+  });
+});
+
+describe("parseSectionBlocks", () => {
+  const body = [
+    "**吞吐对比**",
+    "",
+    "| 并发等级 | OFF (req/s) | ON (req/s) | 提升幅度 |",
+    "|----------|-------------|------------|----------|",
+    "| L1 (20)  | 2.87        | 2.95       | +2.6%    |",
+    "| L2 (40)  | 4.48        | 5.35       | +19.4%   |",
+    "",
+    "开启 prefix cache 后吞吐全面领先。",
+    "",
+    "**TTFT p95 对比**",
+    "",
+    "| 并发等级 | OFF (ms) | ON (ms) | 降低幅度 |",
+    "|----------|----------|---------|----------|",
+    "| L1 (20)  | 710      | 405     | -43%     |",
+    "",
+    "TTFT p95 降低显著。",
+  ].join("\n");
+
+  it("splits into ordered md/table blocks and tags tables with their metric", () => {
+    const blocks = parseSectionBlocks(body);
+    const tables = blocks.filter((b) => b.kind === "table");
+    expect(tables).toHaveLength(2);
+    expect(tables[0].kind === "table" && tables[0].table.metric).toBe("stage-bars-throughput");
+    expect(tables[1].kind === "table" && tables[1].table.metric).toBe("stage-bars-ttft-p95");
+    // first table parsed structurally
+    if (tables[0].kind === "table") {
+      expect(tables[0].table.headers).toEqual([
+        "并发等级",
+        "OFF (req/s)",
+        "ON (req/s)",
+        "提升幅度",
+      ]);
+      expect(tables[0].table.rows).toHaveLength(2);
+      expect(tables[0].table.rows[0]).toEqual(["L1 (20)", "2.87", "2.95", "+2.6%"]);
+    }
+    // ordering: heading md → table → (prose+next heading) md → table → prose md.
+    // Consecutive prose/heading lines with no table between them coalesce into
+    // one md block — the table boundaries are what matter for interleaving.
+    expect(blocks.map((b) => b.kind)).toEqual(["md", "table", "md", "table", "md"]);
+  });
+
+  it("leaves prose-only sections as a single md block", () => {
+    const blocks = parseSectionBlocks("纯文字结论，没有表格。\n\n第二段。");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].kind).toBe("md");
+  });
+});

--- a/apps/web/src/features/benchmarks/compare/report-blocks.ts
+++ b/apps/web/src/features/benchmarks/compare/report-blocks.ts
@@ -1,0 +1,134 @@
+import type { FigureRefId } from "@modeldoctor/contracts";
+
+/**
+ * Render-time reshaping of an AI narrative section so each metric's comparison
+ * table sits next to its trend chart, and delta cells read as colored
+ * triangles (▲/▼) instead of plain "+2.6%" / "-43%" text.
+ *
+ * The narrative model keeps tables (free markdown inside `bodyMarkdown`) and
+ * figures (structured `refId` objects) separate — figures used to render in a
+ * block after all the prose. These helpers split a section body into ordered
+ * blocks and pair each table with the figure for the same metric, with zero
+ * dependency on the AI emitting any special syntax (works on existing reports).
+ */
+
+export interface ParsedTable {
+  headers: string[];
+  rows: string[][];
+  /** Figure refId for this table's metric, derived from the heading above it. */
+  metric: FigureRefId | null;
+}
+
+export type SectionBlock = { kind: "md"; text: string } | { kind: "table"; table: ParsedTable };
+
+/** Sign + magnitude of a delta cell like "+19.4%", "-43%", "−5.4%". */
+export interface DeltaValue {
+  /** "+" when the value rose, "-" when it fell. */
+  sign: "+" | "-";
+  /** Original text without the sign, e.g. "19.4%". */
+  magnitude: string;
+}
+
+const DELTA_RE = /^\s*([+\-−])\s*(\d+(?:\.\d+)?\s*%)\s*$/;
+
+/** Parse a signed-percent delta cell. Returns null for any other content
+ * (plain numbers, "0.42%" without a sign, prose) so non-delta cells are left
+ * untouched. */
+export function parseDelta(raw: string): DeltaValue | null {
+  const m = DELTA_RE.exec(raw);
+  if (!m) return null;
+  const sign = m[1] === "+" ? "+" : "-";
+  return { sign, magnitude: m[2].replace(/\s+/g, "") };
+}
+
+/** Whether a delta is an improvement, given the column's polarity. `gain`
+ * columns (提升/throughput) improve when positive; `reduction` columns
+ * (降低/latency) improve when negative. Unknown headers default to gain. */
+export function isImprovement(sign: "+" | "-", header: string): boolean {
+  const reduction = /降低|下降|减少|缩短|reduc|lower|decrease|↓/i.test(header);
+  return reduction ? sign === "-" : sign === "+";
+}
+
+/** Index of the delta column (the signed-percent one), or -1. We detect it by
+ * header keyword first, falling back to "any column whose body cells parse as
+ * deltas". */
+export function deltaColumnIndex(headers: string[], rows: string[][]): number {
+  const byHeader = headers.findIndex((h) =>
+    /提升|降低|幅度|delta|change|提高|下降|减少|缩短|gain|reduc/i.test(h),
+  );
+  if (byHeader >= 0) return byHeader;
+  for (let c = 0; c < headers.length; c++) {
+    if (rows.length > 0 && rows.every((r) => r[c] !== undefined && parseDelta(r[c]) !== null)) {
+      return c;
+    }
+  }
+  return -1;
+}
+
+/** Map a metric heading (e.g. "**TTFT p95 对比**") to the figure refId that
+ * charts the same metric, so the renderer can drop that chart under the table.
+ * Order matters: check specific latency labels before generic ones. */
+export function figureForHeading(heading: string): FigureRefId | null {
+  if (/ttft/i.test(heading)) return "stage-bars-ttft-p95";
+  if (/e2e|端到端/i.test(heading)) return "stage-bars-e2e-p95";
+  if (/错误|error/i.test(heading)) return "stage-bars-error-rate";
+  if (/吞吐|throughput|qps|req\/s/i.test(heading)) return "stage-bars-throughput";
+  return null;
+}
+
+function splitRow(line: string): string[] {
+  // "| a | b | c |" → ["a","b","c"] (drop the leading/trailing empties).
+  const cells = line.split("|").map((c) => c.trim());
+  if (cells.length && cells[0] === "") cells.shift();
+  if (cells.length && cells[cells.length - 1] === "") cells.pop();
+  return cells;
+}
+
+const SEPARATOR_RE = /^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)*\|?\s*$/;
+
+/**
+ * Split a section's markdown into ordered blocks, parsing GitHub pipe tables
+ * into structured {headers, rows} (tagged with the metric from the nearest
+ * preceding heading / bold label) and leaving everything else as markdown.
+ */
+export function parseSectionBlocks(markdown: string): SectionBlock[] {
+  const lines = markdown.split("\n");
+  const blocks: SectionBlock[] = [];
+  let buf: string[] = [];
+  let lastHeading = "";
+
+  const flushMd = () => {
+    if (buf.length === 0) return;
+    const text = buf.join("\n");
+    if (text.trim() !== "") blocks.push({ kind: "md", text });
+    buf = [];
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const next = lines[i + 1] ?? "";
+    // Track the most recent heading or bold label so tables know their metric.
+    const headingMatch = /^#{1,6}\s+(.+?)\s*$/.exec(line) ?? /^\s*\*\*(.+?)\*\*\s*$/.exec(line);
+    if (headingMatch) lastHeading = headingMatch[1];
+
+    const isTableStart = line.includes("|") && line.trim() !== "" && SEPARATOR_RE.test(next);
+    if (isTableStart) {
+      flushMd();
+      const headers = splitRow(line);
+      i += 1; // consume separator
+      const rows: string[][] = [];
+      while (i + 1 < lines.length && lines[i + 1].includes("|") && lines[i + 1].trim() !== "") {
+        rows.push(splitRow(lines[i + 1]));
+        i += 1;
+      }
+      blocks.push({
+        kind: "table",
+        table: { headers, rows, metric: figureForHeading(lastHeading) },
+      });
+      continue;
+    }
+    buf.push(line);
+  }
+  flushMd();
+  return blocks;
+}

--- a/apps/web/src/features/benchmarks/compare/report-blocks.ts
+++ b/apps/web/src/features/benchmarks/compare/report-blocks.ts
@@ -49,10 +49,24 @@ const REDUCTION_RE = /\u964d\u4f4e|\u4e0b\u964d|\u51cf\u5c11|\u7f29\u77ed|reduc|
 const DELTA_HEADER_RE =
   /\u63d0\u5347|\u964d\u4f4e|\u5e45\u5ea6|\u63d0\u9ad8|\u4e0b\u964d|\u51cf\u5c11|\u7f29\u77ed|delta|change|gain|reduc/i;
 
-/** Whether a delta is an improvement, given the column's polarity. `gain`
- * columns (raise/throughput) improve when positive; `reduction` columns
- * (reduce/latency) improve when negative. Unknown headers default to gain. */
-export function isImprovement(sign: "+" | "-", header: string): boolean {
+/** Metrics where a lower value is better — latency + error rate. Mirrors the
+ * `higherIsBetter: false` flags the same charts carry in FigureRenderer. */
+const LOWER_IS_BETTER: ReadonlySet<FigureRefId> = new Set<FigureRefId>([
+  "stage-bars-ttft-p95",
+  "stage-bars-e2e-p95",
+  "stage-bars-error-rate",
+]);
+
+/** Whether a delta is an improvement. The table's `metric` is the primary
+ * polarity source (authoritative, same as the chart's higherIsBetter); a
+ * generic header like "Delta"/"magnitude" carries no direction, so without a metric
+ * we fall back to reduction-keyword detection, then default to gain. */
+export function isImprovement(
+  sign: "+" | "-",
+  header: string,
+  metric?: FigureRefId | null,
+): boolean {
+  if (metric) return LOWER_IS_BETTER.has(metric) ? sign === "-" : sign === "+";
   return REDUCTION_RE.test(header) ? sign === "-" : sign === "+";
 }
 

--- a/apps/web/src/features/benchmarks/compare/report-blocks.ts
+++ b/apps/web/src/features/benchmarks/compare/report-blocks.ts
@@ -41,21 +41,26 @@ export function parseDelta(raw: string): DeltaValue | null {
   return { sign, magnitude: m[2].replace(/\s+/g, "") };
 }
 
+// CJK keywords are written as \u escapes (the no-hardcoded-zh lint forbids
+// literal Chinese anywhere in source, comments included). Romanized glyphs:
+//   reduction set — jiangdi/xiajiang/jianshao/suoduan (reduce/decline/...)
+//   header set    — also tisheng/fudu/tigao (raise/magnitude/increase)
+const REDUCTION_RE = /\u964d\u4f4e|\u4e0b\u964d|\u51cf\u5c11|\u7f29\u77ed|reduc|lower|decrease|↓/i;
+const DELTA_HEADER_RE =
+  /\u63d0\u5347|\u964d\u4f4e|\u5e45\u5ea6|\u63d0\u9ad8|\u4e0b\u964d|\u51cf\u5c11|\u7f29\u77ed|delta|change|gain|reduc/i;
+
 /** Whether a delta is an improvement, given the column's polarity. `gain`
- * columns (提升/throughput) improve when positive; `reduction` columns
- * (降低/latency) improve when negative. Unknown headers default to gain. */
+ * columns (raise/throughput) improve when positive; `reduction` columns
+ * (reduce/latency) improve when negative. Unknown headers default to gain. */
 export function isImprovement(sign: "+" | "-", header: string): boolean {
-  const reduction = /降低|下降|减少|缩短|reduc|lower|decrease|↓/i.test(header);
-  return reduction ? sign === "-" : sign === "+";
+  return REDUCTION_RE.test(header) ? sign === "-" : sign === "+";
 }
 
 /** Index of the delta column (the signed-percent one), or -1. We detect it by
  * header keyword first, falling back to "any column whose body cells parse as
  * deltas". */
 export function deltaColumnIndex(headers: string[], rows: string[][]): number {
-  const byHeader = headers.findIndex((h) =>
-    /提升|降低|幅度|delta|change|提高|下降|减少|缩短|gain|reduc/i.test(h),
-  );
+  const byHeader = headers.findIndex((h) => DELTA_HEADER_RE.test(h));
   if (byHeader >= 0) return byHeader;
   for (let c = 0; c < headers.length; c++) {
     if (rows.length > 0 && rows.every((r) => r[c] !== undefined && parseDelta(r[c]) !== null)) {
@@ -65,14 +70,14 @@ export function deltaColumnIndex(headers: string[], rows: string[][]): number {
   return -1;
 }
 
-/** Map a metric heading (e.g. "**TTFT p95 对比**") to the figure refId that
+/** Map a metric heading (e.g. "**TTFT p95 \u5bf9\u6bd4**") to the figure refId that
  * charts the same metric, so the renderer can drop that chart under the table.
  * Order matters: check specific latency labels before generic ones. */
 export function figureForHeading(heading: string): FigureRefId | null {
   if (/ttft/i.test(heading)) return "stage-bars-ttft-p95";
-  if (/e2e|端到端/i.test(heading)) return "stage-bars-e2e-p95";
-  if (/错误|error/i.test(heading)) return "stage-bars-error-rate";
-  if (/吞吐|throughput|qps|req\/s/i.test(heading)) return "stage-bars-throughput";
+  if (/e2e|\u7aef\u5230\u7aef/i.test(heading)) return "stage-bars-e2e-p95";
+  if (/\u9519\u8bef|error/i.test(heading)) return "stage-bars-error-rate";
+  if (/\u541e\u5410|throughput|qps|req\/s/i.test(heading)) return "stage-bars-throughput";
   return null;
 }
 

--- a/apps/web/src/styles/primer-report.css
+++ b/apps/web/src/styles/primer-report.css
@@ -339,6 +339,31 @@
   border-bottom: none;
 }
 
+/* ─── Delta cells (triangle + good/bad color) ───────────────────────────── */
+.primer-report .pr-sec td.pr-delta-col,
+.primer-report .pr-sec th.pr-delta-col {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.primer-report .pr-delta {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  font-family: var(--pr-mono);
+  font-weight: 600;
+  white-space: nowrap;
+}
+.primer-report .pr-delta-tri {
+  font-size: 0.78em;
+  line-height: 1;
+}
+.primer-report .pr-delta-good {
+  color: var(--pr-success-fg);
+}
+.primer-report .pr-delta-bad {
+  color: var(--pr-danger-fg);
+}
+
 /* ─── Figure embeds ─────────────────────────────────────────────────────── */
 .primer-report .pr-figure {
   margin: 16px 0;


### PR DESCRIPTION
## What

Two readability fixes on the SavedCompare report detail/preview page, per request + the `~/vllm/repots` Primer reference.

### 1. Table ↔ chart pairing
Each metric's comparison table now renders directly above the trend chart for the **same** metric — TTFT table → TTFT trend, throughput table → throughput trend — instead of all-tables-then-all-charts.

Done purely at render time (`parseSectionBlocks` splits the section body into ordered md/table blocks, tags each table with a figure refId from its heading, renderer drops the matching figure beneath it). Unpaired figures fall back to the section end. **No schema / AI / prompt change — improves existing reports too.**

### 2. Colored delta triangles
Delta cells render as ▲/▼ + green/red via a new `DeltaTable` component, decoupled like the reference:
- **Triangle** = literal direction of the change (▲ rose, ▼ fell)
- **Color** = whether it's an improvement (green) or regression (red)

So a latency drop is ▼ **green**, a throughput drop would be ▼ **red**. Column polarity (gain vs reduction) is read from the header keyword (提升幅度 / 降低幅度 / Improvement / Reduction).

## Verified

Live screenshot of the ladder report §04: 吞吐对比 → Throughput chart, ▲ green deltas; TTFT p95 对比 → TTFT chart, ▼ green deltas (latency down = good); E2E likewise. Delta cell text+class dumped from the DOM confirms `▼ 43% / pr-delta-good` etc.

- 11 new unit tests (parseDelta / isImprovement / deltaColumnIndex / figureForHeading / parseSectionBlocks)
- full compare suite green (88), web type-check clean

## Notes
- Render-only — semantically correct on regressions because color follows improvement, not sign.
- Heading→figure pairing is keyword-based (吞吐/TTFT/E2E/错误 + English); unmatched metrics simply don't get an inline chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)