### PR TITLE
feat(benchmarks): connection filter + bulk delete on benchmark list

### DIFF
--- a/apps/api/src/modules/benchmark/benchmark.controller.spec.ts
+++ b/apps/api/src/modules/benchmark/benchmark.controller.spec.ts
@@ -301,6 +301,40 @@ describe("BenchmarkController", () => {
     expect(after).toBeNull();
   });
 
+  it("bulkDelete removes only the caller's rows and reports the count", async () => {
+    const owner = await prisma.user.create({
+      data: { email: "rc-bulk-owner@example.com", passwordHash: "x" },
+    });
+    const stranger = await prisma.user.create({
+      data: { email: "rc-bulk-stranger@example.com", passwordHash: "x" },
+    });
+    const mk = (userId: string) =>
+      prisma.benchmark.create({
+        data: {
+          userId,
+          scenario: "inference",
+          tool: "guidellm",
+          name: "b",
+          params: {},
+          status: "completed",
+        },
+      });
+    const a = await mk(owner.id);
+    const b = await mk(owner.id);
+    const theirs = await mk(stranger.id);
+
+    const ownerArg = { sub: owner.id, email: owner.email, roles: [] };
+    const result = await controller.bulkDelete(ownerArg as never, {
+      ids: [a.id, b.id, theirs.id, "nonexistent"],
+    });
+
+    expect(result.deleted).toBe(2);
+    expect(await prisma.benchmark.findUnique({ where: { id: a.id } })).toBeNull();
+    expect(await prisma.benchmark.findUnique({ where: { id: b.id } })).toBeNull();
+    // The stranger's row must survive a non-admin bulk delete.
+    expect(await prisma.benchmark.findUnique({ where: { id: theirs.id } })).not.toBeNull();
+  });
+
   describe("admin authz", () => {
     it("rejects scope=all from non-admin caller (403)", async () => {
       const user = { sub: "u1", email: "u1@x", roles: [] };

--- a/apps/api/src/modules/benchmark/benchmark.controller.ts
+++ b/apps/api/src/modules/benchmark/benchmark.controller.ts
@@ -1,6 +1,9 @@
 import {
   type Benchmark,
   type BenchmarkChartsResponse,
+  type BulkDeleteBenchmarksRequest,
+  type BulkDeleteBenchmarksResponse,
+  bulkDeleteBenchmarksRequestSchema,
   type CreateBenchmarkRequest,
   createBenchmarkRequestSchema,
   type EndpointReportRange,
@@ -101,6 +104,20 @@ export class BenchmarkController {
   @HttpCode(204)
   async delete(@CurrentUser() user: JwtPayload, @Param("id") id: string): Promise<void> {
     await this.service.delete(id, user.roles.includes("admin") ? undefined : user.sub);
+  }
+
+  @ApiOperation({ summary: "Delete many benchmarks in one request (owner or admin)" })
+  @Post("bulk-delete")
+  async bulkDelete(
+    @CurrentUser() user: JwtPayload,
+    @Body(new ZodValidationPipe(bulkDeleteBenchmarksRequestSchema))
+    body: BulkDeleteBenchmarksRequest,
+  ): Promise<BulkDeleteBenchmarksResponse> {
+    const deleted = await this.service.bulkDelete(
+      body.ids,
+      user.roles.includes("admin") ? undefined : user.sub,
+    );
+    return { deleted };
   }
 
   /** Live log stream for an in-flight benchmark.

--- a/apps/api/src/modules/benchmark/benchmark.service.spec.ts
+++ b/apps/api/src/modules/benchmark/benchmark.service.spec.ts
@@ -342,6 +342,49 @@ describe("BenchmarkService.delete", () => {
   });
 });
 
+describe("BenchmarkService.bulkDelete", () => {
+  let repo: MockRepo;
+  let svc: BenchmarkService;
+
+  beforeEach(() => {
+    repo = new MockRepo();
+    svc = build(repo);
+    vi.clearAllMocks();
+  });
+
+  it("deletes every owned row and returns the count", async () => {
+    repo.setup(makeBenchmarkRow({ id: "b1", status: "completed", userId: "u1" }));
+    repo.setup(makeBenchmarkRow({ id: "b2", status: "completed", userId: "u1" }));
+    const deleted = await svc.bulkDelete(["b1", "b2"], "u1");
+    expect(deleted).toBe(2);
+    expect(repo.delete).toHaveBeenCalledWith("b1");
+    expect(repo.delete).toHaveBeenCalledWith("b2");
+  });
+
+  it("skips rows the caller does not own and only counts the rest", async () => {
+    repo.setup(makeBenchmarkRow({ id: "b1", status: "completed", userId: "u1" }));
+    repo.setup(makeBenchmarkRow({ id: "b2", status: "completed", userId: "other" }));
+    const deleted = await svc.bulkDelete(["b1", "b2"], "u1");
+    expect(deleted).toBe(1);
+    expect(repo.delete).toHaveBeenCalledWith("b1");
+    expect(repo.delete).not.toHaveBeenCalledWith("b2");
+  });
+
+  it("skips missing ids without aborting the batch", async () => {
+    repo.setup(makeBenchmarkRow({ id: "b1", status: "completed", userId: "u1" }));
+    const deleted = await svc.bulkDelete(["missing", "b1"], "u1");
+    expect(deleted).toBe(1);
+    expect(repo.delete).toHaveBeenCalledWith("b1");
+  });
+
+  it("admin (no userId) can delete across owners", async () => {
+    repo.setup(makeBenchmarkRow({ id: "b1", status: "completed", userId: "u1" }));
+    repo.setup(makeBenchmarkRow({ id: "b2", status: "completed", userId: "other" }));
+    const deleted = await svc.bulkDelete(["b1", "b2"], undefined);
+    expect(deleted).toBe(2);
+  });
+});
+
 describe("BenchmarkService.create — failure paths", () => {
   let repo: MockRepo;
   let svc: BenchmarkService;

--- a/apps/api/src/modules/benchmark/benchmark.service.spec.ts
+++ b/apps/api/src/modules/benchmark/benchmark.service.spec.ts
@@ -383,6 +383,13 @@ describe("BenchmarkService.bulkDelete", () => {
     const deleted = await svc.bulkDelete(["b1", "b2"], undefined);
     expect(deleted).toBe(2);
   });
+
+  it("dedupes ids so a repeated id is deleted (and counted) only once", async () => {
+    repo.setup(makeBenchmarkRow({ id: "b1", status: "completed", userId: "u1" }));
+    const deleted = await svc.bulkDelete(["b1", "b1", "b1"], "u1");
+    expect(deleted).toBe(1);
+    expect(repo.delete).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("BenchmarkService.create — failure paths", () => {

--- a/apps/api/src/modules/benchmark/benchmark.service.ts
+++ b/apps/api/src/modules/benchmark/benchmark.service.ts
@@ -298,7 +298,9 @@ export class BenchmarkService {
    */
   async bulkDelete(ids: string[], userId?: string): Promise<number> {
     let deleted = 0;
-    for (const id of ids) {
+    // Dedupe so a caller passing the same id twice doesn't trigger redundant
+    // lookups / driver.cancel calls for one row.
+    for (const id of new Set(ids)) {
       try {
         await this.delete(id, userId);
         deleted++;

--- a/apps/api/src/modules/benchmark/benchmark.service.ts
+++ b/apps/api/src/modules/benchmark/benchmark.service.ts
@@ -286,6 +286,33 @@ export class BenchmarkService {
   }
 
   /**
+   * Delete many benchmarks in one call. Each id goes through {@link delete}
+   * so ownership checks and best-effort driver cancellation behave exactly
+   * like the single-row path. Failures are non-fatal in a bulk op: a
+   * NotFound (already gone, or not owned by the caller) is silently skipped;
+   * any other error is logged and skipped so one bad row can't abort the
+   * whole batch. Returns the count of rows actually deleted.
+   *
+   * Sequential on purpose — parallel deletes would fan out driver.cancel
+   * calls against the K8s apiserver for non-terminal rows.
+   */
+  async bulkDelete(ids: string[], userId?: string): Promise<number> {
+    let deleted = 0;
+    for (const id of ids) {
+      try {
+        await this.delete(id, userId);
+        deleted++;
+      } catch (e) {
+        if (!(e instanceof NotFoundException)) {
+          const err = e as Error;
+          this.log.warn(`bulkDelete: failed to delete ${id}: ${err.message}`);
+        }
+      }
+    }
+    return deleted;
+  }
+
+  /**
    * Connection-anchored 7/30/90-day report. Pulls all of `userId`'s
    * benchmarks within the window, buckets by connectionId in JS, and
    * emits one summary per connection. Bounded data per user/window —

--- a/apps/web/src/features/benchmarks/BenchmarkListFilters.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkListFilters.tsx
@@ -10,6 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useConnections } from "@/features/connections/queries";
 import { DateRangeFilter } from "./DateRangeFilter";
 
 const SEARCH_DEBOUNCE_MS = 300;
@@ -43,6 +44,8 @@ export function BenchmarkListFilters({
   availableTools,
 }: BenchmarkListFiltersProps) {
   const { t } = useTranslation("benchmarks");
+  const connections = useConnections().data ?? [];
+  const selectedConnection = connections.find((c) => c.id === query.connectionId);
 
   function patch(p: Partial<ListBenchmarksQuery>) {
     onChange({ ...query, ...p });
@@ -120,6 +123,36 @@ export function BenchmarkListFilters({
           {STATUSES.map((s) => (
             <SelectItem key={s} value={s}>
               {t(`status.${s}`)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select
+        value={query.connectionId ?? ALL}
+        onValueChange={(v) => patch({ connectionId: v === ALL ? undefined : v })}
+      >
+        <SelectTrigger className="w-[220px]" aria-label={t("filters.connection")}>
+          <SelectValue placeholder={t("filters.connection")}>
+            {selectedConnection ? (
+              <span className="truncate">{selectedConnection.model}</span>
+            ) : (
+              t("filters.connection")
+            )}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL}>{t("filters.any")}</SelectItem>
+          {connections.map((c) => (
+            <SelectItem key={c.id} value={c.id} className="py-2">
+              <div className="flex flex-col gap-0.5">
+                <div className="flex items-baseline gap-2 text-sm">
+                  <span className="font-medium">{c.model}</span>
+                  <span className="text-xs text-muted-foreground">·</span>
+                  <span className="text-xs text-muted-foreground">{c.name}</span>
+                </div>
+                <div className="font-mono text-[11px] text-muted-foreground/70">{c.baseUrl}</div>
+              </div>
             </SelectItem>
           ))}
         </SelectContent>

--- a/apps/web/src/features/benchmarks/BenchmarkListShell.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkListShell.tsx
@@ -45,7 +45,12 @@ import { useLocaleStore } from "@/stores/locale-store";
 import { BenchmarkListFilters } from "./BenchmarkListFilters";
 import { readErrorRate, readP95Latency } from "./compare/metrics";
 import { fmtDurationMs, fmtTimeRange, runDurationMs } from "./duration";
-import { useBenchmarkList, useCreateBenchmark, useDeleteBenchmark } from "./queries";
+import {
+  useBenchmarkList,
+  useBulkDeleteBenchmarks,
+  useCreateBenchmark,
+  useDeleteBenchmark,
+} from "./queries";
 import { SaveAsTemplateDialog } from "./SaveAsTemplateDialog";
 import { SCENARIOS, type ScenarioId } from "./scenarios";
 import { StatusBadge } from "./status-display";
@@ -124,8 +129,10 @@ export function BenchmarkListShell({ scenario }: BenchmarkListShellProps) {
 
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [saveTplBenchmark, setSaveTplBenchmark] = useState<Benchmark | null>(null);
   const deleteBenchmark = useDeleteBenchmark();
+  const bulkDeleteBenchmarks = useBulkDeleteBenchmarks();
   const createBenchmark = useCreateBenchmark();
   const navigate = useNavigate();
 
@@ -209,6 +216,27 @@ export function BenchmarkListShell({ scenario }: BenchmarkListShellProps) {
     });
   }
 
+  // Select-all toggles only the currently-loaded rows (selection across
+  // unfetched pages would silently delete rows the user can't see).
+  const allLoadedSelected = items.length > 0 && items.every((b) => selected.has(b.id));
+  const someLoadedSelected = items.some((b) => selected.has(b.id));
+  const headerChecked: boolean | "indeterminate" = allLoadedSelected
+    ? true
+    : someLoadedSelected
+      ? "indeterminate"
+      : false;
+
+  function toggleAll(checked: boolean) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      for (const b of items) {
+        if (checked) next.add(b.id);
+        else next.delete(b.id);
+      }
+      return next;
+    });
+  }
+
   return (
     <>
       <PageHeader
@@ -216,6 +244,17 @@ export function BenchmarkListShell({ scenario }: BenchmarkListShellProps) {
         subtitle={t(`scenarioDescriptions.${scenario}`)}
         rightSlot={
           <div className="flex gap-2">
+            {selected.size > 0 && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="gap-1 text-destructive hover:text-destructive"
+                onClick={() => setBulkDeleteOpen(true)}
+              >
+                <Trash2 className="h-4 w-4" />
+                {t("bulkDelete.button", { n: selected.size })}
+              </Button>
+            )}
             <Tooltip>
               <TooltipTrigger asChild>
                 <span>
@@ -297,7 +336,13 @@ export function BenchmarkListShell({ scenario }: BenchmarkListShellProps) {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead className="w-10" />
+                  <TableHead className="w-10">
+                    <Checkbox
+                      checked={headerChecked}
+                      onCheckedChange={(c) => toggleAll(c === true)}
+                      aria-label={t("bulkDelete.selectAll")}
+                    />
+                  </TableHead>
                   <TableHead>{t("columns.name")}</TableHead>
                   <TableHead>{t("columns.createdAt")}</TableHead>
                   <TableHead>{t("columns.duration")}</TableHead>
@@ -489,6 +534,31 @@ export function BenchmarkListShell({ scenario }: BenchmarkListShellProps) {
             },
             onError: () => {
               toast.error(t("detail.delete.errors.generic"));
+            },
+          });
+        }}
+      />
+
+      <ConfirmDeleteDialog
+        open={bulkDeleteOpen}
+        onOpenChange={(o) => {
+          if (!o) setBulkDeleteOpen(false);
+        }}
+        title={t("bulkDelete.confirmTitle", { n: selected.size })}
+        description={t("bulkDelete.confirmBody", { n: selected.size })}
+        confirmLabel={t("bulkDelete.confirmAction")}
+        pending={bulkDeleteBenchmarks.isPending}
+        onConfirm={() => {
+          const ids = [...selected];
+          if (ids.length === 0) return;
+          bulkDeleteBenchmarks.mutate(ids, {
+            onSuccess: ({ deleted }) => {
+              setBulkDeleteOpen(false);
+              setSelected(new Set());
+              toast.success(t("bulkDelete.success", { n: deleted }));
+            },
+            onError: () => {
+              toast.error(t("bulkDelete.errors.generic"));
             },
           });
         }}

--- a/apps/web/src/features/benchmarks/BenchmarkListShell.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkListShell.tsx
@@ -15,7 +15,7 @@ import {
   RefreshCw,
   Trash2,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
@@ -135,6 +135,16 @@ export function BenchmarkListShell({ scenario }: BenchmarkListShellProps) {
   const bulkDeleteBenchmarks = useBulkDeleteBenchmarks();
   const createBenchmark = useCreateBenchmark();
   const navigate = useNavigate();
+
+  // Drop the selection whenever the filters (URL params) or scenario change.
+  // `selected` is keyed by id and would otherwise retain now-hidden rows, so a
+  // later bulk delete could silently remove benchmarks the user can no longer
+  // see. Depend on the serialized params (primitive) so the effect only fires
+  // on an actual filter change, not on every render.
+  const searchParamsString = searchParams.toString();
+  useEffect(() => {
+    setSelected(new Set());
+  }, [searchParamsString, scenario]);
 
   async function handleRerunRow(b: Benchmark) {
     if (!b.connectionId) {

--- a/apps/web/src/features/benchmarks/__tests__/BenchmarkListShell.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/BenchmarkListShell.test.tsx
@@ -285,6 +285,25 @@ describe("BenchmarkListShell", () => {
     );
   });
 
+  it("clears the selection when a filter changes (no stale bulk delete of hidden rows)", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      items: [makeBenchmark("a", "guidellm", "completed", guidellmMetrics)],
+      nextCursor: null,
+    } satisfies ListBenchmarksResponse);
+    render(<BenchmarkListShell scenario="inference" />, { wrapper: Wrapper });
+
+    await userEvent.click(await screen.findByRole("checkbox", { name: /select a/i }));
+    expect(screen.getByRole("button", { name: /Delete \(1\)|删除 \(1\)/i })).toBeInTheDocument();
+
+    // Change the Status filter → URL params change → selection must reset.
+    await userEvent.click(screen.getByRole("combobox", { name: /Status|状态/ }));
+    await userEvent.click(screen.getByRole("option", { name: /Completed|已完成/ }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: /Delete \(\d+\)|删除 \(\d+\)/i })).toBeNull(),
+    );
+  });
+
   it("renders the benchmark name in the first content column", async () => {
     vi.mocked(api.get).mockResolvedValueOnce({
       items: [makeBenchmark("r1", "guidellm", "completed", guidellmMetrics)],

--- a/apps/web/src/features/benchmarks/__tests__/BenchmarkListShell.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/BenchmarkListShell.test.tsx
@@ -1,6 +1,6 @@
 import type { Benchmark, ListBenchmarksResponse } from "@modeldoctor/contracts";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
@@ -22,6 +22,15 @@ vi.mock("@/lib/api-client", () => {
 });
 
 import { api } from "@/lib/api-client";
+
+// The connection filter inside BenchmarkListFilters calls useConnections().
+// Stub it so it doesn't consume the list's `api.get` mockResolvedValueOnce
+// responses (which would starve the benchmark-list query of its fixtures).
+vi.mock("@/features/connections/queries", () => ({
+  useConnections: () => ({
+    data: [{ id: "c1", name: "vLLM Local", model: "m", baseUrl: "http://x" }],
+  }),
+}));
 
 // Real adapter-emitted shapes. `summaryMetrics` is the discriminated union
 // `{ tool, data }` written by tool-adapter `parseFinalReport` — see
@@ -242,6 +251,38 @@ describe("BenchmarkListShell", () => {
     // verifying we landed there. Full happy-path is covered by
     // BenchmarkComparePage's own tests.
     await waitFor(() => expect(screen.getByText("compare-stub")).toBeInTheDocument());
+  });
+
+  it("bulk-deletes selected rows via POST /bulk-delete after confirm", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      items: [
+        makeBenchmark("a", "guidellm", "completed", guidellmMetrics),
+        makeBenchmark("b", "guidellm", "completed", guidellmMetrics),
+      ],
+      nextCursor: null,
+    } satisfies ListBenchmarksResponse);
+    vi.mocked(api.post).mockResolvedValue({ deleted: 2 });
+    render(<BenchmarkListShell scenario="inference" />, { wrapper: Wrapper });
+
+    await userEvent.click(await screen.findByRole("checkbox", { name: /select a/i }));
+    await userEvent.click(screen.getByRole("checkbox", { name: /select b/i }));
+
+    // Bulk-delete button appears once a row is selected.
+    await userEvent.click(screen.getByRole("button", { name: /Delete \(2\)|删除 \(2\)/i }));
+
+    // ConfirmDeleteDialog is type-to-confirm: the destructive button stays
+    // disabled until "DELETE" is typed into the keyword input.
+    const dialog = await screen.findByRole("alertdialog");
+    await userEvent.type(within(dialog).getByRole("textbox"), "DELETE");
+    const confirmBtn = within(dialog).getByRole("button", { name: /^Delete$|^确认删除$/ });
+    expect(confirmBtn).not.toBeDisabled();
+    await userEvent.click(confirmBtn);
+
+    await waitFor(() =>
+      expect(api.post).toHaveBeenCalledWith("/api/benchmarks/bulk-delete", {
+        ids: ["a", "b"],
+      }),
+    );
   });
 
   it("renders the benchmark name in the first content column", async () => {

--- a/apps/web/src/features/benchmarks/__tests__/HistoryFilters.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/HistoryFilters.test.tsx
@@ -3,6 +3,18 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import "@/lib/i18n";
+
+// The connection filter calls useConnections(); stub it so these tests don't
+// need a QueryClient / api-client mock.
+vi.mock("@/features/connections/queries", () => ({
+  useConnections: () => ({
+    data: [
+      { id: "conn-1", name: "vLLM Local", model: "Qwen2.5-0.5B", baseUrl: "http://x" },
+      { id: "conn-2", name: "vLLM Remote", model: "Qwen3-8B", baseUrl: "http://y" },
+    ],
+  }),
+}));
+
 import { BenchmarkListFilters } from "../BenchmarkListFilters";
 
 describe("BenchmarkListFilters baseline dropdown", () => {
@@ -44,5 +56,27 @@ describe("BenchmarkListFilters baseline dropdown", () => {
     expect(onChange).toHaveBeenLastCalledWith(
       expect.objectContaining({ isBaseline: undefined, referencesBaseline: undefined }),
     );
+  });
+});
+
+describe("BenchmarkListFilters connection dropdown", () => {
+  it("emits connectionId when a connection is picked", async () => {
+    const onChange = vi.fn();
+    render(<BenchmarkListFilters query={{}} onChange={onChange} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("combobox", { name: /Connection|连接/ }));
+    // Options render model name as the prominent label.
+    await user.click(screen.getByRole("option", { name: /Qwen3-8B/ }));
+    expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({ connectionId: "conn-2" }));
+  });
+
+  it("clears connectionId when 'Any' is picked", async () => {
+    const onChange = vi.fn();
+    render(<BenchmarkListFilters query={{ connectionId: "conn-1" }} onChange={onChange} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("combobox", { name: /Connection|连接/ }));
+    const anyOptions = screen.getAllByRole("option", { name: /^Any|^全部$/ });
+    await user.click(anyOptions[anyOptions.length - 1]);
+    expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({ connectionId: undefined }));
   });
 });

--- a/apps/web/src/features/benchmarks/api.ts
+++ b/apps/web/src/features/benchmarks/api.ts
@@ -1,6 +1,7 @@
 import type {
   Benchmark,
   BenchmarkChartsResponse,
+  BulkDeleteBenchmarksResponse,
   CreateBenchmarkRequest,
   ListBenchmarksQuery,
   ListBenchmarksResponse,
@@ -32,5 +33,7 @@ export const benchmarkApi = {
   create: (body: CreateBenchmarkRequest) => api.post<Benchmark>("/api/benchmarks", body),
   cancel: (id: string) => api.post<Benchmark>(`/api/benchmarks/${id}/cancel`, {}),
   delete: (id: string) => api.del<void>(`/api/benchmarks/${id}`),
+  bulkDelete: (ids: string[]) =>
+    api.post<BulkDeleteBenchmarksResponse>("/api/benchmarks/bulk-delete", { ids }),
   getCharts: (id: string) => api.get<BenchmarkChartsResponse>(`/api/benchmarks/${id}/charts`),
 };

--- a/apps/web/src/features/benchmarks/queries.ts
+++ b/apps/web/src/features/benchmarks/queries.ts
@@ -83,6 +83,17 @@ export function useDeleteBenchmark() {
   });
 }
 
+export function useBulkDeleteBenchmarks() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (ids: string[]) => benchmarkApi.bulkDelete(ids),
+    onSuccess: (_v, ids) => {
+      for (const id of ids) qc.removeQueries({ queryKey: benchmarkKeys.detail(id) });
+      qc.invalidateQueries({ queryKey: benchmarkKeys.lists() });
+    },
+  });
+}
+
 export function useBenchmarkCharts(benchmarkId: string) {
   return useQuery({
     queryKey: benchmarkKeys.charts(benchmarkId),

--- a/apps/web/src/locales/en-US/benchmarks.json
+++ b/apps/web/src/locales/en-US/benchmarks.json
@@ -86,6 +86,7 @@
   "filters": {
     "tool": "Tool",
     "status": "Status",
+    "connection": "Connection",
     "baseline": "Baseline",
     "baselineIs": "Is a baseline",
     "baselineRef": "References a baseline",
@@ -130,6 +131,17 @@
   "compareButton": "Compare ({{n}})",
   "compareDisabledNeedTwo": "Select at least 2 benchmarks to compare",
   "compareDisabledMixedTools": "Compare requires the same tool ({{summary}})",
+  "bulkDelete": {
+    "button": "Delete ({{n}})",
+    "selectAll": "Toggle all rows on this page",
+    "confirmTitle": "Delete {{n}} benchmarks?",
+    "confirmBody": "{{n}} runs will be removed from history along with their raw output. This cannot be undone.",
+    "confirmAction": "Delete",
+    "success": "Deleted {{n}} benchmarks",
+    "errors": {
+      "generic": "Failed to delete the selected benchmarks"
+    }
+  },
   "empty": {
     "title": "No benchmarks yet",
     "filtered": "No benchmarks match these filters",

--- a/apps/web/src/locales/zh-CN/benchmarks.json
+++ b/apps/web/src/locales/zh-CN/benchmarks.json
@@ -86,6 +86,7 @@
   "filters": {
     "tool": "工具",
     "status": "状态",
+    "connection": "连接",
     "baseline": "基线",
     "baselineIs": "是基线",
     "baselineRef": "对比某个基线",
@@ -130,6 +131,17 @@
   "compareButton": "对比 ({{n}})",
   "compareDisabledNeedTwo": "至少选 2 个基准测试才能对比",
   "compareDisabledMixedTools": "对比需要相同 tool（{{summary}}）",
+  "bulkDelete": {
+    "button": "删除 ({{n}})",
+    "selectAll": "全选本页",
+    "confirmTitle": "删除选中的 {{n}} 个基准测试？",
+    "confirmBody": "{{n}} 条记录会从历史里消失，相关原始输出也会清掉。此操作不可撤销。",
+    "confirmAction": "确认删除",
+    "success": "已删除 {{n}} 个基准测试",
+    "errors": {
+      "generic": "批量删除失败"
+    }
+  },
   "empty": {
     "title": "暂无基准测试",
     "filtered": "没有符合筛选条件的记录",

--- a/packages/contracts/src/benchmark.ts
+++ b/packages/contracts/src/benchmark.ts
@@ -105,6 +105,21 @@ export const listBenchmarksResponseSchema = z.object({
 });
 export type ListBenchmarksResponse = z.infer<typeof listBenchmarksResponseSchema>;
 
+// ── Bulk delete ──────────────────────────────────────────────────────
+// POST /api/benchmarks/bulk-delete — delete many rows in one request.
+// Capped at 100 ids per call (mirrors the list page's max selection).
+export const bulkDeleteBenchmarksRequestSchema = z.object({
+  ids: z.array(z.string().min(1)).min(1).max(100),
+});
+export type BulkDeleteBenchmarksRequest = z.infer<typeof bulkDeleteBenchmarksRequestSchema>;
+
+export const bulkDeleteBenchmarksResponseSchema = z.object({
+  // Number of rows actually deleted — ids the caller didn't own or that
+  // were already gone are silently skipped, so this can be < ids.length.
+  deleted: z.number().int().nonnegative(),
+});
+export type BulkDeleteBenchmarksResponse = z.infer<typeof bulkDeleteBenchmarksResponseSchema>;
+
 // ── Create request ───────────────────────────────────────────────────
 export const createBenchmarkRequestSchema = z.object({
   scenario: scenarioIdSchema,


### PR DESCRIPTION
## What

Two additions to the benchmark list page, per request:

1. **Connection dropdown filter** in the shared filter bar.
2. **Batch delete** in the list table.

## Connection filter (frontend-only)

The list endpoint already accepts `connectionId`, so no backend change.

- New `Select` in `BenchmarkListFilters`, options from `useConnections()`.
- Reuses the two-line option style from `ConnectionPicker` (model · name on top, `baseUrl` mono below) plus an **Any** entry — but does **not** reuse `ConnectionPicker` itself, since that's a *selection* control with "+ new connection"/"paste cURL" affordances that don't belong on a filter.
- Persists through the existing `connectionId` URL param; **Clear filters** resets it. Applies across every scenario list (filter component is shared).

## Bulk delete (new backend endpoint)

- `POST /api/benchmarks/bulk-delete { ids }` → `{ deleted }`. `BenchmarkService.bulkDelete()` runs each id through the existing single-delete path, so ownership checks + best-effort driver cancellation match exactly. Not-owned / missing ids are skipped (non-admin can't delete others' rows); returns the count actually deleted. Sequential to avoid fanning out `driver.cancel` against the K8s apiserver.
- List table reuses the existing row-selection `Set` (shared with Compare). Adds a **select-all header checkbox** (indeterminate-aware, current page only) and a destructive **Delete (N)** button that appears once rows are selected, gated behind the type-to-confirm dialog.

## Tests / verification

- API: `bulkDelete` service cases (owner scoping, not-owned skip, missing ids, admin cross-owner) + controller spec asserting a stranger's row survives a non-admin bulk delete. **60 passed**.
- Web: connection-dropdown emit/clear cases + full bulk-delete flow (select → Delete (N) → type DELETE → POST asserted). **19 passed**.
- contracts build ✓ · API/Web type-check ✓ · API/Web lint ✓ (i18n zh/en parity, no-native-select guards pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)