### PR TITLE
feat(compare): prefix-cache hit-rate & top-pod-share as compare figures

### DIFF
--- a/apps/api/src/modules/saved-compares/compare-synthesize.service.spec.ts
+++ b/apps/api/src/modules/saved-compares/compare-synthesize.service.spec.ts
@@ -200,4 +200,55 @@ describe("CompareSynthesizeService", () => {
     const r = await svc.synthesize(userId, savedCompareId, { locale: "zh-CN" });
     expect(r.fromCache).toBe(true);
   });
+
+  // ensurePrefixCacheFigures is a private server-control step; test it directly
+  // (no DB / LLM) so the figure-cap behavior is pinned regardless of the model.
+  describe("ensurePrefixCacheFigures", () => {
+    const pcRun = {
+      missing: false,
+      summaryMetrics: null,
+      serverMetrics: {
+        prefixCache: {
+          hitRatePct: 80,
+          topPodSharePct: 50,
+          perPod: [{ pod: "p1", queries: 100, hits: 80 }],
+          metricTag: "v1",
+        },
+      },
+    };
+    const scWithPrefixCache = { benchmarks: [pcRun, pcRun] };
+    const fig = (i: number) => ({ id: `f${i}`, refId: "compare-grid" as const, caption: `c${i}` });
+
+    it("injects the hit-rate figure when the LLM omitted it", () => {
+      const out = (
+        svc as never as {
+          ensurePrefixCacheFigures: (f: unknown, sc: unknown, l: string) => { refId: string }[];
+        }
+      ).ensurePrefixCacheFigures([fig(0)], scWithPrefixCache, "zh-CN");
+      expect(out).toHaveLength(2);
+      expect(out.at(-1)?.refId).toBe("stage-bars-prefix-cache-hit");
+    });
+
+    it("caps at the 8-figure schema limit, dropping the LLM's last figure (not ours)", () => {
+      const eight = Array.from({ length: 8 }, (_, i) => fig(i));
+      const out = (
+        svc as never as {
+          ensurePrefixCacheFigures: (f: unknown, sc: unknown, l: string) => { refId: string }[];
+        }
+      ).ensurePrefixCacheFigures(eight, scWithPrefixCache, "zh-CN");
+      expect(out).toHaveLength(8);
+      expect(out.at(-1)?.refId).toBe("stage-bars-prefix-cache-hit");
+    });
+
+    it("is a no-op when the runs carry no prefix-cache annotation", () => {
+      const plain = { benchmarks: [{ missing: false, summaryMetrics: null }] };
+      const input = [fig(0)];
+      const out = (
+        svc as never as {
+          ensurePrefixCacheFigures: (f: unknown, sc: unknown, l: string) => unknown[];
+        }
+      ).ensurePrefixCacheFigures(input, plain, "zh-CN");
+      expect(out).toBe(input);
+    });
+  });
 });

