### PR TITLE
fix(web): keep missing ITL p95 as null, not a 0 ms bar

### DIFF
--- a/apps/web/src/features/benchmarks/compare/StageBarChartsSection.tsx
+++ b/apps/web/src/features/benchmarks/compare/StageBarChartsSection.tsx
@@ -68,9 +68,11 @@ export function StageBarChartsSection({ runs }: { runs: StageRun[] }) {
     v: readLatencyPercentiles(r.summaryMetrics, "itl", ["p95"])?.p95 ?? null,
   }));
   const showItl = itlRows.some((x) => x.v !== null);
+  // Keep missing ITL as null (not 0) — ECharts skips the bar, so a run/tool
+  // without ITL reads as "no data" rather than a misleading 0 ms.
   const itlData: StageBarDatum[] = itlRows.map(({ r, v }) => ({
     stage: r.stageLabel,
-    itl: v ?? 0,
+    itl: v,
   }));
 
   // Percentile lines: x = percentile category, series = run.


### PR DESCRIPTION
Follow-up to #303 addressing the Gemini review comment on `StageBarChartsSection`.

Defaulting a missing ITL p95 to `0` rendered a misleading **0 ms** bar (implying instantaneous latency) instead of no bar for runs/tools without ITL. ECharts skips `null` data points, so we preserve `null`.

In practice ITL is all-present or all-absent per tool (compare blocks mixed tools, and the `showItl` gate already hides the chart when no run has ITL), so this is a robustness guard rather than a user-visible bug fix.

Typecheck + `StageBarChartsSection` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)