### PR TITLE
feat(web): align Compare key-metrics & save-dialog with Test-matrix labels

### DIFF
--- a/apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
+++ b/apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
@@ -249,7 +249,12 @@ export function BenchmarkComparePage() {
             <SaveCompareDialog
               open={saveOpen}
               onOpenChange={setSaveOpen}
-              runs={successfulBenchmarks.map((r) => ({ id: r.id, name: r.name, tool: r.tool }))}
+              runs={reportRuns.map((r) => ({
+                id: r.id,
+                name: r.benchmark?.name ?? null,
+                tool: r.tool,
+                label: r.stageLabel,
+              }))}
               baselineId={defaultBaseline}
               context=""
               generateAfterSave={generateAfterSave}

--- a/apps/web/src/features/benchmarks/compare/CompareGrid.tsx
+++ b/apps/web/src/features/benchmarks/compare/CompareGrid.tsx
@@ -9,9 +9,13 @@ import type { ReportBenchmarkSnapshot } from "./ReportSections";
 export interface CompareGridProps {
   runs: ReportBenchmarkSnapshot[];
   baselineId: string | null;
+  /** Short distinguishing label per run id (Test-matrix `label` column). When a
+   *  run has an entry, its column header shows the label instead of the long
+   *  benchmark name, keeping the grid aligned with the matrix. */
+  labels?: Record<string, string>;
 }
 
-export function CompareGrid({ runs, baselineId }: CompareGridProps) {
+export function CompareGrid({ runs, baselineId, labels }: CompareGridProps) {
   const { t } = useTranslation("benchmarks");
 
   // All runs share one tool by the time CompareGrid mounts (validated upstream).
@@ -37,7 +41,7 @@ export function CompareGrid({ runs, baselineId }: CompareGridProps) {
                   run.id === baselineId && "bg-amber-50 dark:bg-amber-950/30",
                 )}
               >
-                {run.name}
+                {labels?.[run.id] ?? run.name}
               </TableHead>
             ))}
           </TableRow>

--- a/apps/web/src/features/benchmarks/compare/ReportSections.tsx
+++ b/apps/web/src/features/benchmarks/compare/ReportSections.tsx
@@ -260,7 +260,11 @@ export function ReportSections({
       {/* 2. CompareGrid */}
       <section>
         <h2 className="mb-3 text-lg font-semibold">{t("savedCompare.report.sectionGrid")}</h2>
-        <CompareGrid runs={livingRuns.map((r) => r.benchmark)} baselineId={baselineId} />
+        <CompareGrid
+          runs={livingRuns.map((r) => r.benchmark)}
+          baselineId={baselineId}
+          labels={Object.fromEntries(livingRuns.map((r) => [r.id, r.stageLabel]))}
+        />
       </section>
 
       {/* 3. Charts */}

--- a/apps/web/src/features/benchmarks/compare/SaveCompareDialog.test.tsx
+++ b/apps/web/src/features/benchmarks/compare/SaveCompareDialog.test.tsx
@@ -101,3 +101,56 @@ describe("SaveCompareDialog validation", () => {
     expect(submitButton()).not.toBeDisabled();
   });
 });
