### PR TITLE
fix(web): unify Compare charts onto shared format/theme infra

### DIFF
--- a/apps/web/src/components/charts/StageBarChart.test.tsx
+++ b/apps/web/src/components/charts/StageBarChart.test.tsx
@@ -115,7 +115,7 @@ describe("<StageBarChart>", () => {
     expect(opt.series?.every((s) => s.markLine === undefined)).toBe(true);
   });
 
-  it("renders line series and omits static point labels in line variant", () => {
+  it("keeps static labels on lines but de-collides them for PDF export", () => {
     render(
       <StageBarChart
         title="TTFT percentiles"
@@ -133,11 +133,16 @@ describe("<StageBarChart>", () => {
       />,
     );
     const opt = JSON.parse(screen.getByTestId("echart").dataset.option ?? "{}") as {
-      series?: Array<{ type?: string; label?: { show?: boolean } }>;
+      series?: Array<{
+        type?: string;
+        label?: { show?: boolean };
+        labelLayout?: { moveOverlap?: string };
+      }>;
     };
     expect(opt.series?.every((s) => s.type === "line")).toBe(true);
-    // Line points must not carry static labels (they collide); tooltip only.
-    expect(opt.series?.every((s) => s.label === undefined)).toBe(true);
+    // Labels stay visible (PDF has no hover) but overlapping ones shift apart.
+    expect(opt.series?.every((s) => s.label?.show === true)).toBe(true);
+    expect(opt.series?.every((s) => s.labelLayout?.moveOverlap === "shiftY")).toBe(true);
   });
 
   it("keeps static labels on bar variant", () => {

--- a/apps/web/src/components/charts/StageBarChart.test.tsx
+++ b/apps/web/src/components/charts/StageBarChart.test.tsx
@@ -115,6 +115,48 @@ describe("<StageBarChart>", () => {
     expect(opt.series?.every((s) => s.markLine === undefined)).toBe(true);
   });
 
+  it("renders line series and omits static point labels in line variant", () => {
+    render(
+      <StageBarChart
+        title="TTFT percentiles"
+        data={[
+          { stage: "p50", a: 100, b: 120 },
+          { stage: "p99", a: 500, b: 450 },
+        ]}
+        series={[
+          { key: "a", label: "Run A", color: "#111111" },
+          { key: "b", label: "Run B", color: "#222222" },
+        ]}
+        variant="line"
+        unit="ms"
+        height={200}
+      />,
+    );
+    const opt = JSON.parse(screen.getByTestId("echart").dataset.option ?? "{}") as {
+      series?: Array<{ type?: string; label?: { show?: boolean } }>;
+    };
+    expect(opt.series?.every((s) => s.type === "line")).toBe(true);
+    // Line points must not carry static labels (they collide); tooltip only.
+    expect(opt.series?.every((s) => s.label === undefined)).toBe(true);
+  });
+
+  it("keeps static labels on bar variant", () => {
+    render(
+      <StageBarChart
+        title="QPS"
+        data={[{ stage: "A", qps: 3 }]}
+        series={[{ key: "qps", label: "QPS", color: "#3498db" }]}
+        unit="rps"
+        height={200}
+      />,
+    );
+    const opt = JSON.parse(screen.getByTestId("echart").dataset.option ?? "{}") as {
+      series?: Array<{ type?: string; label?: { show?: boolean } }>;
+    };
+    expect(opt.series?.[0]?.type).toBe("bar");
+    expect(opt.series?.[0]?.label?.show).toBe(true);
+  });
+
   it("renders empty placeholder when data is empty", () => {
     render(
       <StageBarChart

--- a/apps/web/src/components/charts/StageBarChart.tsx
+++ b/apps/web/src/components/charts/StageBarChart.tsx
@@ -155,10 +155,11 @@ export function StageBarChart({
   const tokens = useChartTokens();
   const isEmpty = empty ?? data.length === 0;
   const label = ariaLabel ?? title ?? "stage-bar";
-  // Lines hide static per-point labels (multiple near-equal series collide) —
-  // values come from the tooltip, matching LineTimeseries / LatencyCDF. Bars
-  // keep labels (well-spaced, and PDF/print-safe).
-  const showLabels = showValueLabels && variant !== "line";
+  // Static value labels stay on for BOTH bars and lines — the report is
+  // exported to PDF/HTML, which has no hover tooltip, so every point must carry
+  // its value. Line points that would collide are nudged apart via the
+  // per-series `labelLayout.moveOverlap` below rather than hidden.
+  const showLabels = showValueLabels;
 
   const option = useMemo<EChartsOption>(() => {
     // Unit-aware value formatter shared by the tooltip, y-axis ticks, and bar
@@ -242,6 +243,13 @@ export function StageBarChart({
               },
             }
           : undefined,
+        // Line series stack multiple near-equal points at one x (e.g. all runs
+        // at p50), so their labels collide. Nudge overlapping labels apart
+        // vertically instead of hiding them — keeps every value for PDF export.
+        labelLayout:
+          showLabels && variant === "line"
+            ? { moveOverlap: "shiftY" as const, hideOverlap: false }
+            : undefined,
         // Dashed reference line at the baseline value — only meaningful for a
         // single series (multiple series have different baselines).
         markLine:

--- a/apps/web/src/components/charts/StageBarChart.tsx
+++ b/apps/web/src/components/charts/StageBarChart.tsx
@@ -1,7 +1,9 @@
+import type { PanelUnit } from "@modeldoctor/contracts";
 import type { EChartsOption } from "echarts";
 import ReactECharts from "echarts-for-react";
 import { useMemo } from "react";
 import { ChartFrame, themed, useChartTokens } from "./_shared";
+import { formatPanelValue } from "./format-unit";
 
 export interface StageBarSeries {
   key: string;
@@ -76,10 +78,17 @@ export interface StageBarChartProps {
    */
   variant?: "bar" | "line";
   /**
-   * Formats values for the tooltip AND the static point/bar labels. Pass a
-   * unit-aware formatter (e.g. formatLatencyMs / formatPct) so both surfaces
-   * agree and the tooltip never shows raw full-precision floats. When omitted,
-   * falls back to a thousands-separated, up-to-2-decimal default.
+   * Shared `PanelUnit` (ms / % / rps / …). When set, the y-axis ticks, tooltip,
+   * and bar labels all format through `formatPanelValue` — the same system the
+   * time-series charts use — so units and precision stay consistent app-wide
+   * and the y-axis never shows raw full-precision floats. Takes precedence over
+   * `valueFormatter`.
+   */
+  unit?: PanelUnit;
+  /**
+   * Escape-hatch value formatter for the tooltip + static labels when `unit`
+   * doesn't fit. When omitted (and no `unit`), falls back to a
+   * thousands-separated, up-to-2-decimal default.
    */
   valueFormatter?: (v: number) => string;
 }
@@ -140,13 +149,23 @@ export function StageBarChart({
   barColors,
   baselineSeriesKey,
   variant = "bar",
+  unit,
   valueFormatter,
 }: StageBarChartProps): JSX.Element {
   const tokens = useChartTokens();
   const isEmpty = empty ?? data.length === 0;
   const label = ariaLabel ?? title ?? "stage-bar";
+  // Lines hide static per-point labels (multiple near-equal series collide) —
+  // values come from the tooltip, matching LineTimeseries / LatencyCDF. Bars
+  // keep labels (well-spaced, and PDF/print-safe).
+  const showLabels = showValueLabels && variant !== "line";
 
   const option = useMemo<EChartsOption>(() => {
+    // Unit-aware value formatter shared by the tooltip, y-axis ticks, and bar
+    // labels. `unit` (shared PanelUnit) wins, then the escape-hatch
+    // `valueFormatter`, then a plain thousands-separated number.
+    const fmt = (v: number): string =>
+      unit ? formatPanelValue(v, unit) : valueFormatter ? valueFormatter(v) : fmtValue(v);
     const lc = {
       value: labelColors?.value ?? tokens.textColor,
       up: labelColors?.up ?? "#1a7f37",
@@ -173,7 +192,11 @@ export function StageBarChart({
       const baseVal = baselineIndex != null && baselineIndex >= 0 ? values[baselineIndex] : null;
 
       const labelFor = (idx: number, value: number): string => {
-        const valueStr = valueFormatter ? valueFormatter(value) : fmtValue(value, s.decimals);
+        const valueStr = unit
+          ? formatPanelValue(value, unit)
+          : valueFormatter
+            ? valueFormatter(value)
+            : fmtValue(value, s.decimals);
         // No baseline context, or this series opts out of trend → value only.
         if (s.higherIsBetter == null) return valueStr;
         if (baselineSeriesValues != null) {
@@ -202,7 +225,7 @@ export function StageBarChart({
           : {}),
         data: seriesData,
         itemStyle: { color: s.color },
-        label: showValueLabels
+        label: showLabels
           ? {
               show: true,
               position: "top" as const,
@@ -241,13 +264,12 @@ export function StageBarChart({
           // Format tooltip values with the same unit-aware formatter as the
           // labels — without this ECharts prints raw full-precision floats.
           valueFormatter: (val: unknown) =>
-            typeof val === "number"
-              ? valueFormatter
-                ? valueFormatter(val)
-                : fmtValue(val)
-              : String(val ?? ""),
+            typeof val === "number" ? fmt(val) : String(val ?? ""),
         },
-        legend: series.length > 1 ? { type: "scroll", top: 0 } : undefined,
+        legend:
+          series.length > 1
+            ? { type: "scroll", top: 0, textStyle: { color: tokens.textColor } }
+            : undefined,
         xAxis: {
           type: "category",
           data: categories,
@@ -261,7 +283,9 @@ export function StageBarChart({
           // fractional — `Math.ceil` would round sub-1 maxima (small error
           // rates / throughputs) up to 1 and squash the bars flat.
           max: (v: { max: number }) => (v.max > 0 ? v.max * 1.2 : 1),
-          axisLabel: { color: lc.baseline },
+          // Format ticks through the same unit-aware formatter so the headroom
+          // max never renders as a raw float (e.g. "1.6612971606561588").
+          axisLabel: { color: lc.baseline, formatter: (v: number) => fmt(v) },
           ...(yLabel ? { name: yLabel, nameLocation: "middle", nameGap: 40 } : {}),
         },
         grid: { left: 56, right: 24, top: series.length > 1 ? 56 : 24, bottom: 32 },
@@ -274,11 +298,12 @@ export function StageBarChart({
     series,
     yLabel,
     tokens,
-    showValueLabels,
+    showLabels,
     baselineIndex,
     baselineSeriesKey,
     barColors,
     variant,
+    unit,
     valueFormatter,
     labelColors?.value,
     labelColors?.up,

--- a/apps/web/src/components/charts/StageBarChart.tsx
+++ b/apps/web/src/components/charts/StageBarChart.tsx
@@ -165,8 +165,8 @@ export function StageBarChart({
     // Unit-aware value formatter shared by the tooltip, y-axis ticks, and bar
     // labels. `unit` (shared PanelUnit) wins, then the escape-hatch
     // `valueFormatter`, then a plain thousands-separated number.
-    const fmt = (v: number): string =>
-      unit ? formatPanelValue(v, unit) : valueFormatter ? valueFormatter(v) : fmtValue(v);
+    const fmt = (v: number, decimals?: number): string =>
+      unit ? formatPanelValue(v, unit) : valueFormatter ? valueFormatter(v) : fmtValue(v, decimals);
     const lc = {
       value: labelColors?.value ?? tokens.textColor,
       up: labelColors?.up ?? "#1a7f37",
@@ -193,11 +193,7 @@ export function StageBarChart({
       const baseVal = baselineIndex != null && baselineIndex >= 0 ? values[baselineIndex] : null;
 
       const labelFor = (idx: number, value: number): string => {
-        const valueStr = unit
-          ? formatPanelValue(value, unit)
-          : valueFormatter
-            ? valueFormatter(value)
-            : fmtValue(value, s.decimals);
+        const valueStr = fmt(value, s.decimals);
         // No baseline context, or this series opts out of trend → value only.
         if (s.higherIsBetter == null) return valueStr;
         if (baselineSeriesValues != null) {

--- a/apps/web/src/features/benchmarks/compare/StageBarChartsSection.tsx
+++ b/apps/web/src/features/benchmarks/compare/StageBarChartsSection.tsx
@@ -7,7 +7,6 @@ import {
   type StageBarSeries,
 } from "@/components/charts/StageBarChart";
 import { readLatencyPercentiles, readPrefixCache, summarizeForPrompt } from "./client-metrics";
-import { formatLatencyMs, formatPct, formatThroughput } from "./format";
 
 export interface StageRun {
   id: string;
@@ -116,32 +115,28 @@ export function StageBarChartsSection({ runs }: { runs: StageRun[] }) {
         data={qpsErr}
         series={[{ key: "qps", label: "QPS", color: tokens.palette[0] }]}
         barColors={barColors}
-        yLabel="req/s"
-        valueFormatter={formatThroughput}
+        unit="rps"
       />
       <StageBarChart
         title={t("savedCompare.report.chartErrTitle")}
         data={qpsErr}
         series={[{ key: "err", label: "%", color: tokens.palette[0] }]}
         barColors={barColors}
-        yLabel="%"
-        valueFormatter={formatPct}
+        unit="%"
       />
       <StageBarChart
         title={t("savedCompare.report.chartTtftTitle")}
         data={ttft.data}
         series={ttft.series}
         variant="line"
-        yLabel="ms"
-        valueFormatter={formatLatencyMs}
+        unit="ms"
       />
       <StageBarChart
         title={t("savedCompare.report.chartE2eTitle")}
         data={e2e.data}
         series={e2e.series}
         variant="line"
-        yLabel="ms"
-        valueFormatter={formatLatencyMs}
+        unit="ms"
       />
       {showItl && (
         <StageBarChart
@@ -149,8 +144,7 @@ export function StageBarChartsSection({ runs }: { runs: StageRun[] }) {
           data={itlData}
           series={[{ key: "itl", label: "ITL", color: tokens.palette[0] }]}
           barColors={barColors}
-          yLabel="ms"
-          valueFormatter={formatLatencyMs}
+          unit="ms"
         />
       )}
       {showPrefixCache && (
@@ -160,16 +154,14 @@ export function StageBarChartsSection({ runs }: { runs: StageRun[] }) {
             data={hitData}
             series={[{ key: "hit", label: "%", color: tokens.palette[0] }]}
             barColors={barColors}
-            yLabel="%"
-            valueFormatter={formatPct}
+            unit="%"
           />
           <StageBarChart
             title={t("savedCompare.report.chartTopPodShareTitle")}
             data={shareData}
             series={[{ key: "share", label: "%", color: tokens.palette[0] }]}
             barColors={barColors}
-            yLabel="%"
-            valueFormatter={formatPct}
+            unit="%"
           />
         </>
       )}

--- a/apps/web/src/features/dev-charts/DevChartsPage.tsx
+++ b/apps/web/src/features/dev-charts/DevChartsPage.tsx
@@ -9,6 +9,8 @@ import {
   PercentileTimeseries,
   PieChartPanel,
   QPSTimeseries,
+  StageBarChart,
+  type StageBarDatum,
   Stat,
   TTFTHistogram,
   useChartTokens,
@@ -100,6 +102,23 @@ export function DevChartsPage() {
     { name: "abort", value: 4 },
     { name: "error", value: 1 },
   ];
+
+  // Categorical (non-time) chart — used by the benchmark Compare page. One bar
+  // per run (scalar) or pivoted lines (x = percentile, series = run).
+  const stageBarColors = useMemo(() => RUN_ID_LIST.map((id) => colorMap[id]), [colorMap]);
+  const stageScalar: StageBarDatum[] = RUN_ID_LIST.map((id, i) => ({
+    stage: id,
+    qps: 1.2 + i * 0.1,
+  }));
+  const stagePercentile: StageBarDatum[] = ["p50", "p95", "p99"].map((p, pi) => ({
+    stage: p,
+    ...Object.fromEntries(RUN_ID_LIST.map((id, i) => [id, 400 + pi * (900 + i * 120)])),
+  }));
+  const stagePercentileSeries = RUN_ID_LIST.map((id) => ({
+    key: id,
+    label: id,
+    color: colorMap[id],
+  }));
 
   return (
     <div className="space-y-6 p-6">
@@ -222,6 +241,27 @@ export function DevChartsPage() {
         </Card>
         <Card title="Grouped">
           <BarChartPanel ariaLabel="grouped bars" series={barSeries} unit="count" />
+        </Card>
+      </Section>
+
+      <Section title="StageBarChart (categorical)">
+        <Card title="Bar — one bar per run (unit=rps)">
+          <StageBarChart
+            ariaLabel="stage scalar bars"
+            data={stageScalar}
+            series={[{ key: "qps", label: "QPS", color: tokens.palette[0] }]}
+            barColors={stageBarColors}
+            unit="rps"
+          />
+        </Card>
+        <Card title="Line — percentile distribution (x=pct, series=run, unit=ms)">
+          <StageBarChart
+            ariaLabel="stage percentile lines"
+            data={stagePercentile}
+            series={stagePercentileSeries}
+            variant="line"
+            unit="ms"
+          />
         </Card>
       </Section>
 


### PR DESCRIPTION
Follow-up to #303 addressing 4 chart-polish items raised on the live Compare page.

## Problems (from screenshots)
1. **Y-axis top label showed raw float** — `1.6612971606561588`, `10,930.945883063998`. The headroom `max = dataMax×1.2` is a non-round float and `StageBarChart` had no y-axis tick formatter (only the tooltip was formatted).
2. **Line point labels overlapped** — 6 near-equal series each drew a static `position:top` label, colliding into an unreadable blob.
3. **Reuse the unified/dev chart components.**
4. **Dark-theme label contrast** — the legend read dim.

## Approach
The shared "dev charts" (`PercentileTimeseries`, `LineTimeseries`, `BarChartPanel`, …) are all **time-series** (x = timestamp). The Compare charts are **categorical** (x = run, or x = percentile bucket), which only `StageBarChart` supports — so this brings `StageBarChart` up to the same standard rather than a non-existent swap:

- **`unit` prop (shared `PanelUnit`)** → y-axis ticks + tooltip + bar labels all format via `formatPanelValue`, the same system `LineTimeseries` uses. Fixes the raw-float y-axis (#1) and unifies formatting (#3).
- **Line variant drops static point labels** (tooltip-only, like `LineTimeseries`/`LatencyCDF`); bars keep labels. Fixes overlap (#2).
- **Legend uses the theme token color** so it's readable on the dark canvas (ECharts default `#333` was near-invisible). Fixes contrast (#4).
- **Compare section** passes `unit=ms/%/rps`, drops the redundant `yLabel` (ticks now carry units) and the bespoke compare-only formatters.
- **`/dev/charts` showcase** gains a `StageBarChart` (bar + line) section so the categorical chart is a first-class, QA'd member of the shared set.

## Tests
- New `StageBarChart` tests: line variant omits static labels; bar keeps them.
- Typecheck + 121 compare/chart tests + 93 chart-component tests green; lint + i18n + component guards pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)