### PR TITLE
fix(web): Compare polish — Grafana-style line tooltips, linkable matrix name, drop redundant env section

### DIFF
--- a/apps/web/src/components/charts/StageBarChart.test.tsx
+++ b/apps/web/src/components/charts/StageBarChart.test.tsx
@@ -115,7 +115,7 @@ describe("<StageBarChart>", () => {
     expect(opt.series?.every((s) => s.markLine === undefined)).toBe(true);
   });
 
-  it("keeps static labels on lines and hides overlapping ones", () => {
+  it("drops static point labels on multi-run lines, reads values off the shared tooltip", () => {
     render(
       <StageBarChart
         title="TTFT percentiles"
@@ -133,17 +133,15 @@ describe("<StageBarChart>", () => {
       />,
     );
     const opt = JSON.parse(screen.getByTestId("echart").dataset.option ?? "{}") as {
-      series?: Array<{
-        type?: string;
-        label?: { show?: boolean };
-        labelLayout?: { hideOverlap?: boolean };
-      }>;
+      series?: Array<{ type?: string; label?: { show?: boolean } }>;
+      tooltip?: { trigger?: string };
     };
     expect(opt.series?.every((s) => s.type === "line")).toBe(true);
-    // Labels stay enabled (PDF has no hover); ECharts hides the ones that would
-    // collide so clustered percentile points don't pile into an unreadable heap.
-    expect(opt.series?.every((s) => s.label?.show === true)).toBe(true);
-    expect(opt.series?.every((s) => s.labelLayout?.hideOverlap === true)).toBe(true);
+    // Grafana-style: no per-point labels to avoid stacking N near-equal values
+    // at one x. Values are read from the shared axis (crosshair) tooltip and the
+    // Key metrics table rendered alongside.
+    expect(opt.series?.every((s) => s.label?.show !== true)).toBe(true);
+    expect(opt.tooltip?.trigger).toBe("axis");
   });
 
   it("keeps static labels on bar variant", () => {

--- a/apps/web/src/components/charts/StageBarChart.test.tsx
+++ b/apps/web/src/components/charts/StageBarChart.test.tsx
@@ -136,6 +136,9 @@ describe("<StageBarChart>", () => {
       series?: Array<{ type?: string; label?: { show?: boolean } }>;
       tooltip?: { trigger?: string };
     };
+    // Assert the length so the `.every()` checks below can't pass vacuously on
+    // an empty series array.
+    expect(opt.series).toHaveLength(2);
     expect(opt.series?.every((s) => s.type === "line")).toBe(true);
     // Grafana-style: no per-point labels to avoid stacking N near-equal values
     // at one x. Values are read from the shared axis (crosshair) tooltip and the

--- a/apps/web/src/components/charts/StageBarChart.test.tsx
+++ b/apps/web/src/components/charts/StageBarChart.test.tsx
@@ -115,7 +115,7 @@ describe("<StageBarChart>", () => {
     expect(opt.series?.every((s) => s.markLine === undefined)).toBe(true);
   });
 
-  it("keeps static labels on lines but de-collides them for PDF export", () => {
+  it("keeps static labels on lines and hides overlapping ones", () => {
     render(
       <StageBarChart
         title="TTFT percentiles"
@@ -136,13 +136,14 @@ describe("<StageBarChart>", () => {
       series?: Array<{
         type?: string;
         label?: { show?: boolean };
-        labelLayout?: { moveOverlap?: string };
+        labelLayout?: { hideOverlap?: boolean };
       }>;
     };
     expect(opt.series?.every((s) => s.type === "line")).toBe(true);
-    // Labels stay visible (PDF has no hover) but overlapping ones shift apart.
+    // Labels stay enabled (PDF has no hover); ECharts hides the ones that would
+    // collide so clustered percentile points don't pile into an unreadable heap.
     expect(opt.series?.every((s) => s.label?.show === true)).toBe(true);
-    expect(opt.series?.every((s) => s.labelLayout?.moveOverlap === "shiftY")).toBe(true);
+    expect(opt.series?.every((s) => s.labelLayout?.hideOverlap === true)).toBe(true);
   });
 
   it("keeps static labels on bar variant", () => {

--- a/apps/web/src/components/charts/StageBarChart.tsx
+++ b/apps/web/src/components/charts/StageBarChart.tsx
@@ -155,12 +155,15 @@ export function StageBarChart({
   const tokens = useChartTokens();
   const isEmpty = empty ?? data.length === 0;
   const label = ariaLabel ?? title ?? "stage-bar";
-  // Static value labels stay on for BOTH bars and lines — the report is
-  // exported to PDF/HTML, which has no hover tooltip. Bars never collide; line
-  // points that pile up at a shared x (all runs at p50) drop the overlapping
-  // labels via `labelLayout.hideOverlap` below — outlier points keep theirs,
-  // and the Key metrics table carries every exact value regardless.
+  // Static value labels are a BAR-only affordance: one value per bar, never
+  // colliding, and useful in the tooltip-less PDF/HTML export. Multi-run LINE
+  // charts (p50/p95/p99 × N runs) would stack many near-equal labels at one x
+  // into an unreadable heap, so — following the mainstream approach (Grafana
+  // time-series panels print no per-point labels) — lines carry NO static
+  // labels and read their values off the shared axis tooltip + the Key metrics
+  // table rendered alongside the charts.
   const showLabels = showValueLabels;
+  const showStaticLabels = showLabels && variant !== "line";
 
   const option = useMemo<EChartsOption>(() => {
     // Unit-aware value formatter shared by the tooltip, y-axis ticks, and bar
@@ -223,7 +226,7 @@ export function StageBarChart({
           : {}),
         data: seriesData,
         itemStyle: { color: s.color },
-        label: showLabels
+        label: showStaticLabels
           ? {
               show: true,
               position: "top" as const,
@@ -240,12 +243,6 @@ export function StageBarChart({
               },
             }
           : undefined,
-        // Line series stack multiple near-equal points at one x (e.g. all runs
-        // at p50), piling their labels into an unreadable heap. Hide the
-        // overlapping ones: a lone outlier (e.g. a p99 spike) sits clear of the
-        // pack and keeps its label, while clustered values fall back to the axis
-        // tooltip and the Key metrics table rendered alongside the charts.
-        labelLayout: showLabels && variant === "line" ? { hideOverlap: true } : undefined,
         // Dashed reference line at the baseline value — only meaningful for a
         // single series (multiple series have different baselines).
         markLine:
@@ -302,7 +299,7 @@ export function StageBarChart({
     series,
     yLabel,
     tokens,
-    showLabels,
+    showStaticLabels,
     baselineIndex,
     baselineSeriesKey,
     barColors,

--- a/apps/web/src/components/charts/StageBarChart.tsx
+++ b/apps/web/src/components/charts/StageBarChart.tsx
@@ -156,9 +156,10 @@ export function StageBarChart({
   const isEmpty = empty ?? data.length === 0;
   const label = ariaLabel ?? title ?? "stage-bar";
   // Static value labels stay on for BOTH bars and lines — the report is
-  // exported to PDF/HTML, which has no hover tooltip, so every point must carry
-  // its value. Line points that would collide are nudged apart via the
-  // per-series `labelLayout.moveOverlap` below rather than hidden.
+  // exported to PDF/HTML, which has no hover tooltip. Bars never collide; line
+  // points that pile up at a shared x (all runs at p50) drop the overlapping
+  // labels via `labelLayout.hideOverlap` below — outlier points keep theirs,
+  // and the Key metrics table carries every exact value regardless.
   const showLabels = showValueLabels;
 
   const option = useMemo<EChartsOption>(() => {
@@ -240,12 +241,11 @@ export function StageBarChart({
             }
           : undefined,
         // Line series stack multiple near-equal points at one x (e.g. all runs
-        // at p50), so their labels collide. Nudge overlapping labels apart
-        // vertically instead of hiding them — keeps every value for PDF export.
-        labelLayout:
-          showLabels && variant === "line"
-            ? { moveOverlap: "shiftY" as const, hideOverlap: false }
-            : undefined,
+        // at p50), piling their labels into an unreadable heap. Hide the
+        // overlapping ones: a lone outlier (e.g. a p99 spike) sits clear of the
+        // pack and keeps its label, while clustered values fall back to the axis
+        // tooltip and the Key metrics table rendered alongside the charts.
+        labelLayout: showLabels && variant === "line" ? { hideOverlap: true } : undefined,
         // Dashed reference line at the baseline value — only meaningful for a
         // single series (multiple series have different baselines).
         markLine:

--- a/apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
+++ b/apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
@@ -165,9 +165,6 @@ export function BenchmarkComparePage() {
     benchmark: b,
     paramsSummary: extractParamsSummary(b.params),
   }));
-  const environmentLines = successfulBenchmarks.map(
-    (b) => `${b.name ?? b.id} · ${b.tool} · ${b.scenario}`,
-  );
 
   return (
     <>
@@ -235,9 +232,6 @@ export function BenchmarkComparePage() {
             <ReportSections
               runs={reportRuns}
               baselineId={defaultBaseline}
-              narrative={null}
-              context={null}
-              environmentLines={environmentLines}
               onReorder={(newIds) => {
                 // URL ids order is the single source of run order — tables,
                 // charts and SaveCompareDialog all follow it via useQueries.

--- a/apps/web/src/features/benchmarks/compare/ReportSections.tsx
+++ b/apps/web/src/features/benchmarks/compare/ReportSections.tsx
@@ -15,9 +15,9 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import type { CompareNarrative } from "@modeldoctor/contracts";
 import { GripVertical } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
 import { CompareGrid } from "./CompareGrid";
 import { readPrefixCache } from "./client-metrics";
 import { formatPct } from "./format";
@@ -62,12 +62,6 @@ export interface ReportRun extends StageRun {
 export interface ReportSectionsProps {
   runs: ReportRun[];
   baselineId: string | null;
-  /** Kept for backward compatibility with BenchmarkComparePage callers — narrative
-   *  rendering itself now lives in `<SavedCompareReport>`. */
-  narrative: CompareNarrative | null;
-  context: string | null;
-  /** Pre-derived per-run "connection / model / tool / version" lines. */
-  environmentLines: string[];
   /**
    * When provided, Test-matrix rows become drag-sortable and the new full id
    * order is reported here after a drop. The caller owns the order (URL ids);
@@ -97,7 +91,13 @@ function MatrixRowCells({
     <>
       <td className="px-3 py-2 font-medium">{r.stageLabel}</td>
       <td className="px-3 py-2">
-        {r.benchmark === null ? t("savedCompare.detail.missingBenchmark") : r.benchmark.name}
+        {r.benchmark === null ? (
+          <span className="opacity-60">{t("savedCompare.detail.missingBenchmark")}</span>
+        ) : (
+          <Link to={`/benchmarks/${r.id}`} className="hover:text-primary hover:underline">
+            {r.benchmark.name}
+          </Link>
+        )}
       </td>
       <td className="px-3 py-2">{r.benchmark?.tool ?? "—"}</td>
       <td className="px-3 py-2">{r.scenario}</td>
@@ -162,13 +162,7 @@ function SortableMatrixRow({
  *
  * `data-report-root` is exposed for the export-as-HTML utility.
  */
-export function ReportSections({
-  runs,
-  baselineId,
-  context,
-  environmentLines,
-  onReorder,
-}: ReportSectionsProps) {
+export function ReportSections({ runs, baselineId, onReorder }: ReportSectionsProps) {
   const { t } = useTranslation("benchmarks");
   // Type-guard predicate (not just `!== null`) so `r.benchmark` narrows to
   // non-null below — lets `CompareGrid` receive `ReportBenchmarkSnapshot[]`
@@ -272,21 +266,9 @@ export function ReportSections({
         <h2 className="mb-3 text-lg font-semibold">{t("savedCompare.report.sectionCharts")}</h2>
         <StageBarChartsSection runs={livingRuns} />
       </section>
-
-      {/* 4. Test environment */}
-      <section>
-        <h2 className="mb-3 text-lg font-semibold">{t("savedCompare.report.sectionEnv")}</h2>
-        <ul className="space-y-1 text-sm text-muted-foreground">
-          {environmentLines.map((line) => (
-            <li key={line}>{line}</li>
-          ))}
-        </ul>
-        {context ? (
-          <div className="mt-3 whitespace-pre-wrap rounded-md border border-border bg-muted/20 p-3 text-sm">
-            {context}
-          </div>
-        ) : null}
-      </section>
+      {/* The former "Test environment" section was dropped: it merely restated
+          the Test-matrix rows. The matrix `name` column now links to each run's
+          benchmark detail page, which carries the full environment context. */}
     </div>
   );
 }

--- a/apps/web/src/locales/en-US/benchmarks.json
+++ b/apps/web/src/locales/en-US/benchmarks.json
@@ -418,7 +418,6 @@
       "sectionCharts": "Charts",
       "sectionAnalysis": "Analysis",
       "sectionConclusion": "Conclusion & recommendation",
-      "sectionEnv": "Test environment",
       "chartQpsTitle": "QPS",
       "chartErrTitle": "Error rate",
       "chartTtftTitle": "TTFT percentiles (ms)",

--- a/apps/web/src/locales/zh-CN/benchmarks.json
+++ b/apps/web/src/locales/zh-CN/benchmarks.json
@@ -418,7 +418,6 @@
       "sectionCharts": "图表",
       "sectionAnalysis": "分析",
       "sectionConclusion": "结论与选型建议",
-      "sectionEnv": "测试环境",
       "chartQpsTitle": "QPS",
       "chartErrTitle": "错误率",
       "chartTtftTitle": "TTFT 分位（ms）",


### PR DESCRIPTION
Compare-page polish from a round of review feedback. Two independent changes (one commit each).

## 1. Percentile line charts — Grafana-style (no static point labels)
The TTFT / e2e percentile line charts printed a static value label on *every* point of *every* run. With 5–6 runs clustering at p50/p95/p99 the labels piled into an unreadable heap.

- First tried `labelLayout.hideOverlap` (commit 1) — but that still leaves the *surviving* labels printed on the canvas, and static per-point labels simply don't scale to N runs at one x.
- **Pivoted (commit 2) to the mainstream approach:** Grafana time-series panels print *no* per-point labels and read values off a shared crosshair tooltip. The line variant now renders **zero static labels**; the existing `tooltip: { trigger: "axis" }` (already a shared crosshair) and the **Key metrics** table carry every value.
- Bars unchanged — one value per bar, no collisions, still useful in the tooltip-less PDF export.

## 2. Linkable matrix name + drop redundant "Test environment" section
- The Test-matrix **`name` column now links** to each run's benchmark detail page (`/benchmarks/:id`), matching the saved-report table and the benchmark list.
- With that link, the **"Test environment"** section — which only restated the matrix rows as `name · tool · scenario` text — is pure duplication. Removed it, along with the now-dead `environmentLines` / `context` / `narrative` props on `ReportSections` and the unused `sectionEnv` i18n key.

## Verification
- `tsc --noEmit` — clean
- Full web unit suite — **925/925 pass** (updated the line-label assertion: `moveOverlap`→none + `tooltip.trigger==="axis"`)
- `biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)