### PR TITLE
refactor: split prefix-cache-validation into lb-strategy + engine-kv-cache

### DIFF
--- a/apps/api/prisma/migrations/20260618090159_rename_scenarios/migration.sql
+++ b/apps/api/prisma/migrations/20260618090159_rename_scenarios/migration.sql
@@ -1,0 +1,9 @@
+-- Scenario id rename (enum-change data fixup; CLAUDE.md carve-out).
+-- prefix-cache-validation -> lb-strategy, kv-cache-stress -> engine-kv-cache.
+-- Only benchmarks / benchmark_templates / alert_events have a `scenario` column.
+UPDATE "benchmarks"          SET "scenario" = 'lb-strategy'     WHERE "scenario" = 'prefix-cache-validation';
+UPDATE "benchmark_templates" SET "scenario" = 'lb-strategy'     WHERE "scenario" = 'prefix-cache-validation';
+UPDATE "alert_events"        SET "scenario" = 'lb-strategy'     WHERE "scenario" = 'prefix-cache-validation';
+UPDATE "benchmarks"          SET "scenario" = 'engine-kv-cache' WHERE "scenario" = 'kv-cache-stress';
+UPDATE "benchmark_templates" SET "scenario" = 'engine-kv-cache' WHERE "scenario" = 'kv-cache-stress';
+UPDATE "alert_events"        SET "scenario" = 'engine-kv-cache' WHERE "scenario" = 'kv-cache-stress';

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -761,7 +761,7 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
     id: "tpl_pc_t1_article",
     name: "路由粘性 · 文章同款 (t1)",
     description:
