### PR TITLE
fix(api): correct thinking-off extraArgs to JSON-object form

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -780,7 +780,11 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
       seed: 42,
       // Disable Qwen3 thinking so it doesn't bloat decode + pollute the
       // prefill / prefix-cache signal. No-op for non-thinking models.
-      extraArgs: "--extra-inputs chat_template_kwargs:'{\"enable_thinking\":false}'",
+      // NOTE: aiperf --extra-inputs needs the FULL JSON-object string form.
+      // The key:value form (chat_template_kwargs:'{...}') sends a STRING and
+      // vLLM rejects it ("chat_template_kwargs must be a dict" -> 400 on every
+      // request). Verified against Qwen3-8B (2026-06-18).
+      extraArgs: '--extra-inputs \'{"chat_template_kwargs":{"enable_thinking":false}}\'',
     },
     tags: ["prefix-cache", "aiperf", "multi-turn", "article"],
     categories: ["chat"],
@@ -806,7 +810,7 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
       conversationTurnMean: 10,
       conversationType: "sticky-user-sessions",
       seed: 42,
-      extraArgs: "--extra-inputs chat_template_kwargs:'{\"enable_thinking\":false}'",
+      extraArgs: '--extra-inputs \'{"chat_template_kwargs":{"enable_thinking":false}}\'',
     },
     tags: ["prefix-cache", "aiperf", "multi-turn", "deep"],
     categories: ["chat"],
@@ -831,7 +835,7 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
       conversationTurnMean: 2,
       conversationType: "sticky-user-sessions",
       seed: 42,
-      extraArgs: "--extra-inputs chat_template_kwargs:'{\"enable_thinking\":false}'",
+      extraArgs: '--extra-inputs \'{"chat_template_kwargs":{"enable_thinking":false}}\'',
     },
     tags: ["prefix-cache", "aiperf", "multi-turn", "shallow"],
     categories: ["chat"],
@@ -850,7 +854,7 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
       mooncakeTrace: "conversation",
       traceReplayWindowSec: 300,
       seed: 42,
-      extraArgs: "--extra-inputs chat_template_kwargs:'{\"enable_thinking\":false}'",
+      extraArgs: '--extra-inputs \'{"chat_template_kwargs":{"enable_thinking":false}}\'',
     },
     tags: ["prefix-cache", "aiperf", "mooncake"],
     categories: ["chat"],
@@ -869,7 +873,7 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
       mooncakeTrace: "toolagent",
       traceReplayWindowSec: 300,
       seed: 42,
-      extraArgs: "--extra-inputs chat_template_kwargs:'{\"enable_thinking\":false}'",
+      extraArgs: '--extra-inputs \'{"chat_template_kwargs":{"enable_thinking":false}}\'',
     },
     tags: ["prefix-cache", "aiperf", "mooncake"],
     categories: ["chat"],

--- a/apps/web/src/locales/en-US/benchmarks.json
+++ b/apps/web/src/locales/en-US/benchmarks.json
@@ -449,7 +449,7 @@
   "forms": {
     "extraArgs": {
       "label": "Advanced (raw CLI)",
-      "placeholder": "--extra-inputs chat_template_kwargs:'{\"enable_thinking\":false}'",
+      "placeholder": "--extra-inputs '{\"chat_template_kwargs\":{\"enable_thinking\":false}}'",
       "help": "Extra raw CLI args, space/newline separated. Cannot override managed flags (model / url / api-key / output paths) — the run errors if you try. Power-user; not guaranteed comparable across runs."
     },
     "evalscope": {

--- a/apps/web/src/locales/zh-CN/benchmarks.json
+++ b/apps/web/src/locales/zh-CN/benchmarks.json
@@ -449,7 +449,7 @@
   "forms": {
     "extraArgs": {
       "label": "高级参数 (raw CLI)",
-      "placeholder": "--extra-inputs chat_template_kwargs:'{\"enable_thinking\":false}'",
+      "placeholder": "--extra-inputs '{\"chat_template_kwargs\":{\"enable_thinking\":false}}'",
       "help": "追加原始 CLI 参数,空格或换行分隔。不可覆盖受管参数(model / url / api-key / 输出路径 等),否则运行会报错。高级用法,不保证跨 run 可比。"
     },
     "evalscope": {


### PR DESCRIPTION
## Bug

PR #296 shipped the 5 prefix-cache aiperf templates with aiperf's **key:value**
extra-inputs form:

```
--extra-inputs chat_template_kwargs:'{"enable_thinking":false}'
```

aiperf sends a `key:value` value as a **string**, so the request body becomes
`"chat_template_kwargs": "{\"enable_thinking\":false}"`. vLLM requires it to be a
**dict**, so it rejects **every** request with
`chat_template_kwargs must be a valid dictionary` → 400 (0 successful requests on
any thinking model). Caught by a smoke run on Qwen3-8B (927/927 errors).

## Fix

Use aiperf's **full JSON-object string** form (documented `--extra-inputs '{...}'`):

```
--extra-inputs '{"chat_template_kwargs":{"enable_thinking":false}}'
```

This serializes to `"chat_template_kwargs": {"enable_thinking": false}` (a dict) →
vLLM accepts it → thinking off. Verified working on Qwen3-8B (errors back to the
normal ~82 context-overflow baseline, no `<think>` in responses).

Touches: the 5 `tpl_pc_*` templates in `seed.ts` (+ a regression-guard comment) and
the form placeholder example in zh-CN / en-US i18n.

Note: the dev DB was already hot-patched to the correct form during debugging; this
makes the seed source (SSOT) + prod match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)