+
+describe("SaveCompareDialog state seeding", () => {
+  function Harness() {
+    // New `runs` array reference on every render — mirrors BenchmarkComparePage's
+    // inline `.map()`, which a background React Query refetch re-creates.
+    const runs = [
+      { id: "b1", name: "r1", tool: "guidellm", label: "A" },
+      { id: "b2", name: "r2", tool: "guidellm", label: "B" },
+    ];
+    return (
+      <SaveCompareDialog open onOpenChange={() => {}} runs={runs} baselineId="b1" context="" />
+    );
+  }
+
+  it("seeds label inputs from the derived `label` on open", () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <MemoryRouter>
+        <QueryClientProvider client={qc}>
+          <Harness />
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+    expect(screen.getByLabelText("r1")).toHaveValue("A");
+    expect(screen.getByLabelText("r2")).toHaveValue("B");
+  });
+
+  it("keeps user edits across a parent re-render while open (fresh runs ref)", async () => {
+    const u = userEvent.setup();
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { rerender } = render(
+      <MemoryRouter>
+        <QueryClientProvider client={qc}>
+          <Harness />
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+    const input = screen.getByLabelText("r1");
+    await u.clear(input);
+    await u.type(input, "Edited");
+    expect(input).toHaveValue("Edited");
+
+    // Parent re-render with a brand-new `runs` reference must NOT re-seed.
+    rerender(
+      <MemoryRouter>
+        <QueryClientProvider client={qc}>
+          <Harness />
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+    expect(screen.getByLabelText("r1")).toHaveValue("Edited");
+  });
+});

--- a/apps/web/src/features/benchmarks/compare/SaveCompareDialog.tsx
+++ b/apps/web/src/features/benchmarks/compare/SaveCompareDialog.tsx
@@ -1,5 +1,23 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import type { Classification } from "@modeldoctor/contracts";
-import { useState } from "react";
+import { GripVertical } from "lucide-react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
@@ -26,6 +44,10 @@ export interface SaveCompareDialogRun {
   id: string;
   name: string | null;
   tool: string;
+  /** Pre-derived short label (Test-matrix `label` column). Seeds the editable
+   *  per-run label input so the dialog mirrors the matrix and "rename" is just
+   *  editing a pre-filled value. */
+  label?: string;
 }
 
 export interface SaveCompareDialogProps {
@@ -36,6 +58,59 @@ export interface SaveCompareDialogProps {
   context: string;
   /** When true, navigate to the saved page with ?generate=1 so it auto-synthesizes. */
   generateAfterSave?: boolean;
+}
+
+// Static sensor options hoisted to module scope (see ReportSections.tsx): keeps
+// dnd-kit sensors stable across re-renders so a drop doesn't recreate them.
+const POINTER_SENSOR_OPTIONS = { activationConstraint: { distance: 4 } };
+const KEYBOARD_SENSOR_OPTIONS = { coordinateGetter: sortableKeyboardCoordinates };
+
+/** One sortable row: grip handle + run name + editable label input. Drag is
+ *  initiated from the handle only so the label text stays editable. */
+function SortableLabelRow({
+  run,
+  value,
+  onChange,
+  handleLabel,
+}: {
+  run: SaveCompareDialogRun;
+  value: string;
+  onChange: (next: string) => void;
+  handleLabel: string;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: run.id,
+  });
+  const name = run.name ?? run.id;
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={`grid grid-cols-[auto_1fr_auto] items-center gap-2 rounded-sm ${
+        isDragging ? "relative z-10 bg-muted/40" : ""
+      }`}
+    >
+      <button
+        type="button"
+        aria-label={handleLabel}
+        className="cursor-grab rounded-sm p-1 text-muted-foreground hover:bg-muted hover:text-foreground active:cursor-grabbing"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+      <Label htmlFor={`label-${run.id}`} className="truncate text-sm font-normal">
+        {name}
+      </Label>
+      <Input
+        id={`label-${run.id}`}
+        aria-label={name}
+        className="w-32"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
+  );
 }
 
 export function SaveCompareDialog({
@@ -50,20 +125,52 @@ export function SaveCompareDialog({
   const navigate = useNavigate();
   const create = useCreateSavedCompare();
   const [name, setName] = useState("");
+  // Local run order — seeded from the incoming (Test-matrix) order each time the
+  // dialog opens; in-dialog drag reorders this copy only and drives the saved
+  // benchmarkIds order. It never writes back to the matrix / URL.
+  const [order, setOrder] = useState<string[]>([]);
   const [labels, setLabels] = useState<Record<string, string>>({});
   const [ctx, setCtx] = useState(context);
   const [classification, setClassification] = useState<Classification>("internal");
   const [clientName, setClientName] = useState("");
 
-  const allLabelled = runs.every((r) => labels[r.id]?.trim());
+  // Re-seed order + labels from the latest matrix order/labels whenever the
+  // dialog opens. The component stays mounted across open/close, so without this
+  // the first-mount snapshot would go stale after a Test-matrix reorder/rename.
+  useEffect(() => {
+    if (!open) return;
+    setOrder(runs.map((r) => r.id));
+    setLabels(Object.fromEntries(runs.map((r) => [r.id, r.label ?? ""])));
+    setCtx(context);
+  }, [open, runs, context]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, POINTER_SENSOR_OPTIONS),
+    useSensor(KeyboardSensor, KEYBOARD_SENSOR_OPTIONS),
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (over === null || active.id === over.id) return;
+    setOrder((prev) =>
+      arrayMove(prev, prev.indexOf(String(active.id)), prev.indexOf(String(over.id))),
+    );
+  }
+
+  const runById = new Map(runs.map((r) => [r.id, r]));
+  const orderedRuns = order
+    .map((id) => runById.get(id))
+    .filter((r): r is SaveCompareDialogRun => !!r);
+
+  const allLabelled = orderedRuns.every((r) => labels[r.id]?.trim());
   const canSubmit = name.trim().length > 0 && allLabelled && !create.isPending;
 
   async function submit() {
     if (!canSubmit) return;
     const sc = await create.mutateAsync({
       name: name.trim(),
-      benchmarkIds: runs.map((r) => r.id),
-      stageLabels: Object.fromEntries(runs.map((r) => [r.id, labels[r.id].trim()])),
+      benchmarkIds: orderedRuns.map((r) => r.id),
+      stageLabels: Object.fromEntries(orderedRuns.map((r) => [r.id, labels[r.id].trim()])),
       baselineId: baselineId ?? undefined,
       context: ctx.trim() || undefined,
       classification,
@@ -97,22 +204,25 @@ export function SaveCompareDialog({
             <div className="text-xs text-muted-foreground mb-2">
               {t("savedCompare.dialog.stageLabelsHint")}
             </div>
-            <div className="space-y-2">
-              {runs.map((r) => (
-                <div key={r.id} className="grid grid-cols-[1fr_auto] items-center gap-2">
-                  <Label htmlFor={`label-${r.id}`} className="text-sm font-normal">
-                    {r.name ?? r.id}
-                  </Label>
-                  <Input
-                    id={`label-${r.id}`}
-                    aria-label={r.name ?? r.id}
-                    className="w-32"
-                    value={labels[r.id] ?? ""}
-                    onChange={(e) => setLabels((p) => ({ ...p, [r.id]: e.target.value }))}
-                  />
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext items={order} strategy={verticalListSortingStrategy}>
+                <div className="space-y-2">
+                  {orderedRuns.map((r) => (
+                    <SortableLabelRow
+                      key={r.id}
+                      run={r}
+                      value={labels[r.id] ?? ""}
+                      onChange={(next) => setLabels((p) => ({ ...p, [r.id]: next }))}
+                      handleLabel={t("compare.dragHandle")}
+                    />
+                  ))}
                 </div>
-              ))}
-            </div>
+              </SortableContext>
+            </DndContext>
           </div>
           <div>
             <Label htmlFor="sc-ctx">{t("savedCompare.dialog.contextLabel")}</Label>

--- a/apps/web/src/features/benchmarks/compare/SaveCompareDialog.tsx
+++ b/apps/web/src/features/benchmarks/compare/SaveCompareDialog.tsx
@@ -17,7 +17,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import type { Classification } from "@modeldoctor/contracts";
 import { GripVertical } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
@@ -134,15 +134,24 @@ export function SaveCompareDialog({
   const [classification, setClassification] = useState<Classification>("internal");
   const [clientName, setClientName] = useState("");
 
-  // Re-seed order + labels from the latest matrix order/labels whenever the
-  // dialog opens. The component stays mounted across open/close, so without this
-  // the first-mount snapshot would go stale after a Test-matrix reorder/rename.
-  useEffect(() => {
-    if (!open) return;
-    setOrder(runs.map((r) => r.id));
-    setLabels(Object.fromEntries(runs.map((r) => [r.id, r.label ?? ""])));
-    setCtx(context);
-  }, [open, runs, context]);
+  // Re-seed order + labels from the latest matrix order/labels on the
+  // closed→open transition only. The component stays mounted across open/close,
+  // so a first-mount snapshot would go stale after a Test-matrix reorder/rename
+  // — but keying an effect off `runs` would re-seed on every parent re-render
+  // (the inline `.map()` hands us a fresh `runs` ref each render, e.g. a
+  // background refetch), wiping the user's in-dialog drag/rename. Deriving from
+  // an open-transition sentinel re-seeds exactly once per open.
+  // Init to false (not `open`) so seeding fires on the first render that sees
+  // `open=true`, whether the dialog mounts already-open or opens later.
+  const [prevOpen, setPrevOpen] = useState(false);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) {
+      setOrder(runs.map((r) => r.id));
+      setLabels(Object.fromEntries(runs.map((r) => [r.id, r.label ?? ""])));
+      setCtx(context);
+    }
+  }
 
   const sensors = useSensors(
     useSensor(PointerSensor, POINTER_SENSOR_OPTIONS),
@@ -170,7 +179,7 @@ export function SaveCompareDialog({
     const sc = await create.mutateAsync({
       name: name.trim(),
       benchmarkIds: orderedRuns.map((r) => r.id),
-      stageLabels: Object.fromEntries(orderedRuns.map((r) => [r.id, labels[r.id].trim()])),
+      stageLabels: Object.fromEntries(orderedRuns.map((r) => [r.id, (labels[r.id] ?? "").trim()])),
       baselineId: baselineId ?? undefined,
       context: ctx.trim() || undefined,
       classification,


### PR DESCRIPTION
Follow-up to #307. Makes the short Test-matrix `label` (e.g. `MX-OFF-r1-a1`) the single run identity used across the Compare page.

## Changes
1. **Key metrics headers use the label.** `CompareGrid` gains an optional `labels` (id → stage label) map; headers render `labels[id] ?? run.name`. So the grid shows `MX-OFF-r1-a1` instead of the long `深会话T2 · QWEN3-8B · MX-OFF-R1-A1`.
2. **Drag-reorder linkage.** Test-matrix drag already reorders the grid and charts via the URL `ids` param (`livingRuns` flows into both `CompareGrid` and `StageBarChartsSection`). Passing the label map keeps the relabeled headers in sync after a drag — no separate ordering state.
3. **Save-as-report dialog.** The Stage-labels section now:
   - renders runs in the current Test-matrix order,
   - seeds each input with the derived label (so "rename" = edit a pre-filled value),
   - is drag-sortable (same `@dnd-kit` setup as the matrix).
   In-dialog order drives the saved `benchmarkIds` order; it does **not** write back to the URL/matrix.

## Verification
- `pnpm -F @modeldoctor/web exec tsc --noEmit` — clean
- `vitest` SaveCompareDialog + CompareGrid — 7/7 pass
- `biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)