--- a/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
+++ b/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
@@ -119,17 +119,19 @@ export class CompareSynthesizeService {
     if (!available.has("stage-bars-prefix-cache-hit")) return figures;
     if (figures.some((f) => f.refId === "stage-bars-prefix-cache-hit")) return figures;
     const zh = locale !== "en-US";
-    return [
-      ...figures,
-      {
-        id: "fig-prefix-cache-hit",
-        refId: "stage-bars-prefix-cache-hit" as const,
-        caption: zh
-          ? "各 stage 的 prefix cache 命中率（越高越好）"
-          : "Prefix cache hit rate by stage (higher is better)",
-        anchorSection: "results" as const,
-      },
-    ];
+    const figure = {
+      id: "fig-prefix-cache-hit",
+      refId: "stage-bars-prefix-cache-hit" as const,
+      caption: zh
+        ? "各 stage 的 prefix cache 命中率（越高越好）"
+        : "Prefix cache hit rate by stage (higher is better)",
+      anchorSection: "results" as const,
+    };
+    // compareNarrativeSchema caps figures at 8. Appending a 9th would fail the
+    // zod parse on setNarrative / read-back → 500. Reserve our slot by dropping
+    // the LLM's last figure when full, rather than slicing our own injected
+    // figure off the end (hit rate is the whole point of this comparison).
+    return [...figures.slice(0, 7), figure];
   }
 
   /**

--- a/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
+++ b/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
@@ -10,7 +10,7 @@ import { Injectable, Logger, NotFoundException, ServiceUnavailableException } fr
 import { LruCache } from "../insights/cache.js";
 import { type ChatMessage, chatCompletion } from "../insights/llm-client.js";
 import { LlmJudgeService } from "../llm-judge/llm-judge.service.js";
-import { availableFigureRefIds, summarizeForPrompt } from "./metrics.js";
+import { availableFigureRefIds, readPrefixCache, summarizeForPrompt } from "./metrics.js";
 import { isBlockingWarning, lintNarrative } from "./narrative-lint.js";
 import { buildRetryFeedback, COMPARE_SYS_PROMPT_EN, COMPARE_SYS_PROMPT_ZH } from "./prompts.js";
 import { SavedComparesService } from "./saved-compares.service.js";
@@ -175,6 +175,8 @@ export class CompareSynthesizeService {
           if (v !== null) nums.push(v);
         }
       }
+      const pc = readPrefixCache(b.serverMetrics);
+      if (pc) nums.push(pc.hitRatePct, pc.topPodSharePct);
     }
     return nums;
   }
@@ -242,9 +244,13 @@ export class CompareSynthesizeService {
         m.e2e === null
           ? "e2e=—"
           : `e2e p50/p90/p99=${m.e2e.p50 ?? "—"}/${m.e2e.p90 ?? "—"}/${m.e2e.p99 ?? "—"}`;
+      const pc = readPrefixCache(b.serverMetrics);
+      const pcLine = pc
+        ? `  prefix_cache_hit%=${pc.hitRatePct.toFixed(1)}  top_pod_share%=${pc.topPodSharePct.toFixed(1)}`
+        : "";
       lines.push(
         `- [${b.stageLabel}] ${b.name ?? "(unnamed)"} · tool=${b.tool ?? "?"} scenario=${b.scenario ?? "?"}`,
-        `  qps=${m.throughput ?? "—"}  err=${m.errorRate ?? "—"}  ${ttftLine}  ${e2eLine}`,
+        `  qps=${m.throughput ?? "—"}  err=${m.errorRate ?? "—"}  ${ttftLine}  ${e2eLine}${pcLine}`,
       );
     }
     if (sc.baselineId) {
@@ -258,7 +264,9 @@ export class CompareSynthesizeService {
     // does not pick a refId for which the bar chart will render empty. Keys
     // outside this list MUST NOT appear in `figures[*].refId`.
     const available = availableFigureRefIds(
-      sc.benchmarks.filter((b) => !b.missing).map((b) => b.summaryMetrics),
+      sc.benchmarks
+        .filter((b) => !b.missing)
+        .map((b) => ({ summaryMetrics: b.summaryMetrics, serverMetrics: b.serverMetrics })),
     );
     lines.push(
       "",

--- a/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
+++ b/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
@@ -86,6 +86,7 @@ export class CompareSynthesizeService {
     parsed = {
       ...parsed,
       hero: this.augmentHero(parsed.hero, sc),
+      figures: this.ensurePrefixCacheFigures(parsed.figures, sc, body.locale),
       lintWarnings: warnings,
     };
 
@@ -94,6 +95,41 @@ export class CompareSynthesizeService {
     this.cache.set(key, { generatedAt: generatedAt.toISOString(), narrative: parsed });
 
     return { narrative: parsed, generatedAt: generatedAt.toISOString(), fromCache: false };
+  }
+
+  /**
+   * Guarantee the prefix-cache hit-rate figure is present when the data
+   * supports it. Hit rate is the metric a prefix-cache-validation comparison
+   * exists to measure, but it isn't in the throughput/latency blob the LLM
+   * fixates on, so weaker models routinely omit it. When the refId is
+   * available and the LLM didn't include it, inject it (anchored to results)
+   * — same server-control pattern as augmentHero. Does nothing for
+   * non-prefix-cache comparisons (refId simply isn't available).
+   */
+  private ensurePrefixCacheFigures(
+    figures: CompareNarrative["figures"],
+    sc: HydratedSavedCompare,
+    locale: string,
+  ): CompareNarrative["figures"] {
+    const available = availableFigureRefIds(
+      sc.benchmarks
+        .filter((b) => !b.missing)
+        .map((b) => ({ summaryMetrics: b.summaryMetrics, serverMetrics: b.serverMetrics })),
+    );
+    if (!available.has("stage-bars-prefix-cache-hit")) return figures;
+    if (figures.some((f) => f.refId === "stage-bars-prefix-cache-hit")) return figures;
+    const zh = locale !== "en-US";
+    return [
+      ...figures,
+      {
+        id: "fig-prefix-cache-hit",
+        refId: "stage-bars-prefix-cache-hit" as const,
+        caption: zh
+          ? "各 stage 的 prefix cache 命中率（越高越好）"
+          : "Prefix cache hit rate by stage (higher is better)",
+        anchorSection: "results" as const,
+      },
+    ];
   }
 
   /**

--- a/apps/api/src/modules/saved-compares/metrics.ts
+++ b/apps/api/src/modules/saved-compares/metrics.ts
@@ -1,4 +1,4 @@
-import type { FigureRefId } from "@modeldoctor/contracts";
+import { type FigureRefId, prefixCacheAnnotationSchema } from "@modeldoctor/contracts";
 import { readMetricSafe } from "@modeldoctor/tool-adapters";
 
 export function readP95Latency(m: unknown): number | null {
@@ -52,20 +52,47 @@ export function summarizeForPrompt(m: unknown): PromptMetricsSummary {
   };
 }
 
+export interface PrefixCacheSummary {
+  hitRatePct: number;
+  topPodSharePct: number;
+}
+
+/** Read serverMetrics.prefixCache (hit rate + top-pod share). Mirrors the
+ * client-side `client-metrics.ts#readPrefixCache`. Null when absent/malformed. */
+export function readPrefixCache(serverMetrics: unknown): PrefixCacheSummary | null {
+  const parsed = prefixCacheAnnotationSchema.safeParse(
+    (serverMetrics as { prefixCache?: unknown } | null)?.prefixCache,
+  );
+  if (!parsed.success) return null;
+  return { hitRatePct: parsed.data.hitRatePct, topPodSharePct: parsed.data.topPodSharePct };
+}
+
+/** One run's two metric blobs. summaryMetrics = tool report (throughput/latency);
+ * serverMetrics = prefix-cache annotation. */
+export interface RunMetricBlobs {
+  summaryMetrics: unknown;
+  serverMetrics?: unknown;
+}
+
 /**
  * Server-side mirror of `apps/web/src/features/benchmarks/compare/client-metrics.ts#availableFigureRefIds`.
- * Returns the figure `refId`s that can render against the given summaries.
+ * Returns the figure `refId`s that can render against the given runs.
  * The prompt sends this set to the LLM so it doesn't pick a refId for which
  * the data is not there (e.g. asking for ttft from vegeta gateway runs).
  */
