### PR TITLE
feat: scenario-aware AI compare reports

### DIFF
--- a/apps/api/prisma/migrations/20260622045244_saved_compare_scenario_tool/migration.sql
+++ b/apps/api/prisma/migrations/20260622045244_saved_compare_scenario_tool/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "saved_compares" ADD COLUMN     "scenario" TEXT,
+ADD COLUMN     "tool" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -367,6 +367,8 @@ model SavedCompare {
   classification   String    @default("internal")
   /// Free-text client / customer name surfaced in the report Hero meta.
   clientName       String?   @map("client_name")
+  scenario         String?   // derived: shared scenario of all member benchmarks
+  tool             String?   // derived: shared tool of all member benchmarks
   /// Monotonically increasing version stamp, bumped by the UI when the
   /// user regenerates or edits the report. Surfaced in Hero meta.
   version          Int       @default(1)

--- a/apps/api/src/modules/saved-compares/compare-synthesize.service.spec.ts
+++ b/apps/api/src/modules/saved-compares/compare-synthesize.service.spec.ts
@@ -82,7 +82,16 @@ vi.mock("../insights/llm-client.js", () => ({
 import { PrismaService } from "../../database/prisma.service.js";
 import { LlmJudgeService } from "../llm-judge/llm-judge.service.js";
 import { CompareSynthesizeService } from "./compare-synthesize.service.js";
+import { buildSystemPrompt } from "./prompts.js";
+import { getReportProfile, resolveReportIntent } from "./report-scenarios/index.js";
 import { SavedComparesService } from "./saved-compares.service.js";
+
+it("lb compare yields a hit-rate-led system prompt", () => {
+  const intent = resolveReportIntent("lb-strategy", 2);
+  const sys = buildSystemPrompt("zh-CN", getReportProfile(intent).promptFragment("zh-CN"));
+  expect(sys).toContain("命中率");
+  expect(sys).toContain("场景专项要求");
+});
 
 describe("CompareSynthesizeService", () => {
   let svc: CompareSynthesizeService;

--- a/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
+++ b/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
@@ -12,7 +12,9 @@ import { type ChatMessage, chatCompletion } from "../insights/llm-client.js";
 import { LlmJudgeService } from "../llm-judge/llm-judge.service.js";
 import { availableFigureRefIds, readPrefixCache, summarizeForPrompt } from "./metrics.js";
 import { isBlockingWarning, lintNarrative } from "./narrative-lint.js";
-import { buildRetryFeedback, COMPARE_SYS_PROMPT_EN, COMPARE_SYS_PROMPT_ZH } from "./prompts.js";
+import { buildRetryFeedback, buildSystemPrompt } from "./prompts.js";
+import { getReportProfile, resolveReportIntent } from "./report-scenarios/index.js";
+import type { ScenarioData } from "./report-scenarios/types.js";
 import { SavedComparesService } from "./saved-compares.service.js";
 
 interface CacheEntry {
@@ -55,8 +57,12 @@ export class CompareSynthesizeService {
       return { narrative: hit.narrative, generatedAt: hit.generatedAt, fromCache: true };
     }
 
-    const sys = body.locale === "en-US" ? COMPARE_SYS_PROMPT_EN : COMPARE_SYS_PROMPT_ZH;
-    const userPrompt = this.buildUserPrompt(sc, body.locale);
+    const runCount = sc.benchmarks.filter((b) => !b.missing).length;
+    const intent = resolveReportIntent(sc.scenario, runCount);
+    const profile = getReportProfile(intent);
+    const scenarioData = profile.dataAssembly(sc);
+    const sys = buildSystemPrompt(body.locale, profile.promptFragment(body.locale));
+    const userPrompt = this.buildUserPrompt(sc, body.locale, scenarioData);
 
     // First attempt
     let parsed = await this.callAndParse(provider, body.locale, [
@@ -248,7 +254,11 @@ export class CompareSynthesizeService {
       .digest("hex");
   }
 
-  private buildUserPrompt(sc: HydratedSavedCompare, locale: string): string {
+  private buildUserPrompt(
+    sc: HydratedSavedCompare,
+    locale: string,
+    scenarioData: ScenarioData,
+  ): string {
     const zh = locale !== "en-US";
     const L = {
       contextHeader: zh ? "## 背景" : "## Context",
@@ -298,21 +308,29 @@ export class CompareSynthesizeService {
       }
     }
 
+    if (scenarioData.promptBlock.trim()) {
+      lines.push("", scenarioData.promptBlock);
+    }
+
     // Tell the LLM which figure refIds actually have data behind them, so it
     // does not pick a refId for which the bar chart will render empty. Keys
-    // outside this list MUST NOT appear in `figures[*].refId`.
+    // outside this list MUST NOT appear in `figures[*].refId`. When the scenario
+    // profile expresses a preference, narrow the offered set to its preferred
+    // figures (intersected with availability); otherwise offer all available.
     const available = availableFigureRefIds(
       sc.benchmarks
         .filter((b) => !b.missing)
         .map((b) => ({ summaryMetrics: b.summaryMetrics, serverMetrics: b.serverMetrics })),
     );
+    const preferred = scenarioData.preferredFigures.filter((r) => available.has(r));
+    const offered = preferred.length > 0 ? preferred : [...available];
     lines.push(
       "",
       zh ? "## 可用图表 refId" : "## Available figure refIds",
       zh
         ? "本次数据集仅支持以下 refId,figures[].refId 不得使用此清单外的值:"
         : "Only these refIds may appear in `figures[].refId` — others will render empty:",
-      ...[...available].map((r) => `- ${r}`),
+      ...offered.map((r) => `- ${r}`),
     );
 
     lines.push("", L.reminder);

--- a/apps/api/src/modules/saved-compares/metrics.spec.ts
+++ b/apps/api/src/modules/saved-compares/metrics.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   availableFigureRefIds,
+  readCapacityCurve,
   readErrorRate,
   readP95Latency,
   readPodDistribution,
@@ -31,6 +32,33 @@ it("offers pod figures when data supports", () => {
   ]);
   expect(set.has("pod-traffic-distribution")).toBe(true);
   expect(set.has("pod-hit-rate")).toBe(true);
+});
+
+it("offers throughput-vs-concurrency when a run carries a capacity curve", () => {
+  const withCurve = { data: { capacityCurve: [{ concurrency: 8, rps: 50, e2eP95Ms: 700 }] } };
+  const set = availableFigureRefIds([{ summaryMetrics: withCurve, serverMetrics: null }]);
+  expect(set.has("throughput-vs-concurrency")).toBe(true);
+});
+
+it("does not offer it without a curve", () => {
+  const set = availableFigureRefIds([{ summaryMetrics: { data: {} }, serverMetrics: null }]);
+  expect(set.has("throughput-vs-concurrency")).toBe(false);
+});
+
+describe("readCapacityCurve", () => {
+  it("returns the curve when present and non-empty", () => {
+    const m = { data: { capacityCurve: [{ concurrency: 4, rps: 30, e2eP95Ms: 500 }] } };
+    expect(readCapacityCurve(m)).toHaveLength(1);
+  });
+
+  it("returns null for empty array", () => {
+    expect(readCapacityCurve({ data: { capacityCurve: [] } })).toBeNull();
+  });
+
+  it("returns null when capacityCurve is absent", () => {
+    expect(readCapacityCurve({ data: {} })).toBeNull();
+    expect(readCapacityCurve(null)).toBeNull();
+  });
 });
 
 describe("metrics readers", () => {

--- a/apps/api/src/modules/saved-compares/metrics.spec.ts
+++ b/apps/api/src/modules/saved-compares/metrics.spec.ts
@@ -1,5 +1,37 @@
 import { describe, expect, it } from "vitest";
-import { readErrorRate, readP95Latency, readThroughput, summarizeForPrompt } from "./metrics.js";
+import {
+  availableFigureRefIds,
+  readErrorRate,
+  readP95Latency,
+  readPodDistribution,
+  readThroughput,
+  summarizeForPrompt,
+} from "./metrics.js";
+
+const withPods = {
+  prefixCache: {
+    hitRatePct: 50,
+    topPodSharePct: 60,
+    perPod: [
+      { pod: "p1", queries: 600, hits: 300 },
+      { pod: "p2", queries: 400, hits: 100 },
+    ],
+    metricTag: "v1",
+  },
+};
+
+it("reads per-pod distribution", () => {
+  expect(readPodDistribution(withPods)).toHaveLength(2);
+});
+
+it("offers pod figures when data supports", () => {
+  const set = availableFigureRefIds([
+    { summaryMetrics: null, serverMetrics: withPods },
+    { summaryMetrics: null, serverMetrics: withPods },
+  ]);
+  expect(set.has("pod-traffic-distribution")).toBe(true);
+  expect(set.has("pod-hit-rate")).toBe(true);
+});
 
 describe("metrics readers", () => {
   it("reads guidellm p95 latency from e2eLatency dist", () => {

--- a/apps/api/src/modules/saved-compares/metrics.ts
+++ b/apps/api/src/modules/saved-compares/metrics.ts
@@ -67,6 +67,23 @@ export function readPrefixCache(serverMetrics: unknown): PrefixCacheSummary | nu
   return { hitRatePct: parsed.data.hitRatePct, topPodSharePct: parsed.data.topPodSharePct };
 }
 
+export interface PodDatum {
+  pod: string;
+  queries: number;
+  hits: number;
+}
+
+/** Read serverMetrics.prefixCache.perPod (per-pod query/hit counts). Null when
+ * the annotation is absent/malformed; [] when present but empty. */
+export function readPodDistribution(serverMetrics: unknown): PodDatum[] | null {
+  const parsed = prefixCacheAnnotationSchema.safeParse(
+    (serverMetrics as { prefixCache?: unknown } | null)?.prefixCache,
+  );
+  if (!parsed.success) return null;
+  const pods = (parsed.data as { perPod?: PodDatum[] }).perPod;
+  return Array.isArray(pods) ? pods : [];
+}
+
 /** One run's two metric blobs. summaryMetrics = tool report (throughput/latency);
  * serverMetrics = prefix-cache annotation. */
 export interface RunMetricBlobs {
@@ -88,10 +105,22 @@ export function availableFigureRefIds(runs: RunMetricBlobs[]): Set<FigureRefId> 
   if (perRun.some((s) => s.errorRate !== null)) out.add("stage-bars-error-rate");
   if (perRun.every((s) => s.ttft !== null)) out.add("stage-bars-ttft-p95");
   if (perRun.every((s) => s.e2e !== null)) out.add("stage-bars-e2e-p95");
+  // cold-warm-delta: available whenever ≥2 runs carry throughput or ttft data.
+  if (perRun.filter((s) => s.throughput !== null || s.ttft !== null).length >= 2) {
+    out.add("cold-warm-delta");
+  }
   // Prefix-cache figures need EVERY run to carry the annotation (complete bars).
-  if (runs.map((r) => readPrefixCache(r.serverMetrics)).every((p) => p !== null)) {
+  const pc = runs.map((r) => readPrefixCache(r.serverMetrics));
+  if (pc.every((p) => p !== null)) {
     out.add("stage-bars-prefix-cache-hit");
     out.add("stage-bars-top-pod-share");
+    // Pod-distribution figures: additionally require every run to carry a
+    // non-empty perPod array (lb-strategy runs only).
+    const pods = runs.map((r) => readPodDistribution(r.serverMetrics));
+    if (pods.every((p) => p !== null && p.length > 0)) {
+      out.add("pod-traffic-distribution");
+      out.add("pod-hit-rate");
+    }
   }
   out.add("compare-grid");
   return out;

--- a/apps/api/src/modules/saved-compares/metrics.ts
+++ b/apps/api/src/modules/saved-compares/metrics.ts
@@ -84,6 +84,20 @@ export function readPodDistribution(serverMetrics: unknown): PodDatum[] | null {
   return Array.isArray(pods) ? pods : [];
 }
 
+export interface CapacityPoint {
+  concurrency: number;
+  rps: number;
+  e2eP95Ms: number;
+}
+
+/** Read guidellm capacityCurve from a run's summaryMetrics ({tool,data}).
+ * Mirrors the client-side `client-metrics.ts#readCapacityCurve`. */
+export function readCapacityCurve(summaryMetrics: unknown): CapacityPoint[] | null {
+  const m = summaryMetrics as { data?: { capacityCurve?: CapacityPoint[] } } | null;
+  const c = m?.data?.capacityCurve;
+  return Array.isArray(c) && c.length > 0 ? c : null;
+}
+
 /** One run's two metric blobs. summaryMetrics = tool report (throughput/latency);
  * serverMetrics = prefix-cache annotation. */
 export interface RunMetricBlobs {
@@ -121,6 +135,9 @@ export function availableFigureRefIds(runs: RunMetricBlobs[]): Set<FigureRefId> 
       out.add("pod-traffic-distribution");
       out.add("pod-hit-rate");
     }
+  }
+  if (runs.some((r) => readCapacityCurve(r.summaryMetrics) !== null)) {
+    out.add("throughput-vs-concurrency");
   }
   out.add("compare-grid");
   return out;

--- a/apps/api/src/modules/saved-compares/prompts.spec.ts
+++ b/apps/api/src/modules/saved-compares/prompts.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { buildSystemPrompt } from "./prompts.js";
+
+it("returns base unchanged for empty fragment", () => {
+  const empty = buildSystemPrompt("zh-CN", "");
+  expect(empty).not.toContain("场景专项要求");
+});
+it("appends the scenario fragment under a header", () => {
+  const out = buildSystemPrompt("zh-CN", "命中率优先");
+  expect(out).toContain("场景专项要求");
+  expect(out).toContain("命中率优先");
+});
+it("uses the English header for en-US", () => {
+  const out = buildSystemPrompt("en-US", "lead with hit rate");
+  expect(out).toContain("Scenario guidance");
+  expect(out).toContain("lead with hit rate");
+});

--- a/apps/api/src/modules/saved-compares/prompts.ts
+++ b/apps/api/src/modules/saved-compares/prompts.ts
@@ -89,9 +89,6 @@ Language: English throughout.
 schemaVersion: 2, locale: "en-US".
 Emit raw JSON only — no \`\`\`json fence, no preamble.`;
 
-export const COMPARE_SYS_PROMPT_ZH = ZH_SCHEMA_INSTRUCTIONS;
-export const COMPARE_SYS_PROMPT_EN = EN_SCHEMA_INSTRUCTIONS;
-
 export function buildSystemPrompt(locale: "zh-CN" | "en-US", scenarioFragment: string): string {
   const base = locale === "en-US" ? EN_SCHEMA_INSTRUCTIONS : ZH_SCHEMA_INSTRUCTIONS;
   if (!scenarioFragment.trim()) return base;

--- a/apps/api/src/modules/saved-compares/prompts.ts
+++ b/apps/api/src/modules/saved-compares/prompts.ts
@@ -34,7 +34,7 @@ interface Narrative {
   ];                     // exactly 6 sections in this order
   figures: Array<{
     id: string;
-    refId: "stage-bars-throughput" | "stage-bars-error-rate" | "stage-bars-ttft-p95" | "stage-bars-e2e-p95" | "stage-bars-prefix-cache-hit" | "stage-bars-top-pod-share" | "compare-grid";
+    refId: "stage-bars-throughput" | "stage-bars-error-rate" | "stage-bars-ttft-p95" | "stage-bars-e2e-p95" | "stage-bars-prefix-cache-hit" | "stage-bars-top-pod-share" | "pod-traffic-distribution" | "pod-hit-rate" | "cold-warm-delta" | "throughput-vs-concurrency" | "compare-grid";
     caption: string;
     anchorSection?: "summary" | "scope" | "method" | "results" | "caveats" | "advice";
   }>;
@@ -67,17 +67,7 @@ Section size targets:
 - 04 results: 2-4 pages, each subsection has 1 figure (via figures[]) + small table + 1-2 paragraphs
 - 05 caveats: ≤ 1 page, data comparability boundaries, known issues, SLO limits
 - 06 advice:  ≤ half page, scenario → config + 0-5 caveats
-
-Prefix-cache runs: when the per-stage data carries prefix_cache_hit% / top_pod_share%
-(lb-strategy, e.g. routing OFF vs ON), the HEADLINE conclusion and the
-first summary card MUST be the cache hit-rate change — that is the metric the
-experiment exists to measure. Use the stage-bars-prefix-cache-hit figure for it and
-stage-bars-top-pod-share to show routing concentration. Treat throughput/TTFT as
-secondary: on small models prefill is cheap so a higher hit rate need NOT improve
-latency — say so plainly rather than leading with a flat throughput delta. A flat
-top-pod share alongside a rising hit rate means better cache locality without
-hot-spotting (good), not a failure. Stage labels like "OFF"/"ON" mean the routing
-toggle, NOT offline/online.`;
+`;
 
 const ZH_SCHEMA_INSTRUCTIONS = `你是一位资深 LLM 推理服务性能分析师。给定多个 benchmark 的对比数据,你要按 ModelDoctor SavedCompare 报告规范产出一份**深度报告**(看起来像分析师手写,不要 AI 味)。
 

--- a/apps/api/src/modules/saved-compares/prompts.ts
+++ b/apps/api/src/modules/saved-compares/prompts.ts
@@ -92,6 +92,13 @@ Emit raw JSON only — no \`\`\`json fence, no preamble.`;
 export const COMPARE_SYS_PROMPT_ZH = ZH_SCHEMA_INSTRUCTIONS;
 export const COMPARE_SYS_PROMPT_EN = EN_SCHEMA_INSTRUCTIONS;
 
+export function buildSystemPrompt(locale: "zh-CN" | "en-US", scenarioFragment: string): string {
+  const base = locale === "en-US" ? EN_SCHEMA_INSTRUCTIONS : ZH_SCHEMA_INSTRUCTIONS;
+  if (!scenarioFragment.trim()) return base;
+  const header = locale === "en-US" ? "\n\n## Scenario guidance\n" : "\n\n## 场景专项要求\n";
+  return `${base}${header}${scenarioFragment}`;
+}
+
 // ────────────────────────────────────────────────────────────────────────
 // Retry prompt — used when lint pass on the first response flagged blocking
 // warnings. Lists the violations and asks the model to regenerate.

--- a/apps/api/src/modules/saved-compares/report-scenarios/capacity.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/capacity.ts
@@ -1,0 +1,18 @@
+import type { FigureRefId, HydratedSavedCompare } from "@modeldoctor/contracts";
+import type { Locale, ReportScenarioProfile, ScenarioData } from "./types.js";
+
+const ZH = `本报告是容量规划(capacity),工具按并发/负载做了 sweep。
+- 主图是 throughput-vs-concurrency:展示吞吐随并发的拐点(饱和点)。
+- HEADLINE 用饱和点的并发档与对应吞吐;若曲线缺失(旧数据)则退回最终聚合百分位,并在 caveats 注明无 sweep 曲线。`;
+const EN = `This is a capacity-planning report (capacity); the tool swept concurrency/load.
+- The lead figure is throughput-vs-concurrency: show the saturation knee.
+- Headline with the knee's concurrency level and its throughput; if the curve is missing (legacy data) fall back to final aggregate percentiles and note "no sweep curve" in caveats.`;
+
+function assemble(_sc: HydratedSavedCompare): ScenarioData {
+  return { promptBlock: "", preferredFigures: ["throughput-vs-concurrency" as FigureRefId, "compare-grid"] };
+}
+export const capacityProfile: ReportScenarioProfile = {
+  intent: "capacity",
+  promptFragment: (l: Locale) => (l === "en-US" ? EN : ZH),
+  dataAssembly: assemble,
+};

--- a/apps/api/src/modules/saved-compares/report-scenarios/capacity.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/capacity.ts
@@ -1,4 +1,4 @@
-import type { FigureRefId, HydratedSavedCompare } from "@modeldoctor/contracts";
+import type { HydratedSavedCompare } from "@modeldoctor/contracts";
 import type { Locale, ReportScenarioProfile, ScenarioData } from "./types.js";
 
 const ZH = `本报告是容量规划(capacity),工具按并发/负载做了 sweep。
@@ -9,7 +9,7 @@ const EN = `This is a capacity-planning report (capacity); the tool swept concur
 - Headline with the knee's concurrency level and its throughput; if the curve is missing (legacy data) fall back to final aggregate percentiles and note "no sweep curve" in caveats.`;
 
 function assemble(_sc: HydratedSavedCompare): ScenarioData {
-  return { promptBlock: "", preferredFigures: ["throughput-vs-concurrency" as FigureRefId, "compare-grid"] };
+  return { promptBlock: "", preferredFigures: ["throughput-vs-concurrency", "compare-grid"] };
 }
 export const capacityProfile: ReportScenarioProfile = {
   intent: "capacity",

--- a/apps/api/src/modules/saved-compares/report-scenarios/default.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/default.ts
@@ -1,0 +1,7 @@
+import type { ReportScenarioProfile } from "./types.js";
+
+export const defaultProfile: ReportScenarioProfile = {
+  intent: "default",
+  promptFragment: () => "",
+  dataAssembly: () => ({ promptBlock: "", preferredFigures: [] }),
+};

--- a/apps/api/src/modules/saved-compares/report-scenarios/engine-kv-cache.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/engine-kv-cache.ts
@@ -1,0 +1,20 @@
+import type { HydratedSavedCompare } from "@modeldoctor/contracts";
+import type { Locale, ReportScenarioProfile, ScenarioData } from "./types.js";
+
+const ZH = `本报告是引擎 KV / 前缀缓存冷热对比(engine-kv-cache)。
+- 主线是冷(R1)→热(R2)的提升:用 cold-warm-delta 展示配对 stage 的吞吐/TTFT Δ%。
+- HEADLINE 用「热轮相对冷轮」的最大增益指标(通常 TTFT 或吞吐)。
+- 命名以 "(rerun)" 配对冷/热;若只有单轮,退化为单点描述,不要编造冷热差。`;
+const EN = `This is an engine KV / prefix-cache cold-vs-warm comparison (engine-kv-cache).
+- The through-line is the cold (R1) → warm (R2) gain: use cold-warm-delta for the paired-stage throughput/TTFT Δ%.
+- Lead with the largest warm-vs-cold gain metric (usually TTFT or throughput).
+- Cold/warm pair by the "(rerun)" name suffix; with a single round, degrade to a single-point description — do not invent a cold/warm delta.`;
+
+function assemble(_sc: HydratedSavedCompare): ScenarioData {
+  return { promptBlock: "", preferredFigures: ["cold-warm-delta", "stage-bars-ttft-p95", "stage-bars-throughput"] };
+}
+export const engineKvCacheProfile: ReportScenarioProfile = {
+  intent: "engine-kv-cache",
+  promptFragment: (l: Locale) => (l === "en-US" ? EN : ZH),
+  dataAssembly: assemble,
+};

--- a/apps/api/src/modules/saved-compares/report-scenarios/engine-kv-cache.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/engine-kv-cache.ts
@@ -11,7 +11,10 @@ const EN = `This is an engine KV / prefix-cache cold-vs-warm comparison (engine-
 - Cold/warm pair by the "(rerun)" name suffix; with a single round, degrade to a single-point description — do not invent a cold/warm delta.`;
 
 function assemble(_sc: HydratedSavedCompare): ScenarioData {
-  return { promptBlock: "", preferredFigures: ["cold-warm-delta", "stage-bars-ttft-p95", "stage-bars-throughput"] };
+  return {
+    promptBlock: "",
+    preferredFigures: ["cold-warm-delta", "stage-bars-ttft-p95", "stage-bars-throughput"],
+  };
 }
 export const engineKvCacheProfile: ReportScenarioProfile = {
   intent: "engine-kv-cache",

--- a/apps/api/src/modules/saved-compares/report-scenarios/gateway.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/gateway.ts
@@ -1,0 +1,18 @@
+import type { HydratedSavedCompare } from "@modeldoctor/contracts";
+import type { Locale, ReportScenarioProfile, ScenarioData } from "./types.js";
+
+const ZH = `本报告是网关 / HTTP 层压测(gateway,vegeta)。
+- 关注 HTTP 吞吐与时延(e2e),没有 LLM 语义指标(TTFT/TPOT 不适用,不要提)。
+- HEADLINE 用吞吐(req/s)或 e2e p95;错误率与状态码分布作为稳定性佐证。`;
+const EN = `This is a gateway / HTTP-layer load test (gateway, vegeta).
+- Focus on HTTP throughput and latency (e2e); there are no LLM semantic metrics (TTFT/TPOT do not apply — do not mention them).
+- Headline with throughput (req/s) or e2e p95; error rate and status-code mix support the stability story.`;
+
+function assemble(_sc: HydratedSavedCompare): ScenarioData {
+  return { promptBlock: "", preferredFigures: ["stage-bars-throughput", "stage-bars-e2e-p95", "stage-bars-error-rate"] };
+}
+export const gatewayProfile: ReportScenarioProfile = {
+  intent: "gateway",
+  promptFragment: (l: Locale) => (l === "en-US" ? EN : ZH),
+  dataAssembly: assemble,
+};

--- a/apps/api/src/modules/saved-compares/report-scenarios/gateway.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/gateway.ts
@@ -9,7 +9,10 @@ const EN = `This is a gateway / HTTP-layer load test (gateway, vegeta).
 - Headline with throughput (req/s) or e2e p95; error rate and status-code mix support the stability story.`;
 
 function assemble(_sc: HydratedSavedCompare): ScenarioData {
-  return { promptBlock: "", preferredFigures: ["stage-bars-throughput", "stage-bars-e2e-p95", "stage-bars-error-rate"] };
+  return {
+    promptBlock: "",
+    preferredFigures: ["stage-bars-throughput", "stage-bars-e2e-p95", "stage-bars-error-rate"],
+  };
 }
 export const gatewayProfile: ReportScenarioProfile = {
   intent: "gateway",

--- a/apps/api/src/modules/saved-compares/report-scenarios/index.spec.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/index.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { resolveReportIntent } from "./index.js";
+
+describe("resolveReportIntent", () => {
+  it("maps lb-strategy directly", () => {
+    expect(resolveReportIntent("lb-strategy", 2)).toBe("lb-strategy");
+  });
+  it("splits inference by run count", () => {
+    expect(resolveReportIntent("inference", 1)).toBe("inference-single");
+    expect(resolveReportIntent("inference", 3)).toBe("inference-multi");
+  });
+  it("falls back to default on null/unknown scenario", () => {
+    expect(resolveReportIntent(null, 2)).toBe("default");
+    expect(resolveReportIntent("nonsense", 2)).toBe("default");
+  });
+});

--- a/apps/api/src/modules/saved-compares/report-scenarios/index.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/index.ts
@@ -1,4 +1,5 @@
 import { defaultProfile } from "./default.js";
+import { lbStrategyProfile } from "./lb-strategy.js";
 import type { ReportIntent, ReportScenarioProfile } from "./types.js";
 
 export function resolveReportIntent(
@@ -24,7 +25,7 @@ export function resolveReportIntent(
 const REGISTRY: Record<ReportIntent, ReportScenarioProfile> = {
   default: defaultProfile,
   // filled in by later tasks (B3/B4):
-  "lb-strategy": defaultProfile,
+  "lb-strategy": lbStrategyProfile,
   "engine-kv-cache": defaultProfile,
   capacity: defaultProfile,
   gateway: defaultProfile,

--- a/apps/api/src/modules/saved-compares/report-scenarios/index.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/index.ts
@@ -1,4 +1,8 @@
 import { defaultProfile } from "./default.js";
+import { capacityProfile } from "./capacity.js";
+import { engineKvCacheProfile } from "./engine-kv-cache.js";
+import { gatewayProfile } from "./gateway.js";
+import { inferenceMultiProfile, inferenceSingleProfile } from "./inference.js";
 import { lbStrategyProfile } from "./lb-strategy.js";
 import type { ReportIntent, ReportScenarioProfile } from "./types.js";
 
@@ -24,13 +28,12 @@ export function resolveReportIntent(
 
 const REGISTRY: Record<ReportIntent, ReportScenarioProfile> = {
   default: defaultProfile,
-  // filled in by later tasks (B3/B4):
   "lb-strategy": lbStrategyProfile,
-  "engine-kv-cache": defaultProfile,
-  capacity: defaultProfile,
-  gateway: defaultProfile,
-  "inference-single": defaultProfile,
-  "inference-multi": defaultProfile,
+  "engine-kv-cache": engineKvCacheProfile,
+  capacity: capacityProfile,
+  gateway: gatewayProfile,
+  "inference-single": inferenceSingleProfile,
+  "inference-multi": inferenceMultiProfile,
 };
 
 export function getReportProfile(intent: ReportIntent): ReportScenarioProfile {

--- a/apps/api/src/modules/saved-compares/report-scenarios/index.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/index.ts
@@ -1,5 +1,5 @@
-import { defaultProfile } from "./default.js";
 import { capacityProfile } from "./capacity.js";
+import { defaultProfile } from "./default.js";
 import { engineKvCacheProfile } from "./engine-kv-cache.js";
 import { gatewayProfile } from "./gateway.js";
 import { inferenceMultiProfile, inferenceSingleProfile } from "./inference.js";
@@ -40,5 +40,5 @@ export function getReportProfile(intent: ReportIntent): ReportScenarioProfile {
   return REGISTRY[intent] ?? defaultProfile;
 }
 
-export { REGISTRY as reportScenarioRegistry };
 export type { ReportScenarioProfile } from "./types.js";
+export { REGISTRY as reportScenarioRegistry };

--- a/apps/api/src/modules/saved-compares/report-scenarios/index.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/index.ts
@@ -1,0 +1,40 @@
+import { defaultProfile } from "./default.js";
+import type { ReportIntent, ReportScenarioProfile } from "./types.js";
+
+export function resolveReportIntent(
+  scenario: string | null | undefined,
+  runCount: number,
+): ReportIntent {
+  switch (scenario) {
+    case "lb-strategy":
+      return "lb-strategy";
+    case "engine-kv-cache":
+      return "engine-kv-cache";
+    case "capacity":
+      return "capacity";
+    case "gateway":
+      return "gateway";
+    case "inference":
+      return runCount <= 1 ? "inference-single" : "inference-multi";
+    default:
+      return "default";
+  }
+}
+
+const REGISTRY: Record<ReportIntent, ReportScenarioProfile> = {
+  default: defaultProfile,
+  // filled in by later tasks (B3/B4):
+  "lb-strategy": defaultProfile,
+  "engine-kv-cache": defaultProfile,
+  capacity: defaultProfile,
+  gateway: defaultProfile,
+  "inference-single": defaultProfile,
+  "inference-multi": defaultProfile,
+};
+
+export function getReportProfile(intent: ReportIntent): ReportScenarioProfile {
+  return REGISTRY[intent] ?? defaultProfile;
+}
+
+export { REGISTRY as reportScenarioRegistry };
+export type { ReportScenarioProfile } from "./types.js";

--- a/apps/api/src/modules/saved-compares/report-scenarios/inference.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/inference.ts
@@ -1,0 +1,31 @@
+import type { HydratedSavedCompare } from "@modeldoctor/contracts";
+import type { Locale, ReportScenarioProfile, ScenarioData } from "./types.js";
+
+const MULTI_ZH = `本报告是多引擎推理对比(inference,多 run)。
+- 主线是不同引擎在吞吐 / TTFT / E2E 上的相对位置;用 compare-grid + stage-bars-throughput + stage-bars-ttft-p95。
+- HEADLINE 用赢家引擎与其吞吐领先幅度;同档差距 <10% 不作为优势判定,直说并列。`;
+const MULTI_EN = `This is a multi-engine inference comparison (inference, multiple runs).
+- The through-line is each engine's relative standing on throughput / TTFT / E2E; use compare-grid + stage-bars-throughput + stage-bars-ttft-p95.
+- Headline with the winning engine and its throughput lead; a <10% gap in a tier is not an advantage — call it a tie.`;
+const SINGLE_ZH = `本报告是单引擎推理基线(inference,单 run 或同引擎多配置)。
+- 主线是该配置的 TTFT / E2E 分布与吞吐;用 stage-bars-ttft-p95 + stage-bars-e2e-p95。
+- 没有跨引擎对比时,不要硬造"赢家";聚焦绝对水平与是否达 SLO。`;
+const SINGLE_EN = `This is a single-engine inference baseline (inference, one run or same-engine configs).
+- The through-line is this config's TTFT / E2E distribution and throughput; use stage-bars-ttft-p95 + stage-bars-e2e-p95.
+- With no cross-engine comparison, do not manufacture a "winner"; focus on absolute levels and SLO attainment.`;
+
+function makeProfile(multi: boolean): ReportScenarioProfile {
+  return {
+    intent: multi ? "inference-multi" : "inference-single",
+    promptFragment: (l: Locale) =>
+      multi ? (l === "en-US" ? MULTI_EN : MULTI_ZH) : l === "en-US" ? SINGLE_EN : SINGLE_ZH,
+    dataAssembly: (_sc: HydratedSavedCompare): ScenarioData => ({
+      promptBlock: "",
+      preferredFigures: multi
+        ? ["compare-grid", "stage-bars-throughput", "stage-bars-ttft-p95"]
+        : ["stage-bars-ttft-p95", "stage-bars-e2e-p95", "stage-bars-throughput"],
+    }),
+  };
+}
+export const inferenceMultiProfile = makeProfile(true);
+export const inferenceSingleProfile = makeProfile(false);

--- a/apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.spec.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { lbStrategyProfile } from "./lb-strategy.js";
+
+const sc = {
+  benchmarks: [
+    {
+      missing: false, stageLabel: "ON", name: "on",
+      serverMetrics: {
+        prefixCache: {
+          hitRatePct: 57.2, topPodSharePct: 41, metricTag: "v1",
+          perPod: [
+            { pod: "p1", queries: 800, hits: 500 },
+            { pod: "p2", queries: 200, hits: 60 },
+          ],
+        },
+      },
+    },
+  ],
+} as never;
+
+it("emits a per-pod distribution block citing pod shares", () => {
+  const data = lbStrategyProfile.dataAssembly(sc);
+  expect(data.promptBlock).toContain("ON");
+  expect(data.promptBlock).toContain("80"); // p1 share% = 800/1000
+  expect(data.preferredFigures).toContain("stage-bars-prefix-cache-hit");
+});
+it("fragment leads with hit-rate", () => {
+  expect(lbStrategyProfile.promptFragment("zh-CN")).toContain("命中率");
+});

--- a/apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.spec.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.spec.ts
@@ -4,10 +4,14 @@ import { lbStrategyProfile } from "./lb-strategy.js";
 const sc = {
   benchmarks: [
     {
-      missing: false, stageLabel: "ON", name: "on",
+      missing: false,
+      stageLabel: "ON",
+      name: "on",
       serverMetrics: {
         prefixCache: {
-          hitRatePct: 57.2, topPodSharePct: 41, metricTag: "v1",
+          hitRatePct: 57.2,
+          topPodSharePct: 41,
+          metricTag: "v1",
           perPod: [
             { pod: "p1", queries: 800, hits: 500 },
             { pod: "p2", queries: 200, hits: 60 },

--- a/apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.ts
@@ -24,14 +24,19 @@ function assemble(sc: HydratedSavedCompare): ScenarioData {
     if (!pods || pods.length === 0) continue;
     const total = pods.reduce((s, p) => s + p.queries, 0) || 1;
     const top = pods
-      .map((p) => ({ pod: p.pod, sharePct: (p.queries / total) * 100, hitPct: p.queries > 0 ? (p.hits / p.queries) * 100 : 0 }))
+      .map((p) => ({
+        pod: p.pod,
+        sharePct: (p.queries / total) * 100,
+        hitPct: p.queries > 0 ? (p.hits / p.queries) * 100 : 0,
+      }))
       .sort((a, z) => z.sharePct - a.sharePct)
       .slice(0, 6)
       .map((p) => `    ${p.pod}: share=${p.sharePct.toFixed(0)}% hit=${p.hitPct.toFixed(0)}%`)
       .join("\n");
     lines.push(`  [${b.stageLabel}] per-pod (top by share):\n${top}`);
   }
-  const promptBlock = lines.length > 0 ? `## Per-pod traffic distribution\n${lines.join("\n")}` : "";
+  const promptBlock =
+    lines.length > 0 ? `## Per-pod traffic distribution\n${lines.join("\n")}` : "";
   return {
     promptBlock,
     preferredFigures: [

--- a/apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.ts
@@ -1,0 +1,50 @@
+import type { HydratedSavedCompare } from "@modeldoctor/contracts";
+import { readPodDistribution } from "../metrics.js";
+import type { Locale, ReportScenarioProfile, ScenarioData } from "./types.js";
+
+const FRAGMENT_ZH = `本报告是负载均衡 / 路由策略验证(lb-strategy)。
+- HEADLINE 与第一张 summary card 必须是 prefix cache 命中率的变化——这是实验存在的理由。
+- 用 stage-bars-prefix-cache-hit 展示命中率,pod-traffic-distribution 展示每 pod 流量占比(集中度),pod-hit-rate 展示每 pod 命中率。
+- 吞吐 / TTFT 视为次要:小模型 prefill 便宜,命中率上升未必改善时延,直说即可,不要拿一个持平的吞吐差当 headline。
+- top-pod share 持平而命中率上升 = 更好的缓存局部性且无热点(好事),不是失败。
+- stage 标签 OFF/ON 指路由开关,不是离线/在线。`;
+
+const FRAGMENT_EN = `This is a load-balancer / routing-strategy validation (lb-strategy).
+- The HEADLINE and first summary card MUST be the prefix-cache hit-rate change — that is why the experiment exists.
+- Use stage-bars-prefix-cache-hit for hit rate, pod-traffic-distribution for each pod's traffic share (concentration), pod-hit-rate for per-pod hit rate.
+- Treat throughput / TTFT as secondary: on small models prefill is cheap, so a higher hit rate need not improve latency — say so plainly rather than leading with a flat throughput delta.
+- A flat top-pod share alongside a rising hit rate means better cache locality without hot-spotting (good), not a failure.
+- Stage labels OFF/ON mean the routing toggle, not offline/online.`;
+
+function assemble(sc: HydratedSavedCompare): ScenarioData {
+  const lines: string[] = [];
+  for (const b of sc.benchmarks) {
+    if (b.missing) continue;
+    const pods = readPodDistribution(b.serverMetrics);
+    if (!pods || pods.length === 0) continue;
+    const total = pods.reduce((s, p) => s + p.queries, 0) || 1;
+    const top = pods
+      .map((p) => ({ pod: p.pod, sharePct: (p.queries / total) * 100, hitPct: p.queries > 0 ? (p.hits / p.queries) * 100 : 0 }))
+      .sort((a, z) => z.sharePct - a.sharePct)
+      .slice(0, 6)
+      .map((p) => `    ${p.pod}: share=${p.sharePct.toFixed(0)}% hit=${p.hitPct.toFixed(0)}%`)
+      .join("\n");
+    lines.push(`  [${b.stageLabel}] per-pod (top by share):\n${top}`);
+  }
+  const promptBlock = lines.length > 0 ? `## Per-pod traffic distribution\n${lines.join("\n")}` : "";
+  return {
+    promptBlock,
+    preferredFigures: [
+      "stage-bars-prefix-cache-hit",
+      "pod-traffic-distribution",
+      "pod-hit-rate",
+      "stage-bars-top-pod-share",
+    ],
+  };
+}
+
+export const lbStrategyProfile: ReportScenarioProfile = {
+  intent: "lb-strategy",
+  promptFragment: (locale: Locale) => (locale === "en-US" ? FRAGMENT_EN : FRAGMENT_ZH),
+  dataAssembly: assemble,
+};

--- a/apps/api/src/modules/saved-compares/report-scenarios/profiles.spec.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/profiles.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { getReportProfile, reportScenarioRegistry } from "./index.js";
+
+it("every intent has a non-default profile except 'default'", () => {
+  for (const [intent, profile] of Object.entries(reportScenarioRegistry)) {
+    expect(profile.intent === intent || intent === "default").toBe(true);
+  }
+});
+it("fragments are non-empty for real intents (both locales)", () => {
+  for (const intent of ["lb-strategy", "engine-kv-cache", "capacity", "gateway", "inference-multi", "inference-single"] as const) {
+    const p = getReportProfile(intent);
+    expect(p.promptFragment("zh-CN").length).toBeGreaterThan(20);
+    expect(p.promptFragment("en-US").length).toBeGreaterThan(20);
+  }
+});

--- a/apps/api/src/modules/saved-compares/report-scenarios/profiles.spec.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/profiles.spec.ts
@@ -7,7 +7,14 @@ it("every intent has a non-default profile except 'default'", () => {
   }
 });
 it("fragments are non-empty for real intents (both locales)", () => {
-  for (const intent of ["lb-strategy", "engine-kv-cache", "capacity", "gateway", "inference-multi", "inference-single"] as const) {
+  for (const intent of [
+    "lb-strategy",
+    "engine-kv-cache",
+    "capacity",
+    "gateway",
+    "inference-multi",
+    "inference-single",
+  ] as const) {
     const p = getReportProfile(intent);
     expect(p.promptFragment("zh-CN").length).toBeGreaterThan(20);
     expect(p.promptFragment("en-US").length).toBeGreaterThan(20);

--- a/apps/api/src/modules/saved-compares/report-scenarios/types.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/types.ts
@@ -1,0 +1,32 @@
+import type { FigureRefId, HydratedSavedCompare } from "@modeldoctor/contracts";
+
+export type Locale = "zh-CN" | "en-US";
+
+/** Stable intent keys — finer than scenario (inference splits by run count). */
+export type ReportIntent =
+  | "lb-strategy"
+  | "engine-kv-cache"
+  | "capacity"
+  | "gateway"
+  | "inference-single"
+  | "inference-multi"
+  | "default";
+
+/** Scenario-specific data the profile assembled from the hydrated compare,
+ * passed to both the user-prompt builder and the figure manifest. */
+export interface ScenarioData {
+  /** Extra markdown block injected into the user prompt (per-pod table,
+   * cold/warm pairing, capacity curve summary, …). Empty string = none. */
+  promptBlock: string;
+  /** refIds the profile wants offered to the LLM, intersected later with the
+   * data-availability set so empty charts never get offered. */
+  preferredFigures: FigureRefId[];
+}
+
+export interface ReportScenarioProfile {
+  intent: ReportIntent;
+  /** Injected after the common base in the system prompt. */
+  promptFragment: (locale: Locale) => string;
+  /** Assemble scenario data from the hydrated compare. */
+  dataAssembly: (sc: HydratedSavedCompare) => ScenarioData;
+}

--- a/apps/api/src/modules/saved-compares/saved-compares.service.spec.ts
+++ b/apps/api/src/modules/saved-compares/saved-compares.service.spec.ts
@@ -3,7 +3,26 @@ import type { TestingModule } from "@nestjs/testing";
 import { Test } from "@nestjs/testing";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { PrismaService } from "../../database/prisma.service.js";
-import { SavedComparesService } from "./saved-compares.service.js";
+import { deriveCompareDims, SavedComparesService } from "./saved-compares.service.js";
+
+describe("deriveCompareDims", () => {
+  it("returns the shared dims when homogeneous", () => {
+    expect(
+      deriveCompareDims([
+        { scenario: "lb-strategy", tool: "aiperf" },
+        { scenario: "lb-strategy", tool: "aiperf" },
+      ]),
+    ).toEqual({ scenario: "lb-strategy", tool: "aiperf" });
+  });
+  it("returns nulls when scenarios differ", () => {
+    expect(
+      deriveCompareDims([
+        { scenario: "lb-strategy", tool: "aiperf" },
+        { scenario: "inference", tool: "aiperf" },
+      ]),
+    ).toEqual({ scenario: null, tool: "aiperf" });
+  });
+});
 
 describe("SavedComparesService", () => {
   let mod: TestingModule;

--- a/apps/api/src/modules/saved-compares/saved-compares.service.spec.ts
+++ b/apps/api/src/modules/saved-compares/saved-compares.service.spec.ts
@@ -22,6 +22,17 @@ describe("deriveCompareDims", () => {
       ]),
     ).toEqual({ scenario: null, tool: "aiperf" });
   });
+  it("returns nulls for an empty set", () => {
+    expect(deriveCompareDims([])).toEqual({ scenario: null, tool: null });
+  });
+  it("returns nulls when both dims differ", () => {
+    expect(
+      deriveCompareDims([
+        { scenario: "lb-strategy", tool: "aiperf" },
+        { scenario: "inference", tool: "guidellm" },
+      ]),
+    ).toEqual({ scenario: null, tool: null });
+  });
 });
 
 describe("SavedComparesService", () => {

--- a/apps/api/src/modules/saved-compares/saved-compares.service.ts
+++ b/apps/api/src/modules/saved-compares/saved-compares.service.ts
@@ -25,6 +25,8 @@ export class SavedComparesService {
     classification: string;
     clientName: string | null;
     version: number;
+    scenario: string | null;
+    tool: string | null;
     narrative: unknown;
     narrativeAt: Date | null;
     createdAt: Date;
@@ -41,6 +43,8 @@ export class SavedComparesService {
       classification: row.classification as Classification,
       clientName: row.clientName,
       version: row.version,
+      scenario: row.scenario,
+      tool: row.tool,
       narrative: row.narrative,
       narrativeAt: row.narrativeAt ? row.narrativeAt.toISOString() : null,
       createdAt: row.createdAt.toISOString(),

--- a/apps/api/src/modules/saved-compares/saved-compares.service.ts
+++ b/apps/api/src/modules/saved-compares/saved-compares.service.ts
@@ -127,7 +127,9 @@ export class SavedComparesService {
     });
 
     const dims = deriveCompareDims(
-      hydratedBenchmarks.filter((b) => !b.missing).map((b) => ({ scenario: b.scenario, tool: b.tool })),
+      hydratedBenchmarks
+        .filter((b) => !b.missing)
+        .map((b) => ({ scenario: b.scenario, tool: b.tool })),
     );
     return {
       ...sc,

--- a/apps/api/src/modules/saved-compares/saved-compares.service.ts
+++ b/apps/api/src/modules/saved-compares/saved-compares.service.ts
@@ -56,6 +56,18 @@ export class SavedComparesService {
     if (new Set(body.benchmarkIds).size !== body.benchmarkIds.length) {
       throw new BadRequestException("benchmarkIds must be unique");
     }
+    const members = await this.prisma.benchmark.findMany({
+      where: { id: { in: body.benchmarkIds } },
+      select: { scenario: true, tool: true },
+    });
+    const scenarios = new Set(members.map((m) => m.scenario));
+    const tools = new Set(members.map((m) => m.tool));
+    if (scenarios.size > 1) {
+      throw new BadRequestException("compare requires a single scenario across all benchmarks");
+    }
+    if (tools.size > 1) {
+      throw new BadRequestException("compare requires a single tool across all benchmarks");
+    }
     const row = await this.prisma.savedCompare.create({
       data: {
         userId,
@@ -66,6 +78,8 @@ export class SavedComparesService {
         context: body.context ?? null,
         classification: body.classification ?? "internal",
         clientName: body.clientName ?? null,
+        scenario: members.length > 0 ? ([...scenarios][0] ?? null) : null,
+        tool: members.length > 0 ? ([...tools][0] ?? null) : null,
       },
     });
     return this.serialize(row);
@@ -112,7 +126,15 @@ export class SavedComparesService {
       };
     });
 
-    return { ...sc, benchmarks: hydratedBenchmarks };
+    const dims = deriveCompareDims(
+      hydratedBenchmarks.filter((b) => !b.missing).map((b) => ({ scenario: b.scenario, tool: b.tool })),
+    );
+    return {
+      ...sc,
+      scenario: sc.scenario ?? dims.scenario,
+      tool: sc.tool ?? dims.tool,
+      benchmarks: hydratedBenchmarks,
+    };
   }
 
   async update(userId: string, id: string, body: UpdateSavedCompareRequest): Promise<SavedCompare> {
@@ -151,4 +173,17 @@ export class SavedComparesService {
       },
     });
   }
+}
+
+/** Derive the shared scenario/tool of a compare's member benchmarks.
+ * Returns nulls when the set is empty or heterogeneous (mixed). */
+export function deriveCompareDims(
+  members: Array<{ scenario?: string | null; tool?: string | null }>,
+): { scenario: string | null; tool: string | null } {
+  const scenarios = new Set(members.map((m) => m.scenario ?? null));
+  const tools = new Set(members.map((m) => m.tool ?? null));
+  return {
+    scenario: scenarios.size === 1 ? ([...scenarios][0] ?? null) : null,
+    tool: tools.size === 1 ? ([...tools][0] ?? null) : null,
+  };
 }

--- a/apps/api/test/e2e/saved-compares.e2e-spec.ts
+++ b/apps/api/test/e2e/saved-compares.e2e-spec.ts
@@ -129,6 +129,39 @@ describe("/api/saved-compares (e2e)", () => {
     runIds = [b1.id, b2.id];
   });
 
+  it("POST rejects mixed-scenario benchmarks with 400", async () => {
+    // Seed a third benchmark with a different scenario
+    const bOther = await prisma.benchmark.create({
+      data: {
+        userId,
+        scenario: "lb-strategy",
+        tool: "guidellm",
+        name: "r-lb",
+        params: {},
+        summaryMetrics: {
+          tool: "guidellm",
+          data: {
+            ttft: { p50: 90, p90: 180, p99: 450 },
+            e2eLatency: { p50: 750, p90: 1400, p99: 2800 },
+            requestsPerSecond: { mean: 3.5 },
+            requests: { total: 1000, error: 5 },
+          },
+        },
+      },
+    });
+
+    // runIds[0] is scenario="inference", bOther is scenario="lb-strategy"
+    await request(ctx.app.getHttpServer())
+      .post("/api/saved-compares")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        name: "mixed-scenario-compare",
+        benchmarkIds: [runIds[0], bOther.id],
+        stageLabels: { [runIds[0]]: "A", [bOther.id]: "B" },
+      })
+      .expect(400);
+  });
+
   it("POST creates, GET hydrates with benchmarks", async () => {
     const created = await request(ctx.app.getHttpServer())
       .post("/api/saved-compares")

--- a/apps/api/test/e2e/saved-compares.e2e-spec.ts
+++ b/apps/api/test/e2e/saved-compares.e2e-spec.ts
@@ -198,7 +198,13 @@ describe("/api/saved-compares (e2e)", () => {
     await request(ctx.app.getHttpServer())
       .post("/api/llm-judge/providers")
       .set("Authorization", `Bearer ${token}`)
-      .send({ name: "default", baseUrl: "http://llm", apiKey: "sk-test", model: "gpt-4", isDefault: true })
+      .send({
+        name: "default",
+        baseUrl: "http://llm",
+        apiKey: "sk-test",
+        model: "gpt-4",
+        isDefault: true,
+      })
       .expect(201);
 
     const r1 = await request(ctx.app.getHttpServer())

--- a/apps/web/src/components/charts/PodDistributionChart.tsx
+++ b/apps/web/src/components/charts/PodDistributionChart.tsx
@@ -1,0 +1,141 @@
+import type { EChartsOption } from "echarts";
+import ReactECharts from "echarts-for-react";
+import { useMemo } from "react";
+import { ChartFrame, themed, useChartTokens } from "./_shared";
+import type { StageBarLabelColors } from "./StageBarChart";
+
+export interface PodDistributionDatum {
+  stage: string;
+  pods: { pod: string; value: number }[];
+}
+
+export interface PodDistributionChartProps {
+  title: string;
+  data: PodDistributionDatum[];
+  /** Unit suffix appended to static value labels, e.g. "%" */
+  unit: string;
+  /** Fixed report light palette — pass REPORT_LABEL_COLORS so labels stay
+   * readable on the always-light "paper" regardless of app theme. */
+  labelColors: StageBarLabelColors;
+  height?: number;
+}
+
+/**
+ * Grouped bar chart: x-axis = stage (compare bucket), one bar per pod within
+ * each stage group. Static value labels (suffixed with `unit`) are rendered on
+ * every bar so the chart reads correctly in print / PDF / HTML export without
+ * hover. Uses the fixed report light palette — not the app's theme tokens —
+ * so it stays consistent with StageBarChart in the same "paper".
+ */
+export function PodDistributionChart({
+  title,
+  data,
+  unit,
+  labelColors,
+  height = 300,
+}: PodDistributionChartProps): JSX.Element {
+  const tokens = useChartTokens();
+  const isEmpty = data.length === 0;
+
+  const option = useMemo<EChartsOption>(() => {
+    const lc = {
+      value: labelColors.value ?? "#1f2328",
+      baseline: labelColors.baseline ?? "#59636e",
+    };
+
+    // Collect all pod names across all stages (preserving first-seen order).
+    const podNamesSet = new Set<string>();
+    for (const datum of data) {
+      for (const p of datum.pods) podNamesSet.add(p.pod);
+    }
+    const podNames = Array.from(podNamesSet);
+
+    // Fixed report palette — 8 colors, cycling for pods beyond 8.
+    const POD_PALETTE = [
+      "hsl(98, 38%, 46%)",
+      "hsl(43, 81%, 47%)",
+      "hsl(190, 65%, 50%)",
+      "hsl(22, 85%, 48%)",
+      "hsl(4, 75%, 47%)",
+      "hsl(208, 73%, 44%)",
+      "hsl(308, 47%, 45%)",
+      "hsl(260, 28%, 42%)",
+    ] as const;
+
+    const categories = data.map((d) => d.stage);
+
+    // One ECharts series per pod; each series has one value per stage (x-category).
+    const ecSeries = podNames.map((pod, podIdx) => {
+      const values = data.map((datum) => {
+        const entry = datum.pods.find((p) => p.pod === pod);
+        return entry !== undefined ? entry.value : null;
+      });
+      const color = POD_PALETTE[podIdx % POD_PALETTE.length];
+      return {
+        name: pod,
+        type: "bar" as const,
+        data: values,
+        itemStyle: { color },
+        label: {
+          show: true,
+          position: "top" as const,
+          color: lc.value,
+          fontSize: 11,
+          fontWeight: 500 as const,
+          lineHeight: 14,
+          formatter: (p: { value: unknown }) =>
+            typeof p.value === "number" ? `${p.value.toFixed(1)}${unit}` : "",
+        },
+      };
+    });
+
+    return themed(
+      {
+        tooltip: {
+          trigger: "axis",
+          valueFormatter: (val: unknown) =>
+            typeof val === "number" ? `${val.toFixed(1)}${unit}` : String(val ?? ""),
+        },
+        legend:
+          podNames.length > 1
+            ? { type: "scroll", top: 0, textStyle: { color: lc.value } }
+            : undefined,
+        xAxis: {
+          type: "category",
+          data: categories,
+          axisLabel: { color: lc.value, fontWeight: 600, fontSize: 12 },
+        },
+        yAxis: {
+          type: "value",
+          max: (v: { max: number }) => (v.max > 0 ? v.max * 1.2 : 1),
+          axisLabel: {
+            color: lc.baseline,
+            formatter: (v: number) => `${v.toFixed(0)}${unit}`,
+          },
+        },
+        grid: {
+          left: 56,
+          right: 24,
+          top: podNames.length > 1 ? 56 : 24,
+          bottom: 32,
+        },
+        series: ecSeries,
+      },
+      tokens,
+    );
+  }, [data, unit, labelColors.value, labelColors.baseline, tokens]);
+
+  return (
+    <div className="rounded-md border border-border p-4">
+      {title ? <div className="mb-2 text-sm font-medium">{title}</div> : null}
+      <ChartFrame ariaLabel={title} height={height} empty={isEmpty}>
+        <ReactECharts
+          option={option}
+          style={{ height: "100%", width: "100%" }}
+          notMerge
+          lazyUpdate
+        />
+      </ChartFrame>
+    </div>
+  );
+}

--- a/apps/web/src/components/charts/ThroughputConcurrencyChart.tsx
+++ b/apps/web/src/components/charts/ThroughputConcurrencyChart.tsx
@@ -1,0 +1,138 @@
+import type { EChartsOption } from "echarts";
+import ReactECharts from "echarts-for-react";
+import { useMemo } from "react";
+import { ChartFrame, themed, useChartTokens } from "./_shared";
+
+export interface ThroughputConcurrencySeries {
+  stage: string;
+  points: { concurrency: number; rps: number }[];
+}
+
+export interface ThroughputConcurrencyChartProps {
+  title: string;
+  series: ThroughputConcurrencySeries[];
+  height?: number;
+}
+
+/** Fixed report light palette — mirrors REPORT_PALETTE in FigureRenderer so
+ * line colors are consistent across all figures on the always-light report paper. */
+const REPORT_PALETTE = [
+  "hsl(98, 38%, 46%)",
+  "hsl(43, 81%, 47%)",
+  "hsl(190, 65%, 50%)",
+  "hsl(22, 85%, 48%)",
+  "hsl(4, 75%, 47%)",
+  "hsl(208, 73%, 44%)",
+  "hsl(308, 47%, 45%)",
+  "hsl(260, 28%, 42%)",
+] as const;
+
+/**
+ * Line chart: x-axis = concurrency, y-axis = throughput (rps), one line per
+ * stage/run. Uses log-scale x-axis (concurrency 1→4→16→64 spans multiple
+ * octaves and reads poorly on a linear axis). Markers are shown on every point
+ * so the chart reads correctly in print / PDF / HTML export without hover.
+ * Colors come from the fixed report light palette — the report "paper" is
+ * always light so we never follow the app theme.
+ */
+export function ThroughputConcurrencyChart({
+  title,
+  series,
+  height = 300,
+}: ThroughputConcurrencyChartProps): JSX.Element {
+  const tokens = useChartTokens();
+  const isEmpty = series.length === 0 || series.every((s) => s.points.length === 0);
+
+  const option = useMemo<EChartsOption>(() => {
+    // Fixed label colors for the always-light report paper.
+    const lc = {
+      value: "#1f2328",
+      baseline: "#59636e",
+    };
+
+    const ecSeries = series.map((s, idx) => {
+      // Sort points by concurrency ascending before plotting.
+      const sorted = [...s.points].sort((a, b) => a.concurrency - b.concurrency);
+      const color = REPORT_PALETTE[idx % REPORT_PALETTE.length];
+      return {
+        name: s.stage,
+        type: "line" as const,
+        data: sorted.map((p) => [p.concurrency, p.rps]),
+        itemStyle: { color },
+        lineStyle: { color, width: 2 },
+        // Markers on every point — required for print-safe rendering.
+        symbol: "circle" as const,
+        symbolSize: 6,
+        label: {
+          show: true,
+          position: "top" as const,
+          color: lc.value,
+          fontSize: 10,
+          fontWeight: 500 as const,
+          formatter: (p: { value: [number, number] | unknown }) => {
+            const v = Array.isArray(p.value) ? p.value[1] : null;
+            return typeof v === "number" ? v.toFixed(1) : "";
+          },
+        },
+      };
+    });
+
+    return themed(
+      {
+        tooltip: {
+          trigger: "axis",
+          valueFormatter: (val: unknown) =>
+            typeof val === "number" ? `${val.toFixed(2)} rps` : String(val ?? ""),
+        },
+        legend:
+          series.length > 1
+            ? { type: "scroll", top: 0, textStyle: { color: lc.value } }
+            : undefined,
+        xAxis: {
+          type: "log" as const,
+          name: "concurrency",
+          nameLocation: "middle" as const,
+          nameGap: 28,
+          axisLabel: {
+            color: lc.baseline,
+            formatter: (v: number) => String(v),
+          },
+        },
+        yAxis: {
+          type: "value" as const,
+          name: "rps",
+          nameLocation: "middle" as const,
+          nameGap: 40,
+          min: 0,
+          max: (v: { max: number }) => (v.max > 0 ? v.max * 1.15 : 1),
+          axisLabel: {
+            color: lc.baseline,
+            formatter: (v: number) => v.toFixed(0),
+          },
+        },
+        grid: {
+          left: 64,
+          right: 24,
+          top: series.length > 1 ? 56 : 32,
+          bottom: 48,
+        },
+        series: ecSeries,
+      },
+      tokens,
+    );
+  }, [series, tokens]);
+
+  return (
+    <div className="rounded-md border border-border p-4">
+      {title ? <div className="mb-2 text-sm font-medium">{title}</div> : null}
+      <ChartFrame ariaLabel={title} height={height} empty={isEmpty}>
+        <ReactECharts
+          option={option}
+          style={{ height: "100%", width: "100%" }}
+          notMerge
+          lazyUpdate
+        />
+      </ChartFrame>
+    </div>
+  );
+}

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.test.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.test.tsx
@@ -112,4 +112,46 @@ describe("FigureRenderer", () => {
     expect(screen.getByText(/data unavailable/i)).toBeInTheDocument();
     expect(screen.queryByTestId("echart")).not.toBeInTheDocument();
   });
+
+  it("renders throughput-vs-concurrency chart WITHOUT the data-unavailable placeholder", () => {
+    // Build a run whose summaryMetrics carries a capacityCurve.
+    const capacityCurveMetrics = {
+      tool: "guidellm",
+      data: {
+        capacityCurve: [
+          { concurrency: 4, rps: 30, e2eP95Ms: 500 },
+          { concurrency: 16, rps: 80, e2eP95Ms: 700 },
+        ],
+      },
+    };
+    const runWithCurve: ReportRun = {
+      id: "curve-run-a",
+      stageLabel: "A",
+      tool: "guidellm",
+      scenario: "capacity",
+      summaryMetrics: capacityCurveMetrics,
+      serverMetrics: null,
+      benchmark: {
+        id: "curve-run-a",
+        name: "Benchmark A",
+        tool: "guidellm",
+        scenario: "capacity",
+        summaryMetrics: capacityCurveMetrics,
+        serverMetrics: null,
+      },
+      paramsSummary: { concurrency: 4 },
+    };
+    render(
+      <FigureRenderer
+        refId="throughput-vs-concurrency"
+        runs={[runWithCurve]}
+        caption="Throughput vs concurrency"
+        figureNumber={5}
+      />,
+    );
+    // The placeholder text must be absent — the run carries a valid capacityCurve.
+    expect(screen.queryByText(/data unavailable/i)).not.toBeInTheDocument();
+    // The figure body should contain the chart (rendered as the echart stub).
+    expect(screen.getByTestId("echart")).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.test.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.test.tsx
@@ -1,0 +1,115 @@
+import "@/lib/i18n";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { ReportRun } from "./ReportSections";
+import { FigureRenderer } from "./FigureRenderer";
+
+// Minimal guidellm summary metrics fixture — provides throughput + ttft + e2e.
+const guidellmMetrics = () => ({
+  tool: "guidellm",
+  data: {
+    ttft: { p50: 120, p95: 400, p99: 600 },
+    itl: { p95: 20 },
+    e2eLatency: { p50: 900, p95: 2200, p99: 3200 },
+    requestsPerSecond: { mean: 4.5 },
+    requests: { total: 100, error: 0 },
+  },
+});
+
+// A serverMetrics blob that carries a full prefixCache annotation including
+// a non-empty perPod array — the minimum needed for pod-traffic-distribution
+// and pod-hit-rate to pass availableFigureRefIds.
+const serverMetricsWithPods = {
+  prefixCache: {
+    hitRatePct: 57.2,
+    topPodSharePct: 65.0,
+    perPod: [
+      { pod: "pod-0", queries: 60, hits: 40 },
+      { pod: "pod-1", queries: 40, hits: 20 },
+    ],
+    metricTag: "v1" as const,
+  },
+};
+
+function makeRun(id: string, stageLabel: string, withPods = false): ReportRun {
+  return {
+    id,
+    stageLabel,
+    tool: "aiperf",
+    scenario: "lb-strategy",
+    summaryMetrics: guidellmMetrics(),
+    serverMetrics: withPods ? serverMetricsWithPods : null,
+    benchmark: {
+      id,
+      name: `Benchmark ${stageLabel}`,
+      tool: "aiperf",
+      scenario: "lb-strategy",
+      summaryMetrics: guidellmMetrics(),
+      serverMetrics: withPods ? serverMetricsWithPods : null,
+    },
+    paramsSummary: { concurrency: 4 },
+  };
+}
+
+const runs: ReportRun[] = [makeRun("run-a", "OFF", true), makeRun("run-b", "ON", true)];
+
+describe("FigureRenderer", () => {
+  it("renders pod-traffic-distribution chart WITHOUT the data-unavailable placeholder", () => {
+    render(
+      <FigureRenderer
+        refId="pod-traffic-distribution"
+        runs={runs}
+        caption="Pod traffic share"
+        figureNumber={1}
+      />,
+    );
+    // The placeholder text contains "data unavailable" — it must be absent.
+    expect(screen.queryByText(/data unavailable/i)).not.toBeInTheDocument();
+    // The figure body should contain the chart (rendered as the echart stub).
+    expect(screen.getByTestId("echart")).toBeInTheDocument();
+  });
+
+  it("renders pod-hit-rate chart WITHOUT the data-unavailable placeholder", () => {
+    render(
+      <FigureRenderer
+        refId="pod-hit-rate"
+        runs={runs}
+        caption="Pod hit rate"
+        figureNumber={2}
+      />,
+    );
+    expect(screen.queryByText(/data unavailable/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId("echart")).toBeInTheDocument();
+  });
+
+  it("renders cold-warm-delta table WITHOUT the data-unavailable placeholder", () => {
+    render(
+      <FigureRenderer
+        refId="cold-warm-delta"
+        runs={runs}
+        caption="Cold vs warm delta"
+        figureNumber={3}
+      />,
+    );
+    expect(screen.queryByText(/data unavailable/i)).not.toBeInTheDocument();
+    // Table headers confirm the delta table rendered.
+    expect(screen.getByText(/Δ QPS vs baseline/i)).toBeInTheDocument();
+    // Both stage labels appear.
+    expect(screen.getByText("OFF")).toBeInTheDocument();
+    expect(screen.getByText("ON")).toBeInTheDocument();
+  });
+
+  it("renders the data-unavailable placeholder when runs lack pod data", () => {
+    const runsNoPods: ReportRun[] = [makeRun("x", "X", false), makeRun("y", "Y", false)];
+    render(
+      <FigureRenderer
+        refId="pod-traffic-distribution"
+        runs={runsNoPods}
+        caption="Pod traffic share"
+        figureNumber={4}
+      />,
+    );
+    expect(screen.getByText(/data unavailable/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("echart")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.test.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.test.tsx
@@ -1,8 +1,8 @@
 import "@/lib/i18n";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { ReportRun } from "./ReportSections";
 import { FigureRenderer } from "./FigureRenderer";
+import type { ReportRun } from "./ReportSections";
 
 // Minimal guidellm summary metrics fixture — provides throughput + ttft + e2e.
 const guidellmMetrics = () => ({
@@ -71,12 +71,7 @@ describe("FigureRenderer", () => {
 
   it("renders pod-hit-rate chart WITHOUT the data-unavailable placeholder", () => {
     render(
-      <FigureRenderer
-        refId="pod-hit-rate"
-        runs={runs}
-        caption="Pod hit rate"
-        figureNumber={2}
-      />,
+      <FigureRenderer refId="pod-hit-rate" runs={runs} caption="Pod hit rate" figureNumber={2} />,
     );
     expect(screen.queryByText(/data unavailable/i)).not.toBeInTheDocument();
     expect(screen.getByTestId("echart")).toBeInTheDocument();

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
@@ -1,13 +1,13 @@
 import type { FigureRefId } from "@modeldoctor/contracts";
 import { memo } from "react";
 import { assignRunColors } from "@/components/charts/_shared";
+import { PodDistributionChart } from "@/components/charts/PodDistributionChart";
 import {
   StageBarChart,
   type StageBarDatum,
   type StageBarLabelColors,
   type StageBarSeries,
 } from "@/components/charts/StageBarChart";
-import { PodDistributionChart } from "@/components/charts/PodDistributionChart";
 import { ThroughputConcurrencyChart } from "@/components/charts/ThroughputConcurrencyChart";
 import {
   availableFigureRefIds,

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
@@ -8,8 +8,10 @@ import {
   type StageBarSeries,
 } from "@/components/charts/StageBarChart";
 import { PodDistributionChart } from "@/components/charts/PodDistributionChart";
+import { ThroughputConcurrencyChart } from "@/components/charts/ThroughputConcurrencyChart";
 import {
   availableFigureRefIds,
+  readCapacityCurve,
   readPodDistribution,
   readPrefixCache,
   summarizeForPrompt,
@@ -285,6 +287,15 @@ export const FigureRenderer = memo(function FigureRenderer({
         labelColors={REPORT_LABEL_COLORS}
       />
     );
+  } else if (refId === "throughput-vs-concurrency") {
+    const series = summaries
+      .map(({ r }) => ({ r, curve: readCapacityCurve(r.summaryMetrics) }))
+      .filter((x) => x.curve)
+      .map(({ r, curve }) => ({
+        stage: r.stageLabel,
+        points: (curve ?? []).map((p) => ({ concurrency: p.concurrency, rps: p.rps })),
+      }));
+    chart = <ThroughputConcurrencyChart title="Throughput vs concurrency" series={series} />;
   } else if (refId === "cold-warm-delta") {
     chart = <ColdWarmDeltaTable runs={runs} baselineId={baselineId} />;
   } else if (refId === "compare-grid") {

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
@@ -7,7 +7,13 @@ import {
   type StageBarLabelColors,
   type StageBarSeries,
 } from "@/components/charts/StageBarChart";
-import { availableFigureRefIds, readPrefixCache, summarizeForPrompt } from "./client-metrics";
+import { PodDistributionChart } from "@/components/charts/PodDistributionChart";
+import {
+  availableFigureRefIds,
+  readPodDistribution,
+  readPrefixCache,
+  summarizeForPrompt,
+} from "./client-metrics";
 import type { ReportRun } from "./ReportSections";
 
 export interface FigureRendererProps {
@@ -241,6 +247,46 @@ export const FigureRenderer = memo(function FigureRenderer({
         labelColors={REPORT_LABEL_COLORS}
       />
     );
+  } else if (refId === "pod-traffic-distribution") {
+    const data = summaries
+      .map(({ r }) => ({ r, pods: readPodDistribution(r.benchmark?.serverMetrics) }))
+      .filter((x) => x.pods && x.pods.length > 0)
+      .map(({ r, pods }) => {
+        const total = (pods ?? []).reduce((s, p) => s + p.queries, 0) || 1;
+        return {
+          stage: r.stageLabel,
+          pods: (pods ?? []).map((p) => ({ pod: p.pod, value: (p.queries / total) * 100 })),
+        };
+      });
+    chart = (
+      <PodDistributionChart
+        title="Per-pod traffic share"
+        data={data}
+        unit="%"
+        labelColors={REPORT_LABEL_COLORS}
+      />
+    );
+  } else if (refId === "pod-hit-rate") {
+    const data = summaries
+      .map(({ r }) => ({ r, pods: readPodDistribution(r.benchmark?.serverMetrics) }))
+      .filter((x) => x.pods && x.pods.length > 0)
+      .map(({ r, pods }) => ({
+        stage: r.stageLabel,
+        pods: (pods ?? []).map((p) => ({
+          pod: p.pod,
+          value: p.queries > 0 ? (p.hits / p.queries) * 100 : 0,
+        })),
+      }));
+    chart = (
+      <PodDistributionChart
+        title="Per-pod hit rate"
+        data={data}
+        unit="%"
+        labelColors={REPORT_LABEL_COLORS}
+      />
+    );
+  } else if (refId === "cold-warm-delta") {
+    chart = <ColdWarmDeltaTable runs={runs} baselineId={baselineId} />;
   } else if (refId === "compare-grid") {
     chart = <FourMetricTable runs={runs} />;
   }
@@ -288,6 +334,71 @@ function FourMetricTable({ runs }: { runs: ReportRun[] }) {
             </td>
             <td style={{ textAlign: "right", fontFamily: "var(--pr-mono)" }}>
               {s.e2e?.p90?.toFixed(0) ?? "—"}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+/** Compact cold-warm delta table: one row per stage, QPS / TTFT p90 / E2E p90
+ * columns, plus a Δ% column vs the baseline stage. Models FourMetricTable's
+ * markup — static text, mono font for numbers, no hover dependency. */
+function ColdWarmDeltaTable({
+  runs,
+  baselineId,
+}: {
+  runs: ReportRun[];
+  baselineId?: string | null;
+}) {
+  const rows = runs
+    .filter((r) => r.benchmark !== null)
+    .map((r) => ({ r, s: summarizeForPrompt(r.summaryMetrics) }));
+
+  const baseIdx = baselineIndexOf(rows, baselineId) ?? 0;
+  const baseRow = rows[baseIdx];
+  const baseS = baseRow?.s;
+
+  function deltaPct(value: number | null | undefined, base: number | null | undefined): string {
+    if (value == null || base == null || base === 0) return "—";
+    const d = ((value - base) / Math.abs(base)) * 100;
+    return `${d >= 0 ? "+" : ""}${d.toFixed(1)}%`;
+  }
+
+  // Δ% is compared against QPS (higher-is-better) — we surface all three
+  // metrics' raw values and a single Δ% on QPS as the headline delta.
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Stage</th>
+          <th style={{ textAlign: "right" }}>QPS</th>
+          <th style={{ textAlign: "right" }}>TTFT p90 (ms)</th>
+          <th style={{ textAlign: "right" }}>E2E p90 (ms)</th>
+          <th style={{ textAlign: "right" }}>Δ QPS vs baseline</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map(({ r, s }, idx) => (
+          <tr key={r.id}>
+            <td>
+              <strong>{r.stageLabel}</strong>
+              {idx === baseIdx ? (
+                <span style={{ fontFamily: "var(--pr-mono)", color: "#59636e" }}> baseline</span>
+              ) : null}
+            </td>
+            <td style={{ textAlign: "right", fontFamily: "var(--pr-mono)" }}>
+              {s.throughput?.toFixed(2) ?? "—"}
+            </td>
+            <td style={{ textAlign: "right", fontFamily: "var(--pr-mono)" }}>
+              {s.ttft?.p90?.toFixed(0) ?? "—"}
+            </td>
+            <td style={{ textAlign: "right", fontFamily: "var(--pr-mono)" }}>
+              {s.e2e?.p90?.toFixed(0) ?? "—"}
+            </td>
+            <td style={{ textAlign: "right", fontFamily: "var(--pr-mono)" }}>
+              {idx === baseIdx ? "—" : deltaPct(s.throughput, baseS?.throughput)}
             </td>
           </tr>
         ))}

--- a/apps/web/src/features/benchmarks/compare/client-metrics.ts
+++ b/apps/web/src/features/benchmarks/compare/client-metrics.ts
@@ -34,6 +34,23 @@ export function readPrefixCache(serverMetrics: unknown): PrefixCacheSummary | nu
   return { hitRatePct: parsed.data.hitRatePct, topPodSharePct: parsed.data.topPodSharePct };
 }
 
+export interface PodDatum {
+  pod: string;
+  queries: number;
+  hits: number;
+}
+
+/** Read serverMetrics.prefixCache.perPod (per-pod query/hit counts). Null when
+ * the annotation is absent/malformed; [] when present but empty. */
+export function readPodDistribution(serverMetrics: unknown): PodDatum[] | null {
+  const parsed = prefixCacheAnnotationSchema.safeParse(
+    (serverMetrics as { prefixCache?: unknown } | null)?.prefixCache,
+  );
+  if (!parsed.success) return null;
+  const pods = (parsed.data as { perPod?: PodDatum[] }).perPod;
+  return Array.isArray(pods) ? pods : [];
+}
+
 /**
  * Client-side mirror of `apps/api/src/modules/saved-compares/metrics.ts#summarizeForPrompt`.
  * Used by `StageBarChartsSection` to derive chart datasets from raw `summaryMetrics`
@@ -112,6 +129,10 @@ export function availableFigureRefIds(runs: RunMetricBlobs[]): Set<FigureRefId> 
   if (perRun.some((s) => s.errorRate !== null)) out.add("stage-bars-error-rate");
   if (perRun.every((s) => s.ttft !== null)) out.add("stage-bars-ttft-p95");
   if (perRun.every((s) => s.e2e !== null)) out.add("stage-bars-e2e-p95");
+  // cold-warm-delta: available whenever ≥2 runs carry throughput or ttft data.
+  if (perRun.filter((s) => s.throughput !== null || s.ttft !== null).length >= 2) {
+    out.add("cold-warm-delta");
+  }
   // Prefix-cache figures: require EVERY run to carry the annotation so the
   // bar chart is complete across stages (mixing some-with / some-without
   // would render misleading gaps).
@@ -119,6 +140,13 @@ export function availableFigureRefIds(runs: RunMetricBlobs[]): Set<FigureRefId> 
   if (pc.every((p) => p !== null)) {
     out.add("stage-bars-prefix-cache-hit");
     out.add("stage-bars-top-pod-share");
+    // Pod-distribution figures: additionally require every run to carry a
+    // non-empty perPod array (lb-strategy runs only).
+    const pods = runs.map((r) => readPodDistribution(r.serverMetrics));
+    if (pods.every((p) => p !== null && p.length > 0)) {
+      out.add("pod-traffic-distribution");
+      out.add("pod-hit-rate");
+    }
   }
   // compare-grid only needs any of throughput/err/ttft/e2e — always available
   // when there's at least one summary; degrades cell-by-cell.

--- a/apps/web/src/features/benchmarks/compare/client-metrics.ts
+++ b/apps/web/src/features/benchmarks/compare/client-metrics.ts
@@ -13,6 +13,20 @@ export interface PrefixCacheSummary {
   topPodSharePct: number;
 }
 
+export interface CapacityPoint {
+  concurrency: number;
+  rps: number;
+  e2eP95Ms: number;
+}
+
+/** Read guidellm capacityCurve from a run's summaryMetrics ({tool,data}).
+ * Keep in sync with server mirror `apps/api/src/modules/saved-compares/metrics.ts#readCapacityCurve`. */
+export function readCapacityCurve(summaryMetrics: unknown): CapacityPoint[] | null {
+  const m = summaryMetrics as { data?: { capacityCurve?: CapacityPoint[] } } | null;
+  const c = m?.data?.capacityCurve;
+  return Array.isArray(c) && c.length > 0 ? c : null;
+}
+
 /** One run's two metric blobs — summaryMetrics (tool report) carries
  * throughput/latency; serverMetrics carries the prefix-cache annotation. */
 export interface RunMetricBlobs {
@@ -147,6 +161,11 @@ export function availableFigureRefIds(runs: RunMetricBlobs[]): Set<FigureRefId> 
       out.add("pod-traffic-distribution");
       out.add("pod-hit-rate");
     }
+  }
+  // Capacity-curve figure — keep in sync with server mirror
+  // `apps/api/src/modules/saved-compares/metrics.ts#availableFigureRefIds`.
+  if (runs.some((r) => readCapacityCurve(r.summaryMetrics) !== null)) {
+    out.add("throughput-vs-concurrency");
   }
   // compare-grid only needs any of throughput/err/ttft/e2e — always available
   // when there's at least one summary; degrades cell-by-cell.

--- a/docs/superpowers/plans/2026-06-22-scenario-aware-ai-reports.md
+++ b/docs/superpowers/plans/2026-06-22-scenario-aware-ai-reports.md
@@ -1,0 +1,1329 @@
+# Scenario-Aware AI Reports — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the SavedCompare「Generate AI report」(System B) produce visibly different reports per benchmark scenario — by keying generation off `scenario` via a Report Scenario Profile registry that controls prompt fragment, available figures, and assembled data.
+
+**Architecture:** Add a server-side `ReportScenarioProfile` registry (one module per scenario), resolved from the compare's `scenario`. The deep-report synthesizer composes `base system prompt + scenario promptFragment`, drives the available-figure set from the profile's `figureManifest`, and feeds profile-assembled data into the user prompt. New figures stay React-rendered from already-hydrated metrics (no server code execution). Backend hardens the「same scenario + same tool」invariant and persists the derived `scenario`/`tool` on the compare.
+
+**Tech Stack:** TypeScript, NestJS (apps/api), Zod contracts (packages/contracts), Prisma/Postgres, React + ECharts (apps/web), Vitest, tool-adapters (packages/tool-adapters).
+
+**Spec:** `docs/superpowers/specs/2026-06-22-scenario-aware-ai-reports-design.md`
+
+**Worktree:** `/Users/fangyong/vllm/modeldoctor/scenario-reports` on `feat/scenario-aware-ai-reports`. First run needs `pnpm -r build` once (so `packages/*/dist` exists for api typecheck). DB is the shared local dev DB; **do not** `prisma migrate reset`.
+
+---
+
+## File Structure
+
+**Group A — Selection layer (backend invariant + persisted scenario/tool)**
+- Modify: `apps/api/prisma/schema.prisma` — add `scenario String?`, `tool String?` to `SavedCompare`
+- Create: `apps/api/prisma/migrations/<ts>_saved_compare_scenario_tool/migration.sql` (via `migrate dev --create-only`)
+- Modify: `packages/contracts/src/saved-compares/saved-compares.ts` — surface `scenario`/`tool`
+- Modify: `apps/api/src/modules/saved-compares/saved-compares.service.ts` — validate homogeneity, persist, compute-on-read fallback
+- Test: `apps/api/test/e2e/saved-compares.e2e-spec.ts`, `apps/api/src/modules/saved-compares/saved-compares.service.spec.ts`
+
+**Group B — Report Scenario Profile registry**
+- Create: `apps/api/src/modules/saved-compares/report-scenarios/types.ts`
+- Create: `apps/api/src/modules/saved-compares/report-scenarios/{lb-strategy,inference,capacity,gateway,engine-kv-cache,default}.ts`
+- Create: `apps/api/src/modules/saved-compares/report-scenarios/index.ts` (registry + resolver)
+- Test: `apps/api/src/modules/saved-compares/report-scenarios/index.spec.ts`
+
+**Group C — Wire profiles into synthesizer**
+- Modify: `apps/api/src/modules/saved-compares/prompts.ts` — export base builder, scenario injection
+- Modify: `apps/api/src/modules/saved-compares/compare-synthesize.service.ts` — resolve profile, inject fragment, manifest-driven refIds, assembled data
+
+**Group D — Phase-1 figures**
+- Modify: `packages/contracts/src/benchmark.ts` — expose `perPod` shape if not already exported
+- Modify: `packages/contracts/src/saved-compares/compare-narrative.ts` — new `FigureRefId`s
+- Modify: `apps/api/src/modules/saved-compares/metrics.ts` + `apps/web/src/features/benchmarks/compare/client-metrics.ts` — `readPodDistribution`, availability (mirror)
+- Modify: `apps/api/src/modules/saved-compares/prompts.ts` — refId list in `COMMON_SCHEMA_BLOCK`
+- Create: `apps/web/src/components/charts/PodDistributionChart.tsx`
+- Modify: `apps/web/src/features/benchmarks/compare/FigureRenderer.tsx` — render cases
+
+**Group E — Capacity sweep curve**
+- Modify: `packages/tool-adapters/src/guidellm/schema.ts` — optional `capacityCurve`
+- Modify: `packages/tool-adapters/src/guidellm/runtime.ts` — populate from all benches
+- Modify: `packages/contracts/src/saved-compares/compare-narrative.ts` — `throughput-vs-concurrency` refId
+- Modify: metrics mirror — availability + reader
+- Create: `apps/web/src/components/charts/ThroughputConcurrencyChart.tsx`
+- Modify: `FigureRenderer.tsx` — render case
+
+---
+
+## Conventions for every task
+
+- Commit messages use conventional prefixes; body ends with the Co-Authored-By line from CLAUDE.md. Explicit `git add <files>` — never `git add -A`.
+- Run api unit tests: `pnpm -F @modeldoctor/api test -- <file>`. Web: `pnpm -F @modeldoctor/web test -- <file>`. Contracts/tool-adapters: `pnpm -F @modeldoctor/contracts test` / `pnpm -F @modeldoctor/tool-adapters test`.
+- After contract or tool-adapter changes that api/web import, rebuild that package: `pnpm -F @modeldoctor/contracts build` (api/web consume `dist`).
+
+---
+
+## Group A — Selection layer
+
+### Task A1: Add nullable `scenario`/`tool` columns to SavedCompare
+
+**Files:**
+- Modify: `apps/api/prisma/schema.prisma` (the `SavedCompare` model, ~line 350-382)
+- Create: `apps/api/prisma/migrations/<ts>_saved_compare_scenario_tool/migration.sql`
+
+- [ ] **Step 1: Edit the Prisma model**
+
+In the `SavedCompare` model, add two optional columns next to `clientName`:
+
+```prisma
+  scenario     String?  // derived: shared scenario of all member benchmarks
+  tool         String?  // derived: shared tool of all member benchmarks
+```
+
+- [ ] **Step 2: Generate the migration (schema-only, no data DML)**
+
+Run: `cd apps/api && pnpm prisma migrate dev --create-only --name saved_compare_scenario_tool`
+Expected: a new `migration.sql` containing only `ALTER TABLE "SavedCompare" ADD COLUMN "scenario" TEXT; ALTER TABLE "SavedCompare" ADD COLUMN "tool" TEXT;` (column names may be quoted differently — verify it is **only** ADD COLUMN, no UPDATE/INSERT/DELETE).
+
+- [ ] **Step 3: Apply + regenerate client**
+
+Run: `cd apps/api && pnpm prisma migrate dev` then `pnpm prisma generate`
+Expected: migration applies clean; `@prisma/client` types now include `scenario`/`tool` on `SavedCompare`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/prisma/schema.prisma apps/api/prisma/migrations
+git commit -m "feat(api): add nullable scenario/tool columns to SavedCompare"
+```
+
+### Task A2: Surface `scenario`/`tool` in the contract + serializer
+
+**Files:**
+- Modify: `packages/contracts/src/saved-compares/saved-compares.ts:23-52` (savedCompareSchema)
+- Modify: `apps/api/src/modules/saved-compares/saved-compares.service.ts:17-49` (serialize)
+- Test: `packages/contracts/src/saved-compares/saved-compares.spec.ts` (create if absent)
+
+- [ ] **Step 1: Write a failing contract test**
+
+In `packages/contracts/src/saved-compares/saved-compares.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { savedCompareSchema } from "./saved-compares.js";
+
+const base = {
+  id: "c1", userId: "u1", name: "n", benchmarkIds: ["a", "b"],
+  stageLabels: { a: "OFF", b: "ON" }, baselineId: null, context: null,
+  classification: "internal", clientName: null, version: 1,
+  narrative: null, narrativeAt: null,
+  createdAt: "2026-06-22T00:00:00.000Z", updatedAt: "2026-06-22T00:00:00.000Z",
+};
+
+it("accepts nullable scenario/tool", () => {
+  const p = savedCompareSchema.parse({ ...base, scenario: "lb-strategy", tool: "aiperf" });
+  expect(p.scenario).toBe("lb-strategy");
+  expect(savedCompareSchema.parse({ ...base }).scenario ?? null).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `pnpm -F @modeldoctor/contracts test -- saved-compares.spec`
+Expected: FAIL — `scenario` stripped/undefined (not in schema yet).
+
+- [ ] **Step 3: Add fields to `savedCompareSchema`**
+
+Inside the `.object({ ... })` (before `narrative`), add:
+
+```ts
+    scenario: z.string().nullable().optional(),
+    tool: z.string().nullable().optional(),
+```
+
+- [ ] **Step 4: Surface in serializer**
+
+In `saved-compares.service.ts`, add `scenario: string | null;` and `tool: string | null;` to the `serialize` row param type, and in the returned object add:
+
+```ts
+      scenario: row.scenario,
+      tool: row.tool,
+```
+
+- [ ] **Step 5: Run tests + build contract**
+
+Run: `pnpm -F @modeldoctor/contracts test -- saved-compares.spec && pnpm -F @modeldoctor/contracts build`
+Expected: PASS; contract `dist` rebuilt.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/contracts/src/saved-compares/saved-compares.ts packages/contracts/src/saved-compares/saved-compares.spec.ts apps/api/src/modules/saved-compares/saved-compares.service.ts
+git commit -m "feat(contracts): surface scenario/tool on SavedCompare"
+```
+
+### Task A3: Enforce same-scenario+same-tool on create; persist; derive-on-read
+
+**Files:**
+- Modify: `apps/api/src/modules/saved-compares/saved-compares.service.ts` (`create`, `getHydrated`)
+- Test: `apps/api/src/modules/saved-compares/saved-compares.service.spec.ts` (create if absent)
+
+- [ ] **Step 1: Add a pure helper for derivation**
+
+At the bottom of `saved-compares.service.ts` (module scope, exported for test):
+
+```ts
+/** Derive the shared scenario/tool of a compare's member benchmarks.
+ * Returns nulls when the set is empty or heterogeneous (mixed). */
+export function deriveCompareDims(
+  members: Array<{ scenario?: string | null; tool?: string | null }>,
+): { scenario: string | null; tool: string | null } {
+  const scenarios = new Set(members.map((m) => m.scenario ?? null));
+  const tools = new Set(members.map((m) => m.tool ?? null));
+  return {
+    scenario: scenarios.size === 1 ? ([...scenarios][0] ?? null) : null,
+    tool: tools.size === 1 ? ([...tools][0] ?? null) : null,
+  };
+}
+```
+
+- [ ] **Step 2: Write failing service tests**
+
+In `saved-compares.service.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { deriveCompareDims } from "./saved-compares.service.js";
+
+describe("deriveCompareDims", () => {
+  it("returns the shared dims when homogeneous", () => {
+    expect(
+      deriveCompareDims([
+        { scenario: "lb-strategy", tool: "aiperf" },
+        { scenario: "lb-strategy", tool: "aiperf" },
+      ]),
+    ).toEqual({ scenario: "lb-strategy", tool: "aiperf" });
+  });
+  it("returns nulls when scenarios differ", () => {
+    expect(
+      deriveCompareDims([
+        { scenario: "lb-strategy", tool: "aiperf" },
+        { scenario: "inference", tool: "aiperf" },
+      ]),
+    ).toEqual({ scenario: null, tool: "aiperf" });
+  });
+});
+```
+
+- [ ] **Step 3: Run, verify fail**
+
+Run: `pnpm -F @modeldoctor/api test -- saved-compares.service.spec`
+Expected: FAIL — `deriveCompareDims` not exported yet (until Step 1 lands) → then PASS once Step 1 in place. (If you wrote Step 1 first, this step verifies green; otherwise it drives it.)
+
+- [ ] **Step 4: Enforce + persist in `create`**
+
+Replace the body of `create` so that, after the uniqueness check, it fetches the member benchmarks, validates homogeneity, and persists derived dims:
+
+```ts
+  async create(userId: string, body: CreateSavedCompareRequest): Promise<SavedCompare> {
+    if (new Set(body.benchmarkIds).size !== body.benchmarkIds.length) {
+      throw new BadRequestException("benchmarkIds must be unique");
+    }
+    const members = await this.prisma.benchmark.findMany({
+      where: { id: { in: body.benchmarkIds } },
+      select: { scenario: true, tool: true },
+    });
+    const scenarios = new Set(members.map((m) => m.scenario));
+    const tools = new Set(members.map((m) => m.tool));
+    if (scenarios.size > 1) {
+      throw new BadRequestException("compare requires a single scenario across all benchmarks");
+    }
+    if (tools.size > 1) {
+      throw new BadRequestException("compare requires a single tool across all benchmarks");
+    }
+    const row = await this.prisma.savedCompare.create({
+      data: {
+        userId,
+        name: body.name,
+        benchmarkIds: body.benchmarkIds,
+        stageLabels: body.stageLabels,
+        baselineId: body.baselineId ?? null,
+        context: body.context ?? null,
+        classification: body.classification ?? "internal",
+        clientName: body.clientName ?? null,
+        scenario: members.length > 0 ? ([...scenarios][0] ?? null) : null,
+        tool: members.length > 0 ? ([...tools][0] ?? null) : null,
+      },
+    });
+    return this.serialize(row);
+  }
+```
+
+- [ ] **Step 5: Compute-on-read fallback in `getHydrated`**
+
+At the end of `getHydrated`, before `return`, derive when the stored value is null (old rows):
+
+```ts
+    const dims = deriveCompareDims(
+      hydratedBenchmarks.filter((b) => !b.missing).map((b) => ({ scenario: b.scenario, tool: b.tool })),
+    );
+    return {
+      ...sc,
+      scenario: sc.scenario ?? dims.scenario,
+      tool: sc.tool ?? dims.tool,
+      benchmarks: hydratedBenchmarks,
+    };
+```
+
+- [ ] **Step 6: Run unit tests**
+
+Run: `pnpm -F @modeldoctor/api test -- saved-compares.service.spec`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/modules/saved-compares/saved-compares.service.ts apps/api/src/modules/saved-compares/saved-compares.service.spec.ts
+git commit -m "feat(api): enforce single scenario+tool per compare and persist derived dims"
+```
+
+### Task A4: e2e — create rejects mixed scenario
+
+**Files:**
+- Modify: `apps/api/test/e2e/saved-compares.e2e-spec.ts`
+
+- [ ] **Step 1: Add a failing e2e case**
+
+Add a test that seeds two benchmarks with different `scenario` values and asserts `POST /api/saved-compares` returns 400. Follow the existing seeding helpers in this file (it already creates `scenario: "inference", tool: "guidellm"` benchmarks — add one with `scenario: "lb-strategy"`):
+
+```ts
+it("rejects a compare spanning two scenarios", async () => {
+  const a = await createBenchmark({ scenario: "inference", tool: "guidellm" });
+  const b = await createBenchmark({ scenario: "lb-strategy", tool: "guidellm" });
+  await request(app.getHttpServer())
+    .post("/api/saved-compares")
+    .set(authHeader)
+    .send({ name: "mix", benchmarkIds: [a.id, b.id], stageLabels: { [a.id]: "A", [b.id]: "B" } })
+    .expect(400);
+});
+```
+
+(Use whatever `createBenchmark` / `authHeader` helpers the file already defines; if it inlines prisma inserts, mirror that.)
+
+- [ ] **Step 2: Run, verify it passes (logic already landed in A3)**
+
+Run: `pnpm test:e2e:api -- saved-compares`
+Expected: PASS (constraint enforced). Also confirm the existing same-scenario tests still pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/test/e2e/saved-compares.e2e-spec.ts
+git commit -m "test(api): e2e covers mixed-scenario compare rejection"
+```
+
+---
+
+## Group B — Report Scenario Profile registry
+
+### Task B1: Profile types
+
+**Files:**
+- Create: `apps/api/src/modules/saved-compares/report-scenarios/types.ts`
+
+- [ ] **Step 1: Write the types module**
+
+```ts
+import type { FigureRefId, HydratedSavedCompare } from "@modeldoctor/contracts";
+
+export type Locale = "zh-CN" | "en-US";
+
+/** Stable intent keys — finer than scenario (inference splits by run count). */
+export type ReportIntent =
+  | "lb-strategy"
+  | "engine-kv-cache"
+  | "capacity"
+  | "gateway"
+  | "inference-single"
+  | "inference-multi"
+  | "default";
+
+/** Scenario-specific data the profile assembled from the hydrated compare,
+ * passed to both the user-prompt builder and the figure manifest. */
+export interface ScenarioData {
+  /** Extra markdown block injected into the user prompt (per-pod table,
+   * cold/warm pairing, capacity curve summary, …). Empty string = none. */
+  promptBlock: string;
+  /** refIds the profile wants offered to the LLM, intersected later with the
+   * data-availability set so empty charts never get offered. */
+  preferredFigures: FigureRefId[];
+}
+
+export interface ReportScenarioProfile {
+  intent: ReportIntent;
+  /** Injected after the common base in the system prompt. */
+  promptFragment: (locale: Locale) => string;
+  /** Assemble scenario data from the hydrated compare. */
+  dataAssembly: (sc: HydratedSavedCompare) => ScenarioData;
+}
+```
+
+- [ ] **Step 2: Build api to typecheck**
+
+Run: `pnpm -F @modeldoctor/api type-check` (or `pnpm -F @modeldoctor/api build`)
+Expected: PASS (no consumers yet).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/modules/saved-compares/report-scenarios/types.ts
+git commit -m "feat(api): report-scenario profile types"
+```
+
+### Task B2: Resolver + registry skeleton with default profile
+
+**Files:**
+- Create: `apps/api/src/modules/saved-compares/report-scenarios/default.ts`
+- Create: `apps/api/src/modules/saved-compares/report-scenarios/index.ts`
+- Test: `apps/api/src/modules/saved-compares/report-scenarios/index.spec.ts`
+
+- [ ] **Step 1: Default profile (no-op fragment, no extra data)**
+
+`default.ts`:
+
+```ts
+import type { ReportScenarioProfile } from "./types.js";
+
+export const defaultProfile: ReportScenarioProfile = {
+  intent: "default",
+  promptFragment: () => "",
+  dataAssembly: () => ({ promptBlock: "", preferredFigures: [] }),
+};
+```
+
+- [ ] **Step 2: Write failing resolver test**
+
+`index.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { resolveReportIntent } from "./index.js";
+
+describe("resolveReportIntent", () => {
+  it("maps lb-strategy directly", () => {
+    expect(resolveReportIntent("lb-strategy", 2)).toBe("lb-strategy");
+  });
+  it("splits inference by run count", () => {
+    expect(resolveReportIntent("inference", 1)).toBe("inference-single");
+    expect(resolveReportIntent("inference", 3)).toBe("inference-multi");
+  });
+  it("falls back to default on null/unknown scenario", () => {
+    expect(resolveReportIntent(null, 2)).toBe("default");
+    expect(resolveReportIntent("nonsense", 2)).toBe("default");
+  });
+});
+```
+
+- [ ] **Step 3: Run, verify fail**
+
+Run: `pnpm -F @modeldoctor/api test -- report-scenarios/index.spec`
+Expected: FAIL — `resolveReportIntent` undefined.
+
+- [ ] **Step 4: Implement resolver + registry**
+
+`index.ts`:
+
+```ts
+import { defaultProfile } from "./default.js";
+import type { ReportIntent, ReportScenarioProfile } from "./types.js";
+
+export function resolveReportIntent(
+  scenario: string | null | undefined,
+  runCount: number,
+): ReportIntent {
+  switch (scenario) {
+    case "lb-strategy":
+      return "lb-strategy";
+    case "engine-kv-cache":
+      return "engine-kv-cache";
+    case "capacity":
+      return "capacity";
+    case "gateway":
+      return "gateway";
+    case "inference":
+      return runCount <= 1 ? "inference-single" : "inference-multi";
+    default:
+      return "default";
+  }
+}
+
+const REGISTRY: Record<ReportIntent, ReportScenarioProfile> = {
+  default: defaultProfile,
+  // filled in B3/B4:
+  "lb-strategy": defaultProfile,
+  "engine-kv-cache": defaultProfile,
+  capacity: defaultProfile,
+  gateway: defaultProfile,
+  "inference-single": defaultProfile,
+  "inference-multi": defaultProfile,
+};
+
+export function getReportProfile(intent: ReportIntent): ReportScenarioProfile {
+  return REGISTRY[intent] ?? defaultProfile;
+}
+
+export { REGISTRY as reportScenarioRegistry };
+export type { ReportScenarioProfile } from "./types.js";
+```
+
+- [ ] **Step 5: Run, verify pass**
+
+Run: `pnpm -F @modeldoctor/api test -- report-scenarios/index.spec`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/modules/saved-compares/report-scenarios/default.ts apps/api/src/modules/saved-compares/report-scenarios/index.ts apps/api/src/modules/saved-compares/report-scenarios/index.spec.ts
+git commit -m "feat(api): report-scenario resolver + registry skeleton"
+```
+
+### Task B3: lb-strategy profile (the headline scenario)
+
+**Files:**
+- Create: `apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.ts`
+- Modify: `apps/api/src/modules/saved-compares/report-scenarios/index.ts` (register)
+- Test: `apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.spec.ts`
+
+This profile folds in the prefix-cache guidance currently hardcoded in `prompts.ts` (`COMMON_STYLE_RULES`, the "Prefix-cache runs:" paragraph) and assembles a per-pod distribution table from `serverMetrics.prefixCache.perPod`.
+
+- [ ] **Step 1: Write failing test for dataAssembly**
+
+`lb-strategy.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { lbStrategyProfile } from "./lb-strategy.js";
+
+const sc = {
+  benchmarks: [
+    {
+      missing: false, stageLabel: "ON", name: "on",
+      serverMetrics: {
+        prefixCache: {
+          hitRatePct: 57.2, topPodSharePct: 41,
+          perPod: [
+            { pod: "p1", queries: 800, hits: 500 },
+            { pod: "p2", queries: 200, hits: 60 },
+          ],
+        },
+      },
+    },
+  ],
+} as never;
+
+it("emits a per-pod distribution block citing pod shares", () => {
+  const data = lbStrategyProfile.dataAssembly(sc);
+  expect(data.promptBlock).toContain("ON");
+  expect(data.promptBlock).toContain("80"); // p1 share% = 800/1000
+  expect(data.preferredFigures).toContain("stage-bars-prefix-cache-hit");
+});
+it("fragment leads with hit-rate", () => {
+  expect(lbStrategyProfile.promptFragment("zh-CN")).toContain("命中率");
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `pnpm -F @modeldoctor/api test -- report-scenarios/lb-strategy.spec`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement the profile**
+
+`lb-strategy.ts`:
+
+```ts
+import type { HydratedSavedCompare } from "@modeldoctor/contracts";
+import { readPodDistribution } from "../metrics.js";
+import type { Locale, ReportScenarioProfile, ScenarioData } from "./types.js";
+
+const FRAGMENT_ZH = `本报告是负载均衡 / 路由策略验证(lb-strategy)。
+- HEADLINE 与第一张 summary card 必须是 prefix cache 命中率的变化——这是实验存在的理由。
+- 用 stage-bars-prefix-cache-hit 展示命中率,pod-traffic-distribution 展示每 pod 流量占比(集中度),pod-hit-rate 展示每 pod 命中率。
+- 吞吐 / TTFT 视为次要:小模型 prefill 便宜,命中率上升未必改善时延,直说即可,不要拿一个持平的吞吐差当 headline。
+- top-pod share 持平而命中率上升 = 更好的缓存局部性且无热点(好事),不是失败。
+- stage 标签 OFF/ON 指路由开关,不是离线/在线。`;
+
+const FRAGMENT_EN = `This is a load-balancer / routing-strategy validation (lb-strategy).
+- The HEADLINE and first summary card MUST be the prefix-cache hit-rate change — that is why the experiment exists.
+- Use stage-bars-prefix-cache-hit for hit rate, pod-traffic-distribution for each pod's traffic share (concentration), pod-hit-rate for per-pod hit rate.
+- Treat throughput / TTFT as secondary: on small models prefill is cheap, so a higher hit rate need not improve latency — say so plainly rather than leading with a flat throughput delta.
+- A flat top-pod share alongside a rising hit rate means better cache locality without hot-spotting (good), not a failure.
+- Stage labels OFF/ON mean the routing toggle, not offline/online.`;
+
+function assemble(sc: HydratedSavedCompare): ScenarioData {
+  const lines: string[] = [];
+  for (const b of sc.benchmarks) {
+    if (b.missing) continue;
+    const pods = readPodDistribution(b.serverMetrics);
+    if (!pods || pods.length === 0) continue;
+    const total = pods.reduce((s, p) => s + p.queries, 0) || 1;
+    const top = pods
+      .map((p) => ({ pod: p.pod, sharePct: (p.queries / total) * 100, hitPct: p.queries > 0 ? (p.hits / p.queries) * 100 : 0 }))
+      .sort((a, z) => z.sharePct - a.sharePct)
+      .slice(0, 6)
+      .map((p) => `    ${p.pod}: share=${p.sharePct.toFixed(0)}% hit=${p.hitPct.toFixed(0)}%`)
+      .join("\n");
+    lines.push(`  [${b.stageLabel}] per-pod (top by share):\n${top}`);
+  }
+  const promptBlock = lines.length > 0 ? `## Per-pod traffic distribution\n${lines.join("\n")}` : "";
+  return {
+    promptBlock,
+    preferredFigures: [
+      "stage-bars-prefix-cache-hit",
+      "pod-traffic-distribution",
+      "pod-hit-rate",
+      "stage-bars-top-pod-share",
+    ],
+  };
+}
+
+export const lbStrategyProfile: ReportScenarioProfile = {
+  intent: "lb-strategy",
+  promptFragment: (locale: Locale) => (locale === "en-US" ? FRAGMENT_EN : FRAGMENT_ZH),
+  dataAssembly: assemble,
+};
+```
+
+> Note: `readPodDistribution` and the `pod-*` refIds land in Group D. Until then this file won't typecheck. Order Group D Tasks D1–D2 **before** building api, or stub `readPodDistribution` returning `[]` and the refIds will be added to the enum in D1. Recommended order: do D1–D2 right after B1, then return here. The plan lists Group D separately for clarity; the executor may interleave.
+
+- [ ] **Step 4: Register it**
+
+In `index.ts`, import `lbStrategyProfile` and set `"lb-strategy": lbStrategyProfile` in `REGISTRY`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `pnpm -F @modeldoctor/api test -- report-scenarios/lb-strategy.spec`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.ts apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.spec.ts apps/api/src/modules/saved-compares/report-scenarios/index.ts
+git commit -m "feat(api): lb-strategy report profile (hit-rate + per-pod distribution)"
+```
+
+### Task B4: Remaining four profiles
+
+**Files:**
+- Create: `report-scenarios/{engine-kv-cache,capacity,gateway,inference}.ts`
+- Modify: `report-scenarios/index.ts`
+- Test: `report-scenarios/profiles.spec.ts`
+
+Each profile follows the B3 shape. Fragments below; `dataAssembly` returns `preferredFigures` and (where noted) a `promptBlock`.
+
+- [ ] **Step 1: engine-kv-cache** — `engine-kv-cache.ts`
+
+```ts
+import type { HydratedSavedCompare } from "@modeldoctor/contracts";
+import { summarizeForPrompt } from "../metrics.js";
+import type { Locale, ReportScenarioProfile, ScenarioData } from "./types.js";
+
+const ZH = `本报告是引擎 KV / 前缀缓存冷热对比(engine-kv-cache)。
+- 主线是冷(R1)→热(R2)的提升:用 cold-warm-delta 展示配对 stage 的吞吐/TTFT Δ%。
+- HEADLINE 用「热轮相对冷轮」的最大增益指标(通常 TTFT 或吞吐)。
+- 命名以 "(rerun)" 配对冷/热;若只有单轮,退化为单点描述,不要编造冷热差。`;
+const EN = `This is an engine KV / prefix-cache cold-vs-warm comparison (engine-kv-cache).
+- The through-line is the cold (R1) → warm (R2) gain: use cold-warm-delta for the paired-stage throughput/TTFT Δ%.
+- Lead with the largest warm-vs-cold gain metric (usually TTFT or throughput).
+- Cold/warm pair by the "(rerun)" name suffix; with a single round, degrade to a single-point description — do not invent a cold/warm delta.`;
+
+function assemble(_sc: HydratedSavedCompare): ScenarioData {
+  return { promptBlock: "", preferredFigures: ["cold-warm-delta", "stage-bars-ttft-p95", "stage-bars-throughput"] };
+}
+export const engineKvCacheProfile: ReportScenarioProfile = {
+  intent: "engine-kv-cache",
+  promptFragment: (l: Locale) => (l === "en-US" ? EN : ZH),
+  dataAssembly: assemble,
+};
+```
+
+- [ ] **Step 2: capacity** — `capacity.ts`
+
+```ts
+import type { HydratedSavedCompare } from "@modeldoctor/contracts";
+import type { Locale, ReportScenarioProfile, ScenarioData } from "./types.js";
+
+const ZH = `本报告是容量规划(capacity),工具按并发/负载做了 sweep。
+- 主图是 throughput-vs-concurrency:展示吞吐随并发的拐点(饱和点)。
+- HEADLINE 用饱和点的并发档与对应吞吐;若曲线缺失(旧数据)则退回最终聚合百分位,并在 caveats 注明无 sweep 曲线。`;
+const EN = `This is a capacity-planning report (capacity); the tool swept concurrency/load.
+- The lead figure is throughput-vs-concurrency: show the saturation knee.
+- Headline with the knee's concurrency level and its throughput; if the curve is missing (legacy data) fall back to final aggregate percentiles and note "no sweep curve" in caveats.`;
+
+function assemble(_sc: HydratedSavedCompare): ScenarioData {
+  return { promptBlock: "", preferredFigures: ["throughput-vs-concurrency", "compare-grid"] };
+}
+export const capacityProfile: ReportScenarioProfile = {
+  intent: "capacity",
+  promptFragment: (l: Locale) => (l === "en-US" ? EN : ZH),
+  dataAssembly: assemble,
+};
+```
+
+- [ ] **Step 3: gateway** — `gateway.ts`
+
+```ts
+import type { HydratedSavedCompare } from "@modeldoctor/contracts";
+import type { Locale, ReportScenarioProfile, ScenarioData } from "./types.js";
+
+const ZH = `本报告是网关 / HTTP 层压测(gateway,vegeta)。
+- 关注 HTTP 吞吐与时延(e2e),没有 LLM 语义指标(TTFT/TPOT 不适用,不要提)。
+- HEADLINE 用吞吐(req/s)或 e2e p95;错误率与状态码分布作为稳定性佐证。`;
+const EN = `This is a gateway / HTTP-layer load test (gateway, vegeta).
+- Focus on HTTP throughput and latency (e2e); there are no LLM semantic metrics (TTFT/TPOT do not apply — do not mention them).
+- Headline with throughput (req/s) or e2e p95; error rate and status-code mix support the stability story.`;
+
+function assemble(_sc: HydratedSavedCompare): ScenarioData {
+  return { promptBlock: "", preferredFigures: ["stage-bars-throughput", "stage-bars-e2e-p95", "stage-bars-error-rate"] };
+}
+export const gatewayProfile: ReportScenarioProfile = {
+  intent: "gateway",
+  promptFragment: (l: Locale) => (l === "en-US" ? EN : ZH),
+  dataAssembly: assemble,
+};
+```
+
+- [ ] **Step 4: inference (single + multi share one module)** — `inference.ts`
+
+```ts
+import type { HydratedSavedCompare } from "@modeldoctor/contracts";
+import type { Locale, ReportScenarioProfile, ScenarioData } from "./types.js";
+
+const MULTI_ZH = `本报告是多引擎推理对比(inference,多 run)。
+- 主线是不同引擎在吞吐 / TTFT / E2E 上的相对位置;用 compare-grid + stage-bars-throughput + stage-bars-ttft-p95。
+- HEADLINE 用赢家引擎与其吞吐领先幅度;同档差距 <10% 不作为优势判定,直说并列。`;
+const MULTI_EN = `This is a multi-engine inference comparison (inference, multiple runs).
+- The through-line is each engine's relative standing on throughput / TTFT / E2E; use compare-grid + stage-bars-throughput + stage-bars-ttft-p95.
+- Headline with the winning engine and its throughput lead; a <10% gap in a tier is not an advantage — call it a tie.`;
+const SINGLE_ZH = `本报告是单引擎推理基线(inference,单 run 或同引擎多配置)。
+- 主线是该配置的 TTFT / E2E 分布与吞吐;用 stage-bars-ttft-p95 + stage-bars-e2e-p95。
+- 没有跨引擎对比时,不要硬造"赢家";聚焦绝对水平与是否达 SLO。`;
+const SINGLE_EN = `This is a single-engine inference baseline (inference, one run or same-engine configs).
+- The through-line is this config's TTFT / E2E distribution and throughput; use stage-bars-ttft-p95 + stage-bars-e2e-p95.
+- With no cross-engine comparison, do not manufacture a "winner"; focus on absolute levels and SLO attainment.`;
+
+function makeProfile(multi: boolean): ReportScenarioProfile {
+  return {
+    intent: multi ? "inference-multi" : "inference-single",
+    promptFragment: (l: Locale) =>
+      multi ? (l === "en-US" ? MULTI_EN : MULTI_ZH) : l === "en-US" ? SINGLE_EN : SINGLE_ZH,
+    dataAssembly: (_sc: HydratedSavedCompare): ScenarioData => ({
+      promptBlock: "",
+      preferredFigures: multi
+        ? ["compare-grid", "stage-bars-throughput", "stage-bars-ttft-p95"]
+        : ["stage-bars-ttft-p95", "stage-bars-e2e-p95", "stage-bars-throughput"],
+    }),
+  };
+}
+export const inferenceMultiProfile = makeProfile(true);
+export const inferenceSingleProfile = makeProfile(false);
+```
+
+- [ ] **Step 5: Register all four (+ inference split) in `index.ts`**
+
+Import and set: `"engine-kv-cache": engineKvCacheProfile`, `capacity: capacityProfile`, `gateway: gatewayProfile`, `"inference-multi": inferenceMultiProfile`, `"inference-single": inferenceSingleProfile`.
+
+- [ ] **Step 6: Write a registry coverage test**
+
+`profiles.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { getReportProfile, reportScenarioRegistry } from "./index.js";
+
+it("every intent has a non-default profile except 'default'", () => {
+  for (const [intent, profile] of Object.entries(reportScenarioRegistry)) {
+    expect(profile.intent === intent || intent === "default").toBe(true);
+  }
+});
+it("fragments are non-empty for real intents (both locales)", () => {
+  for (const intent of ["lb-strategy", "engine-kv-cache", "capacity", "gateway", "inference-multi", "inference-single"] as const) {
+    const p = getReportProfile(intent);
+    expect(p.promptFragment("zh-CN").length).toBeGreaterThan(20);
+    expect(p.promptFragment("en-US").length).toBeGreaterThan(20);
+  }
+});
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `pnpm -F @modeldoctor/api test -- report-scenarios`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/modules/saved-compares/report-scenarios/engine-kv-cache.ts apps/api/src/modules/saved-compares/report-scenarios/capacity.ts apps/api/src/modules/saved-compares/report-scenarios/gateway.ts apps/api/src/modules/saved-compares/report-scenarios/inference.ts apps/api/src/modules/saved-compares/report-scenarios/index.ts apps/api/src/modules/saved-compares/report-scenarios/profiles.spec.ts
+git commit -m "feat(api): engine-kv-cache, capacity, gateway, inference report profiles"
+```
+
+---
+
+## Group D — Phase-1 figures (do D1–D2 before B3 builds)
+
+### Task D1: New FigureRefIds + expose perPod shape
+
+**Files:**
+- Modify: `packages/contracts/src/saved-compares/compare-narrative.ts:68-80` (figureRefIdSchema)
+- Verify/Modify: `packages/contracts/src/benchmark.ts` (`prefixCacheAnnotationSchema` — ensure `perPod` is part of the exported schema; it already is per investigation at ~235-247)
+- Test: `packages/contracts/src/saved-compares/compare-narrative.spec.ts` (create if absent)
+
+- [ ] **Step 1: Add refIds to the enum**
+
+In `figureRefIdSchema`, add three entries (keep existing ones):
+
+```ts
+  "pod-traffic-distribution",
+  "pod-hit-rate",
+  "cold-warm-delta",
+```
+
+(The `throughput-vs-concurrency` refId is added in Task E3.)
+
+- [ ] **Step 2: Write a failing test**
+
+`compare-narrative.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { figureRefIdSchema } from "./compare-narrative.js";
+it("accepts the new phase-1 refIds", () => {
+  for (const r of ["pod-traffic-distribution", "pod-hit-rate", "cold-warm-delta"]) {
+    expect(figureRefIdSchema.parse(r)).toBe(r);
+  }
+});
+```
+
+- [ ] **Step 3: Run + build**
+
+Run: `pnpm -F @modeldoctor/contracts test -- compare-narrative.spec && pnpm -F @modeldoctor/contracts build`
+Expected: PASS, dist rebuilt.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/contracts/src/saved-compares/compare-narrative.ts packages/contracts/src/saved-compares/compare-narrative.spec.ts
+git commit -m "feat(contracts): add phase-1 figure refIds (pod distribution, pod hit-rate, cold-warm delta)"
+```
+
+### Task D2: `readPodDistribution` + availability (server + client mirror)
+
+**Files:**
+- Modify: `apps/api/src/modules/saved-compares/metrics.ts`
+- Modify: `apps/web/src/features/benchmarks/compare/client-metrics.ts`
+- Test: `apps/api/src/modules/saved-compares/metrics.spec.ts` (create/extend)
+
+- [ ] **Step 1: Write failing test (server)**
+
+In `metrics.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { availableFigureRefIds, readPodDistribution } from "./metrics.js";
+
+const withPods = {
+  prefixCache: { hitRatePct: 50, topPodSharePct: 60, perPod: [
+    { pod: "p1", queries: 600, hits: 300 }, { pod: "p2", queries: 400, hits: 100 },
+  ] },
+};
+it("reads per-pod distribution", () => {
+  expect(readPodDistribution(withPods)).toHaveLength(2);
+});
+it("offers pod figures + cold-warm-delta when data supports", () => {
+  const set = availableFigureRefIds([
+    { summaryMetrics: null, serverMetrics: withPods },
+    { summaryMetrics: null, serverMetrics: withPods },
+  ]);
+  expect(set.has("pod-traffic-distribution")).toBe(true);
+  expect(set.has("pod-hit-rate")).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `pnpm -F @modeldoctor/api test -- saved-compares/metrics.spec`
+Expected: FAIL — `readPodDistribution` undefined.
+
+- [ ] **Step 3: Implement reader + availability (server `metrics.ts`)**
+
+Add a reader. Read the actual `prefixCacheAnnotationSchema` field name for the pod array (investigation: `perPod: [{ pod, queries, hits }]`):
+
+```ts
+export interface PodDatum { pod: string; queries: number; hits: number }
+
+/** Read serverMetrics.prefixCache.perPod (per-pod query/hit counts). Null when
+ * the annotation is absent/malformed; [] when present but empty. */
+export function readPodDistribution(serverMetrics: unknown): PodDatum[] | null {
+  const parsed = prefixCacheAnnotationSchema.safeParse(
+    (serverMetrics as { prefixCache?: unknown } | null)?.prefixCache,
+  );
+  if (!parsed.success) return null;
+  const pods = (parsed.data as { perPod?: PodDatum[] }).perPod;
+  return Array.isArray(pods) ? pods : [];
+}
+```
+
+In `availableFigureRefIds`, inside the existing `if (pc.every((p) => p !== null))` block (where prefix-cache figures get added), also add the pod figures when every run carries a non-empty perPod array:
+
+```ts
+  const pods = runs.map((r) => readPodDistribution(r.serverMetrics));
+  if (pods.every((p) => p !== null && p.length > 0)) {
+    out.add("pod-traffic-distribution");
+    out.add("pod-hit-rate");
+  }
+```
+
+Add `cold-warm-delta` when ≥2 runs carry a throughput or ttft summary (it's a paired-stage delta over `summarizeForPrompt`):
+
+```ts
+  if (perRun.filter((s) => s.throughput !== null || s.ttft !== null).length >= 2) {
+    out.add("cold-warm-delta");
+  }
+```
+
+- [ ] **Step 4: Mirror in client `client-metrics.ts`**
+
+Add the identical `PodDatum`/`readPodDistribution` and the same three additions to the client `availableFigureRefIds`. Keep the "Keep this in sync" comment accurate.
+
+- [ ] **Step 5: Run server tests + web typecheck**
+
+Run: `pnpm -F @modeldoctor/api test -- saved-compares/metrics.spec && pnpm -F @modeldoctor/web type-check`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/modules/saved-compares/metrics.ts apps/api/src/modules/saved-compares/metrics.spec.ts apps/web/src/features/benchmarks/compare/client-metrics.ts
+git commit -m "feat: per-pod distribution reader + figure availability (server/client mirror)"
+```
+
+### Task D3: Update prompt schema refId list
+
+**Files:**
+- Modify: `apps/api/src/modules/saved-compares/prompts.ts:35-40` (COMMON_SCHEMA_BLOCK figures union)
+
+- [ ] **Step 1: Extend the inline refId union in `COMMON_SCHEMA_BLOCK`**
+
+Update the `refId:` union string to include the new ids:
+
+```ts
+  refId: "stage-bars-throughput" | "stage-bars-error-rate" | "stage-bars-ttft-p95" | "stage-bars-e2e-p95" | "stage-bars-prefix-cache-hit" | "stage-bars-top-pod-share" | "pod-traffic-distribution" | "pod-hit-rate" | "cold-warm-delta" | "throughput-vs-concurrency" | "compare-grid";
+```
+
+- [ ] **Step 2: Remove the hardcoded prefix-cache paragraph from `COMMON_STYLE_RULES`**
+
+Delete the "Prefix-cache runs: …" paragraph (lines ~71-80) — it now lives in the lb-strategy `promptFragment`. The base prompt stays scenario-agnostic.
+
+- [ ] **Step 3: Build api**
+
+Run: `pnpm -F @modeldoctor/api build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/modules/saved-compares/prompts.ts
+git commit -m "refactor(api): base prompt lists all refIds; move prefix-cache guidance to lb profile"
+```
+
+### Task D4: PodDistributionChart + cold-warm-delta + FigureRenderer cases
+
+**Files:**
+- Create: `apps/web/src/components/charts/PodDistributionChart.tsx`
+- Modify: `apps/web/src/features/benchmarks/compare/FigureRenderer.tsx`
+- Test: `apps/web/src/features/benchmarks/compare/FigureRenderer.test.tsx` (extend)
+
+- [ ] **Step 1: Build the chart component**
+
+`PodDistributionChart.tsx` — follow the styling/structure of `apps/web/src/components/charts/StageBarChart.tsx` (read it first). It renders, **per stage**, a horizontal bar list of pods. Props:
+
+```tsx
+export interface PodDistributionDatum { stage: string; pods: { pod: string; value: number }[] }
+export interface PodDistributionChartProps {
+  title: string;
+  data: PodDistributionDatum[];
+  /** "%" for share, "%" for hit rate — formatting unit */
+  unit: string;
+  labelColors: import("./StageBarChart").StageBarLabelColors;
+}
+```
+
+Render an ECharts (or the same primitive StageBarChart uses) grouped horizontal bar: one group per stage, one bar per pod, value labels suffixed with `unit`, fixed REPORT light palette. Keep it print-safe (static labels, no hover dependency) — mirror StageBarChart's label rules.
+
+- [ ] **Step 2: Wire render cases in FigureRenderer**
+
+In `FigureRenderer.tsx`, import `readPodDistribution` from `./client-metrics` and `PodDistributionChart`. Add branches after the `stage-bars-top-pod-share` block:
+
+```tsx
+  } else if (refId === "pod-traffic-distribution") {
+    const data = summaries
+      .map(({ r }) => ({ r, pods: readPodDistribution(r.benchmark?.serverMetrics) }))
+      .filter((x) => x.pods && x.pods.length > 0)
+      .map(({ r, pods }) => {
+        const total = (pods ?? []).reduce((s, p) => s + p.queries, 0) || 1;
+        return { stage: r.stageLabel, pods: (pods ?? []).map((p) => ({ pod: p.pod, value: (p.queries / total) * 100 })) };
+      });
+    chart = <PodDistributionChart title="Per-pod traffic share" data={data} unit="%" labelColors={REPORT_LABEL_COLORS} />;
+  } else if (refId === "pod-hit-rate") {
+    const data = summaries
+      .map(({ r }) => ({ r, pods: readPodDistribution(r.benchmark?.serverMetrics) }))
+      .filter((x) => x.pods && x.pods.length > 0)
+      .map(({ r, pods }) => ({
+        stage: r.stageLabel,
+        pods: (pods ?? []).map((p) => ({ pod: p.pod, value: p.queries > 0 ? (p.hits / p.queries) * 100 : 0 })),
+      }));
+    chart = <PodDistributionChart title="Per-pod hit rate" data={data} unit="%" labelColors={REPORT_LABEL_COLORS} />;
+  } else if (refId === "cold-warm-delta") {
+    chart = <ColdWarmDeltaTable runs={runs} baselineId={baselineId} />;
+  }
+```
+
+- [ ] **Step 3: Add `ColdWarmDeltaTable` (local component, like FourMetricTable)**
+
+A compact table: rows = stages, columns = QPS / TTFT p90 / E2E p90, with Δ% vs the baseline stage (reuse `summarizeForPrompt`). Model it on `FourMetricTable` at the bottom of FigureRenderer; add a Δ% column computed against `baselineIndexOf`'s stage.
+
+- [ ] **Step 4: Extend the FigureRenderer test**
+
+In `FigureRenderer.test.tsx`, add a case: runs carrying `serverMetrics.prefixCache.perPod` render a `pod-traffic-distribution` figure (assert it is NOT the "data unavailable" placeholder — i.e. the figure body has chart content). Follow existing test setup in the file.
+
+- [ ] **Step 5: Run web tests**
+
+Run: `pnpm -F @modeldoctor/web test -- FigureRenderer`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/charts/PodDistributionChart.tsx apps/web/src/features/benchmarks/compare/FigureRenderer.tsx apps/web/src/features/benchmarks/compare/FigureRenderer.test.tsx
+git commit -m "feat(web): pod-distribution, pod-hit-rate, cold-warm-delta figures"
+```
+
+---
+
+## Group C — Wire profiles into the synthesizer
+
+### Task C1: Base system prompt + scenario injection
+
+**Files:**
+- Modify: `apps/api/src/modules/saved-compares/prompts.ts`
+
+- [ ] **Step 1: Export a composable builder**
+
+Add an exported function that appends a scenario fragment to the existing locale base. Keep `COMPARE_SYS_PROMPT_ZH/EN` for back-compat; add:
+
+```ts
+export function buildSystemPrompt(locale: "zh-CN" | "en-US", scenarioFragment: string): string {
+  const base = locale === "en-US" ? EN_SCHEMA_INSTRUCTIONS : ZH_SCHEMA_INSTRUCTIONS;
+  if (!scenarioFragment.trim()) return base;
+  const header = locale === "en-US" ? "\n\n## Scenario guidance\n" : "\n\n## 场景专项要求\n";
+  return `${base}${header}${scenarioFragment}`;
+}
+```
+
+- [ ] **Step 2: Build api**
+
+Run: `pnpm -F @modeldoctor/api build`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/modules/saved-compares/prompts.ts
+git commit -m "feat(api): composable system prompt with scenario fragment injection"
+```
+
+### Task C2: Resolve profile in compare-synthesize
+
+**Files:**
+- Modify: `apps/api/src/modules/saved-compares/compare-synthesize.service.ts`
+- Test: `apps/api/src/modules/saved-compares/compare-synthesize.service.spec.ts` (create if absent)
+
+- [ ] **Step 1: Resolve profile and compose the system prompt**
+
+In `synthesize`, replace the `const sys = …` line with profile resolution:
+
+```ts
+    const runCount = sc.benchmarks.filter((b) => !b.missing).length;
+    const intent = resolveReportIntent(sc.scenario, runCount);
+    const profile = getReportProfile(intent);
+    const scenarioData = profile.dataAssembly(sc);
+    const sys = buildSystemPrompt(body.locale, profile.promptFragment(body.locale));
+    const userPrompt = this.buildUserPrompt(sc, body.locale, scenarioData);
+```
+
+Add imports:
+
+```ts
+import { getReportProfile, resolveReportIntent } from "./report-scenarios/index.js";
+import { buildSystemPrompt } from "./prompts.js";
+```
+
+(Drop the now-unused `COMPARE_SYS_PROMPT_*` imports if no longer referenced.)
+
+- [ ] **Step 2: Thread scenarioData into `buildUserPrompt` + manifest-driven refIds**
+
+Change `buildUserPrompt` signature to `(sc, locale, scenarioData: ScenarioData)`. After the per-stage loop, if `scenarioData.promptBlock` is non-empty, push it. Then replace the "Available figure refIds" block so the offered set is `availableFigureRefIds(...) ∩ (preferredFigures ∪ always-available)`:
+
+```ts
+    const available = availableFigureRefIds(
+      sc.benchmarks.filter((b) => !b.missing).map((b) => ({ summaryMetrics: b.summaryMetrics, serverMetrics: b.serverMetrics })),
+    );
+    // Profile preference narrows ordering; never offer a refId whose data is absent.
+    const preferred = scenarioData.preferredFigures.filter((r) => available.has(r));
+    const offered = preferred.length > 0 ? preferred : [...available];
+```
+
+Use `offered` where the code currently spreads `[...available]`.
+
+- [ ] **Step 3: Update `ensurePrefixCacheFigures` guard (still valid)**
+
+No change needed — it still injects the hit-rate figure when available and absent. Leave as-is.
+
+- [ ] **Step 4: Write a service test (prompt composition, no live LLM)**
+
+Extract `buildUserPrompt` test via a thin exported helper or test the private through a small refactor: make `buildSystemPrompt` usage observable by asserting `resolveReportIntent` + `getReportProfile` produce an lb fragment for an lb compare. Minimal test:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { getReportProfile, resolveReportIntent } from "./report-scenarios/index.js";
+import { buildSystemPrompt } from "./prompts.js";
+
+it("lb compare yields a hit-rate-led system prompt", () => {
+  const intent = resolveReportIntent("lb-strategy", 2);
+  const sys = buildSystemPrompt("zh-CN", getReportProfile(intent).promptFragment("zh-CN"));
+  expect(sys).toContain("命中率");
+  expect(sys).toContain("场景专项要求");
+});
+```
+
+- [ ] **Step 5: Run tests + build**
+
+Run: `pnpm -F @modeldoctor/api test -- compare-synthesize && pnpm -F @modeldoctor/api build`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/modules/saved-compares/compare-synthesize.service.ts apps/api/src/modules/saved-compares/compare-synthesize.service.spec.ts
+git commit -m "feat(api): drive deep report by scenario profile (prompt + figure manifest)"
+```
+
+---
+
+## Group E — Capacity sweep curve
+
+### Task E1: `capacityCurve` field on guidellm report schema
+
+**Files:**
+- Modify: `packages/tool-adapters/src/guidellm/schema.ts:67-83`
+- Test: `packages/tool-adapters/src/guidellm/schema.spec.ts`
+
+- [ ] **Step 1: Write failing schema test**
+
+In `schema.spec.ts`, add:
+
+```ts
+it("accepts an optional capacityCurve", () => {
+  const base = { /* a valid GuidellmReport — copy from an existing passing case */ };
+  const withCurve = { ...base, capacityCurve: [{ concurrency: 16, rps: 120, e2eP95Ms: 900 }] };
+  expect(guidellmReportSchema.parse(withCurve).capacityCurve?.[0].concurrency).toBe(16);
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `pnpm -F @modeldoctor/tool-adapters test -- guidellm/schema.spec`
+Expected: FAIL — `capacityCurve` stripped.
+
+- [ ] **Step 3: Add the field**
+
+In `guidellmReportSchema`, add (after `requests`):
+
+```ts
+  capacityCurve: z
+    .array(z.object({ concurrency: z.number(), rps: z.number(), e2eP95Ms: z.number() }))
+    .optional(),
+```
+
+- [ ] **Step 4: Run + build**
+
+Run: `pnpm -F @modeldoctor/tool-adapters test -- guidellm/schema.spec && pnpm -F @modeldoctor/tool-adapters build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/tool-adapters/src/guidellm/schema.ts packages/tool-adapters/src/guidellm/schema.spec.ts
+git commit -m "feat(tool-adapters): optional capacityCurve on guidellm report"
+```
+
+### Task E2: Populate `capacityCurve` from all sweep benches
+
+**Files:**
+- Modify: `packages/tool-adapters/src/guidellm/runtime.ts:150-188` (`mapGuidellmRawToReport`)
+- Test: `packages/tool-adapters/src/guidellm/runtime.spec.ts`
+
+- [ ] **Step 1: Write failing test**
+
+In `runtime.spec.ts`, add a case feeding a raw object whose `benchmarks` array has 3 entries (each with `metrics.request_concurrency.successful.mean`, `metrics.requests_per_second.successful.mean`, `metrics.request_latency.successful.percentiles.p95`), and assert `parseFinalReport` (or the mapper) yields `capacityCurve.length === 3` sorted by concurrency. Mirror the existing fixture style in this file / `__fixtures__`.
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `pnpm -F @modeldoctor/tool-adapters test -- guidellm/runtime.spec`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement — build the curve when >1 bench**
+
+In `mapGuidellmRawToReport`, after computing the existing fields from `benches[0]`, add a curve derived from every bench (reuse the existing `successful`/`latency`/`rate` helpers):
+
+```ts
+  const capacityCurve =
+    benches.length > 1
+      ? benches
+          .map((bn) => {
+            const mx = (bn.metrics as Record<string, unknown> | undefined) ?? {};
+            return {
+              concurrency: Number(successful(mx, "request_concurrency").mean ?? 0),
+              rps: Number(successful(mx, "requests_per_second").mean ?? 0),
+              e2eP95Ms: latency(mx, "request_latency").p95 * 1000,
+            };
+          })
+          .sort((a, z) => a.concurrency - z.concurrency)
+      : undefined;
+```
+
+and include `capacityCurve,` in the returned object.
+
+- [ ] **Step 4: Run + build**
+
+Run: `pnpm -F @modeldoctor/tool-adapters test -- guidellm/runtime.spec && pnpm -F @modeldoctor/tool-adapters build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/tool-adapters/src/guidellm/runtime.ts packages/tool-adapters/src/guidellm/runtime.spec.ts
+git commit -m "feat(tool-adapters): extract capacity sweep curve from guidellm benchmarks[]"
+```
+
+### Task E3: `throughput-vs-concurrency` refId + availability + reader
+
+**Files:**
+- Modify: `packages/contracts/src/saved-compares/compare-narrative.ts` (figureRefIdSchema)
+- Modify: `apps/api/.../metrics.ts` + `apps/web/.../client-metrics.ts` (reader + availability mirror)
+- Test: extend `metrics.spec.ts`
+
+- [ ] **Step 1: Add refId to enum + rebuild contracts**
+
+Add `"throughput-vs-concurrency"` to `figureRefIdSchema`. Run `pnpm -F @modeldoctor/contracts build`.
+
+- [ ] **Step 2: Reader + availability (server + client mirror)**
+
+Add to both metrics modules:
+
+```ts
+export interface CapacityPoint { concurrency: number; rps: number; e2eP95Ms: number }
+/** Read guidellm capacityCurve from a run's summaryMetrics ({tool,data}). */
+export function readCapacityCurve(summaryMetrics: unknown): CapacityPoint[] | null {
+  const m = summaryMetrics as { data?: { capacityCurve?: CapacityPoint[] } } | null;
+  const c = m?.data?.capacityCurve;
+  return Array.isArray(c) && c.length > 0 ? c : null;
+}
+```
+
+In `availableFigureRefIds`, add `throughput-vs-concurrency` when any run carries a curve:
+
+```ts
+  if (runs.some((r) => readCapacityCurve(r.summaryMetrics) !== null)) {
+    out.add("throughput-vs-concurrency");
+  }
+```
+
+- [ ] **Step 3: Test (server)**
+
+Add to `metrics.spec.ts`: a run with `summaryMetrics.data.capacityCurve` makes `throughput-vs-concurrency` available; one without does not.
+
+- [ ] **Step 4: Run + build + commit**
+
+Run: `pnpm -F @modeldoctor/api test -- saved-compares/metrics.spec && pnpm -F @modeldoctor/web type-check`
+
+```bash
+git add packages/contracts/src/saved-compares/compare-narrative.ts apps/api/src/modules/saved-compares/metrics.ts apps/api/src/modules/saved-compares/metrics.spec.ts apps/web/src/features/benchmarks/compare/client-metrics.ts
+git commit -m "feat: throughput-vs-concurrency refId + capacity-curve reader (server/client mirror)"
+```
+
+### Task E4: ThroughputConcurrencyChart + FigureRenderer case + prompt union
+
+**Files:**
+- Create: `apps/web/src/components/charts/ThroughputConcurrencyChart.tsx`
+- Modify: `apps/web/src/features/benchmarks/compare/FigureRenderer.tsx`
+- Modify: `apps/api/src/modules/saved-compares/prompts.ts` (already includes the id from D3 step 1 — verify)
+- Test: `FigureRenderer.test.tsx`
+
+- [ ] **Step 1: Build the line chart**
+
+`ThroughputConcurrencyChart.tsx` — a line chart (x = concurrency log scale, y = rps), one line per stage/run, REPORT light palette, print-safe labels. Follow the ECharts setup used by existing report charts. Props:
+
+```tsx
+export interface ThroughputConcurrencySeries { stage: string; points: { concurrency: number; rps: number }[] }
+export interface ThroughputConcurrencyChartProps { title: string; series: ThroughputConcurrencySeries[] }
+```
+
+- [ ] **Step 2: FigureRenderer case**
+
+Import `readCapacityCurve` + the chart. Add:
+
+```tsx
+  } else if (refId === "throughput-vs-concurrency") {
+    const series = summaries
+      .map(({ r }) => ({ r, curve: readCapacityCurve(r.summaryMetrics) }))
+      .filter((x) => x.curve)
+      .map(({ r, curve }) => ({ stage: r.stageLabel, points: (curve ?? []).map((p) => ({ concurrency: p.concurrency, rps: p.rps })) }));
+    chart = <ThroughputConcurrencyChart title="Throughput vs concurrency" series={series} />;
+  }
+```
+
+- [ ] **Step 3: Test + run**
+
+Add a FigureRenderer test: a run with `summaryMetrics.data.capacityCurve` renders the figure (not the placeholder).
+Run: `pnpm -F @modeldoctor/web test -- FigureRenderer`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/charts/ThroughputConcurrencyChart.tsx apps/web/src/features/benchmarks/compare/FigureRenderer.tsx apps/web/src/features/benchmarks/compare/FigureRenderer.test.tsx
+git commit -m "feat(web): throughput-vs-concurrency capacity figure"
+```
+
+---
+
+## Final verification
+
+- [ ] **Whole-workspace build + lint + test**
+
+Run: `pnpm -r build && pnpm -r lint && pnpm -r test`
+Expected: all PASS. (First run in this worktree: `pnpm -r build` must precede api typecheck.)
+
+- [ ] **Manual smoke (optional, single dev session — kill it after):** start `pnpm dev`, open an lb-strategy SavedCompare, click「Generate AI report」, confirm the report leads with hit-rate and shows the per-pod distribution figure; open a capacity compare and confirm the throughput-vs-concurrency curve. Kill the dev server.
+
+- [ ] **Follow-up issue comments (per CLAUDE.md / [[feedback_temp_followups]]):** post comments noting the Phase-2 deferrals (latency-distribution needs rawOutput wiring; lb traffic-topology + hit-rate timeseries need request logs / interval snapshots; evalscope/aiperf sample histograms; aiperf KV-cache field) on the relevant tracking issue.
+
+- [ ] **Open the PR** once green (see CLAUDE.md PR follow-through).
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** selection layer (A), profile registry + 5 scenarios (B), synthesizer wiring (C), Phase-1 figures incl. lb per-pod (D), capacity sweep curve (E). All §6 scope items covered. `latency-distribution` intentionally Phase-2 (spec-corrected — needs rawOutput, not hydrated in compare).
+- **Ordering caveat:** B3 (lb profile) imports `readPodDistribution` and `pod-*` refIds from Group D — execute D1–D2 before B3 builds (noted inline in B3 Step 3).
+- **Mirror discipline:** every figure-availability change touches BOTH `apps/api/.../metrics.ts` and `apps/web/.../client-metrics.ts` (D2, E3). The "keep in sync" comments are load-bearing.
+- **Name consistency:** `readPodDistribution`, `readCapacityCurve`, `resolveReportIntent`, `getReportProfile`, `buildSystemPrompt`, `deriveCompareDims`, `ScenarioData.{promptBlock,preferredFigures}`, `ReportScenarioProfile.{intent,promptFragment,dataAssembly}` used consistently across tasks.
+</content>

--- a/docs/superpowers/specs/2026-06-22-scenario-aware-ai-reports-design.md
+++ b/docs/superpowers/specs/2026-06-22-scenario-aware-ai-reports-design.md
@@ -1,0 +1,168 @@
+# 场景感知的 AI 报告（Scenario-Aware AI Reports）— 设计文档
+
+- 日期：2026-06-22
+- 分支：`feat/scenario-aware-ai-reports`
+- 范围：System B（SavedCompare「Generate AI report」深度报告）。**不动** System A（Insights 快速诊断）。
+
+## 1. 问题
+
+「Generate AI report」生成的深度报告**千篇一律**，无论跑的是 LB 策略验证、多引擎吞吐对比，还是 KV cache 冷热，骨架与图表都一样。
+
+根因（已通过代码调查确认）三层：
+
+1. **全场景共用一个 system prompt**（`apps/api/src/modules/saved-compares/prompts.ts`）。唯一一句场景相关的话是「prefix-cache 报告 headline 必须引用命中率变化」，其余完全通用。
+2. **figure 是固定通用枚举**（`packages/contracts/src/saved-compares/compare-narrative.ts`）：7 种 `stage-bars-*` 柱状图，全场景共享。LB 报告和吞吐报告**用的是同一批柱子**——这是视觉雷同的真凶。
+3. **输入数据被压平成同一形状**（`compare-synthesize.service.ts`）：只喂 per-stage 的 qps/err/ttft/e2e（+ lb 多两个字段）。没有 per-pod 分布、冷热分轮、并发曲线等场景专属数据。
+
+对比参考项目 `/Users/fangyong/vllm/repots`：它的骨架**也是固定的**（7 段），但差异化全部落在「关键结果」段的**图 + 喂进去的指标**，由场景驱动（每场景手写 `make_charts.py`）。ModelDoctor 缺的正是「场景」这一层——而 System A 早已用 `EvaluationProfile` 实现了这层，System B 没有。
+
+## 2. 已定决策
+
+| 决策点 | 结论 | 理由 |
+|---|---|---|
+| 架构 | **A：场景 profile 化**（服务端单次 JSON 调用 + 数据驱动渲染的 figure 组件） | 产品是私有化自托管 OSS：服务端代码执行沙箱（C 路线）是安全/运维负担，与「易自托管」核心卖点冲突；报告是交付物，需确定性、一致性、品牌内交互式图表；场景是有限已知集，预建组件质量地板更高。Agent Skills（SKILL.md）是为「带文件系统+代码执行的 agent runtime」设计的，不适配服务端单次 schema 约束调用。C 路线不是错的，是早了——可作长尾逃生口后接。 |
+| 选择机制 | **后端硬约束 same-scenario + same-tool；SavedCompare 持久化派生的 `scenario`/`tool`；报告 profile 纯按 `scenario` 选**；`inference` 用 benchmark 数量区分单/多引擎。**无需手动覆盖。** | 现状「同场景同工具」只是前端软约束（混选时隐藏保存按钮），后端零校验、可绕过。下沉为后端不变量 + 持久化，是 industry-standard fix，且让报告层一行读出场景。 |
+| 报告骨架 | **保留固定 6 段**（summary/scope/method/results/caveats/advice） | 与 reports 项目同构（固定骨架不显雷同）；差异化靠 results 段的图 + 各段内容侧重 + prompt 故事线，而非重排骨架；不动 lint/渲染/TOC 管线，风险最低。 |
+| 本期范围 | **Phase 1 + capacity sweep 曲线** | 见 §6。 |
+
+## 3. 「skill 之神，不背 sandbox 之形」
+
+用户最初提议「把场景做成 skills 让 AI 按 skills 生成报告」。我们采纳其**模式**（每场景 = 一个自包含、可插拔、版本化的指令+资源 bundle），但**不采用** Anthropic Agent Skills 的运行机制（SKILL.md 文件夹 + 渐进式披露 + agentic loop + 代码执行）——因为 System B 是服务端一次性 JSON API 调用，没有 agent 运行时。bundle 以服务端 TypeScript 模块形式落地（见 §4.2）。
+
+## 4. 设计
+
+### 4.1 选择层
+
+**后端约束**（`apps/api/src/modules/saved-compares/saved-compares.service.ts` + contract）：
+
+- 创建 SavedCompare 时，hydrate 所有 benchmark 后校验：全部 `scenario` 相同、全部 `tool` 相同，否则 400。
+- 在 `SavedCompare` 上持久化派生字段 `scenario: ScenarioId` 与 `tool: BenchmarkTool`（Prisma migration 用 `prisma migrate dev --create-only` 生成；回填存量行用其成员 benchmark 的共同值）。
+- 前端现有的「混选时隐藏保存按钮」软拦保留（更好的即时反馈），但不再是唯一防线。
+
+**报告意图判定**（`scenario` → reportIntent）：
+
+| `scenario` | reportIntent | 备注 |
+|---|---|---|
+| `lb-strategy` | LB 策略验证 | 命中率 + 流量分布 |
+| `engine-kv-cache` | KV/前缀缓存冷热 | 靠 `(rerun)` 命名配对冷/热 |
+| `capacity` | 容量规划 | sweep 曲线 |
+| `gateway` | 网关/HTTP 层 | vegeta |
+| `inference`（单 run） | 单引擎基线 | |
+| `inference`（多 run） | 多引擎对比 | 用 compare 内 benchmark 数量区分 |
+
+### 4.2 Report Scenario Profile 注册表
+
+新目录 `apps/api/src/modules/saved-compares/report-scenarios/`，一场景一文件 + 一个 `index.ts` 注册表（对齐 System A 的 profile 模式）。
+
+```ts
+// report-scenarios/types.ts
+export interface ReportScenarioProfile {
+  scenario: ScenarioId;
+  /** 区分 inference 单/多引擎等子意图 */
+  resolveIntent?: (ctx: ScenarioContext) => string;
+  /** 注入到通用 system prompt 之后的场景片段（故事线 / 主指标 / 各段侧重 / 有哪些图） */
+  promptFragment: (ctx: ScenarioContext) => { zh: string; en: string };
+  /** 该场景用哪些 figure、优先级、锚到哪个 section */
+  figureManifest: (data: ScenarioData) => FigurePlan[];
+  /** 从 benchmarks 装配场景专属数据（喂 prompt + 供 figure 渲染） */
+  dataAssembly: (benchmarks: HydratedBenchmarkRef[]) => ScenarioData;
+}
+```
+
+- `promptFragment`：**纯文本**，立刻让每种报告读起来就不同。收编现在 `prompts.ts` 里硬编码的 prefix-cache 特判 → 变成 lb-strategy 的 fragment。
+- 通用基座（schema + 12 条 style rules）**不变**；最终 system prompt = 基座 + `promptFragment`。
+- 注册表缺省项（mixed / 未知）回退到现有通用模板，保证不回归。
+
+### 4.3 Figure 体系扩展
+
+所有 figure 仍是 **React 组件 + refId，数据驱动渲染，服务端不出图**（保持确定性、可缓存、品牌内交互式）。新增 `FigureRefId` 到 `compare-narrative.ts` 枚举，对应组件加进 `FigureRenderer.tsx`。
+
+**Phase 1 新增（现有数据即可画）：**
+
+| refId | 场景 | 数据来源 | 说明 |
+|---|---|---|---|
+| `pod-traffic-distribution` | lb-strategy | `serverMetrics.prefixCache.perPod[].queries` | 每 pod 流量占比，看集中度 |
+| `pod-hit-rate` | lb-strategy | `perPod[].hits / .queries` | 每 pod 命中率 |
+| `latency-distribution` | inference / gateway | `rawOutput.files`（guidellm/vegeta，经 `benchmark-charts.service.ts` 解析） | CDF / 直方图 |
+| `cold-warm-delta` | engine-kv-cache | `(rerun)` 配对的两行 summaryMetrics | 冷热 Δ% |
+
+**Phase 1 + 本期追加（需补数据管线）：**
+
+| refId | 场景 | 工作 |
+|---|---|---|
+| `throughput-vs-concurrency` | capacity | 解析 `rawOutput.files.report` 的 guidellm sweep → 新增 `summaryMetrics.capacityCurve[]`（`mapGuidellmRawToReport` 扩展）→ 前端折线图 |
+
+**明确推迟到 Phase 2（不在本期）：**
+
+- lb 的 `traffic-topology`（路由拓扑/sticky 验证）——需 request→pod 路由日志，现无。
+- lb 的 `hit-rate-timeseries`——需定时快照，现只存单点。
+- evalscope/aiperf 样本级直方图——需持久化原始样本。
+- aiperf 的 KV cache 字段缺失。
+
+> 按 [[feedback_temp_followups]]：以上每项在对应 GitHub issue 留 follow-up 评论。
+
+### 4.4 Prompt 装配流
+
+`compare-synthesize.service.ts`：
+
+1. 读 `SavedCompare.scenario` → 取对应 `ReportScenarioProfile`（无则回退通用）。
+2. `dataAssembly(benchmarks)` → `ScenarioData`。
+3. system prompt = 基座 + `promptFragment(ctx)`。
+4. user prompt 现有 per-stage 数据 + `ScenarioData` 衍生的场景专属段（如 per-pod 分布表、冷热配对、capacityCurve 摘要）。
+5. `figureManifest(data)` 决定**实际可用的 figure refIds** 注入 prompt（替代现在的固定 `availableFigureRefIds()`）。
+6. lint + 一次重试 **不变**。
+
+## 5. 数据可用性总览（调查结论）
+
+| 场景 | 现成可画 | 需补数据 |
+|---|---|---|
+| lb-strategy | per-pod 流量分布、per-pod 命中率、全局命中率 KPI、top-pod-share | 路由拓扑/粘性、命中率时序 |
+| inference | 百分位柱、CDF/直方图(guidellm/vegeta)、吞吐 KPI | evalscope/aiperf 样本分布 |
+| gateway | 吞吐/时延 KPI、CDF、状态码分布 | 无 |
+| engine-kv-cache | 冷/热对比(evalscope+guidellm) | aiperf 缓存字段、样本直方图 |
+| capacity | 仅最终百分位 | **吞吐 vs 并发曲线**（sweep 在 MinIO，本期解析入库） |
+
+## 6. 范围
+
+**本期（Phase 1 + capacity 曲线）：**
+
+1. 选择层：后端约束 same-scenario+same-tool + `SavedCompare.scenario/tool` 持久化（含 migration + 存量回填）。
+2. Report Scenario Profile 注册表骨架 + types。
+3. **全 5 场景的 `promptFragment`**（zh/en）。
+4. Phase 1 figure 组件 + refId：`pod-traffic-distribution`、`pod-hit-rate`、`latency-distribution`、`cold-warm-delta`。
+5. lb-strategy / engine-kv-cache 的 `dataAssembly`。
+6. **capacity sweep 解析**：`summaryMetrics.capacityCurve[]` + `throughput-vs-concurrency` figure。
+7. `compare-synthesize.service.ts` 接入 profile（system prompt 注入 + figureManifest 驱动可用 figure）。
+8. 测试：后端约束的 e2e、各 profile 的 figureManifest/promptFragment 单测、capacity 解析单测。
+
+**非本期（Phase 2，单独立项 + issue follow-up）：** lb 路由拓扑、lb 命中率时序、evalscope/aiperf 样本直方图、aiperf KV 字段。
+
+## 7. 不变量 / 不回归
+
+- System A（Insights）完全不动。
+- 通用 schema + 12 条 style rules + lint/retry 管线不动。
+- 6 段骨架与编号不动。
+- 未知/混合场景回退现有通用模板，老报告不回归。
+- 所有新 figure 数据驱动、服务端不执行代码。
+
+## 8. 风险
+
+| 风险 | 缓解 |
+|---|---|
+| 存量 SavedCompare 回填 scenario/tool 时遇到历史混合数据 | 回填脚本对混合行标 `mixed`，报告回退通用模板，不报错 |
+| capacity sweep JSON 结构跨 guidellm 版本变化 | 解析做防御性校验，缺字段则降级为「仅最终百分位」（现状），不 throw |
+| 新 figure 在某 benchmark 缺对应数据 | `figureManifest` 按 `dataAssembly` 实际产出动态裁剪，缺数据则不列该 figure |
+| Prisma migration | 用 `prisma migrate dev --create-only`，不手写 SQL（[[feedback_prisma_migrations]]）；built-in 数据走 seed.ts（[[feedback_prisma_seed_for_builtins]]） |
+
+## 9. 关键文件（落点）
+
+- `apps/api/src/modules/saved-compares/saved-compares.service.ts` — 后端约束
+- `apps/api/prisma/schema.prisma` + migration — `SavedCompare.scenario/tool`、`summaryMetrics.capacityCurve`
+- `apps/api/src/modules/saved-compares/report-scenarios/**` — 新注册表（一场景一文件）
+- `apps/api/src/modules/saved-compares/prompts.ts` — 基座保留，特判收编
+- `apps/api/src/modules/saved-compares/compare-synthesize.service.ts` — 接入 profile
+- `packages/contracts/src/saved-compares/compare-narrative.ts` — 新 FigureRefId
+- `packages/tool-adapters/src/guidellm/runtime.ts` — sweep 解析
+- `apps/web/src/features/benchmarks/compare/FigureRenderer.tsx` + 新图组件
+</content>
+</invoke>

--- a/docs/superpowers/specs/2026-06-22-scenario-aware-ai-reports-design.md
+++ b/docs/superpowers/specs/2026-06-22-scenario-aware-ai-reports-design.md
@@ -36,7 +36,7 @@
 **后端约束**（`apps/api/src/modules/saved-compares/saved-compares.service.ts` + contract）：
 
 - 创建 SavedCompare 时，hydrate 所有 benchmark 后校验：全部 `scenario` 相同、全部 `tool` 相同，否则 400。
-- 在 `SavedCompare` 上持久化派生字段 `scenario: ScenarioId` 与 `tool: BenchmarkTool`（Prisma migration 用 `prisma migrate dev --create-only` 生成；回填存量行用其成员 benchmark 的共同值）。
+- 在 `SavedCompare` 上持久化派生字段 `scenario: String?` 与 `tool: String?`（Prisma migration 用 `prisma migrate dev --create-only`，**纯加列，schema-only，无数据 DML**）。新建时写入；**读取时若为 null 则从 hydrated benchmarks 现场派生**（compute-on-read 兜底），因此**无需存量回填迁移**——避免业务数据 DML（CLAUDE.md 限制）。
 - 前端现有的「混选时隐藏保存按钮」软拦保留（更好的即时反馈），但不再是唯一防线。
 
 **报告意图判定**（`scenario` → reportIntent）：
@@ -77,14 +77,15 @@ export interface ReportScenarioProfile {
 
 所有 figure 仍是 **React 组件 + refId，数据驱动渲染，服务端不出图**（保持确定性、可缓存、品牌内交互式）。新增 `FigureRefId` 到 `compare-narrative.ts` 枚举，对应组件加进 `FigureRenderer.tsx`。
 
-**Phase 1 新增（现有数据即可画）：**
+**Phase 1 新增（compare 已 hydrate 的数据即可画）：**
 
 | refId | 场景 | 数据来源 | 说明 |
 |---|---|---|---|
 | `pod-traffic-distribution` | lb-strategy | `serverMetrics.prefixCache.perPod[].queries` | 每 pod 流量占比，看集中度 |
 | `pod-hit-rate` | lb-strategy | `perPod[].hits / .queries` | 每 pod 命中率 |
-| `latency-distribution` | inference / gateway | `rawOutput.files`（guidellm/vegeta，经 `benchmark-charts.service.ts` 解析） | CDF / 直方图 |
 | `cold-warm-delta` | engine-kv-cache | `(rerun)` 配对的两行 summaryMetrics | 冷热 Δ% |
+
+> **设计期修正**：`latency-distribution`（CDF/直方图）原列 Phase 1，但 compare 报告的 figure 只从已 hydrate 的 `summaryMetrics`/`serverMetrics` 渲染，原始样本在 `rawOutput`（MinIO/DB blob，compare 流程不加载）→ 需额外 rawOutput 拉取 wiring，**改到 Phase 2**。
 
 **Phase 1 + 本期追加（需补数据管线）：**
 
@@ -126,7 +127,7 @@ export interface ReportScenarioProfile {
 
 **本期（Phase 1 + capacity 曲线）：**
 
-1. 选择层：后端约束 same-scenario+same-tool + `SavedCompare.scenario/tool` 持久化（含 migration + 存量回填）。
+1. 选择层：后端约束 same-scenario+same-tool + `SavedCompare.scenario/tool` 持久化（nullable 加列 migration + compute-on-read 兜底，无回填）。
 2. Report Scenario Profile 注册表骨架 + types。
 3. **全 5 场景的 `promptFragment`**（zh/en）。
 4. Phase 1 figure 组件 + refId：`pod-traffic-distribution`、`pod-hit-rate`、`latency-distribution`、`cold-warm-delta`。
@@ -149,7 +150,7 @@ export interface ReportScenarioProfile {
 
 | 风险 | 缓解 |
 |---|---|
-| 存量 SavedCompare 回填 scenario/tool 时遇到历史混合数据 | 回填脚本对混合行标 `mixed`，报告回退通用模板，不报错 |
+| 存量 SavedCompare 无 scenario/tool（旧行）| compute-on-read 现场派生；若成员 benchmark 已删/混合则视为未知，报告回退通用模板，不报错 |
 | capacity sweep JSON 结构跨 guidellm 版本变化 | 解析做防御性校验，缺字段则降级为「仅最终百分位」（现状），不 throw |
 | 新 figure 在某 benchmark 缺对应数据 | `figureManifest` 按 `dataAssembly` 实际产出动态裁剪，缺数据则不列该 figure |
 | Prisma migration | 用 `prisma migrate dev --create-only`，不手写 SQL（[[feedback_prisma_migrations]]）；built-in 数据走 seed.ts（[[feedback_prisma_seed_for_builtins]]） |

--- a/packages/contracts/src/saved-compares/compare-narrative.spec.ts
+++ b/packages/contracts/src/saved-compares/compare-narrative.spec.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { figureRefIdSchema } from "./compare-narrative.js";
+
+it("accepts the new phase-1 refIds", () => {
+  for (const r of ["pod-traffic-distribution", "pod-hit-rate", "cold-warm-delta"]) {
+    expect(figureRefIdSchema.parse(r)).toBe(r);
+  }
+});

--- a/packages/contracts/src/saved-compares/compare-narrative.ts
+++ b/packages/contracts/src/saved-compares/compare-narrative.ts
@@ -81,6 +81,9 @@ export const figureRefIdSchema = z.enum([
   "pod-traffic-distribution",
   "pod-hit-rate",
   "cold-warm-delta",
+  // Capacity-planning figure — rendered from summaryMetrics.data.capacityCurve
+  // (guidellm sweep runs only). Available when any run carries a capacity curve.
+  "throughput-vs-concurrency",
 ]);
 export type FigureRefId = z.infer<typeof figureRefIdSchema>;
 

--- a/packages/contracts/src/saved-compares/compare-narrative.ts
+++ b/packages/contracts/src/saved-compares/compare-narrative.ts
@@ -76,6 +76,11 @@ export const figureRefIdSchema = z.enum([
   "stage-bars-prefix-cache-hit",
   "stage-bars-top-pod-share",
   "compare-grid",
+  // Phase-1 figures — rendered from serverMetrics.prefixCache.perPod and
+  // cold/warm delta computations.
+  "pod-traffic-distribution",
+  "pod-hit-rate",
+  "cold-warm-delta",
 ]);
 export type FigureRefId = z.infer<typeof figureRefIdSchema>;
 

--- a/packages/contracts/src/saved-compares/saved-compares.spec.ts
+++ b/packages/contracts/src/saved-compares/saved-compares.spec.ts
@@ -2,11 +2,20 @@ import { describe, expect, it } from "vitest";
 import { savedCompareSchema } from "./saved-compares.js";
 
 const base = {
-  id: "c1", userId: "u1", name: "n", benchmarkIds: ["a", "b"],
-  stageLabels: { a: "OFF", b: "ON" }, baselineId: null, context: null,
-  classification: "internal", clientName: null, version: 1,
-  narrative: null, narrativeAt: null,
-  createdAt: "2026-06-22T00:00:00.000Z", updatedAt: "2026-06-22T00:00:00.000Z",
+  id: "c1",
+  userId: "u1",
+  name: "n",
+  benchmarkIds: ["a", "b"],
+  stageLabels: { a: "OFF", b: "ON" },
+  baselineId: null,
+  context: null,
+  classification: "internal",
+  clientName: null,
+  version: 1,
+  narrative: null,
+  narrativeAt: null,
+  createdAt: "2026-06-22T00:00:00.000Z",
+  updatedAt: "2026-06-22T00:00:00.000Z",
 };
 
 it("accepts nullable scenario/tool", () => {

--- a/packages/contracts/src/saved-compares/saved-compares.spec.ts
+++ b/packages/contracts/src/saved-compares/saved-compares.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { savedCompareSchema } from "./saved-compares.js";
+
+const base = {
+  id: "c1", userId: "u1", name: "n", benchmarkIds: ["a", "b"],
+  stageLabels: { a: "OFF", b: "ON" }, baselineId: null, context: null,
+  classification: "internal", clientName: null, version: 1,
+  narrative: null, narrativeAt: null,
+  createdAt: "2026-06-22T00:00:00.000Z", updatedAt: "2026-06-22T00:00:00.000Z",
+};
+
+it("accepts nullable scenario/tool", () => {
+  const p = savedCompareSchema.parse({ ...base, scenario: "lb-strategy", tool: "aiperf" });
+  expect(p.scenario).toBe("lb-strategy");
+  expect(savedCompareSchema.parse({ ...base }).scenario ?? null).toBeNull();
+});

--- a/packages/contracts/src/saved-compares/saved-compares.ts
+++ b/packages/contracts/src/saved-compares/saved-compares.ts
@@ -32,6 +32,8 @@ export const savedCompareSchema = z
     classification: classificationSchema.default("internal"),
     clientName: z.string().max(120).nullable(),
     version: z.number().int().positive().default(1),
+    scenario: z.string().nullable().optional(),
+    tool: z.string().nullable().optional(),
     narrative: z.unknown().nullable(), // shape lives in compare-narrative.ts; kept loose here
     narrativeAt: z.string().datetime().nullable(),
     createdAt: z.string().datetime(),

--- a/packages/tool-adapters/src/guidellm/runtime.spec.ts
+++ b/packages/tool-adapters/src/guidellm/runtime.spec.ts
@@ -263,6 +263,78 @@ describe("guidellm.parseFinalReport", () => {
   });
 });
 
+describe("guidellm.parseFinalReport capacityCurve", () => {
+  function makeBench(concurrency: number, rps: number, e2eLatencySeconds: number) {
+    return {
+      metrics: {
+        request_concurrency: {
+          successful: { mean: concurrency, max: concurrency, percentiles: { p50: concurrency, p90: concurrency, p95: concurrency, p99: concurrency } },
+        },
+        requests_per_second: {
+          successful: { mean: rps, max: rps, percentiles: { p50: rps, p90: rps, p95: rps, p99: rps } },
+        },
+        request_latency: {
+          successful: {
+            mean: e2eLatencySeconds,
+            max: e2eLatencySeconds,
+            percentiles: { p50: e2eLatencySeconds, p90: e2eLatencySeconds, p95: e2eLatencySeconds, p99: e2eLatencySeconds },
+          },
+        },
+        time_to_first_token_ms: {
+          successful: { mean: 0, max: 0, percentiles: { p50: 0, p90: 0, p95: 0, p99: 0 } },
+        },
+        inter_token_latency_ms: {
+          successful: { mean: 0, max: 0, percentiles: { p50: 0, p90: 0, p95: 0, p99: 0 } },
+        },
+        output_tokens_per_second: {
+          successful: { mean: 0, max: 0, percentiles: { p50: 0, p90: 0, p95: 0, p99: 0 } },
+        },
+        prompt_tokens_per_second: {
+          successful: { mean: 0, max: 0, percentiles: { p50: 0, p90: 0, p95: 0, p99: 0 } },
+        },
+        tokens_per_second: {
+          successful: { mean: 0, max: 0, percentiles: { p50: 0, p90: 0, p95: 0, p99: 0 } },
+        },
+        request_totals: { total: 10, successful: 10, errored: 0, incomplete: 0 },
+      },
+    };
+  }
+
+  it("extracts capacityCurve sorted ascending by concurrency from 3 sweep benches", () => {
+    // Input: non-sorted concurrency order (64, 4, 16) to verify sort
+    const raw = {
+      benchmarks: [
+        makeBench(64, 30, 2.5),  // concurrency=64, e2eP95Ms=2500
+        makeBench(4, 5, 0.1),    // concurrency=4,  e2eP95Ms=100
+        makeBench(16, 15, 0.8),  // concurrency=16, e2eP95Ms=800
+      ],
+    };
+    const buf = Buffer.from(JSON.stringify(raw), "utf8");
+    const result = parseFinalReport("", { report: buf });
+    if (result.tool !== "guidellm") throw new Error(`expected guidellm, got ${result.tool}`);
+
+    const curve = result.data.capacityCurve;
+    expect(curve).toBeDefined();
+    expect(curve).toHaveLength(3);
+
+    // Sorted ascending by concurrency
+    expect(curve![0].concurrency).toBe(4);
+    expect(curve![1].concurrency).toBe(16);
+    expect(curve![2].concurrency).toBe(64);
+
+    // First point: e2eP95Ms = 0.1 seconds × 1000 = 100 ms
+    expect(curve![0].e2eP95Ms).toBeCloseTo(100);
+  });
+
+  it("returns undefined capacityCurve for single-bench (non-sweep) runs", () => {
+    const raw = { benchmarks: [makeBench(8, 10, 0.5)] };
+    const buf = Buffer.from(JSON.stringify(raw), "utf8");
+    const result = parseFinalReport("", { report: buf });
+    if (result.tool !== "guidellm") throw new Error(`expected guidellm, got ${result.tool}`);
+    expect(result.data.capacityCurve).toBeUndefined();
+  });
+});
+
 describe("guidellm extraArgs escape hatch", () => {
   const withExtra = (extraArgs: string) =>
     buildCommand({ runId: "r1", params: { ...defaultParams, extraArgs }, connection: baseConn })

--- a/packages/tool-adapters/src/guidellm/runtime.spec.ts
+++ b/packages/tool-adapters/src/guidellm/runtime.spec.ts
@@ -268,16 +268,29 @@ describe("guidellm.parseFinalReport capacityCurve", () => {
     return {
       metrics: {
         request_concurrency: {
-          successful: { mean: concurrency, max: concurrency, percentiles: { p50: concurrency, p90: concurrency, p95: concurrency, p99: concurrency } },
+          successful: {
+            mean: concurrency,
+            max: concurrency,
+            percentiles: { p50: concurrency, p90: concurrency, p95: concurrency, p99: concurrency },
+          },
         },
         requests_per_second: {
-          successful: { mean: rps, max: rps, percentiles: { p50: rps, p90: rps, p95: rps, p99: rps } },
+          successful: {
+            mean: rps,
+            max: rps,
+            percentiles: { p50: rps, p90: rps, p95: rps, p99: rps },
+          },
         },
         request_latency: {
           successful: {
             mean: e2eLatencySeconds,
             max: e2eLatencySeconds,
-            percentiles: { p50: e2eLatencySeconds, p90: e2eLatencySeconds, p95: e2eLatencySeconds, p99: e2eLatencySeconds },
+            percentiles: {
+              p50: e2eLatencySeconds,
+              p90: e2eLatencySeconds,
+              p95: e2eLatencySeconds,
+              p99: e2eLatencySeconds,
+            },
           },
         },
         time_to_first_token_ms: {
@@ -304,9 +317,9 @@ describe("guidellm.parseFinalReport capacityCurve", () => {
     // Input: non-sorted concurrency order (64, 4, 16) to verify sort
     const raw = {
       benchmarks: [
-        makeBench(64, 30, 2.5),  // concurrency=64, e2eP95Ms=2500
-        makeBench(4, 5, 0.1),    // concurrency=4,  e2eP95Ms=100
-        makeBench(16, 15, 0.8),  // concurrency=16, e2eP95Ms=800
+        makeBench(64, 30, 2.5), // concurrency=64, e2eP95Ms=2500
+        makeBench(4, 5, 0.1), // concurrency=4,  e2eP95Ms=100
+        makeBench(16, 15, 0.8), // concurrency=16, e2eP95Ms=800
       ],
     };
     const buf = Buffer.from(JSON.stringify(raw), "utf8");

--- a/packages/tool-adapters/src/guidellm/runtime.ts
+++ b/packages/tool-adapters/src/guidellm/runtime.ts
@@ -166,6 +166,20 @@ function mapGuidellmRawToReport(raw: Record<string, unknown>): GuidellmReport {
     p99: e2e.p99 * 1000,
   };
 
+  const capacityCurve =
+    benches.length > 1
+      ? benches
+          .map((bn) => {
+            const mx = (bn.metrics as Record<string, unknown> | undefined) ?? {};
+            return {
+              concurrency: Number(successful(mx, "request_concurrency").mean ?? 0),
+              rps: Number(successful(mx, "requests_per_second").mean ?? 0),
+              e2eP95Ms: latency(mx, "request_latency").p95 * 1000,
+            };
+          })
+          .sort((a, z) => a.concurrency - z.concurrency)
+      : undefined;
+
   return {
     ttft: latency(metrics, "time_to_first_token_ms"),
     itl: latency(metrics, "inter_token_latency_ms"),
@@ -184,6 +198,7 @@ function mapGuidellmRawToReport(raw: Record<string, unknown>): GuidellmReport {
       mean: Number(concurrencySrc.mean ?? 0),
       max: Number(concurrencySrc.max ?? 0),
     },
+    capacityCurve,
   };
 }
 

--- a/packages/tool-adapters/src/guidellm/schema.spec.ts
+++ b/packages/tool-adapters/src/guidellm/schema.spec.ts
@@ -151,6 +151,25 @@ describe("guidellmReportSchema", () => {
     expect(r.success).toBe(true);
   });
 
+  it("accepts an optional capacityCurve", () => {
+    const dist = { mean: 1, p50: 1, p90: 1, p95: 1, p99: 1 };
+    const base = {
+      ttft: dist,
+      itl: dist,
+      e2eLatency: dist,
+      requestsPerSecond: { mean: 1 },
+      outputTokensPerSecond: { mean: 1 },
+      inputTokensPerSecond: { mean: 1 },
+      totalTokensPerSecond: { mean: 1 },
+      concurrency: { mean: 1, max: 1 },
+      requests: { total: 1, success: 1, error: 0, incomplete: 0 },
+    };
+    const withCurve = { ...base, capacityCurve: [{ concurrency: 16, rps: 120, e2eP95Ms: 900 }] };
+    expect(guidellmReportSchema.parse(withCurve).capacityCurve?.[0].concurrency).toBe(16);
+    // without curve still parses (field is optional)
+    expect(guidellmReportSchema.parse(base).capacityCurve).toBeUndefined();
+  });
+
   // gemini Item 1: requests counts nonnegative
   it("rejects requests.total = -1", () => {
     const dist = { mean: 1, p50: 1, p90: 1, p95: 1, p99: 1 };

--- a/packages/tool-adapters/src/guidellm/schema.ts
+++ b/packages/tool-adapters/src/guidellm/schema.ts
@@ -79,6 +79,9 @@ export const guidellmReportSchema = z.object({
     error: z.number().int().nonnegative(),
     incomplete: z.number().int().nonnegative(),
   }),
+  capacityCurve: z
+    .array(z.object({ concurrency: z.number(), rps: z.number(), e2eP95Ms: z.number() }))
+    .optional(),
 });
 export type GuidellmReport = z.infer<typeof guidellmReportSchema>;
 


### PR DESCRIPTION
## Why

「Generate AI report」(SavedCompare 深度报告) 此前不分场景 —— LB 策略验证、多引擎吞吐对比、KV cache 冷热，骨架与图表都一样。根因三层：全场景共用一个 system prompt、figure 是固定通用柱状图枚举、输入数据被压平成同一形状。

## What

给 System B 加一层 **Report Scenario Profile 注册表**（一场景一模块），按 benchmark 的 `scenario` 选择，控制：scenario prompt 片段、注入用户提示词的场景数据、偏好的 figure 集合。差异化落在 results 段的**图 + 内容 + prompt 故事线**；固定 6 段骨架保留。

- **A 选择层**：后端硬约束「同 scenario + 同 tool」，`SavedCompare` 持久化派生 `scenario`/`tool`（nullable 加列 + compute-on-read，无回填）。
- **B Profile 注册表**：resolver + 5 场景 profile（lb-strategy 命中率优先 + per-pod 流量分布；engine-kv-cache / capacity / gateway / inference 单·多）。
- **C 接线**：synthesizer = `base prompt + scenario fragment`，figure 由 manifest 驱动，默认/未知场景行为不变。
- **D Phase-1 figures**：`pod-traffic-distribution`、`pod-hit-rate`、`cold-warm-delta`（server/client availability 镜像，数据来自已 hydrate metrics，服务端不出图）。
- **E capacity 曲线**：从 guidellm 全部 sweep benches 解析 `capacityCurve` → `throughput-vs-concurrency` 折线图。

## 范围（设计期修正）
- `latency-distribution`（CDF/直方图）→ **Phase 2**：原始样本在 `rawOutput`（compare 不加载），需额外拉取 wiring。
- 其余 Phase-2（lb 路由拓扑 / 命中率时序、evalscope/aiperf 样本直方图、aiperf KV 字段）见 spec §6。

## 测试
全工作区 build + lint 通过；测试 api 1047 / web 929 / contracts 178 / tool-adapters 249。覆盖：选择层 e2e（混 scenario → 400）、profile 注册表、figure availability 镜像、capacity 解析、FigureRenderer 各新图。整分支终审：mirror PASS、11 个 refId 全部贯通 5 层、selection 不变量无洞。

文档：`docs/superpowers/specs/2026-06-22-scenario-aware-ai-reports-design.md`、`docs/superpowers/plans/2026-06-22-scenario-aware-ai-reports.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)