-      "Higress 文章同款多轮:60 会话 × 5 轮,in 200 / out 800,concurrency 20。关/开 ai-load-balancer 各跑一次,对比 TTFT 与 Prometheus 命中率 / 逐-pod 集中度。",
+      "【LB prefix_cache 策略路由验证 · 多轮粘性】Higress 文章同款多轮:60 会话 × 5 轮,in 200 / out 800,concurrency 20。关/开 ai-load-balancer 各跑一次,对比 TTFT 与 Prometheus 命中率 / 逐-pod 集中度。",
     scenario: "lb-strategy",
     tool: "aiperf",
     config: {
@@ -793,7 +793,7 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
     id: "tpl_pc_t2_deep",
     name: "路由粘性 · 深会话 (t2)",
     description:
-      "深会话:30 会话 × 10 轮,前缀累积最多,prefix-cache 路由收益最敏感。关/开对照的首选档。",
+      "【LB prefix_cache 策略路由验证 · 多轮粘性】深会话:30 会话 × 10 轮,前缀累积最多,prefix-cache 路由收益最敏感。关/开对照的首选档。",
     scenario: "lb-strategy",
     tool: "aiperf",
     config: {
@@ -818,7 +818,8 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
   {
     id: "tpl_pc_t3_shallow",
     name: "路由粘性 · 浅会话 (t3)",
-    description: "浅会话:120 会话 × 2 轮,对照锚点,前缀复用少、prefix-cache 收益最小。",
+    description:
+      "【LB prefix_cache 策略路由验证 · 多轮粘性】浅会话:120 会话 × 2 轮,对照锚点,前缀复用少、prefix-cache 收益最小。",
     scenario: "lb-strategy",
     tool: "aiperf",
     config: {
@@ -844,8 +845,8 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
     id: "tpl_pc_mooncake_conv",
     name: "缓存感知 · Mooncake 对话",
     description:
-      "Mooncake conversation trace(~40% 前缀复用)开环回放,业界标准缓存感知负载。回放前 5 分钟切片(约 1000 请求)按 trace 时间戳发压,既代表真实形态又能干净出报告(全量 ~59 分钟会压垮汇总导出)。",
-    scenario: "lb-strategy",
+      "【引擎块级前缀缓存 · 真实 Kimi 流量;多副本 LB 路由验证见 lb-strategy】Mooncake conversation trace(~40% 前缀复用)开环回放,业界标准缓存感知负载。回放前 5 分钟切片(约 1000 请求)按 trace 时间戳发压,既代表真实形态又能干净出报告(全量 ~59 分钟会压垮汇总导出)。",
+    scenario: "engine-kv-cache",
     tool: "aiperf",
     config: {
       endpointType: "chat",
@@ -863,8 +864,8 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
     id: "tpl_pc_mooncake_agent",
     name: "缓存感知 · Mooncake Agent",
     description:
-      "Mooncake toolagent trace(~59% 前缀复用)开环回放,长 system prompt + 工具形态。回放前 5 分钟切片(约 1000 请求),按 trace 时间戳发压,干净出报告。",
-    scenario: "lb-strategy",
+      "【引擎块级前缀缓存 · 真实 Kimi 流量;多副本 LB 路由验证见 lb-strategy】Mooncake toolagent trace(~59% 前缀复用)开环回放,长 system prompt + 工具形态。回放前 5 分钟切片(约 1000 请求),按 trace 时间戳发压,干净出报告。",
+    scenario: "engine-kv-cache",
     tool: "aiperf",
     config: {
       endpointType: "chat",

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -227,10 +227,10 @@ const EVALUATION_PROFILES: EvaluationProfileSeed[] = [
 type Tool = "guidellm" | "evalscope" | "aiperf" | "vegeta";
 type SeedScenario =
   | "inference"
-  | "kv-cache-stress"
+  | "engine-kv-cache"
   | "capacity"
   | "gateway"
-  | "prefix-cache-validation";
+  | "lb-strategy";
 interface BenchmarkTemplateSeed {
   id: string;
   name: string;
@@ -460,7 +460,7 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
     name: "KV Cache · Task 1 · 8K prompt · parallel 8",
     description:
       "evalscope perf · 8000-9000 token prompts · parallel 8 · 64 次请求 · 160-200 输出 token，seed=42 复现锁定。配 `<run>(rerun)` 子 benchmark 触发 KvCacheStressReport 的 cold/warm 对比。",
-    scenario: "kv-cache-stress",
+    scenario: "engine-kv-cache",
     tool: "evalscope",
     config: {
       dataset: "longalpaca",
@@ -481,7 +481,7 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
     name: "KV Cache · Task 2 · 8K prompt · parallel 16",
     description:
       "evalscope perf · 8000-9000 token prompts · parallel 16 · 128 次请求 · 160-200 输出 token，seed=42 复现锁定。配 `<run>(rerun)` 子 benchmark 触发 KvCacheStressReport 的 cold/warm 对比。",
-    scenario: "kv-cache-stress",
+    scenario: "engine-kv-cache",
     tool: "evalscope",
     config: {
       dataset: "longalpaca",
@@ -502,7 +502,7 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
     name: "KV Cache · Task 3 · 11K prompt · parallel 8",
     description:
       "evalscope perf · 11000-13000 token prompts · parallel 8 · 64 次请求 · 300-400 输出 token，seed=42 复现锁定。配 `<run>(rerun)` 子 benchmark 触发 KvCacheStressReport 的 cold/warm 对比。",
-    scenario: "kv-cache-stress",
+    scenario: "engine-kv-cache",
     tool: "evalscope",
     config: {
       dataset: "longalpaca",
@@ -523,7 +523,7 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
     name: "KV Cache · Task 4 · 11K prompt · parallel 16",
     description:
       "evalscope perf · 11000-13000 token prompts · parallel 16 · 128 次请求 · 300-400 输出 token，seed=42 复现锁定。配 `<run>(rerun)` 子 benchmark 触发 KvCacheStressReport 的 cold/warm 对比。",
-    scenario: "kv-cache-stress",
+    scenario: "engine-kv-cache",
     tool: "evalscope",
     config: {
       dataset: "longalpaca",
@@ -544,7 +544,7 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
     name: "KV Cache · Task 5 · 14K prompt · parallel 8",
     description:
       "evalscope perf · 14000-16000 token prompts · parallel 8 · 64 次请求 · 100-200 输出 token，seed=42 复现锁定。配 `<run>(rerun)` 子 benchmark 触发 KvCacheStressReport 的 cold/warm 对比。",
-    scenario: "kv-cache-stress",
+    scenario: "engine-kv-cache",
     tool: "evalscope",
     config: {
       dataset: "longalpaca",
@@ -565,7 +565,7 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
     name: "KV Cache · Task 6 · 14K prompt · parallel 16",
     description:
       "evalscope perf · 14000-16000 token prompts · parallel 16 · 128 次请求 · 100-200 输出 token，seed=42 复现锁定。配 `<run>(rerun)` 子 benchmark 触发 KvCacheStressReport 的 cold/warm 对比。",
-    scenario: "kv-cache-stress",
+    scenario: "engine-kv-cache",
     tool: "evalscope",
     config: {
       dataset: "longalpaca",
@@ -762,7 +762,7 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
     name: "路由粘性 · 文章同款 (t1)",
     description:
       "Higress 文章同款多轮:60 会话 × 5 轮,in 200 / out 800,concurrency 20。关/开 ai-load-balancer 各跑一次,对比 TTFT 与 Prometheus 命中率 / 逐-pod 集中度。",
-    scenario: "prefix-cache-validation",
+    scenario: "lb-strategy",
     tool: "aiperf",
     config: {
       concurrency: 20,
@@ -794,7 +794,7 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
     name: "路由粘性 · 深会话 (t2)",
     description:
       "深会话:30 会话 × 10 轮,前缀累积最多,prefix-cache 路由收益最敏感。关/开对照的首选档。",
-    scenario: "prefix-cache-validation",
+    scenario: "lb-strategy",
     tool: "aiperf",
     config: {
       concurrency: 20,
@@ -819,7 +819,7 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
     id: "tpl_pc_t3_shallow",
     name: "路由粘性 · 浅会话 (t3)",
     description: "浅会话:120 会话 × 2 轮,对照锚点,前缀复用少、prefix-cache 收益最小。",
-    scenario: "prefix-cache-validation",
+    scenario: "lb-strategy",
     tool: "aiperf",
     config: {
       concurrency: 20,
@@ -845,7 +845,7 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
     name: "缓存感知 · Mooncake 对话",
     description:
       "Mooncake conversation trace(~40% 前缀复用)开环回放,业界标准缓存感知负载。回放前 5 分钟切片(约 1000 请求)按 trace 时间戳发压,既代表真实形态又能干净出报告(全量 ~59 分钟会压垮汇总导出)。",
-    scenario: "prefix-cache-validation",
+    scenario: "lb-strategy",
     tool: "aiperf",
     config: {
       endpointType: "chat",
@@ -864,7 +864,7 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
     name: "缓存感知 · Mooncake Agent",
     description:
       "Mooncake toolagent trace(~59% 前缀复用)开环回放,长 system prompt + 工具形态。回放前 5 分钟切片(约 1000 请求),按 trace 时间戳发压,干净出报告。",
-    scenario: "prefix-cache-validation",
+    scenario: "lb-strategy",
     tool: "aiperf",
     config: {
       endpointType: "chat",
@@ -934,7 +934,7 @@ async function seedBenchmarkTemplates(): Promise<void> {
             : evalscopeParamsSchema;
     const validatedBase = base.parse(t.config);
     // Apply scenario-level constraints uniformly across tools. For
-    // (inference, evalscope) and (kv-cache-stress, evalscope) this is
+    // (inference, evalscope) and (engine-kv-cache, evalscope) this is
     // a no-op — those scenarios' paramsConstraints maps have no entry
     // for evalscope, so applyScenarioConstraints returns the bare
     // adapter schema and re-parses the same shape. We still call it

--- a/apps/api/src/modules/benchmark/storage/report-loader.spec.ts
+++ b/apps/api/src/modules/benchmark/storage/report-loader.spec.ts
@@ -172,7 +172,7 @@ describe("ReportLoader", () => {
 
 function makePrefixCacheDeps() {
   const base = makeDeps();
-  // Bench is a prefix-cache-validation scenario with a connection that has an
+  // Bench is a lb-strategy scenario with a connection that has an
   // explicit prometheusDatasourceId binding.
   (base.repo.findById as ReturnType<typeof vi.fn>).mockImplementation(async (id: string) => ({
     id,
@@ -180,7 +180,7 @@ function makePrefixCacheDeps() {
     tool: "aiperf",
     userId: "u1",
     name: "pcv",
-    scenario: "prefix-cache-validation",
+    scenario: "lb-strategy",
     connectionId: "conn-1",
     connection: {
       id: "conn-1",
@@ -231,7 +231,7 @@ describe("ReportLoader – prefix-cache snapshot hook", () => {
     deps = makePrefixCacheDeps();
   });
 
-  it("snapshots and calls mergeServerMetrics when scenario=prefix-cache-validation and ds resolves", async () => {
+  it("snapshots and calls mergeServerMetrics when scenario=lb-strategy and ds resolves", async () => {
     const loader = newPrefixCacheLoader(deps);
     await loader.tryLoad("r1");
     // Must use the datasourceId path (not connectionId) so we never fall back
@@ -252,7 +252,7 @@ describe("ReportLoader – prefix-cache snapshot hook", () => {
     );
   });
 
-  it("skips snapshot when scenario != prefix-cache-validation (no promFetcher call)", async () => {
+  it("skips snapshot when scenario != lb-strategy (no promFetcher call)", async () => {
     (deps.repo.findById as ReturnType<typeof vi.fn>).mockImplementation(async (id: string) => ({
       id,
       status: "running",
@@ -289,7 +289,7 @@ describe("ReportLoader – prefix-cache snapshot hook", () => {
       tool: "aiperf",
       userId: "u1",
       name: "pcv",
-      scenario: "prefix-cache-validation",
+      scenario: "lb-strategy",
       connectionId: null,
       connection: null,
       startedAt: new Date(),
@@ -342,7 +342,7 @@ describe("ReportLoader – prefix-cache snapshot hook", () => {
       tool: "aiperf",
       userId: "u1",
       name: "pcv",
-      scenario: "prefix-cache-validation",
+      scenario: "lb-strategy",
       connectionId: "conn-1",
       connection: {
         id: "conn-1",
@@ -378,7 +378,7 @@ describe("ReportLoader – prefix-cache snapshot hook", () => {
       tool: "aiperf",
       userId: "u1",
       name: "pcv",
-      scenario: "prefix-cache-validation",
+      scenario: "lb-strategy",
       connectionId: "conn-1",
       connection: {
         id: "conn-1",

--- a/apps/api/src/modules/benchmark/storage/report-loader.ts
+++ b/apps/api/src/modules/benchmark/storage/report-loader.ts
@@ -21,7 +21,7 @@ export interface ReportLoaderDeps {
   sse: SseHub;
   byTool?: typeof defaultByTool;
   /** Optional: when provided, a prefix-cache snapshot is taken after completion
-   *  for `prefix-cache-validation` benchmarks that have a Prometheus datasource.
+   *  for `lb-strategy` benchmarks that have a Prometheus datasource.
    *  Both `prefixCacheSnapshot` and `promFetcher` must be provided together —
    *  the hook is silently skipped if either is absent. */
   prefixCacheSnapshot?: PrefixCacheSnapshotService;
@@ -127,7 +127,7 @@ export class ReportLoader {
   /**
    * Best-effort prefix-cache metric snapshot. Guards:
    *   1. Both `prefixCacheSnapshot` and `promFetcher` must be injected.
-   *   2. scenario must be "prefix-cache-validation".
+   *   2. scenario must be "lb-strategy".
    *   3. The connection must have an explicit `prometheusDatasourceId` binding.
    *      If there is no binding we skip entirely — we must NOT fall back to the
    *      workspace-default datasource (which would silently snapshot the wrong
@@ -148,7 +148,7 @@ export class ReportLoader {
       opts;
     if (!this.deps.prefixCacheSnapshot || !this.deps.promFetcher) return;
     try {
-      if (scenario !== "prefix-cache-validation") return;
+      if (scenario !== "lb-strategy") return;
       // Graceful degrade: no explicit datasource binding → skip (never fall
       // back to the workspace default — that would be a wrong datasource).
       if (!prometheusDatasourceId) return;

--- a/apps/api/src/modules/mcp/tools/run-benchmark.tool.ts
+++ b/apps/api/src/modules/mcp/tools/run-benchmark.tool.ts
@@ -26,7 +26,7 @@ export function registerRunBenchmark(server: McpServer, deps: McpToolDeps): void
       inputShape: {
         scenario: z
           .string()
-          .describe("inference | capacity | gateway | prefix-cache-validation | kv-cache-stress"),
+          .describe("inference | capacity | gateway | lb-strategy | engine-kv-cache"),
         tool: z.string().describe("guidellm | vegeta | evalscope | aiperf"),
         connectionId: z.string().min(1).describe("Target connection id."),
         name: z.string().min(1).max(128).describe("Run name."),

--- a/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
+++ b/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
@@ -99,7 +99,7 @@ export class CompareSynthesizeService {
 
   /**
    * Guarantee the prefix-cache hit-rate figure is present when the data
-   * supports it. Hit rate is the metric a prefix-cache-validation comparison
+   * supports it. Hit rate is the metric a lb-strategy comparison
    * exists to measure, but it isn't in the throughput/latency blob the LLM
    * fixates on, so weaker models routinely omit it. When the refId is
    * available and the LLM didn't include it, inject it (anchored to results)

--- a/apps/api/src/modules/saved-compares/prompts.ts
+++ b/apps/api/src/modules/saved-compares/prompts.ts
@@ -69,7 +69,7 @@ Section size targets:
 - 06 advice:  ≤ half page, scenario → config + 0-5 caveats
 
 Prefix-cache runs: when the per-stage data carries prefix_cache_hit% / top_pod_share%
-(prefix-cache-validation, e.g. routing OFF vs ON), the HEADLINE conclusion and the
+(lb-strategy, e.g. routing OFF vs ON), the HEADLINE conclusion and the
 first summary card MUST be the cache hit-rate change — that is the metric the
 experiment exists to measure. Use the stage-bars-prefix-cache-hit figure for it and
 stage-bars-top-pod-share to show routing concentration. Treat throughput/TTFT as

--- a/apps/web/src/components/sidebar/sidebar-config.tsx
+++ b/apps/web/src/components/sidebar/sidebar-config.tsx
@@ -58,12 +58,12 @@ export const sidebarGroups: SidebarGroup[] = [
       { to: "/benchmarks/capacity", icon: Activity, labelKey: "items.benchmarkCapacity" },
       { to: "/benchmarks/gateway", icon: Network, labelKey: "items.benchmarkGateway" },
       {
-        to: "/benchmarks/prefix-cache-validation",
+        to: "/benchmarks/lb-strategy",
         icon: Layers,
         labelKey: "items.benchmarkPrefixCache",
       },
       {
-        to: "/benchmarks/kv-cache-stress",
+        to: "/benchmarks/engine-kv-cache",
         icon: Database,
         labelKey: "items.benchmarkKvCacheStress",
       },

--- a/apps/web/src/features/benchmark-templates/TemplateForm.tsx
+++ b/apps/web/src/features/benchmark-templates/TemplateForm.tsx
@@ -131,13 +131,13 @@ export function TemplateForm({ mode, isAdmin, displayScenario, displayTool }: Te
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {(
-                    ["inference", "capacity", "gateway", "lb-strategy"] as ScenarioId[]
-                  ).map((sid) => (
-                    <SelectItem key={sid} value={sid}>
-                      {t(`list.tabs.${sid}`)}
-                    </SelectItem>
-                  ))}
+                  {(["inference", "capacity", "gateway", "lb-strategy"] as ScenarioId[]).map(
+                    (sid) => (
+                      <SelectItem key={sid} value={sid}>
+                        {t(`list.tabs.${sid}`)}
+                      </SelectItem>
+                    ),
+                  )}
                 </SelectContent>
               </Select>
             )}

--- a/apps/web/src/features/benchmark-templates/TemplateForm.tsx
+++ b/apps/web/src/features/benchmark-templates/TemplateForm.tsx
@@ -132,7 +132,7 @@ export function TemplateForm({ mode, isAdmin, displayScenario, displayTool }: Te
                 </SelectTrigger>
                 <SelectContent>
                   {(
-                    ["inference", "capacity", "gateway", "prefix-cache-validation"] as ScenarioId[]
+                    ["inference", "capacity", "gateway", "lb-strategy"] as ScenarioId[]
                   ).map((sid) => (
                     <SelectItem key={sid} value={sid}>
                       {t(`list.tabs.${sid}`)}

--- a/apps/web/src/features/benchmark-templates/TemplateListPage.tsx
+++ b/apps/web/src/features/benchmark-templates/TemplateListPage.tsx
@@ -20,7 +20,7 @@ const SCENARIO_TABS: { id: ScenarioId; labelKey: string }[] = [
   { id: "inference", labelKey: "list.tabs.inference" },
   { id: "capacity", labelKey: "list.tabs.capacity" },
   { id: "gateway", labelKey: "list.tabs.gateway" },
-  { id: "prefix-cache-validation", labelKey: "list.tabs.prefix-cache-validation" },
+  { id: "lb-strategy", labelKey: "list.tabs.lb-strategy" },
 ];
 
 export function TemplateListPage() {

--- a/apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkCreatePage.tsx
@@ -216,8 +216,8 @@ export function BenchmarkCreatePage() {
     inference: "benchmarkInference",
     capacity: "benchmarkCapacity",
     gateway: "benchmarkGateway",
-    "prefix-cache-validation": "benchmarkPrefixCache",
-    "kv-cache-stress": "benchmarkKvCacheStress",
+    "lb-strategy": "benchmarkPrefixCache",
+    "engine-kv-cache": "benchmarkKvCacheStress",
   };
   const breadcrumbs = [
     { label: tSidebar("groups.benchmarks") },

--- a/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
@@ -167,14 +167,14 @@ function ReportSection({ benchmark }: { benchmark: Benchmark }) {
       return <CapacityReport benchmark={benchmark} />;
     case "gateway":
       return <GatewayReport benchmark={benchmark} />;
-    case "prefix-cache-validation":
+    case "lb-strategy":
       return (
         <div className="space-y-6">
           <InferenceReport benchmark={benchmark} />
           <PrefixCachePanel serverMetrics={benchmark.serverMetrics} />
         </div>
       );
-    case "kv-cache-stress":
+    case "engine-kv-cache":
       return <KvCacheStressReport benchmark={benchmark} />;
     default:
       return <UnknownReport benchmark={benchmark} />;
@@ -274,8 +274,8 @@ const SCENARIO_SIDEBAR_KEY: Record<ScenarioId, string> = {
   inference: "benchmarkInference",
   capacity: "benchmarkCapacity",
   gateway: "benchmarkGateway",
-  "prefix-cache-validation": "benchmarkPrefixCache",
-  "kv-cache-stress": "benchmarkKvCacheStress",
+  "lb-strategy": "benchmarkPrefixCache",
+  "engine-kv-cache": "benchmarkKvCacheStress",
 };
 
 export function BenchmarkDetailPage() {

--- a/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
@@ -175,7 +175,15 @@ function ReportSection({ benchmark }: { benchmark: Benchmark }) {
         </div>
       );
     case "engine-kv-cache":
-      return <KvCacheStressReport benchmark={benchmark} />;
+      // evalscope = KV-backend view; aiperf mooncake = prefix-cache view.
+      return benchmark.tool === "aiperf" ? (
+        <div className="space-y-6">
+          <InferenceReport benchmark={benchmark} />
+          <PrefixCachePanel serverMetrics={benchmark.serverMetrics} />
+        </div>
+      ) : (
+        <KvCacheStressReport benchmark={benchmark} />
+      );
     default:
       return <UnknownReport benchmark={benchmark} />;
   }

--- a/apps/web/src/features/benchmarks/BenchmarkKvCacheStressPage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkKvCacheStressPage.tsx
@@ -1,5 +1,5 @@
 import { BenchmarkListShell } from "./BenchmarkListShell";
 
 export function BenchmarkKvCacheStressPage() {
-  return <BenchmarkListShell scenario="kv-cache-stress" />;
+  return <BenchmarkListShell scenario="engine-kv-cache" />;
 }

--- a/apps/web/src/features/benchmarks/BenchmarkListShell.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkListShell.tsx
@@ -70,8 +70,8 @@ const SCENARIO_SIDEBAR_KEY: Record<ScenarioId, string> = {
   inference: "benchmarkInference",
   capacity: "benchmarkCapacity",
   gateway: "benchmarkGateway",
-  "prefix-cache-validation": "benchmarkPrefixCache",
-  "kv-cache-stress": "benchmarkKvCacheStress",
+  "lb-strategy": "benchmarkPrefixCache",
+  "engine-kv-cache": "benchmarkKvCacheStress",
 };
 
 export function BenchmarkListShell({ scenario }: BenchmarkListShellProps) {

--- a/apps/web/src/features/benchmarks/BenchmarkPrefixCachePage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkPrefixCachePage.tsx
@@ -1,5 +1,5 @@
 import { BenchmarkListShell } from "./BenchmarkListShell";
 
 export function BenchmarkPrefixCachePage() {
-  return <BenchmarkListShell scenario="prefix-cache-validation" />;
+  return <BenchmarkListShell scenario="lb-strategy" />;
 }

--- a/apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
+++ b/apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
@@ -32,8 +32,8 @@ const SCENARIO_SIDEBAR_KEY: Record<ScenarioId, string> = {
   inference: "benchmarkInference",
   capacity: "benchmarkCapacity",
   gateway: "benchmarkGateway",
-  "prefix-cache-validation": "benchmarkPrefixCache",
-  "kv-cache-stress": "benchmarkKvCacheStress",
+  "lb-strategy": "benchmarkPrefixCache",
+  "engine-kv-cache": "benchmarkKvCacheStress",
 };
 
 function parseIds(searchParams: URLSearchParams): string[] {

--- a/apps/web/src/features/benchmarks/compare/client-metrics.ts
+++ b/apps/web/src/features/benchmarks/compare/client-metrics.ts
@@ -22,7 +22,7 @@ export interface RunMetricBlobs {
 
 /**
  * Read the prefix-cache annotation from a run's `serverMetrics` blob (stored
- * at `serverMetrics.prefixCache` on completion of a prefix-cache-validation
+ * at `serverMetrics.prefixCache` on completion of a lb-strategy
  * run). Returns null when absent or malformed — non-prefix-cache runs and
  * runs whose Prometheus snapshot found no data both degrade to null.
  */

--- a/apps/web/src/features/benchmarks/reports/KvCacheStressReport.tsx
+++ b/apps/web/src/features/benchmarks/reports/KvCacheStressReport.tsx
@@ -26,8 +26,8 @@ function fmt(n: number, digits = 1): string {
 const RERUN_SUFFIX = " (rerun)";
 
 /**
- * The "kv-cache-stress" scenario now renders evalscope's report shape (the
- * legacy kv-cache-stress tool is being retired in Phase 9). When a sibling
+ * The "engine-kv-cache" scenario now renders evalscope's report shape (the
+ * legacy engine-kv-cache tool is being retired in Phase 9). When a sibling
  * benchmark named `<name> (rerun)` exists in the same scope, we render a
  * cold-vs-warm delta table comparing the cold first run (R1) against the
  * warm rerun (R2). Otherwise the rerun panel is omitted.
@@ -90,7 +90,7 @@ function ColdWarmPairPanel({ benchmark, cold }: ColdWarmPairPanelProps) {
 
   const list = useBenchmarkList({
     connectionId: benchmark.connectionId ?? undefined,
-    scenario: "kv-cache-stress",
+    scenario: "engine-kv-cache",
     search: sourceName,
     // Restrict to terminal-success benchmarks so an in-flight rerun doesn't
     // accidentally match as the sibling pair (its summaryMetrics is null and

--- a/apps/web/src/features/benchmarks/reports/__tests__/KvCacheStressReport.test.tsx
+++ b/apps/web/src/features/benchmarks/reports/__tests__/KvCacheStressReport.test.tsx
@@ -58,7 +58,7 @@ const baseBenchmark = {
   id: "b1",
   name: "KV Cache · Task 1",
   tool: "evalscope",
-  scenario: "kv-cache-stress",
+  scenario: "engine-kv-cache",
   status: "completed",
   summaryMetrics: { tool: "evalscope", data: baseData },
 } as unknown as Benchmark;

--- a/apps/web/src/features/benchmarks/scenarios.ts
+++ b/apps/web/src/features/benchmarks/scenarios.ts
@@ -9,8 +9,8 @@ export const SCENARIO_ICONS: Record<ScenarioId, LucideIcon> = {
   inference: Gauge,
   capacity: Activity,
   gateway: Network,
-  "prefix-cache-validation": Layers,
-  "kv-cache-stress": Database,
+  "lb-strategy": Layers,
+  "engine-kv-cache": Database,
 };
 
 export { SCENARIOS, type ScenarioId };

--- a/apps/web/src/features/deployment-recipes/data.ts
+++ b/apps/web/src/features/deployment-recipes/data.ts
@@ -158,7 +158,7 @@ export const MODELS: ModelEntry[] = [
   // -------- KV cache offload 实战配方 ----------------------------------------
   // 这两行是同一个底层模型(Qwen3-32B)+ 同一引擎(vllm-ascend)+ 不同 KV
   // cache 后端的对比配方。源自 theriseunion/repots 2026-05-10/05-11 在
-  // Atlas 800I A2 / 8×910B4 实测得出的两套生产可用方案,作 `kv-cache-stress`
+  // Atlas 800I A2 / 8×910B4 实测得出的两套生产可用方案,作 `engine-kv-cache`
   // benchmark scenario 的目标参考。两条 recipe 都是 `community` 状态:镜像内部
   // 构建 + vLLM 0.18 / yrcache 1.5.0 兼容性 hot-patch,不在上游 release。
   {

--- a/apps/web/src/features/insights/__tests__/ScoreBanner.test.tsx
+++ b/apps/web/src/features/insights/__tests__/ScoreBanner.test.tsx
@@ -17,8 +17,8 @@ describe("ScoreBanner", () => {
           inference: 92,
           capacity: 75,
           gateway: 82,
-          "prefix-cache-validation": null,
-          "kv-cache-stress": null,
+          "lb-strategy": null,
+          "engine-kv-cache": null,
         }}
         totalChecks={18}
         totalRuns={25}
@@ -39,8 +39,8 @@ describe("ScoreBanner", () => {
           inference: null,
           capacity: null,
           gateway: null,
-          "prefix-cache-validation": null,
-          "kv-cache-stress": null,
+          "lb-strategy": null,
+          "engine-kv-cache": null,
         }}
         totalChecks={0}
         totalRuns={0}
@@ -58,8 +58,8 @@ describe("ScoreBanner", () => {
           inference: 92,
           capacity: null,
           gateway: null,
-          "prefix-cache-validation": null,
-          "kv-cache-stress": null,
+          "lb-strategy": null,
+          "engine-kv-cache": null,
         }}
         totalChecks={7}
         totalRuns={5}

--- a/apps/web/src/features/insights/__tests__/evaluate.test.ts
+++ b/apps/web/src/features/insights/__tests__/evaluate.test.ts
@@ -88,8 +88,8 @@ describe("compositeScore", () => {
         inference: null,
         capacity: null,
         gateway: null,
-        "prefix-cache-validation": null,
-        "kv-cache-stress": null,
+        "lb-strategy": null,
+        "engine-kv-cache": null,
       }),
     ).toBeNull();
   });
@@ -100,8 +100,8 @@ describe("compositeScore", () => {
         inference: 90,
         capacity: 70,
         gateway: 80,
-        "prefix-cache-validation": null,
-        "kv-cache-stress": null,
+        "lb-strategy": null,
+        "engine-kv-cache": null,
       }),
     ).toBe(80);
   });
@@ -112,8 +112,8 @@ describe("compositeScore", () => {
         inference: 90,
         capacity: null,
         gateway: 70,
-        "prefix-cache-validation": null,
-        "kv-cache-stress": null,
+        "lb-strategy": null,
+        "engine-kv-cache": null,
       }),
     ).toBe(80);
   });

--- a/apps/web/src/locales/en-US/benchmark-templates.json
+++ b/apps/web/src/locales/en-US/benchmark-templates.json
@@ -14,7 +14,7 @@
       "inference": "Inference benchmark",
       "capacity": "Capacity planning",
       "gateway": "Gateway load test",
-      "lb-strategy": "Prefix-cache validation"
+      "lb-strategy": "LB strategy"
     },
     "filters": {
       "search": "Search name or description…",

--- a/apps/web/src/locales/en-US/benchmark-templates.json
+++ b/apps/web/src/locales/en-US/benchmark-templates.json
@@ -14,7 +14,7 @@
       "inference": "Inference benchmark",
       "capacity": "Capacity planning",
       "gateway": "Gateway load test",
-      "prefix-cache-validation": "Prefix-cache validation"
+      "lb-strategy": "Prefix-cache validation"
     },
     "filters": {
       "search": "Search name or description…",

--- a/apps/web/src/locales/en-US/benchmarks.json
+++ b/apps/web/src/locales/en-US/benchmarks.json
@@ -12,7 +12,7 @@
       "inference": "New Inference Benchmark",
       "capacity": "New Capacity Plan",
       "gateway": "New Gateway Test",
-      "prefix-cache-validation": "New Prefix-cache Validation"
+      "lb-strategy": "New Prefix-cache Validation"
     },
     "subtitle": "Configure parameters, then submit",
     "sections": {
@@ -126,7 +126,7 @@
     "inference": "TTFT / TPOT / single-run throughput baseline",
     "capacity": "SLO-driven load step sweep",
     "gateway": "Higress / API path HTTP performance",
-    "prefix-cache-validation": "Verify Higress ai-load-balancer prefix-cache pins same-prefix requests to one vLLM replica"
+    "lb-strategy": "Verify Higress ai-load-balancer prefix-cache pins same-prefix requests to one vLLM replica"
   },
   "compareButton": "Compare ({{n}})",
   "compareDisabledNeedTwo": "Select at least 2 benchmarks to compare",

--- a/apps/web/src/locales/en-US/benchmarks.json
+++ b/apps/web/src/locales/en-US/benchmarks.json
@@ -12,7 +12,7 @@
       "inference": "New Inference Benchmark",
       "capacity": "New Capacity Plan",
       "gateway": "New Gateway Test",
-      "lb-strategy": "New Prefix-cache Validation"
+      "lb-strategy": "New LB-strategy Validation"
     },
     "subtitle": "Configure parameters, then submit",
     "sections": {
@@ -126,7 +126,7 @@
     "inference": "TTFT / TPOT / single-run throughput baseline",
     "capacity": "SLO-driven load step sweep",
     "gateway": "Higress / API path HTTP performance",
-    "lb-strategy": "Verify Higress ai-load-balancer prefix-cache pins same-prefix requests to one vLLM replica"
+    "lb-strategy": "Validate LB routing strategies (currently ai-load-balancer prefix_cache) pin same-prefix requests to one replica"
   },
   "compareButton": "Compare ({{n}})",
   "compareDisabledNeedTwo": "Select at least 2 benchmarks to compare",

--- a/apps/web/src/locales/zh-CN/benchmark-templates.json
+++ b/apps/web/src/locales/zh-CN/benchmark-templates.json
@@ -14,7 +14,7 @@
       "inference": "推理性能基准",
       "capacity": "容量规划",
       "gateway": "网关压测",
-      "lb-strategy": "Prefix-cache 验证"
+      "lb-strategy": "负载均衡策略"
     },
     "filters": {
       "search": "按名称或描述搜索…",

--- a/apps/web/src/locales/zh-CN/benchmark-templates.json
+++ b/apps/web/src/locales/zh-CN/benchmark-templates.json
@@ -14,7 +14,7 @@
       "inference": "推理性能基准",
       "capacity": "容量规划",
       "gateway": "网关压测",
-      "prefix-cache-validation": "Prefix-cache 验证"
+      "lb-strategy": "Prefix-cache 验证"
     },
     "filters": {
       "search": "按名称或描述搜索…",

--- a/apps/web/src/locales/zh-CN/benchmarks.json
+++ b/apps/web/src/locales/zh-CN/benchmarks.json
@@ -12,7 +12,7 @@
       "inference": "新建推理性能基准",
       "capacity": "新建容量规划",
       "gateway": "新建网关压测",
-      "prefix-cache-validation": "新建 Prefix-cache 验证"
+      "lb-strategy": "新建 Prefix-cache 验证"
     },
     "subtitle": "配置参数后提交",
     "sections": {
@@ -126,7 +126,7 @@
     "inference": "TTFT / TPOT / 单次吞吐基线",
     "capacity": "SLO 驱动的负载阶梯扫描",
     "gateway": "Higress / API 链路 HTTP 性能",
-    "prefix-cache-validation": "验证 Higress ai-load-balancer prefix-cache 策略下相同前缀请求是否粘到同一 vLLM 副本"
+    "lb-strategy": "验证 Higress ai-load-balancer prefix-cache 策略下相同前缀请求是否粘到同一 vLLM 副本"
   },
   "compareButton": "对比 ({{n}})",
   "compareDisabledNeedTwo": "至少选 2 个基准测试才能对比",

--- a/apps/web/src/locales/zh-CN/benchmarks.json
+++ b/apps/web/src/locales/zh-CN/benchmarks.json
@@ -12,7 +12,7 @@
       "inference": "新建推理性能基准",
       "capacity": "新建容量规划",
       "gateway": "新建网关压测",
-      "lb-strategy": "新建 Prefix-cache 验证"
+      "lb-strategy": "新建 负载均衡策略验证"
     },
     "subtitle": "配置参数后提交",
     "sections": {
@@ -126,7 +126,7 @@
     "inference": "TTFT / TPOT / 单次吞吐基线",
     "capacity": "SLO 驱动的负载阶梯扫描",
     "gateway": "Higress / API 链路 HTTP 性能",
-    "lb-strategy": "验证 Higress ai-load-balancer prefix-cache 策略下相同前缀请求是否粘到同一 vLLM 副本"
+    "lb-strategy": "验证不同负载均衡策略(当前 ai-load-balancer prefix_cache)下相同前缀请求是否粘到同一副本"
   },
   "compareButton": "对比 ({{n}})",
   "compareDisabledNeedTwo": "至少选 2 个基准测试才能对比",

--- a/apps/web/src/router/index.tsx
+++ b/apps/web/src/router/index.tsx
@@ -86,11 +86,11 @@ export const routes: RouteObject[] = [
           { path: "benchmarks/capacity", element: <BenchmarkCapacityPage /> },
           { path: "benchmarks/gateway", element: <BenchmarkGatewayPage /> },
           {
-            path: "benchmarks/prefix-cache-validation",
+            path: "benchmarks/lb-strategy",
             element: <BenchmarkPrefixCachePage />,
           },
           {
-            path: "benchmarks/kv-cache-stress",
+            path: "benchmarks/engine-kv-cache",
             element: <BenchmarkKvCacheStressPage />,
           },
           { path: "benchmarks/compare", element: <BenchmarkCompareGate /> },

--- a/docs/superpowers/plans/2026-06-18-scenario-split-lb-engine.md
+++ b/docs/superpowers/plans/2026-06-18-scenario-split-lb-engine.md
@@ -1,0 +1,362 @@
+# Scenario split (`lb-strategy` + `engine-kv-cache`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename the conflated `prefix-cache-validation` → `lb-strategy` and `kv-cache-stress` → `engine-kv-cache`, re-home the mooncake templates to `engine-kv-cache`, and make the engine-cache report tool-aware — so LB-routing validation and engine prefix-cache validation are cleanly separated.
+
+**Architecture:** The two scenario ids are unique string tokens, so a scoped find-replace across `packages/` + `apps/` does the mechanical rename (code + i18n keys + tests). Structural edits then layer on: scenario labels/descriptions/tools, aiperf added to `engine-kv-cache`, mooncake templates moved to `engine-kv-cache`, a tool-aware report branch, a data-fixup migration, and i18n description text.
+
+**Tech Stack:** TypeScript, zod (`scenarioIdSchema`), NestJS + Prisma (seed + migration), React + react-i18next (web), Vitest, biome, pnpm monorepo.
+
+---
+
+## File Structure
+
+- **Mechanical rename (Task 1):** every `.ts/.tsx/.json` under `packages/` + `apps/` containing the literal `prefix-cache-validation` or `kv-cache-stress` (≈40 code files + 4 i18n + 5 test files). EXCLUDES `docs/` (the spec/plan intentionally name the old ids).
+- **`packages/tool-adapters/src/scenarios.ts`** — the two `SCENARIOS` config bodies (labels/descriptions/tools) + the report-component field.
+- **`packages/tool-adapters/src/aiperf/index.ts`** — add `engine-kv-cache` to aiperf's scenarios.
+- **`apps/api/prisma/seed.ts`** — move the 2 mooncake templates to `engine-kv-cache` + descriptions.
+- **`apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx`** — tool-aware `engine-kv-cache` report branch.
+- **`apps/api/prisma/migrations/<ts>_rename_scenarios/migration.sql`** — data fixup on `benchmarks` / `benchmark_templates` / `alert_events`.
+- **`apps/web/src/locales/{zh-CN,en-US}/benchmarks.json` + `benchmark-templates.json`** — scenario label/description text.
+
+---
+
+## Task 1: Mechanical id rename (code + i18n keys + tests)
+
+**Files:** all `.ts/.tsx/.json` under `packages/` + `apps/` with the two literals (NOT `docs/`).
+
+- [ ] **Step 1: Replace the two id strings everywhere except docs**
+
+Run (from repo root):
+```bash
+grep -rl --include='*.ts' --include='*.tsx' --include='*.json' \
+  -e 'prefix-cache-validation' -e 'kv-cache-stress' packages apps \
+  | grep -v node_modules | grep -v '/dist/' \
+  | xargs sed -i '' \
+      -e 's/prefix-cache-validation/lb-strategy/g' \
+      -e 's/kv-cache-stress/engine-kv-cache/g'
+```
+(macOS `sed -i ''`. This renames the scenario-id occurrences in code, i18n keys, and tests. The shorter substrings `prefix-cache` / `kv-cache` WITHOUT the suffix are untouched, so prose like "prefix-cache 策略" survives.)
+
+- [ ] **Step 2: Verify no stray old ids remain in code (docs are expected to keep them)**
+
+Run: `grep -rn 'prefix-cache-validation\|kv-cache-stress' packages apps | grep -v node_modules | grep -v '/dist/'`
+Expected: no output (empty).
+
+- [ ] **Step 3: Build the renamed packages so downstream typechecks see new enum**
+
+Run: `pnpm -F @modeldoctor/contracts -F @modeldoctor/tool-adapters build`
+Expected: both build (the `scenarioIdSchema` enum now has `lb-strategy` / `engine-kv-cache`).
+
+- [ ] **Step 4: Commit the mechanical rename**
+
+```bash
+git add -u packages apps
+git commit -m "$(printf 'refactor(scenarios): rename ids prefix-cache-validation->lb-strategy, kv-cache-stress->engine-kv-cache\n\nMechanical id rename across code, i18n keys, and tests (docs keep old ids).\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 2: Scenario configs — labels, descriptions, tools
+
+**Files:** Modify `packages/tool-adapters/src/scenarios.ts`
+
+After Task 1 the keys are already `lb-strategy` / `engine-kv-cache`. Now fix their bodies.
+
+- [ ] **Step 1: Rewrite the `lb-strategy` config body**
+
+Replace the `"lb-strategy": { ... }` block with:
+```ts
+  "lb-strategy": {
+    label: "负载均衡策略验证",
+    description:
+      "验证不同负载均衡策略对路由 / 缓存复用 / 延迟的影响,跨 LB 配置对照。当前:Higress ai-load-balancer prefix_cache(同前缀粘到同副本);后续可扩展 least-request / GPU-aware / 多集群等策略。",
+    tools: ["aiperf"],
+    paramsConstraints: {},
+    reportComponent: "PrefixCachePanel",
+  },
+```
+
+- [ ] **Step 2: Rewrite the `engine-kv-cache` config body (add aiperf)**
+
+Replace the `"engine-kv-cache": { ... }` block with:
+```ts
+  "engine-kv-cache": {
+    label: "引擎 KV / 前缀缓存",
+    description:
+      "单实例 / 引擎级缓存有效性:evalscope 对比不同 KV 卸载后端(vanilla / LMCache / YRCache),aiperf 用 mooncake 真实生产 trace 测块级前缀复用。注:块级共享对应引擎 APC,多副本下的 LB 路由验证请用 lb-strategy。",
+    tools: ["evalscope", "aiperf"],
+    paramsConstraints: {},
+    reportComponent: "KvCacheStressReport",
+  },
+```
+
+- [ ] **Step 3: Add `"PrefixCachePanel"` to the `reportComponent` union if missing**
+
+In the `ScenarioConfig` interface `reportComponent` union, ensure `"PrefixCachePanel"` is a member (it already is per the existing type). If not present, add it.
+
+- [ ] **Step 4: Verify tool-adapters builds + lint**
+
+Run: `pnpm -F @modeldoctor/tool-adapters build && pnpm -F @modeldoctor/tool-adapters lint`
+Expected: both pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/tool-adapters/src/scenarios.ts
+git commit -m "$(printf 'feat(scenarios): reframe lb-strategy (general LB) + engine-kv-cache (+aiperf)\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 3: aiperf adapter — add `engine-kv-cache` scenario
+
+**Files:** Modify `packages/tool-adapters/src/aiperf/index.ts:10`; Test `packages/tool-adapters/src/scenarios.spec.ts`
+
+After Task 1, aiperf's scenarios is `["inference", "lb-strategy"]`. It must also list `engine-kv-cache` (mooncake moves there) or the invariant fails.
+
+- [ ] **Step 1: Run the invariant test to see it fail**
+
+Run: `pnpm -F @modeldoctor/tool-adapters test -- scenarios`
+Expected: FAIL — `assertScenariosInvariant` reports `engine-kv-cache.tools includes 'aiperf'` (from Task 2) but `aiperf.scenarios` does not include `engine-kv-cache`.
+
+- [ ] **Step 2: Add `engine-kv-cache` to aiperf scenarios**
+
+In `aiperf/index.ts`, change:
+```ts
+  scenarios: ["inference", "lb-strategy"] as const,
+```
+to:
+```ts
+  scenarios: ["inference", "lb-strategy", "engine-kv-cache"] as const,
+```
+
+- [ ] **Step 3: Run the invariant test to verify it passes**
+
+Run: `pnpm -F @modeldoctor/tool-adapters test -- scenarios`
+Expected: PASS (bidirectional invariant holds: evalscope + aiperf both list engine-kv-cache; engine-kv-cache.tools = [evalscope, aiperf]).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/tool-adapters/src/aiperf/index.ts packages/tool-adapters/src/scenarios.spec.ts
+git commit -m "$(printf 'feat(scenarios): aiperf valid in engine-kv-cache (mooncake home)\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 4: Re-home mooncake templates to `engine-kv-cache` (seed.ts)
+
+**Files:** Modify `apps/api/prisma/seed.ts`
+
+After Task 1 all 5 prefix-cache templates have `scenario: "lb-strategy"`. The 2 mooncake ones must move to `engine-kv-cache`; update the 5 descriptions.
+
+- [ ] **Step 1: Move the two mooncake templates' scenario to engine-kv-cache**
+
+In `tpl_pc_mooncake_conv` and `tpl_pc_mooncake_agent` rows, change `scenario: "lb-strategy"` → `scenario: "engine-kv-cache"`. (Find them by the ids `tpl_pc_mooncake_conv` / `tpl_pc_mooncake_agent`; the t1/t2/t3 rows keep `lb-strategy`.)
+
+- [ ] **Step 2: Update the 5 descriptions for the new framing**
+
+For `tpl_pc_t1_article` / `tpl_pc_t2_deep` / `tpl_pc_t3_shallow`, prepend to their `description`:
+`"【LB prefix_cache 策略路由验证 · 多轮粘性】"`.
+For `tpl_pc_mooncake_conv` / `tpl_pc_mooncake_agent`, prepend:
+`"【引擎块级前缀缓存 · 真实 Kimi 流量;多副本 LB 路由验证见 lb-strategy】"`.
+
+- [ ] **Step 3: Run the seed to verify validation + upsert under the new scenarios**
+
+Run: `pnpm -F @modeldoctor/api db:seed`
+Expected: completes without zod error (templates re-validate via `aiperfParamsSchema` + `applyScenarioConstraints` on the new scenario ids; aiperf is valid in both per Tasks 2-3).
+
+- [ ] **Step 4: Verify the scenario landed**
+
+Run: `PGPASSWORD=modeldoctor psql -h localhost -U modeldoctor -d modeldoctor -t -A -F'|' -c "select id, scenario from benchmark_templates where id like 'tpl_pc_%' order by id;"`
+Expected: t1/t2/t3 = `lb-strategy`; mooncake_conv/agent = `engine-kv-cache`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/prisma/seed.ts
+git commit -m "$(printf 'feat(seed): re-home mooncake templates to engine-kv-cache\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 5: Tool-aware report for `engine-kv-cache`
+
+**Files:** Modify `apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx` (the `switch (benchmark.scenario)`)
+
+After Task 1, the switch cases are `case "lb-strategy"` (renders InferenceReport + PrefixCachePanel — correct, keep) and `case "engine-kv-cache"` (renders `<KvCacheStressReport/>` — wrong for aiperf mooncake, which is evalscope-shaped).
+
+- [ ] **Step 1: Make the engine-kv-cache case tool-aware**
+
+Replace:
+```tsx
+    case "engine-kv-cache":
+      return <KvCacheStressReport benchmark={benchmark} />;
+```
+with:
+```tsx
+    case "engine-kv-cache":
+      // evalscope = KV-backend view; aiperf mooncake = prefix-cache view.
+      return benchmark.tool === "aiperf" ? (
+        <div className="space-y-6">
+          <InferenceReport benchmark={benchmark} />
+          <PrefixCachePanel serverMetrics={benchmark.serverMetrics} />
+        </div>
+      ) : (
+        <KvCacheStressReport benchmark={benchmark} />
+      );
+```
+(`InferenceReport` and `PrefixCachePanel` are already imported in this file — they're used by the `lb-strategy` case.)
+
+- [ ] **Step 2: Typecheck web**
+
+Run: `pnpm -F @modeldoctor/web exec tsc --noEmit -p tsconfig.json`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
+git commit -m "$(printf 'feat(web): tool-aware engine-kv-cache report (aiperf mooncake -> prefix-cache view)\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 6: Data-fixup migration (rename scenario in existing rows)
+
+**Files:** Create `apps/api/prisma/migrations/<timestamp>_rename_scenarios/migration.sql`
+
+The enum rename orphans existing rows; UPDATE them. Only `benchmarks` / `benchmark_templates` / `alert_events` have a `scenario` column (verified).
+
+- [ ] **Step 1: Create an empty migration (no schema change)**
+
+Run: `pnpm -F @modeldoctor/api exec prisma migrate dev --create-only --name rename_scenarios`
+Expected: creates `apps/api/prisma/migrations/<ts>_rename_scenarios/migration.sql` (likely empty — schema unchanged).
+
+- [ ] **Step 2: Write the data-fixup SQL into that migration file**
+
+Set the file contents to:
+```sql
+-- Scenario id rename (enum-change data fixup; CLAUDE.md carve-out).
+UPDATE "benchmarks"          SET "scenario" = 'lb-strategy'     WHERE "scenario" = 'prefix-cache-validation';
+UPDATE "benchmark_templates" SET "scenario" = 'lb-strategy'     WHERE "scenario" = 'prefix-cache-validation';
+UPDATE "alert_events"        SET "scenario" = 'lb-strategy'     WHERE "scenario" = 'prefix-cache-validation';
+UPDATE "benchmarks"          SET "scenario" = 'engine-kv-cache' WHERE "scenario" = 'kv-cache-stress';
+UPDATE "benchmark_templates" SET "scenario" = 'engine-kv-cache' WHERE "scenario" = 'kv-cache-stress';
+UPDATE "alert_events"        SET "scenario" = 'engine-kv-cache' WHERE "scenario" = 'kv-cache-stress';
+```
+
+- [ ] **Step 3: Apply the migration to dev DB**
+
+Run: `pnpm -F @modeldoctor/api exec prisma migrate dev`
+Expected: applies; no rows left with the old ids.
+
+- [ ] **Step 4: Verify no old-id rows remain**
+
+Run: `PGPASSWORD=modeldoctor psql -h localhost -U modeldoctor -d modeldoctor -t -A -c "select count(*) from benchmarks where scenario in ('prefix-cache-validation','kv-cache-stress');"`
+Expected: `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/prisma/migrations
+git commit -m "$(printf 'feat(api): migration renaming scenario ids on existing rows\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 7: i18n scenario label / description text
+
+**Files:** Modify `apps/web/src/locales/{zh-CN,en-US}/benchmarks.json`
+
+Task 1 renamed the JSON KEYS to `lb-strategy` / `engine-kv-cache`. The VALUE text still says "Prefix-cache" / old framing. Update the user-facing strings.
+
+- [ ] **Step 1: Find the renamed scenario text entries**
+
+Run: `grep -n '"lb-strategy"\|"engine-kv-cache"\|kvCacheStress' apps/web/src/locales/zh-CN/benchmarks.json apps/web/src/locales/en-US/benchmarks.json`
+
+- [ ] **Step 2: Update zh-CN values**
+
+For the `lb-strategy` create-title + description entries, set:
+- title: `"新建 负载均衡策略验证"`
+- description: `"验证不同 LB 策略(当前 ai-load-balancer prefix_cache)下相同前缀请求是否粘到同一副本"`
+For `engine-kv-cache` entries, set the label/description to the "引擎 KV / 前缀缓存" framing (evalscope 后端 + aiperf mooncake).
+
+- [ ] **Step 3: Update en-US values**
+
+Mirror in English: `"New LB-strategy validation"` / `"Validate LB routing strategies (currently ai-load-balancer prefix_cache) pin same-prefix requests to one replica"`; engine-kv-cache → "Engine KV / prefix cache".
+
+- [ ] **Step 4: Validate JSON parses**
+
+Run: `node -e "['zh-CN','en-US'].forEach(l=>JSON.parse(require('fs').readFileSync('apps/web/src/locales/'+l+'/benchmarks.json','utf8')));console.log('ok')"`
+Expected: `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/locales
+git commit -m "$(printf 'feat(web): i18n text for renamed scenarios (zh-CN + en-US)\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 8: Full verification + PR
+
+- [ ] **Step 1: Build workspace**
+
+Run: `pnpm -r build`
+Expected: all packages build (api needs `prisma generate` first if a fresh worktree — run `pnpm -F @modeldoctor/api exec prisma generate` then rebuild if it errors on the client).
+
+- [ ] **Step 2: Lint + tests across touched packages**
+
+Run:
+```bash
+pnpm -F @modeldoctor/tool-adapters test
+pnpm lint
+```
+Expected: green. Fix any test still asserting the old ids (Task 1 should have renamed them; verify `scenarios.spec.ts`, `report-loader.spec.ts`, `KvCacheStressReport.test.tsx`, the insights tests).
+
+- [ ] **Step 3: Push**
+
+```bash
+git push -u origin refactor/scenario-split-lb-engine
+```
+
+- [ ] **Step 4: Open PR (do NOT merge — user confirms)**
+
+```bash
+gh pr create --base main --title "refactor: split prefix-cache-validation into lb-strategy + engine-kv-cache" --body "$(cat <<'BODY'
+## What
+Splits the conflated `prefix-cache-validation` scenario:
+- `prefix-cache-validation` → **`lb-strategy`** — general LB routing-strategy validation (current: ai-load-balancer prefix_cache). Multi-turn templates (t1/t2/t3).
+- `kv-cache-stress` → **`engine-kv-cache`** — single-instance engine cache (evalscope KV backends + aiperf realistic mooncake). Mooncake templates re-homed here.
+
+Mooncake's block-level sharing doesn't map to the LB's per-message-SHA1 routing, so it belongs in engine-cache, not LB-routing. (Empirically: same 8B fleet, mooncake ~8% hit vs multi-turn t2_deep ~80% / OFF ~35%.)
+
+Breaking id rename → ships a data-fixup migration (benchmarks/templates/alert_events) in the same PR. engine-kv-cache report is tool-aware (aiperf → prefix-cache view, evalscope → KV-backend view).
+
+Spec: `docs/superpowers/specs/2026-06-18-scenario-split-lb-engine-design.md`
+
+## Test
+- `scenarios.spec.ts` enum + invariant; seed re-validates + re-homes templates; migration leaves 0 old-id rows; `pnpm -r build` + `pnpm lint` green.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+)"
+```
+
+- [ ] **Step 5: Verify CI** (per CLAUDE.md PR follow-through)
+
+Run: `gh pr checks` and `gh api repos/weetime/modeldoctor/commits/$(git rev-parse HEAD)/check-runs --jq '.check_runs[]|"\(.name): \(.status)/\(.conclusion)"'`
+Surface results; do not declare done until checks resolve.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** rename (T1) ✓; scenario configs + tools (T2) ✓; aiperf+engine-kv-cache invariant (T3) ✓; template re-home + descriptions (T4) ✓; tool-aware report (T5) ✓; migration on the 3 verified tables (T6) ✓; i18n text (T7) ✓; verify+PR (T8) ✓. No traffic-governance category (out of scope) — not in any task ✓.
+- **Placeholders:** none — exact sed, exact config bodies, exact SQL, exact report branch.
+- **Type consistency:** new ids `lb-strategy` / `engine-kv-cache` used identically in every task; `reportComponent` values `PrefixCachePanel` / `KvCacheStressReport` match the interface union; aiperf scenarios list matches engine-kv-cache.tools (invariant pinned by T3).
+- **Risk note:** if Task 1's sed renames a test fixture string that should stay (unlikely — ids are unique), Task 8 lint/test catches it.

--- a/docs/superpowers/specs/2026-06-18-scenario-split-lb-engine-design.md
+++ b/docs/superpowers/specs/2026-06-18-scenario-split-lb-engine-design.md
@@ -1,0 +1,154 @@
+# Scenario split: `lb-strategy` + `engine-kv-cache` — design
+
+Date: 2026-06-18
+Status: design approved (brainstorming), pending spec review → implementation plan
+
+## Problem
+
+The `prefix-cache-validation` scenario conflates **two methodologically distinct
+test targets**, which caused a multi-hour false debugging chase:
+
+1. **Load-balancer routing strategy** (gateway / multi-replica): does the LB route
+   prefix-sharing requests to the same replica so the engine's prefix cache is
+   reused across the fleet? Validated by comparing LB configs (e.g. Higress
+   ai-load-balancer `prefix_cache` ON vs OFF). The Higress LB routes by a
+   per-user-turn **message-content SHA1** (`prefix_cache/lb_policy.go::computeSHA1`),
+   so the right workload is **multi-turn sticky conversations** (t1/t2/t3 templates),
+   where leading turns are byte-identical across a conversation.
+2. **Engine prefix/KV cache** (single instance): does the inference engine reuse KV
+   blocks for shared prefixes? Validated by realistic block-level workloads. The
+   **mooncake** templates (real Kimi traces: `timestamp/input_length/output_length/hash_ids`,
+   block-level sharing) belong here.
+
+Putting the mooncake templates in `prefix-cache-validation` is wrong: mooncake's
+**block-level** sharing does not map to the LB's **message-level** routing, so on a
+multi-replica setup the hit rate looks flat (~8%) even when the LB works perfectly —
+which reads as "the LB is broken" when it is not. (Empirically confirmed: same 8B
+multi-replica setup, mooncake = 8% hit, multi-turn t2_deep = ~80% hit / OFF ~35%.)
+
+There is already a sibling scenario `kv-cache-stress` (evalscope, KV-backend
+comparison) that is the natural home for engine-level cache testing.
+
+## Decisions (locked during brainstorming)
+
+1. **Split via semantic ID renames** (breaking; the user chose renamed IDs over
+   keep-id-relabel):
+   - `prefix-cache-validation` → **`lb-strategy`** — general "负载均衡策略验证".
+     Tests LB routing strategies; the current one is Higress ai-load-balancer
+     `prefix_cache`; future ones (multi-cluster, least-request, GPU-aware…) are
+     additional strategies compared via SavedCompare across LB configs. NOT
+     prefix-cache-specific in name.
+   - `kv-cache-stress` → **`engine-kv-cache`** — "引擎 KV/前缀缓存". Single-instance
+     engine cache effectiveness: evalscope KV backends (vanilla/LMCache/YRCache)
+     **plus** aiperf realistic-traffic mooncake.
+2. **Re-home templates** (seed.ts):
+   - `tpl_pc_t1_article` / `tpl_pc_t2_deep` / `tpl_pc_t3_shallow` → `lb-strategy`.
+   - `tpl_pc_mooncake_conv` / `tpl_pc_mooncake_agent` → `engine-kv-cache`.
+3. **No traffic-governance category/grouping now** (YAGNI). The broader 流量治理
+   suite (canary, A/B-染色, failover, multi-cluster) is future, each its own scenario;
+   the sidebar grouping is introduced only when a 2nd traffic-governance scenario
+   lands. Out of scope here.
+4. **Single coupled PR** (rename cascades across contracts → tool-adapters → seed →
+   migration → web/i18n).
+
+## Non-goals
+
+- No new "traffic-governance" category field or sidebar grouping.
+- No new scenarios (canary / A-B / failover / multi-cluster).
+- No change to the LB plugin or its routing algorithm.
+- No change to the metrics captured (prefix-cache annotation stays as-is).
+
+## Architecture / changes
+
+### 1. Contracts (`packages/contracts/src/benchmark.ts`)
+`scenarioIdSchema` enum: replace `"prefix-cache-validation"` → `"lb-strategy"`,
+`"kv-cache-stress"` → `"engine-kv-cache"`. `ScenarioId` is inferred from it.
+
+### 2. Tool-adapters (`packages/tool-adapters/src/`)
+- `scenarios.ts`: rename the two `ScenarioId` union members + `scenarioIdSchema`
+  enum + the two `SCENARIOS` keys; rewrite their `label` / `description`:
+  - `lb-strategy`: label "负载均衡策略验证"; desc — tests LB routing strategies
+    (current: Higress ai-load-balancer prefix_cache; compare LB configs via
+    SavedCompare). tools `["aiperf"]`. reportComponent: keep `"InferenceReport"`
+    (prefix-cache compare figures already work via the SavedCompare narrative).
+  - `engine-kv-cache`: label "引擎 KV/前缀缓存"; desc — single-instance engine cache
+    (evalscope KV backends + aiperf mooncake realistic traffic). tools
+    `["evalscope", "aiperf"]` (adds aiperf). reportComponent: `"KvCacheStressReport"`
+    (see report note below).
+- Adapter `scenarios` arrays + the `assertScenariosInvariant` bidirectional check:
+  - `aiperf/index.ts`: `["inference", "prefix-cache-validation"]` →
+    `["inference", "lb-strategy", "engine-kv-cache"]`.
+  - `evalscope/index.ts`: `["inference", "kv-cache-stress"]` →
+    `["inference", "engine-kv-cache"]`.
+- `scenarios.spec.ts`: update the enum/invariant expectations.
+
+### 3. Seed (`apps/api/prisma/seed.ts`)
+- 5 prefix-cache templates: change `scenario` field +
+  - t1/t2/t3 → `lb-strategy`; descriptions → "LB prefix_cache 策略路由验证(多轮粘性,
+    turn 间共享逐字节相同的前导历史 → 命中)".
+  - mooncake_conv/agent → `engine-kv-cache`; descriptions → "引擎块级前缀缓存(真实
+    Kimi mooncake 流量;块级共享对应引擎 APC,不是 LB 消息级路由 —— 多副本下验证 LB
+    路由请用 lb-strategy 的多轮模板)".
+- Each row re-validates through `aiperfParamsSchema` + `applyScenarioConstraints`
+  on the NEW scenario id; aiperf must be in both scenarios' tools (it is, per §2).
+
+### 4. Migration (`apps/api/prisma/migrations/…`)
+A one-off data-fixup migration (the CLAUDE.md "enum-change data fixup" carve-out —
+analogous to the tool-retirement deletes), schema-unchanged. **Only 3 tables have a
+`scenario` column** (verified via information_schema): `benchmarks`,
+`benchmark_templates`, `alert_events`. (`saved_compares` does NOT — no UPDATE needed.)
+```sql
+UPDATE benchmarks          SET scenario = 'lb-strategy'     WHERE scenario = 'prefix-cache-validation';
+UPDATE benchmark_templates SET scenario = 'lb-strategy'     WHERE scenario = 'prefix-cache-validation';
+UPDATE alert_events        SET scenario = 'lb-strategy'     WHERE scenario = 'prefix-cache-validation';
+UPDATE benchmarks          SET scenario = 'engine-kv-cache' WHERE scenario = 'kv-cache-stress';
+UPDATE benchmark_templates SET scenario = 'engine-kv-cache' WHERE scenario = 'kv-cache-stress';
+UPDATE alert_events        SET scenario = 'engine-kv-cache' WHERE scenario = 'kv-cache-stress';
+```
+Without it, existing rows (45 + 5 on the old LB id, 3 + 6 on the old engine id) fail
+`scenarioIdSchema.parse` on every list/detail/metric read. Generate via
+`prisma migrate dev --create-only` per project rule.
+
+### 5. Web (`apps/web/src`)
+Rename the two scenario ids everywhere they are hardcoded:
+- `features/benchmarks/scenarios.ts` `SCENARIO_ICONS` keys.
+- report-component mapping + any `scenario === "prefix-cache-validation"` /
+  `"kv-cache-stress"` literals (grep: `BenchmarkKvCacheStressPage.tsx`,
+  `BenchmarkListShell.tsx`, `TemplateListPage.tsx`, `TemplateForm.tsx`,
+  `deployment-recipes/data.ts`, plus the `SCENARIO_SIDEBAR_KEY` map referenced in
+  CLAUDE.md).
+- i18n: rename the scenario label/description keys under the new ids in
+  `locales/{zh-CN,en-US}/benchmarks.json` + `benchmark-templates.json`.
+
+### 6. Report rendering (`BenchmarkDetailPage.tsx` — `switch (benchmark.scenario)`)
+Reports are picked by a per-scenario `switch` (verified). Today:
+`prefix-cache-validation` → `<InferenceReport/> + <PrefixCachePanel/>`;
+`kv-cache-stress` → `<KvCacheStressReport/>`. Changes:
+- Rename `case "prefix-cache-validation"` → `case "lb-strategy"` (keep the
+  InferenceReport + PrefixCachePanel body — PrefixCachePanel shows hit% / per-pod
+  share, exactly what LB-routing validation needs).
+- Replace `case "kv-cache-stress"` → `case "engine-kv-cache"` and make it
+  **tool-aware**, because mooncake is aiperf and `KvCacheStressReport` is
+  evalscope-shaped:
+  ```tsx
+  case "engine-kv-cache":
+    return benchmark.tool === "aiperf"
+      ? <div className="space-y-6"><InferenceReport benchmark={benchmark} /><PrefixCachePanel serverMetrics={benchmark.serverMetrics} /></div>
+      : <KvCacheStressReport benchmark={benchmark} />;
+  ```
+  (aiperf mooncake gets the prefix-cache view; evalscope keeps the KV-backend view.)
+- Also update the `reportComponent` field in `scenarios.ts` for the two scenarios to
+  match (informational; the detail page switch is the source of truth for rendering).
+
+## Testing
+- `scenarios.spec.ts`: new enum + invariant.
+- Seed validates + UPSERTs the 5 re-homed templates under their new scenarios.
+- Migration applies cleanly; old rows readable under new ids (no zod parse failure).
+- Web: any test referencing the old scenario ids updated; `pnpm lint` + typecheck.
+- Manual: a `lb-strategy` t2_deep run + an `engine-kv-cache` mooncake run both render
+  their detail report without error.
+
+## Rollout / risk
+- Breaking id rename — the migration MUST ship in the same PR (single coupled PR per
+  the project convention) so deployed history stays readable.
+- Prod: `migrate deploy` runs the UPDATE; then `prisma db seed` re-homes templates.

--- a/packages/contracts/src/benchmark.ts
+++ b/packages/contracts/src/benchmark.ts
@@ -7,8 +7,8 @@ export const scenarioIdSchema = z.enum([
   "inference",
   "capacity",
   "gateway",
-  "prefix-cache-validation",
-  "kv-cache-stress",
+  "lb-strategy",
+  "engine-kv-cache",
 ]);
 export type ScenarioId = z.infer<typeof scenarioIdSchema>;
 

--- a/packages/contracts/src/saved-compares/compare-narrative.ts
+++ b/packages/contracts/src/saved-compares/compare-narrative.ts
@@ -71,7 +71,7 @@ export const figureRefIdSchema = z.enum([
   "stage-bars-ttft-p95",
   "stage-bars-e2e-p95",
   // Prefix-cache figures — populated from serverMetrics.prefixCache, only
-  // available for prefix-cache-validation runs. hit = cache hit-rate %,
+  // available for lb-strategy runs. hit = cache hit-rate %,
   // top-pod = the busiest pod's share of queries (routing concentration).
   "stage-bars-prefix-cache-hit",
   "stage-bars-top-pod-share",

--- a/packages/tool-adapters/src/aiperf/index.ts
+++ b/packages/tool-adapters/src/aiperf/index.ts
@@ -7,7 +7,7 @@ export { aiperfReadMetric } from "./read-metric.js";
 
 export const aiperfAdapter: ToolAdapter = {
   name: "aiperf",
-  scenarios: ["inference", "lb-strategy"] as const,
+  scenarios: ["inference", "lb-strategy", "engine-kv-cache"] as const,
   paramsSchema: aiperfParamsSchema,
   reportSchema: aiperfReportSchema,
   paramDefaults: aiperfParamDefaults,

--- a/packages/tool-adapters/src/aiperf/index.ts
+++ b/packages/tool-adapters/src/aiperf/index.ts
@@ -7,7 +7,7 @@ export { aiperfReadMetric } from "./read-metric.js";
 
 export const aiperfAdapter: ToolAdapter = {
   name: "aiperf",
-  scenarios: ["inference", "prefix-cache-validation"] as const,
+  scenarios: ["inference", "lb-strategy"] as const,
   paramsSchema: aiperfParamsSchema,
   reportSchema: aiperfReportSchema,
   paramDefaults: aiperfParamDefaults,

--- a/packages/tool-adapters/src/category-defaults.ts
+++ b/packages/tool-adapters/src/category-defaults.ts
@@ -36,7 +36,7 @@ export const GUIDELLM_CATEGORY_DEFAULTS = {
 /**
  * evalscope perf supports chat/completions and completions; the schema's
  * `apiPath` enum gates the rest. Embedding / rerank / image / audio are out
- * of scope for the inference + kv-cache-stress scenarios where evalscope
+ * of scope for the inference + engine-kv-cache scenarios where evalscope
  * is offered, so they get `unsupported` markers like guidellm.
  */
 export const EVALSCOPE_CATEGORY_DEFAULTS = {

--- a/packages/tool-adapters/src/core/row-descriptor.ts
+++ b/packages/tool-adapters/src/core/row-descriptor.ts
@@ -36,7 +36,7 @@ export type MetricRowSpec =
 // adapter-side "what columns does my tool contribute" knowledge stays
 // single-sourced; one update fans out to all three without drift.
 //
-// Tool-specific extras (evalscope's prefix-cache hit rate, kv-cache-stress
+// Tool-specific extras (evalscope's prefix-cache hit rate, engine-kv-cache
 // cold/warm panel, etc.) live in their own report components, not here.
 export const SHARED_INFERENCE_ROWS: readonly MetricRowSpec[] = [
   { source: "raw", labelKey: "ttftMean", section: "ttft", field: "mean", unitSuffix: "ms" },

--- a/packages/tool-adapters/src/evalscope/index.ts
+++ b/packages/tool-adapters/src/evalscope/index.ts
@@ -7,7 +7,7 @@ export { evalscopeReadMetric } from "./read-metric.js";
 
 export const evalscopeAdapter: ToolAdapter = {
   name: "evalscope",
-  scenarios: ["inference", "kv-cache-stress"] as const,
+  scenarios: ["inference", "engine-kv-cache"] as const,
   paramsSchema: evalscopeParamsSchema,
   reportSchema: evalscopeReportSchema,
   paramDefaults: evalscopeParamDefaults,

--- a/packages/tool-adapters/src/scenarios.spec.ts
+++ b/packages/tool-adapters/src/scenarios.spec.ts
@@ -14,13 +14,13 @@ describe("SCENARIOS constant", () => {
       "capacity",
       "gateway",
       "inference",
-      "kv-cache-stress",
-      "prefix-cache-validation",
+      "engine-kv-cache",
+      "lb-strategy",
     ]);
   });
 
-  it("kv-cache-stress scenario lists evalscope only (legacy tool retired)", () => {
-    expect([...SCENARIOS["kv-cache-stress"].tools]).toEqual(["evalscope"]);
+  it("engine-kv-cache scenario lists evalscope only (legacy tool retired)", () => {
+    expect([...SCENARIOS["engine-kv-cache"].tools]).toEqual(["evalscope"]);
   });
 
   it("inference scenario lists guidellm, evalscope, and aiperf", () => {

--- a/packages/tool-adapters/src/scenarios.spec.ts
+++ b/packages/tool-adapters/src/scenarios.spec.ts
@@ -12,15 +12,19 @@ describe("SCENARIOS constant", () => {
   it("declares all known scenarios", () => {
     expect(Object.keys(SCENARIOS).sort()).toEqual([
       "capacity",
+      "engine-kv-cache",
       "gateway",
       "inference",
-      "engine-kv-cache",
       "lb-strategy",
     ]);
   });
 
-  it("engine-kv-cache scenario lists evalscope only (legacy tool retired)", () => {
-    expect([...SCENARIOS["engine-kv-cache"].tools]).toEqual(["evalscope"]);
+  it("engine-kv-cache scenario lists evalscope + aiperf (mooncake home)", () => {
+    expect([...SCENARIOS["engine-kv-cache"].tools].sort()).toEqual(["aiperf", "evalscope"]);
+  });
+
+  it("lb-strategy scenario lists aiperf only", () => {
+    expect([...SCENARIOS["lb-strategy"].tools]).toEqual(["aiperf"]);
   });
 
   it("inference scenario lists guidellm, evalscope, and aiperf", () => {

--- a/packages/tool-adapters/src/scenarios.ts
+++ b/packages/tool-adapters/src/scenarios.ts
@@ -6,15 +6,15 @@ export type ScenarioId =
   | "inference"
   | "capacity"
   | "gateway"
-  | "prefix-cache-validation"
-  | "kv-cache-stress";
+  | "lb-strategy"
+  | "engine-kv-cache";
 
 export const scenarioIdSchema = z.enum([
   "inference",
   "capacity",
   "gateway",
-  "prefix-cache-validation",
-  "kv-cache-stress",
+  "lb-strategy",
+  "engine-kv-cache",
 ]);
 
 export interface ScenarioConfig {
@@ -60,7 +60,7 @@ export const SCENARIOS: Record<ScenarioId, ScenarioConfig> = {
     paramsConstraints: {},
     reportComponent: "GatewayReport",
   },
-  "prefix-cache-validation": {
+  "lb-strategy": {
     label: "Prefix-cache 路由验证",
     description:
       "验证 Higress ai-load-balancer prefix-cache 策略下相同前缀请求是否粘到同一 vLLM 副本",
@@ -68,7 +68,7 @@ export const SCENARIOS: Record<ScenarioId, ScenarioConfig> = {
     paramsConstraints: {},
     reportComponent: "InferenceReport",
   },
-  "kv-cache-stress": {
+  "engine-kv-cache": {
     label: "KV cache 后端压测",
     description:
       "长 prompt 冷/暖双轮 evalscope perf,对比不同 KV 卸载后端 (vanilla / LMCache / YRCache) 的 TTFT / 吞吐 / prefix-cache 命中率",

--- a/packages/tool-adapters/src/scenarios.ts
+++ b/packages/tool-adapters/src/scenarios.ts
@@ -2,12 +2,7 @@ import { z } from "zod";
 import type { ToolName } from "./core/interface.js";
 import { allAdapters, byTool } from "./core/registry.js";
 
-export type ScenarioId =
-  | "inference"
-  | "capacity"
-  | "gateway"
-  | "lb-strategy"
-  | "engine-kv-cache";
+export type ScenarioId = "inference" | "capacity" | "gateway" | "lb-strategy" | "engine-kv-cache";
 
 export const scenarioIdSchema = z.enum([
   "inference",
@@ -61,18 +56,18 @@ export const SCENARIOS: Record<ScenarioId, ScenarioConfig> = {
     reportComponent: "GatewayReport",
   },
   "lb-strategy": {
-    label: "Prefix-cache 路由验证",
+    label: "负载均衡策略验证",
     description:
-      "验证 Higress ai-load-balancer prefix-cache 策略下相同前缀请求是否粘到同一 vLLM 副本",
+      "验证不同负载均衡策略对路由 / 缓存复用 / 延迟的影响,跨 LB 配置对照。当前:Higress ai-load-balancer prefix_cache(同前缀粘到同副本);后续可扩展 least-request / GPU-aware / 多集群等策略。",
     tools: ["aiperf"],
     paramsConstraints: {},
     reportComponent: "InferenceReport",
   },
   "engine-kv-cache": {
-    label: "KV cache 后端压测",
+    label: "引擎 KV / 前缀缓存",
     description:
-      "长 prompt 冷/暖双轮 evalscope perf,对比不同 KV 卸载后端 (vanilla / LMCache / YRCache) 的 TTFT / 吞吐 / prefix-cache 命中率",
-    tools: ["evalscope"],
+      "单实例 / 引擎级缓存有效性:evalscope 对比不同 KV 卸载后端 (vanilla / LMCache / YRCache),aiperf 用 mooncake 真实生产 trace 测块级前缀复用。注:块级共享对应引擎 APC,多副本下的 LB 路由验证请用 lb-strategy。",
+    tools: ["evalscope", "aiperf"],
     paramsConstraints: {},
     reportComponent: "KvCacheStressReport",
   },


### PR DESCRIPTION
## What
Splits the conflated `prefix-cache-validation` scenario into two methodologically distinct targets:

- `prefix-cache-validation` → **`lb-strategy`** — general LB routing-strategy validation (current strategy: Higress ai-load-balancer `prefix_cache`). Multi-turn sticky templates (t1/t2/t3). Future strategies (multi-cluster, least-request, GPU-aware…) are additional LB configs compared here.
- `kv-cache-stress` → **`engine-kv-cache`** — single-instance engine cache. evalscope KV backends (vanilla/LMCache/YRCache) **plus** aiperf realistic `mooncake` trace. Mooncake templates re-homed here.

**Why:** mooncake shares at the token-**block** level, but the LB routes at the per-message-**SHA1** level — so on a multi-replica fleet mooncake hit-rate looks flat (~8%) even when the LB works perfectly, which reads as "LB broken". Empirically, same 8B fleet: mooncake ~8% vs multi-turn t2_deep ~80% (warm) / ~35% (OFF). Mooncake belongs in engine-cache, not LB-routing.

## Changes
- Breaking scenario-id rename across contracts enum, tool-adapters (`scenarios.ts` + adapter `scenarios[]` + invariant), seed, web, i18n, tests.
- aiperf now valid in `engine-kv-cache` (mooncake's home); `scenarios.spec` asserts the new tool memberships.
- `engine-kv-cache` detail report is **tool-aware**: aiperf → InferenceReport + PrefixCachePanel; evalscope → KvCacheStressReport.
- Data-fixup migration on `benchmarks` / `benchmark_templates` / `alert_events` (single coupled PR so deployed history stays readable).

Spec: `docs/superpowers/specs/2026-06-18-scenario-split-lb-engine-design.md` · Plan: `docs/superpowers/plans/2026-06-18-scenario-split-lb-engine.md`

## Test
- `pnpm -r build` ✓ · root `pnpm lint` ✓ · tool-adapters 246 ✓ · api 1009 ✓ · web affected 26 ✓
- Local dev DB: seed re-homes templates (t1/t2/t3 → lb-strategy, mooncake → engine-kv-cache); migration leaves **0** old-id rows (benchmarks now lb-strategy=46, engine-kv-cache=3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)