### PR TITLE
refactor(web): drop `as Benchmark` cast in SavedCompare report mapping

### DIFF
--- a/apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
+++ b/apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
@@ -14,14 +14,7 @@ import { CompareToolbar } from "./CompareToolbar";
 import { type ReportRun, ReportSections } from "./ReportSections";
 import { shortRunLabels } from "./run-label";
 import { SaveCompareDialog } from "./SaveCompareDialog";
-
-function extractParamsSummary(params: unknown): { concurrency?: number } {
-  if (!params || typeof params !== "object") return {};
-  const p = params as Record<string, unknown>;
-  return {
-    concurrency: typeof p.concurrency === "number" ? p.concurrency : undefined,
-  };
-}
+import { extractParamsSummary } from "./to-report-runs";
 
 const SCENARIO_SIDEBAR_KEY: Record<ScenarioId, string> = {
   inference: "benchmarkInference",

--- a/apps/web/src/features/benchmarks/compare/CompareGrid.tsx
+++ b/apps/web/src/features/benchmarks/compare/CompareGrid.tsx
@@ -1,13 +1,13 @@
-import type { Benchmark } from "@modeldoctor/contracts";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Table, TableBody, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { MetricRow } from "./MetricRow";
 import { rowDescriptorsForTool } from "./metrics";
+import type { ReportBenchmarkSnapshot } from "./ReportSections";
 
 export interface CompareGridProps {
-  runs: Benchmark[];
+  runs: ReportBenchmarkSnapshot[];
   baselineId: string | null;
 }
 

--- a/apps/web/src/features/benchmarks/compare/MetricRow.tsx
+++ b/apps/web/src/features/benchmarks/compare/MetricRow.tsx
@@ -1,15 +1,15 @@
-import type { Benchmark } from "@modeldoctor/contracts";
 import { useTranslation } from "react-i18next";
 import { TableCell, TableRow } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { formatLatencyMs, formatPct, formatPercentFromFraction, formatThroughput } from "./format";
 import { deltaText, type MetricRowDescriptor } from "./metrics";
+import type { ReportBenchmarkSnapshot } from "./ReportSections";
 import { VerdictBadge } from "./VerdictBadge";
 import { verdictFor } from "./verdict";
 
 export interface MetricRowProps {
   descriptor: MetricRowDescriptor;
-  runs: Benchmark[];
+  runs: ReportBenchmarkSnapshot[];
   baselineId: string | null;
 }
 

--- a/apps/web/src/features/benchmarks/compare/ReportSections.tsx
+++ b/apps/web/src/features/benchmarks/compare/ReportSections.tsx
@@ -23,9 +23,39 @@ import { readPrefixCache } from "./client-metrics";
 import { formatPct } from "./format";
 import { StageBarChartsSection, type StageRun } from "./StageBarChartsSection";
 
+/**
+ * The slice of a benchmark the report actually reads off `ReportRun.benchmark`
+ * (verified consumer set via grep of `r.benchmark.*` across `compare/*.tsx`:
+ * `name` + `tool` here, plus id / name / tool / summaryMetrics that `CompareGrid`
+ * reads off the runs it's handed).
+ *
+ * Spelled out explicitly rather than `Pick<Benchmark, …>` on purpose: the two
+ * producers feed values *looser* than `Benchmark`'s — `BenchmarkComparePage`
+ * passes a full `Benchmark` (assignable here), but `toReportRuns()` synthesises
+ * this from `HydratedBenchmarkRef`, whose `name` is nullable and whose `tool` /
+ * `summaryMetrics` / `serverMetrics` are `string` / `unknown` rather than
+ * `Benchmark`'s enum + `Record`. A `Pick<Benchmark>` would reject those without a
+ * cast on every field — exactly the `as Benchmark` we're removing here. (These
+ * field types match `StageRun.summaryMetrics: unknown` already used in this path.)
+ *
+ * Dropping the blanket `as Benchmark` cast in `toReportRuns()` is the point: that
+ * cast silenced every missing-field error and let `serverMetrics` ship absent
+ * (#302). A figure that now reaches for a field outside this set fails to compile
+ * instead of silently reading `undefined`.
+ */
+export interface ReportBenchmarkSnapshot {
+  id: string;
+  name: string | null;
+  tool: string;
+  scenario: string;
+  summaryMetrics: unknown;
+  serverMetrics: unknown;
+}
+
 export interface ReportRun extends StageRun {
-  /** Full benchmark snapshot, or null if the underlying benchmark was deleted. */
-  benchmark: Benchmark | null;
+  /** Benchmark snapshot (see `ReportBenchmarkSnapshot`), or null if the
+   *  underlying benchmark was deleted. */
+  benchmark: ReportBenchmarkSnapshot | null;
   paramsSummary: { concurrency?: number };
 }
 

--- a/apps/web/src/features/benchmarks/compare/ReportSections.tsx
+++ b/apps/web/src/features/benchmarks/compare/ReportSections.tsx
@@ -15,7 +15,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import type { Benchmark, CompareNarrative } from "@modeldoctor/contracts";
+import type { CompareNarrative } from "@modeldoctor/contracts";
 import { GripVertical } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { CompareGrid } from "./CompareGrid";
@@ -170,7 +170,12 @@ export function ReportSections({
   onReorder,
 }: ReportSectionsProps) {
   const { t } = useTranslation("benchmarks");
-  const livingRuns = runs.filter((r) => r.benchmark !== null);
+  // Type-guard predicate (not just `!== null`) so `r.benchmark` narrows to
+  // non-null below — lets `CompareGrid` receive `ReportBenchmarkSnapshot[]`
+  // without an `as` cast.
+  const livingRuns = runs.filter(
+    (r): r is ReportRun & { benchmark: ReportBenchmarkSnapshot } => r.benchmark !== null,
+  );
   // lb-strategy matrix gains Hit Rate / Top Pod Share columns, but only when
   // every living run carries the prefix-cache annotation (matches the chart
   // gate — partial data would render misleading blanks).
@@ -255,10 +260,7 @@ export function ReportSections({
       {/* 2. CompareGrid */}
       <section>
         <h2 className="mb-3 text-lg font-semibold">{t("savedCompare.report.sectionGrid")}</h2>
-        <CompareGrid
-          runs={livingRuns.map((r) => r.benchmark) as Benchmark[]}
-          baselineId={baselineId}
-        />
+        <CompareGrid runs={livingRuns.map((r) => r.benchmark)} baselineId={baselineId} />
       </section>
 
       {/* 3. Charts */}

--- a/apps/web/src/features/benchmarks/compare/metrics.ts
+++ b/apps/web/src/features/benchmarks/compare/metrics.ts
@@ -1,4 +1,4 @@
-import type { Benchmark, BenchmarkTool } from "@modeldoctor/contracts";
+import type { Benchmark } from "@modeldoctor/contracts";
 import {
   type MetricFormat,
   type MetricRowSpec,
@@ -39,14 +39,18 @@ export type { MetricFormat, VerdictKind };
 
 export interface MetricRowDescriptor {
   labelKey: string; // "compare.metricRowLabel.<key>"
-  read: (m: SummaryMetrics) => number | null;
+  // `unknown`, not `SummaryMetrics`: the grid feeds these from
+  // `ReportBenchmarkSnapshot.summaryMetrics` (typed `unknown`, since the
+  // SavedCompare hydration path under-types it). Every `read` impl already casts
+  // its arg internally via `readMetricSafe` / `readRawField`, so this is honest.
+  read: (m: unknown) => number | null;
   verdictKind?: VerdictKind;
   digits?: number; // default 1
   unitSuffix?: string; // for the cell display (e.g. "ms", "%")
   format?: MetricFormat; // named formatter; takes precedence over digits/unitSuffix
 }
 
-function readRawField(metrics: SummaryMetrics, section: string, field: string): number | null {
+function readRawField(metrics: unknown, section: string, field: string): number | null {
   const t = metrics as { tool?: unknown; data?: Record<string, unknown> } | null;
   if (!t?.data) return null;
   const dist = t.data[section] as Record<string, unknown> | undefined;
@@ -97,7 +101,7 @@ export function deltaText(kind: VerdictKind, baseline: number, current: number):
   return `${pct >= 0 ? "+" : ""}${pct.toFixed(1)}%`;
 }
 
-export function rowDescriptorsForTool(tool: BenchmarkTool): MetricRowDescriptor[] {
+export function rowDescriptorsForTool(tool: string): MetricRowDescriptor[] {
   const specs = rowDescriptorsByTool[tool as keyof typeof rowDescriptorsByTool] as
     | readonly MetricRowSpec[]
     | undefined;

--- a/apps/web/src/features/benchmarks/compare/to-report-runs.ts
+++ b/apps/web/src/features/benchmarks/compare/to-report-runs.ts
@@ -1,10 +1,12 @@
-import type { Benchmark, HydratedBenchmarkRef } from "@modeldoctor/contracts";
+import type { HydratedBenchmarkRef } from "@modeldoctor/contracts";
 import type { ReportRun } from "./ReportSections";
 
 /** Params blob → the compact summary the matrix renders (concurrency only;
  * workload/duration are not meaningful across these tools — see the scenario
- * redesign that dropped those matrix columns). */
-function extractParamsSummary(params: unknown): ReportRun["paramsSummary"] {
+ * redesign that dropped those matrix columns). Shared with `BenchmarkComparePage`,
+ * which builds its own `ReportRun[]` from live `Benchmark` rows but derives
+ * `paramsSummary` identically. */
+export function extractParamsSummary(params: unknown): ReportRun["paramsSummary"] {
   if (!params || typeof params !== "object") return {};
   const p = params as Record<string, unknown>;
   return {
@@ -23,9 +25,10 @@ function extractParamsSummary(params: unknown): ReportRun["paramsSummary"] {
  * prefix-cache-hit / top-pod-share figures from one surface.)
  *
  * `serverMetrics` carries `serverMetrics.prefixCache`, required by the
- * prefix-cache figures; `?? null` matches the `Benchmark.serverMetrics`
- * nullable type. The synthetic snapshot only fills the fields the report
- * actually reads off `ReportRun.benchmark`.
+ * prefix-cache figures; `?? null` normalises "absent" to null. The snapshot is
+ * typed as `ReportBenchmarkSnapshot` (not `Benchmark`) — exactly the fields the
+ * report reads — so it needs no `as Benchmark` cast, and the next missing field
+ * is a compile error rather than a silent `undefined` (the #302 footgun).
  */
 export function toReportRuns(benchmarks: HydratedBenchmarkRef[]): ReportRun[] {
   return benchmarks.map((b) => ({
@@ -36,15 +39,14 @@ export function toReportRuns(benchmarks: HydratedBenchmarkRef[]): ReportRun[] {
     summaryMetrics: b.summaryMetrics,
     benchmark: b.missing
       ? null
-      : ({
+      : {
           id: b.id,
           name: b.name ?? null,
           tool: b.tool ?? "",
           scenario: b.scenario ?? "",
           summaryMetrics: b.summaryMetrics,
           serverMetrics: b.serverMetrics ?? null,
-          params: b.params,
-        } as Benchmark),
+        },
     paramsSummary: extractParamsSummary(b.params),
   }));
 }


### PR DESCRIPTION
## What

Removes the `as Benchmark` cast in `toReportRuns()` — the mechanism that let #302's `serverMetrics` omission compile and ship to two surfaces with zero signal.

- New `ReportBenchmarkSnapshot` interface in `ReportSections.tsx` — exactly the fields the report reads off `ReportRun.benchmark` (`id` / `name` / `tool` / `scenario` / `summaryMetrics` / `serverMetrics`).
- `ReportRun.benchmark` narrowed from `Benchmark | null` → `ReportBenchmarkSnapshot | null`.
- The synthetic snapshot literal now stands on its own type — no cast, and its now-unused `params` field is dropped.
- `BenchmarkComparePage` still passes a full `Benchmark` (assignable to the snapshot — no break).
- Bonus: `extractParamsSummary` was a byte-identical 3rd copy; it's now shared from `to-report-runs.ts`.

## Deviation from the issue (worth a look)

The issue proposed `Pick<Benchmark, …>`. That **does not compile** — the cast was masking *field-level* type mismatches, not just missing fields:

| field | `HydratedBenchmarkRef` (source) | `Benchmark` (Pick target) |
|---|---|---|
| `name` | `string \| null` | `string` |
| `tool` | `string` | enum |
| `scenario` | `string` | `ScenarioId` enum |
| `summaryMetrics` | `unknown` | `Record<string, unknown> \| null` |
| `serverMetrics` | `unknown` | `Record<string, unknown> \| null` |

A literal `Pick<Benchmark>` would force an `as` cast on **every field** — exactly what the issue wants gone. So the snapshot is spelled out as a hand-authored interface matching what the report path actually consumes (and `StageRun.summaryMetrics` is already `unknown` in this same path, so it's consistent). Full `Benchmark` remains assignable to it.

## Acceptance

- ✅ No `as Benchmark` cast left in the report mapping path.
- ✅ `pnpm -F web` typecheck green.
- ✅ Guard verified: temporarily reading `r.benchmark.toolVersion` (outside the set) → `error TS2339: Property 'toolVersion' does not exist on type 'ReportBenchmarkSnapshot'`.
- ✅ All 95 `compare/` tests pass; biome clean.

Follow-up to #302. addresses #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)