### PR TITLE
fix(web): sidebar/title labels for renamed scenarios

### DIFF
--- a/apps/web/src/locales/en-US/sidebar.json
+++ b/apps/web/src/locales/en-US/sidebar.json
@@ -15,7 +15,7 @@
     "benchmarkInference": "Inference Performance",
     "benchmarkCapacity": "Capacity Planning",
     "benchmarkGateway": "Gateway Load Test",
-    "benchmarkPrefixCache": "Prefix-cache Validation",
+    "benchmarkPrefixCache": "LB-strategy Validation",
     "endpointReports": "Test Insights",
     "compareReports": "Compare Reports",
     "benchmarkTemplates": "Test Templates",
@@ -30,6 +30,6 @@
     "logout": "Logout",
     "devCharts": "Dev Charts",
     "deploymentRecipes": "Deployment Recipes",
-    "benchmarkKvCacheStress": "KV Cache Stress"
+    "benchmarkKvCacheStress": "Engine KV / Prefix Cache"
   }
 }

--- a/apps/web/src/locales/zh-CN/sidebar.json
+++ b/apps/web/src/locales/zh-CN/sidebar.json
@@ -15,7 +15,7 @@
     "benchmarkInference": "推理性能基准",
     "benchmarkCapacity": "容量规划",
     "benchmarkGateway": "网关压测",
-    "benchmarkPrefixCache": "Prefix-cache 验证",
+    "benchmarkPrefixCache": "负载均衡策略验证",
     "endpointReports": "测试洞察",
     "compareReports": "对比报告",
     "benchmarkTemplates": "测试模板",
@@ -30,6 +30,6 @@
     "logout": "退出登录",
     "devCharts": "图表调试",
     "deploymentRecipes": "部署示例",
-    "benchmarkKvCacheStress": "KV cache 压测"
+    "benchmarkKvCacheStress": "引擎 KV / 前缀缓存"
   }
 }


### PR DESCRIPTION
## What
Follow-up to #300. The sidebar item labels — which double as the benchmark list-page **title** — live under the camelCase i18n keys `items.benchmarkPrefixCache` / `items.benchmarkKvCacheStress`. The scenario-id rename in #300 didn't touch these (they don't contain the `prefix-cache-validation` string), so the page still showed **"Prefix-cache Validation"**.

Updated the label text only (keys kept — they're internal ids referenced via `SCENARIO_SIDEBAR_KEY` in BenchmarkListShell / DetailPage / CreatePage / ComparePage + sidebar-config):

| key | zh-CN | en-US |
|---|---|---|
| `benchmarkPrefixCache` | 负载均衡策略验证 | LB-strategy Validation |
| `benchmarkKvCacheStress` | 引擎 KV / 前缀缓存 | Engine KV / Prefix Cache |

`engine-metrics.json` "Prefix cache" labels are the real engine metric names — left untouched.

## Test
- `pnpm -F web lint` ✓ (i18n parity OK, no hardcoded zh, biome clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)