### PR TITLE
fix(web): carry serverMetrics into SavedCompare report runs

### DIFF
--- a/apps/web/src/features/benchmarks/compare/ReportDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/compare/ReportDetailPage.tsx
@@ -1,4 +1,4 @@
-import type { Benchmark, CompareNarrative } from "@modeldoctor/contracts";
+import type { CompareNarrative } from "@modeldoctor/contracts";
 import { Eye, RefreshCw, Sparkles, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -9,18 +9,8 @@ import { Button } from "@/components/ui/button";
 import { useLlmJudgeProvider } from "@/features/settings/queries";
 import { useDeleteSavedCompare, useSavedCompare, useSynthesizeSavedCompare } from "./queries";
 import { ReportProgress } from "./ReportProgress";
-import type { ReportRun } from "./ReportSections";
 import { SavedCompareReport } from "./SavedCompareReport";
-
-function extractParamsSummary(params: unknown): ReportRun["paramsSummary"] {
-  if (!params || typeof params !== "object") return {};
-  const p = params as Record<string, unknown>;
-  return {
-    workload: typeof p.workload === "string" ? p.workload : undefined,
-    concurrency: typeof p.concurrency === "number" ? p.concurrency : undefined,
-    duration: typeof p.duration === "number" ? p.duration : undefined,
-  };
-}
+import { toReportRuns } from "./to-report-runs";
 
 /**
  * In-app saved-comparison detail: `/reports/:id` (inside `<AppShell>`).
@@ -128,29 +118,7 @@ export function ReportDetailPage() {
   const sc = query.data;
   const narrative = narrativeOverride ?? (sc.narrative as CompareNarrative | null);
 
-  const reportRuns: ReportRun[] = sc.benchmarks.map((b) => ({
-    id: b.id,
-    stageLabel: b.stageLabel,
-    tool: b.tool ?? "",
-    scenario: b.scenario ?? "",
-    summaryMetrics: b.summaryMetrics,
-    benchmark: b.missing
-      ? null
-      : ({
-          id: b.id,
-          name: b.name ?? null,
-          tool: b.tool ?? "",
-          scenario: b.scenario ?? "",
-          summaryMetrics: b.summaryMetrics,
-          // serverMetrics carries serverMetrics.prefixCache — required by the
-          // prefix-cache-hit / top-pod-share figures (FigureRenderer reads it
-          // from r.benchmark.serverMetrics). Without it those figures render
-          // "data unavailable" even though the API returns it on the ref.
-          serverMetrics: b.serverMetrics ?? null,
-          params: b.params,
-        } as Benchmark),
-    paramsSummary: extractParamsSummary(b.params),
-  }));
+  const reportRuns = toReportRuns(sc.benchmarks);
 
   function onDelete() {
     del.mutate(id, { onSuccess: () => navigate("/benchmarks/compare/saved") });

--- a/apps/web/src/features/benchmarks/compare/ReportDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/compare/ReportDetailPage.tsx
@@ -142,6 +142,11 @@ export function ReportDetailPage() {
           tool: b.tool ?? "",
           scenario: b.scenario ?? "",
           summaryMetrics: b.summaryMetrics,
+          // serverMetrics carries serverMetrics.prefixCache — required by the
+          // prefix-cache-hit / top-pod-share figures (FigureRenderer reads it
+          // from r.benchmark.serverMetrics). Without it those figures render
+          // "data unavailable" even though the API returns it on the ref.
+          serverMetrics: b.serverMetrics,
           params: b.params,
         } as Benchmark),
     paramsSummary: extractParamsSummary(b.params),

--- a/apps/web/src/features/benchmarks/compare/ReportDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/compare/ReportDetailPage.tsx
@@ -146,7 +146,7 @@ export function ReportDetailPage() {
           // prefix-cache-hit / top-pod-share figures (FigureRenderer reads it
           // from r.benchmark.serverMetrics). Without it those figures render
           // "data unavailable" even though the API returns it on the ref.
-          serverMetrics: b.serverMetrics,
+          serverMetrics: b.serverMetrics ?? null,
           params: b.params,
         } as Benchmark),
     paramsSummary: extractParamsSummary(b.params),

--- a/apps/web/src/features/benchmarks/compare/ReportPreviewPage.tsx
+++ b/apps/web/src/features/benchmarks/compare/ReportPreviewPage.tsx
@@ -1,4 +1,4 @@
-import type { Benchmark, CompareNarrative } from "@modeldoctor/contracts";
+import type { CompareNarrative } from "@modeldoctor/contracts";
 import { ArrowLeft, Download, Printer } from "lucide-react";
 import { useRef } from "react";
 import { useTranslation } from "react-i18next";
@@ -6,18 +6,8 @@ import { Link, useParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { exportPageAsHtml } from "./exportHtml";
 import { useSavedCompare } from "./queries";
-import type { ReportRun } from "./ReportSections";
 import { SavedCompareReport } from "./SavedCompareReport";
-
-function extractParamsSummary(params: unknown): ReportRun["paramsSummary"] {
-  if (!params || typeof params !== "object") return {};
-  const p = params as Record<string, unknown>;
-  return {
-    workload: typeof p.workload === "string" ? p.workload : undefined,
-    concurrency: typeof p.concurrency === "number" ? p.concurrency : undefined,
-    duration: typeof p.duration === "number" ? p.duration : undefined,
-  };
-}
+import { toReportRuns } from "./to-report-runs";
 
 /**
  * Standalone report preview: `/reports/:id/preview`.
@@ -83,24 +73,7 @@ export function ReportPreviewPage() {
     );
   }
 
-  const reportRuns: ReportRun[] = sc.benchmarks.map((b) => ({
-    id: b.id,
-    stageLabel: b.stageLabel,
-    tool: b.tool ?? "",
-    scenario: b.scenario ?? "",
-    summaryMetrics: b.summaryMetrics,
-    benchmark: b.missing
-      ? null
-      : ({
-          id: b.id,
-          name: b.name ?? null,
-          tool: b.tool ?? "",
-          scenario: b.scenario ?? "",
-          summaryMetrics: b.summaryMetrics,
-          params: b.params,
-        } as Benchmark),
-    paramsSummary: extractParamsSummary(b.params),
-  }));
+  const reportRuns = toReportRuns(sc.benchmarks);
 
   function onExport() {
     if (reportRef.current) void exportPageAsHtml(reportRef.current, sc.name);

--- a/apps/web/src/features/benchmarks/compare/to-report-runs.ts
+++ b/apps/web/src/features/benchmarks/compare/to-report-runs.ts
@@ -1,0 +1,50 @@
+import type { Benchmark, HydratedBenchmarkRef } from "@modeldoctor/contracts";
+import type { ReportRun } from "./ReportSections";
+
+/** Params blob → the compact summary the report header renders. */
+function extractParamsSummary(params: unknown): ReportRun["paramsSummary"] {
+  if (!params || typeof params !== "object") return {};
+  const p = params as Record<string, unknown>;
+  return {
+    workload: typeof p.workload === "string" ? p.workload : undefined,
+    concurrency: typeof p.concurrency === "number" ? p.concurrency : undefined,
+    duration: typeof p.duration === "number" ? p.duration : undefined,
+  };
+}
+
+/**
+ * Map the SavedCompare API's hydrated benchmark refs into the `ReportRun` shape
+ * the report renderer consumes.
+ *
+ * SINGLE SOURCE — both the in-app detail page (`/reports/:id`) and the
+ * print/export preview (`/reports/:id/preview`) call this, so the two surfaces
+ * can't drift. (Past bug: this mapping was copy-pasted into both pages and
+ * `serverMetrics` was copied in one but not the other, dropping the
+ * prefix-cache-hit / top-pod-share figures from one surface.)
+ *
+ * `serverMetrics` carries `serverMetrics.prefixCache`, required by the
+ * prefix-cache figures; `?? null` matches the `Benchmark.serverMetrics`
+ * nullable type. The synthetic snapshot only fills the fields the report
+ * actually reads off `ReportRun.benchmark`.
+ */
+export function toReportRuns(benchmarks: HydratedBenchmarkRef[]): ReportRun[] {
+  return benchmarks.map((b) => ({
+    id: b.id,
+    stageLabel: b.stageLabel,
+    tool: b.tool ?? "",
+    scenario: b.scenario ?? "",
+    summaryMetrics: b.summaryMetrics,
+    benchmark: b.missing
+      ? null
+      : ({
+          id: b.id,
+          name: b.name ?? null,
+          tool: b.tool ?? "",
+          scenario: b.scenario ?? "",
+          summaryMetrics: b.summaryMetrics,
+          serverMetrics: b.serverMetrics ?? null,
+          params: b.params,
+        } as Benchmark),
+    paramsSummary: extractParamsSummary(b.params),
+  }));
+}


### PR DESCRIPTION
## Bug
On SavedCompare reports (`/reports/{id}`), the **prefix-cache hit-rate** and **top-pod-share** figures render `data unavailable` even though the data exists and the AI narrative correctly references them.

## Root cause
`ReportDetailPage.tsx` maps each `HydratedBenchmarkRef` (API returns `serverMetrics` at the ref's top level) into a synthetic `Benchmark` snapshot for `ReportRun.benchmark`, but **omitted `serverMetrics`** — it copied `summaryMetrics` only. `FigureRenderer` reads the prefix-cache figures from `r.benchmark.serverMetrics` → `undefined` → unavailable. The latency/error/throughput figures read `summaryMetrics` (which *was* copied), so they worked — that asymmetry is the tell.

Not an AI-prompt issue: the server's `availableFigureRefIds` correctly judged the figures available (serverMetrics present server-side) so the LLM rightly picked them; the front-end mapping just dropped the field.

## Fix
One line — copy `serverMetrics: b.serverMetrics` into the synthetic snapshot. Affects every aiperf `lb-strategy` / `engine-kv-cache` saved report.

## Test
- `pnpm -F web` typecheck ✓ · lint ✓ · contracts/tool-adapters build ✓
- Existing saved compares (data already in DB) will render the figures correctly once the front-end loads this build — no data backfill needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)