-export function availableFigureRefIds(summaries: unknown[]): Set<FigureRefId> {
+export function availableFigureRefIds(runs: RunMetricBlobs[]): Set<FigureRefId> {
   const out = new Set<FigureRefId>();
-  if (summaries.length === 0) return out;
-  const perRun = summaries.map((m) => summarizeForPrompt(m));
+  if (runs.length === 0) return out;
+  const perRun = runs.map((r) => summarizeForPrompt(r.summaryMetrics));
   if (perRun.some((s) => s.throughput !== null)) out.add("stage-bars-throughput");
   if (perRun.some((s) => s.errorRate !== null)) out.add("stage-bars-error-rate");
   if (perRun.every((s) => s.ttft !== null)) out.add("stage-bars-ttft-p95");
   if (perRun.every((s) => s.e2e !== null)) out.add("stage-bars-e2e-p95");
+  // Prefix-cache figures need EVERY run to carry the annotation (complete bars).
+  if (runs.map((r) => readPrefixCache(r.serverMetrics)).every((p) => p !== null)) {
+    out.add("stage-bars-prefix-cache-hit");
+    out.add("stage-bars-top-pod-share");
+  }
   out.add("compare-grid");
   return out;
 }

--- a/apps/api/src/modules/saved-compares/prompts.ts
+++ b/apps/api/src/modules/saved-compares/prompts.ts
@@ -34,7 +34,7 @@ interface Narrative {
   ];                     // exactly 6 sections in this order
   figures: Array<{
     id: string;
-    refId: "stage-bars-throughput" | "stage-bars-error-rate" | "stage-bars-ttft-p95" | "stage-bars-e2e-p95" | "compare-grid";
+    refId: "stage-bars-throughput" | "stage-bars-error-rate" | "stage-bars-ttft-p95" | "stage-bars-e2e-p95" | "stage-bars-prefix-cache-hit" | "stage-bars-top-pod-share" | "compare-grid";
     caption: string;
     anchorSection?: "summary" | "scope" | "method" | "results" | "caveats" | "advice";
   }>;
@@ -66,7 +66,18 @@ Section size targets:
 - 03 method:  1-2 pages, workload / hardware / tool / version / key aligned params
 - 04 results: 2-4 pages, each subsection has 1 figure (via figures[]) + small table + 1-2 paragraphs
 - 05 caveats: ≤ 1 page, data comparability boundaries, known issues, SLO limits
-- 06 advice:  ≤ half page, scenario → config + 0-5 caveats`;
+- 06 advice:  ≤ half page, scenario → config + 0-5 caveats
+
+Prefix-cache runs: when the per-stage data carries prefix_cache_hit% / top_pod_share%
+(prefix-cache-validation, e.g. routing OFF vs ON), the HEADLINE conclusion and the
+first summary card MUST be the cache hit-rate change — that is the metric the
+experiment exists to measure. Use the stage-bars-prefix-cache-hit figure for it and
+stage-bars-top-pod-share to show routing concentration. Treat throughput/TTFT as
+secondary: on small models prefill is cheap so a higher hit rate need NOT improve
+latency — say so plainly rather than leading with a flat throughput delta. A flat
+top-pod share alongside a rising hit rate means better cache locality without
+hot-spotting (good), not a failure. Stage labels like "OFF"/"ON" mean the routing
+toggle, NOT offline/online.`;
 
 const ZH_SCHEMA_INSTRUCTIONS = `你是一位资深 LLM 推理服务性能分析师。给定多个 benchmark 的对比数据,你要按 ModelDoctor SavedCompare 报告规范产出一份**深度报告**(看起来像分析师手写,不要 AI 味)。
 

--- a/apps/api/src/modules/saved-compares/saved-compares.service.ts
+++ b/apps/api/src/modules/saved-compares/saved-compares.service.ts
@@ -102,6 +102,7 @@ export class SavedComparesService {
         tool: b.tool,
         scenario: b.scenario,
         summaryMetrics: b.summaryMetrics,
+        serverMetrics: b.serverMetrics,
         params: b.params,
         createdAt: b.createdAt.toISOString(),
       };

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
@@ -7,7 +7,7 @@ import {
   type StageBarLabelColors,
   type StageBarSeries,
 } from "@/components/charts/StageBarChart";
-import { availableFigureRefIds, summarizeForPrompt } from "./client-metrics";
+import { availableFigureRefIds, readPrefixCache, summarizeForPrompt } from "./client-metrics";
 import type { ReportRun } from "./ReportSections";
 
 export interface FigureRendererProps {
@@ -99,7 +99,12 @@ export const FigureRenderer = memo(function FigureRenderer({
     REPORT_PALETTE,
   );
 
-  const available = availableFigureRefIds(runs.map((r) => r.summaryMetrics));
+  const available = availableFigureRefIds(
+    runs.map((r) => ({
+      summaryMetrics: r.summaryMetrics,
+      serverMetrics: r.benchmark?.serverMetrics,
+    })),
+  );
   if (!available.has(refId)) {
     return (
       <figure className="pr-figure">
@@ -193,6 +198,46 @@ export const FigureRenderer = memo(function FigureRenderer({
         series={series}
         yLabel="ms"
         baselineSeriesKey={baselineKeyOf(rows, baselineId)}
+        labelColors={REPORT_LABEL_COLORS}
+      />
+    );
+  } else if (refId === "stage-bars-prefix-cache-hit") {
+    const rows = summaries
+      .map(({ r }) => ({ r, pc: readPrefixCache(r.benchmark?.serverMetrics) }))
+      .filter((x) => x.pc !== null);
+    const data: StageBarDatum[] = rows.map(({ r, pc }) => ({
+      stage: r.stageLabel,
+      hit: pc?.hitRatePct ?? 0,
+    }));
+    chart = (
+      <StageBarChart
+        title="Prefix cache hit rate"
+        data={data}
+        series={[{ key: "hit", label: "%", color: "#1a7f37", decimals: 1, higherIsBetter: true }]}
+        barColors={rows.map(({ r }) => colorMap[r.id])}
+        yLabel="%"
+        baselineIndex={baselineIndexOf(rows, baselineId)}
+        labelColors={REPORT_LABEL_COLORS}
+      />
+    );
+  } else if (refId === "stage-bars-top-pod-share") {
+    const rows = summaries
+      .map(({ r }) => ({ r, pc: readPrefixCache(r.benchmark?.serverMetrics) }))
+      .filter((x) => x.pc !== null);
+    const data: StageBarDatum[] = rows.map(({ r, pc }) => ({
+      stage: r.stageLabel,
+      share: pc?.topPodSharePct ?? 0,
+    }));
+    chart = (
+      <StageBarChart
+        title="Top pod share"
+        data={data}
+        // No higherIsBetter: concentration isn't strictly good or bad — a flat
+        // share with rising hit rate = good locality without hot-spotting.
+        series={[{ key: "share", label: "%", color: "#8250df", decimals: 1 }]}
+        barColors={rows.map(({ r }) => colorMap[r.id])}
+        yLabel="%"
+        baselineIndex={baselineIndexOf(rows, baselineId)}
         labelColors={REPORT_LABEL_COLORS}
       />
     );

--- a/apps/web/src/features/benchmarks/compare/__tests__/client-metrics.test.ts
+++ b/apps/web/src/features/benchmarks/compare/__tests__/client-metrics.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { availableFigureRefIds, readPrefixCache } from "../client-metrics";
+
+const summary = {
+  tool: "aiperf",
+  data: {
+    ttft: { mean: 1, p50: 1, p90: 2, p95: 3, p99: 4 },
+    e2eLatency: { mean: 1, p50: 1, p90: 2, p95: 3, p99: 4 },
+    throughput: { requestsPerSec: 2.5 },
+    requests: { total: 100, success: 100, error: 0, errorRate: 0 },
+  },
+};
+
+const withPrefixCache = (hit: number, share: number) => ({
+  prefixCache: {
+    hitRatePct: hit,
+    topPodSharePct: share,
+    perPod: [{ pod: "p0", queries: 100, hits: hit }],
+    metricTag: "v1" as const,
+  },
+});
+
+describe("readPrefixCache", () => {
+  it("parses a valid annotation", () => {
+    expect(readPrefixCache(withPrefixCache(57.6, 18.9))).toEqual({
+      hitRatePct: 57.6,
+      topPodSharePct: 18.9,
+    });
+  });
+  it("degrades to null for absent / malformed serverMetrics", () => {
+    expect(readPrefixCache(null)).toBeNull();
+    expect(readPrefixCache({})).toBeNull();
+    expect(readPrefixCache({ prefixCache: { hitRatePct: "nope" } })).toBeNull();
+  });
+});
+
+describe("availableFigureRefIds — prefix-cache figures", () => {
+  it("adds prefix-cache refIds only when EVERY run carries the annotation", () => {
+    const all = availableFigureRefIds([
+      { summaryMetrics: summary, serverMetrics: withPrefixCache(30, 19) },
+      { summaryMetrics: summary, serverMetrics: withPrefixCache(58, 19) },
+    ]);
+    expect(all.has("stage-bars-prefix-cache-hit")).toBe(true);
+    expect(all.has("stage-bars-top-pod-share")).toBe(true);
+  });
+
+  it("omits prefix-cache refIds when any run lacks the annotation", () => {
+    const mixed = availableFigureRefIds([
+      { summaryMetrics: summary, serverMetrics: withPrefixCache(30, 19) },
+      { summaryMetrics: summary, serverMetrics: null },
+    ]);
+    expect(mixed.has("stage-bars-prefix-cache-hit")).toBe(false);
+    expect(mixed.has("stage-bars-top-pod-share")).toBe(false);
+    // non-prefix-cache figures still resolve from summaryMetrics
+    expect(mixed.has("stage-bars-throughput")).toBe(true);
+    expect(mixed.has("stage-bars-ttft-p95")).toBe(true);
+  });
+});

--- a/apps/web/src/features/benchmarks/compare/client-metrics.ts
+++ b/apps/web/src/features/benchmarks/compare/client-metrics.ts
@@ -1,4 +1,4 @@
-import type { FigureRefId } from "@modeldoctor/contracts";
+import { type FigureRefId, prefixCacheAnnotationSchema } from "@modeldoctor/contracts";
 import { readMetricSafe } from "@modeldoctor/tool-adapters/schemas";
 
 export interface PromptMetricsSummary {
@@ -6,6 +6,32 @@ export interface PromptMetricsSummary {
   errorRate: number | null;
   ttft: { p50: number | null; p90: number | null; p99: number | null } | null;
   e2e: { p50: number | null; p90: number | null; p99: number | null } | null;
+}
+
+export interface PrefixCacheSummary {
+  hitRatePct: number;
+  topPodSharePct: number;
+}
+
+/** One run's two metric blobs — summaryMetrics (tool report) carries
+ * throughput/latency; serverMetrics carries the prefix-cache annotation. */
+export interface RunMetricBlobs {
+  summaryMetrics: unknown;
+  serverMetrics?: unknown;
+}
+
+/**
+ * Read the prefix-cache annotation from a run's `serverMetrics` blob (stored
+ * at `serverMetrics.prefixCache` on completion of a prefix-cache-validation
+ * run). Returns null when absent or malformed — non-prefix-cache runs and
+ * runs whose Prometheus snapshot found no data both degrade to null.
+ */
+export function readPrefixCache(serverMetrics: unknown): PrefixCacheSummary | null {
+  const parsed = prefixCacheAnnotationSchema.safeParse(
+    (serverMetrics as { prefixCache?: unknown } | null)?.prefixCache,
+  );
+  if (!parsed.success) return null;
+  return { hitRatePct: parsed.data.hitRatePct, topPodSharePct: parsed.data.topPodSharePct };
 }
 
 /**
@@ -53,14 +79,22 @@ export function summarizeForPrompt(m: unknown): PromptMetricsSummary {
  * Keep this in sync with the server's mirror in
  * `apps/api/src/modules/saved-compares/metrics.ts#availableFigureRefIds`.
  */
-export function availableFigureRefIds(summaries: unknown[]): Set<FigureRefId> {
+export function availableFigureRefIds(runs: RunMetricBlobs[]): Set<FigureRefId> {
   const out = new Set<FigureRefId>();
-  if (summaries.length === 0) return out;
-  const perRun = summaries.map((m) => summarizeForPrompt(m));
+  if (runs.length === 0) return out;
+  const perRun = runs.map((r) => summarizeForPrompt(r.summaryMetrics));
   if (perRun.some((s) => s.throughput !== null)) out.add("stage-bars-throughput");
   if (perRun.some((s) => s.errorRate !== null)) out.add("stage-bars-error-rate");
   if (perRun.every((s) => s.ttft !== null)) out.add("stage-bars-ttft-p95");
   if (perRun.every((s) => s.e2e !== null)) out.add("stage-bars-e2e-p95");
+  // Prefix-cache figures: require EVERY run to carry the annotation so the
+  // bar chart is complete across stages (mixing some-with / some-without
+  // would render misleading gaps).
+  const pc = runs.map((r) => readPrefixCache(r.serverMetrics));
+  if (pc.every((p) => p !== null)) {
+    out.add("stage-bars-prefix-cache-hit");
+    out.add("stage-bars-top-pod-share");
+  }
   // compare-grid only needs any of throughput/err/ttft/e2e — always available
   // when there's at least one summary; degrades cell-by-cell.
   out.add("compare-grid");

--- a/apps/web/src/features/benchmarks/compare/report-blocks.test.ts
+++ b/apps/web/src/features/benchmarks/compare/report-blocks.test.ts
@@ -82,6 +82,13 @@ describe("figureForHeading", () => {
     expect(figureForHeading("错误率")).toBe("stage-bars-error-rate");
     expect(figureForHeading("选型建议")).toBeNull();
   });
+
+  it("maps prefix-cache headings, top-pod before hit", () => {
+    expect(figureForHeading("命中率对比")).toBe("stage-bars-prefix-cache-hit");
+    expect(figureForHeading("Prefix cache hit rate")).toBe("stage-bars-prefix-cache-hit");
+    expect(figureForHeading("最高副本占比")).toBe("stage-bars-top-pod-share");
+    expect(figureForHeading("Top Pod Share")).toBe("stage-bars-top-pod-share");
+  });
 });
 
 describe("parseSectionBlocks", () => {

--- a/apps/web/src/features/benchmarks/compare/report-blocks.ts
+++ b/apps/web/src/features/benchmarks/compare/report-blocks.ts
@@ -92,10 +92,12 @@ export function figureForHeading(heading: string): FigureRefId | null {
   if (/e2e|\u7aef\u5230\u7aef/i.test(heading)) return "stage-bars-e2e-p95";
   if (/\u9519\u8bef|error/i.test(heading)) return "stage-bars-error-rate";
   if (/\u541e\u5410|throughput|qps|req\/s/i.test(heading)) return "stage-bars-throughput";
-  // Prefix-cache headings. \u547d\u4e2d=hit, \u526f\u672c=replica/pod,
-  // \u5360\u6bd4=share. Check top-pod before hit so "top pod share" doesn't
-  // get swallowed by a generic hit match.
-  if (/top.?pod|\u526f\u672c|\u5360\u6bd4/i.test(heading)) return "stage-bars-top-pod-share";
+  // Prefix-cache headings. \u547d\u4e2d=hit, \u526f\u672c\u5360\u6bd4=top-pod
+  // share. Match the full \u526f\u672c\u5360\u6bd4 phrase (not \u526f\u672c or
+  // \u5360\u6bd4 alone, which falsely match unrelated headings like
+  // "\u526f\u672c\u6570" or any "\u5360\u6bd4" metric). Check top-pod before hit
+  // so "top pod share" doesn't get swallowed by a generic hit match.
+  if (/top.?pod|\u526f\u672c\u5360\u6bd4/i.test(heading)) return "stage-bars-top-pod-share";
   if (/\u547d\u4e2d|hit.?rate|cache.?hit/i.test(heading)) return "stage-bars-prefix-cache-hit";
   return null;
 }

--- a/apps/web/src/features/benchmarks/compare/report-blocks.ts
+++ b/apps/web/src/features/benchmarks/compare/report-blocks.ts
@@ -92,6 +92,11 @@ export function figureForHeading(heading: string): FigureRefId | null {
   if (/e2e|\u7aef\u5230\u7aef/i.test(heading)) return "stage-bars-e2e-p95";
   if (/\u9519\u8bef|error/i.test(heading)) return "stage-bars-error-rate";
   if (/\u541e\u5410|throughput|qps|req\/s/i.test(heading)) return "stage-bars-throughput";
+  // Prefix-cache headings. \u547d\u4e2d=hit, \u526f\u672c=replica/pod,
+  // \u5360\u6bd4=share. Check top-pod before hit so "top pod share" doesn't
+  // get swallowed by a generic hit match.
+  if (/top.?pod|\u526f\u672c|\u5360\u6bd4/i.test(heading)) return "stage-bars-top-pod-share";
+  if (/\u547d\u4e2d|hit.?rate|cache.?hit/i.test(heading)) return "stage-bars-prefix-cache-hit";
   return null;
 }
 

--- a/packages/contracts/src/saved-compares/compare-narrative.ts
+++ b/packages/contracts/src/saved-compares/compare-narrative.ts
@@ -70,6 +70,11 @@ export const figureRefIdSchema = z.enum([
   "stage-bars-error-rate",
   "stage-bars-ttft-p95",
   "stage-bars-e2e-p95",
+  // Prefix-cache figures — populated from serverMetrics.prefixCache, only
+  // available for prefix-cache-validation runs. hit = cache hit-rate %,
+  // top-pod = the busiest pod's share of queries (routing concentration).
+  "stage-bars-prefix-cache-hit",
+  "stage-bars-top-pod-share",
   "compare-grid",
 ]);
 export type FigureRefId = z.infer<typeof figureRefIdSchema>;

--- a/packages/contracts/src/saved-compares/saved-compares.ts
+++ b/packages/contracts/src/saved-compares/saved-compares.ts
@@ -85,6 +85,9 @@ export interface HydratedBenchmarkRef {
   tool?: string;
   scenario?: string;
   summaryMetrics?: unknown;
+  /** serverMetrics blob — carries serverMetrics.prefixCache for prefix-cache
+   * figures (hit rate / top-pod share) in the compare report. */
+  serverMetrics?: unknown;
   params?: unknown;
   createdAt?: string;
 }


### PR DESCRIPTION
## What

Surfaces the two prefix-cache validation metrics — **hit rate** and **top-pod share** — as first-class figures in the **comparison report** (the `saved-compares` / `compare` path), where previously they only existed on the single-benchmark report panel.

## Changes

- **Compare figures** (`FigureRenderer`, `client-metrics`, `report-blocks`): render prefix-cache hit-rate & top-pod-share stage bars as compare figures, with client-side metric extraction + tests.
- **Contracts** (`saved-compares`): new figure refIds in the narrative schema.
- **API synthesize** (`metrics.ts`, `prompts.ts`, `compare-synthesize.service.ts`): expose the figures to the LLM, and **server-inject the hit-rate figure when the data supports it** — hit rate is the whole point of a prefix-cache comparison but isn't in the throughput/latency blob the judge model fixates on, so weaker models routinely omit it. Mirrors the existing `augmentHero` server-control pattern; no-op for non-prefix-cache comparisons.

## Verification

- contracts build ✓ · API + Web type-check ✓ · API + Web lint ✓
- Tests: web compare (client-metrics + report-blocks) **18 passed**, api saved-compares **56 passed**.

> Picks up in-progress work that had been sitting unpushed on a local worktree; the loose `compare-synthesize` change (the server-inject method) is committed here as `2877fd2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)