### PR TITLE
feat: latency-distribution CDF figure in compare reports (Phase 2)

### DIFF
--- a/apps/api/src/modules/saved-compares/compare-synthesize.service.spec.ts
+++ b/apps/api/src/modules/saved-compares/compare-synthesize.service.spec.ts
@@ -80,6 +80,7 @@ vi.mock("../insights/llm-client.js", () => ({
 }));
 
 import { PrismaService } from "../../database/prisma.service.js";
+import { BenchmarkChartsService } from "../benchmark/benchmark-charts.service.js";
 import { LlmJudgeService } from "../llm-judge/llm-judge.service.js";
 import { CompareSynthesizeService } from "./compare-synthesize.service.js";
 import { buildSystemPrompt } from "./prompts.js";
@@ -104,6 +105,7 @@ describe("CompareSynthesizeService", () => {
       providers: [
         CompareSynthesizeService,
         SavedComparesService,
+        BenchmarkChartsService,
         PrismaService,
         {
           provide: ConfigService,

--- a/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
+++ b/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
@@ -120,7 +120,11 @@ export class CompareSynthesizeService {
     const available = availableFigureRefIds(
       sc.benchmarks
         .filter((b) => !b.missing)
-        .map((b) => ({ summaryMetrics: b.summaryMetrics, serverMetrics: b.serverMetrics, hasLatencyCdf: !!b.latencyCdf?.samples?.length })),
+        .map((b) => ({
+          summaryMetrics: b.summaryMetrics,
+          serverMetrics: b.serverMetrics,
+          hasLatencyCdf: !!b.latencyCdf?.samples?.length,
+        })),
     );
     if (!available.has("stage-bars-prefix-cache-hit")) return figures;
     if (figures.some((f) => f.refId === "stage-bars-prefix-cache-hit")) return figures;
@@ -320,7 +324,11 @@ export class CompareSynthesizeService {
     const available = availableFigureRefIds(
       sc.benchmarks
         .filter((b) => !b.missing)
-        .map((b) => ({ summaryMetrics: b.summaryMetrics, serverMetrics: b.serverMetrics, hasLatencyCdf: !!b.latencyCdf?.samples?.length })),
+        .map((b) => ({
+          summaryMetrics: b.summaryMetrics,
+          serverMetrics: b.serverMetrics,
+          hasLatencyCdf: !!b.latencyCdf?.samples?.length,
+        })),
     );
     const preferred = scenarioData.preferredFigures.filter((r) => available.has(r));
     const offered = preferred.length > 0 ? preferred : [...available];

--- a/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
+++ b/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
@@ -120,7 +120,7 @@ export class CompareSynthesizeService {
     const available = availableFigureRefIds(
       sc.benchmarks
         .filter((b) => !b.missing)
-        .map((b) => ({ summaryMetrics: b.summaryMetrics, serverMetrics: b.serverMetrics, hasLatencyCdf: !!b.latencyCdf })),
+        .map((b) => ({ summaryMetrics: b.summaryMetrics, serverMetrics: b.serverMetrics, hasLatencyCdf: !!b.latencyCdf?.samples?.length })),
     );
     if (!available.has("stage-bars-prefix-cache-hit")) return figures;
     if (figures.some((f) => f.refId === "stage-bars-prefix-cache-hit")) return figures;
@@ -320,7 +320,7 @@ export class CompareSynthesizeService {
     const available = availableFigureRefIds(
       sc.benchmarks
         .filter((b) => !b.missing)
-        .map((b) => ({ summaryMetrics: b.summaryMetrics, serverMetrics: b.serverMetrics, hasLatencyCdf: !!b.latencyCdf })),
+        .map((b) => ({ summaryMetrics: b.summaryMetrics, serverMetrics: b.serverMetrics, hasLatencyCdf: !!b.latencyCdf?.samples?.length })),
     );
     const preferred = scenarioData.preferredFigures.filter((r) => available.has(r));
     const offered = preferred.length > 0 ? preferred : [...available];

--- a/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
+++ b/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
@@ -120,7 +120,7 @@ export class CompareSynthesizeService {
     const available = availableFigureRefIds(
       sc.benchmarks
         .filter((b) => !b.missing)
-        .map((b) => ({ summaryMetrics: b.summaryMetrics, serverMetrics: b.serverMetrics })),
+        .map((b) => ({ summaryMetrics: b.summaryMetrics, serverMetrics: b.serverMetrics, hasLatencyCdf: !!b.latencyCdf })),
     );
     if (!available.has("stage-bars-prefix-cache-hit")) return figures;
     if (figures.some((f) => f.refId === "stage-bars-prefix-cache-hit")) return figures;
@@ -320,7 +320,7 @@ export class CompareSynthesizeService {
     const available = availableFigureRefIds(
       sc.benchmarks
         .filter((b) => !b.missing)
-        .map((b) => ({ summaryMetrics: b.summaryMetrics, serverMetrics: b.serverMetrics })),
+        .map((b) => ({ summaryMetrics: b.summaryMetrics, serverMetrics: b.serverMetrics, hasLatencyCdf: !!b.latencyCdf })),
     );
     const preferred = scenarioData.preferredFigures.filter((r) => available.has(r));
     const offered = preferred.length > 0 ? preferred : [...available];

--- a/apps/api/src/modules/saved-compares/metrics.spec.ts
+++ b/apps/api/src/modules/saved-compares/metrics.spec.ts
@@ -45,6 +45,25 @@ it("does not offer it without a curve", () => {
   expect(set.has("throughput-vs-concurrency")).toBe(false);
 });
 
+it("offers latency-distribution when >=2 runs each carry a CDF", () => {
+  const set = availableFigureRefIds([
+    { summaryMetrics: null, serverMetrics: null, hasLatencyCdf: true },
+    { summaryMetrics: null, serverMetrics: null, hasLatencyCdf: true },
+  ]);
+  expect(set.has("latency-distribution")).toBe(true);
+});
+it("does not offer latency-distribution if any run lacks a CDF", () => {
+  const set = availableFigureRefIds([
+    { summaryMetrics: null, serverMetrics: null, hasLatencyCdf: true },
+    { summaryMetrics: null, serverMetrics: null, hasLatencyCdf: false },
+  ]);
+  expect(set.has("latency-distribution")).toBe(false);
+});
+it("does not offer latency-distribution for a single run", () => {
+  const set = availableFigureRefIds([{ summaryMetrics: null, serverMetrics: null, hasLatencyCdf: true }]);
+  expect(set.has("latency-distribution")).toBe(false);
+});
+
 describe("readCapacityCurve", () => {
   it("returns the curve when present and non-empty", () => {
     const m = { data: { capacityCurve: [{ concurrency: 4, rps: 30, e2eP95Ms: 500 }] } };

--- a/apps/api/src/modules/saved-compares/metrics.spec.ts
+++ b/apps/api/src/modules/saved-compares/metrics.spec.ts
@@ -60,7 +60,9 @@ it("does not offer latency-distribution if any run lacks a CDF", () => {
   expect(set.has("latency-distribution")).toBe(false);
 });
 it("does not offer latency-distribution for a single run", () => {
-  const set = availableFigureRefIds([{ summaryMetrics: null, serverMetrics: null, hasLatencyCdf: true }]);
+  const set = availableFigureRefIds([
+    { summaryMetrics: null, serverMetrics: null, hasLatencyCdf: true },
+  ]);
   expect(set.has("latency-distribution")).toBe(false);
 });
 

--- a/apps/api/src/modules/saved-compares/metrics.ts
+++ b/apps/api/src/modules/saved-compares/metrics.ts
@@ -103,6 +103,8 @@ export function readCapacityCurve(summaryMetrics: unknown): CapacityPoint[] | nu
 export interface RunMetricBlobs {
   summaryMetrics: unknown;
   serverMetrics?: unknown;
+  /** True when the run carries pre-computed latency CDF samples (guidellm/vegeta). */
+  hasLatencyCdf?: boolean;
 }
 
 /**
@@ -138,6 +140,9 @@ export function availableFigureRefIds(runs: RunMetricBlobs[]): Set<FigureRefId> 
   }
   if (runs.some((r) => readCapacityCurve(r.summaryMetrics) !== null)) {
     out.add("throughput-vs-concurrency");
+  }
+  if (runs.length >= 2 && runs.every((r) => r.hasLatencyCdf)) {
+    out.add("latency-distribution");
   }
   out.add("compare-grid");
   return out;

--- a/apps/api/src/modules/saved-compares/prompts.ts
+++ b/apps/api/src/modules/saved-compares/prompts.ts
@@ -34,7 +34,7 @@ interface Narrative {
   ];                     // exactly 6 sections in this order
   figures: Array<{
     id: string;
-    refId: "stage-bars-throughput" | "stage-bars-error-rate" | "stage-bars-ttft-p95" | "stage-bars-e2e-p95" | "stage-bars-prefix-cache-hit" | "stage-bars-top-pod-share" | "pod-traffic-distribution" | "pod-hit-rate" | "cold-warm-delta" | "throughput-vs-concurrency" | "compare-grid";
+    refId: "stage-bars-throughput" | "stage-bars-error-rate" | "stage-bars-ttft-p95" | "stage-bars-e2e-p95" | "stage-bars-prefix-cache-hit" | "stage-bars-top-pod-share" | "pod-traffic-distribution" | "pod-hit-rate" | "cold-warm-delta" | "throughput-vs-concurrency" | "latency-distribution" | "compare-grid";
     caption: string;
     anchorSection?: "summary" | "scope" | "method" | "results" | "caveats" | "advice";
   }>;

--- a/apps/api/src/modules/saved-compares/report-scenarios/gateway.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/gateway.ts
@@ -11,7 +11,7 @@ const EN = `This is a gateway / HTTP-layer load test (gateway, vegeta).
 function assemble(_sc: HydratedSavedCompare): ScenarioData {
   return {
     promptBlock: "",
-    preferredFigures: ["stage-bars-throughput", "stage-bars-e2e-p95", "stage-bars-error-rate"],
+    preferredFigures: ["stage-bars-throughput", "stage-bars-e2e-p95", "latency-distribution", "stage-bars-error-rate"],
   };
 }
 export const gatewayProfile: ReportScenarioProfile = {

--- a/apps/api/src/modules/saved-compares/report-scenarios/gateway.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/gateway.ts
@@ -11,7 +11,12 @@ const EN = `This is a gateway / HTTP-layer load test (gateway, vegeta).
 function assemble(_sc: HydratedSavedCompare): ScenarioData {
   return {
     promptBlock: "",
-    preferredFigures: ["stage-bars-throughput", "stage-bars-e2e-p95", "latency-distribution", "stage-bars-error-rate"],
+    preferredFigures: [
+      "stage-bars-throughput",
+      "stage-bars-e2e-p95",
+      "latency-distribution",
+      "stage-bars-error-rate",
+    ],
   };
 }
 export const gatewayProfile: ReportScenarioProfile = {

--- a/apps/api/src/modules/saved-compares/report-scenarios/inference.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/inference.ts
@@ -23,7 +23,12 @@ function makeProfile(multi: boolean): ReportScenarioProfile {
       promptBlock: "",
       preferredFigures: multi
         ? ["compare-grid", "stage-bars-throughput", "stage-bars-ttft-p95", "latency-distribution"]
-        : ["stage-bars-ttft-p95", "stage-bars-e2e-p95", "stage-bars-throughput", "latency-distribution"],
+        : [
+            "stage-bars-ttft-p95",
+            "stage-bars-e2e-p95",
+            "stage-bars-throughput",
+            "latency-distribution",
+          ],
     }),
   };
 }

--- a/apps/api/src/modules/saved-compares/report-scenarios/inference.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/inference.ts
@@ -22,8 +22,8 @@ function makeProfile(multi: boolean): ReportScenarioProfile {
     dataAssembly: (_sc: HydratedSavedCompare): ScenarioData => ({
       promptBlock: "",
       preferredFigures: multi
-        ? ["compare-grid", "stage-bars-throughput", "stage-bars-ttft-p95"]
-        : ["stage-bars-ttft-p95", "stage-bars-e2e-p95", "stage-bars-throughput"],
+        ? ["compare-grid", "stage-bars-throughput", "stage-bars-ttft-p95", "latency-distribution"]
+        : ["stage-bars-ttft-p95", "stage-bars-e2e-p95", "stage-bars-throughput", "latency-distribution"],
     }),
   };
 }

--- a/apps/api/src/modules/saved-compares/saved-compares.module.ts
+++ b/apps/api/src/modules/saved-compares/saved-compares.module.ts
@@ -1,7 +1,7 @@
 import { Module } from "@nestjs/common";
 import { DatabaseModule } from "../../database/database.module.js";
-import { LlmJudgeModule } from "../llm-judge/llm-judge.module.js";
 import { BenchmarkChartsService } from "../benchmark/benchmark-charts.service.js";
+import { LlmJudgeModule } from "../llm-judge/llm-judge.module.js";
 import { CompareSynthesizeService } from "./compare-synthesize.service.js";
 import { SavedComparesController } from "./saved-compares.controller.js";
 import { SavedComparesService } from "./saved-compares.service.js";

--- a/apps/api/src/modules/saved-compares/saved-compares.module.ts
+++ b/apps/api/src/modules/saved-compares/saved-compares.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 import { DatabaseModule } from "../../database/database.module.js";
 import { LlmJudgeModule } from "../llm-judge/llm-judge.module.js";
+import { BenchmarkChartsService } from "../benchmark/benchmark-charts.service.js";
 import { CompareSynthesizeService } from "./compare-synthesize.service.js";
 import { SavedComparesController } from "./saved-compares.controller.js";
 import { SavedComparesService } from "./saved-compares.service.js";
@@ -8,7 +9,7 @@ import { SavedComparesService } from "./saved-compares.service.js";
 @Module({
   imports: [DatabaseModule, LlmJudgeModule],
   controllers: [SavedComparesController],
-  providers: [SavedComparesService, CompareSynthesizeService],
+  providers: [SavedComparesService, CompareSynthesizeService, BenchmarkChartsService],
   exports: [SavedComparesService, CompareSynthesizeService],
 })
 export class SavedComparesModule {}

--- a/apps/api/src/modules/saved-compares/saved-compares.service.spec.ts
+++ b/apps/api/src/modules/saved-compares/saved-compares.service.spec.ts
@@ -4,7 +4,11 @@ import { Test } from "@nestjs/testing";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { PrismaService } from "../../database/prisma.service.js";
 import { BenchmarkChartsService } from "../benchmark/benchmark-charts.service.js";
-import { deriveCompareDims, downsampleSamples, SavedComparesService } from "./saved-compares.service.js";
+import {
+  deriveCompareDims,
+  downsampleSamples,
+  SavedComparesService,
+} from "./saved-compares.service.js";
 
 describe("downsampleSamples", () => {
   it("returns the same length when at or below cap", () => {

--- a/apps/api/src/modules/saved-compares/saved-compares.service.spec.ts
+++ b/apps/api/src/modules/saved-compares/saved-compares.service.spec.ts
@@ -29,6 +29,12 @@ describe("downsampleSamples", () => {
     expect(result[0]).toBe(arr[0]);
   });
 
+  it("last element matches original last (preserves tail latency)", () => {
+    const arr = Array.from({ length: 5000 }, (_, i) => i);
+    const result = downsampleSamples(arr, 1500);
+    expect(result[result.length - 1]).toBe(arr[arr.length - 1]);
+  });
+
   it("result is monotonic non-decreasing", () => {
     const arr = Array.from({ length: 5000 }, (_, i) => i);
     const result = downsampleSamples(arr, 1500);

--- a/apps/api/src/modules/saved-compares/saved-compares.service.spec.ts
+++ b/apps/api/src/modules/saved-compares/saved-compares.service.spec.ts
@@ -3,7 +3,36 @@ import type { TestingModule } from "@nestjs/testing";
 import { Test } from "@nestjs/testing";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { PrismaService } from "../../database/prisma.service.js";
-import { deriveCompareDims, SavedComparesService } from "./saved-compares.service.js";
+import { BenchmarkChartsService } from "../benchmark/benchmark-charts.service.js";
+import { deriveCompareDims, downsampleSamples, SavedComparesService } from "./saved-compares.service.js";
+
+describe("downsampleSamples", () => {
+  it("returns the same length when at or below cap", () => {
+    const arr = Array.from({ length: 10 }, (_, i) => i);
+    const result = downsampleSamples(arr, 1500);
+    expect(result).toHaveLength(10);
+  });
+
+  it("returns exactly cap elements when above cap", () => {
+    const arr = Array.from({ length: 5000 }, (_, i) => i);
+    const result = downsampleSamples(arr, 1500);
+    expect(result).toHaveLength(1500);
+  });
+
+  it("first element matches original first", () => {
+    const arr = Array.from({ length: 5000 }, (_, i) => i);
+    const result = downsampleSamples(arr, 1500);
+    expect(result[0]).toBe(arr[0]);
+  });
+
+  it("result is monotonic non-decreasing", () => {
+    const arr = Array.from({ length: 5000 }, (_, i) => i);
+    const result = downsampleSamples(arr, 1500);
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i]).toBeGreaterThanOrEqual(result[i - 1]);
+    }
+  });
+});
 
 describe("deriveCompareDims", () => {
   it("returns the shared dims when homogeneous", () => {
@@ -47,6 +76,7 @@ describe("SavedComparesService", () => {
     mod = await Test.createTestingModule({
       providers: [
         SavedComparesService,
+        BenchmarkChartsService,
         PrismaService,
         {
           provide: ConfigService,

--- a/apps/api/src/modules/saved-compares/saved-compares.service.ts
+++ b/apps/api/src/modules/saved-compares/saved-compares.service.ts
@@ -9,10 +9,24 @@ import type {
 import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
 import { Prisma } from "@prisma/client";
 import { PrismaService } from "../../database/prisma.service.js";
+import { BenchmarkChartsService } from "../benchmark/benchmark-charts.service.js";
+
+const CDF_SAMPLE_CAP = 1500;
+/** Evenly downsample to at most `cap` points — preserves CDF shape, caps payload. */
+export function downsampleSamples(samples: number[], cap = CDF_SAMPLE_CAP): number[] {
+  if (samples.length <= cap) return samples;
+  const step = samples.length / cap;
+  const out: number[] = [];
+  for (let i = 0; i < cap; i++) out.push(samples[Math.floor(i * step)]);
+  return out;
+}
 
 @Injectable()
 export class SavedComparesService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly charts: BenchmarkChartsService,
+  ) {}
 
   private serialize(row: {
     id: string;
@@ -123,6 +137,15 @@ export class SavedComparesService {
         serverMetrics: b.serverMetrics,
         params: b.params,
         createdAt: b.createdAt.toISOString(),
+        latencyCdf: (() => {
+          const charts = this.charts.extract({
+            id: b.id,
+            tool: b.tool,
+            status: b.status,
+            rawOutput: b.rawOutput as Record<string, unknown> | null,
+          });
+          return charts.latencyCdf ? { samples: downsampleSamples(charts.latencyCdf.samples) } : null;
+        })(),
       };
     });
 

--- a/apps/api/src/modules/saved-compares/saved-compares.service.ts
+++ b/apps/api/src/modules/saved-compares/saved-compares.service.ts
@@ -12,12 +12,17 @@ import { PrismaService } from "../../database/prisma.service.js";
 import { BenchmarkChartsService } from "../benchmark/benchmark-charts.service.js";
 
 const CDF_SAMPLE_CAP = 1500;
-/** Evenly downsample to at most `cap` points — preserves CDF shape, caps payload. */
+/** Evenly downsample to at most `cap` points — preserves CDF shape, caps payload.
+ * Uses an endpoint-inclusive step so both the first (min) and last (max/p100)
+ * samples survive: tail latency is the whole point of a latency CDF. */
 export function downsampleSamples(samples: number[], cap = CDF_SAMPLE_CAP): number[] {
   if (samples.length <= cap) return samples;
-  const step = samples.length / cap;
+  if (cap <= 1) return samples.slice(0, cap);
+  const step = (samples.length - 1) / (cap - 1);
   const out: number[] = [];
-  for (let i = 0; i < cap; i++) out.push(samples[Math.floor(i * step)]);
+  for (let i = 0; i < cap; i++) {
+    out.push(samples[Math.min(Math.floor(i * step), samples.length - 1)]);
+  }
   return out;
 }
 

--- a/apps/api/src/modules/saved-compares/saved-compares.service.ts
+++ b/apps/api/src/modules/saved-compares/saved-compares.service.ts
@@ -144,7 +144,9 @@ export class SavedComparesService {
             status: b.status,
             rawOutput: b.rawOutput as Record<string, unknown> | null,
           });
-          return charts.latencyCdf ? { samples: downsampleSamples(charts.latencyCdf.samples) } : null;
+          return charts.latencyCdf
+            ? { samples: downsampleSamples(charts.latencyCdf.samples) }
+            : null;
         })(),
       };
     });

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.test.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.test.tsx
@@ -51,6 +51,27 @@ function makeRun(id: string, stageLabel: string, withPods = false): ReportRun {
   };
 }
 
+function makeRunWithCdf(id: string, stageLabel: string, samples: number[]): ReportRun {
+  return {
+    id,
+    stageLabel,
+    tool: "guidellm",
+    scenario: "t2-deep",
+    summaryMetrics: guidellmMetrics(),
+    serverMetrics: null,
+    benchmark: {
+      id,
+      name: `Benchmark ${stageLabel}`,
+      tool: "guidellm",
+      scenario: "t2-deep",
+      summaryMetrics: guidellmMetrics(),
+      serverMetrics: null,
+      latencyCdf: { samples },
+    },
+    paramsSummary: { concurrency: 4 },
+  };
+}
+
 const runs: ReportRun[] = [makeRun("run-a", "OFF", true), makeRun("run-b", "ON", true)];
 
 describe("FigureRenderer", () => {
@@ -147,6 +168,25 @@ describe("FigureRenderer", () => {
     // The placeholder text must be absent — the run carries a valid capacityCurve.
     expect(screen.queryByText(/data unavailable/i)).not.toBeInTheDocument();
     // The figure body should contain the chart (rendered as the echart stub).
+    expect(screen.getByTestId("echart")).toBeInTheDocument();
+  });
+
+  it("renders latency-distribution CDF overlay WITHOUT the data-unavailable placeholder", () => {
+    const runsWithCdf: ReportRun[] = [
+      makeRunWithCdf("cdf-run-a", "OFF", [10, 20, 30, 40]),
+      makeRunWithCdf("cdf-run-b", "ON", [15, 25, 35, 45]),
+    ];
+    render(
+      <FigureRenderer
+        refId="latency-distribution"
+        runs={runsWithCdf}
+        caption="Latency CDF by stage"
+        figureNumber={6}
+      />,
+    );
+    // The placeholder text must be absent — both runs carry latencyCdf.
+    expect(screen.queryByText(/data unavailable/i)).not.toBeInTheDocument();
+    // The LatencyCDF component renders an ECharts canvas (stubbed as data-testid="echart").
     expect(screen.getByTestId("echart")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
@@ -112,7 +112,7 @@ export const FigureRenderer = memo(function FigureRenderer({
     runs.map((r) => ({
       summaryMetrics: r.summaryMetrics,
       serverMetrics: r.benchmark?.serverMetrics,
-      hasLatencyCdf: !!r.benchmark?.latencyCdf,
+      hasLatencyCdf: !!r.benchmark?.latencyCdf?.samples?.length,
     })),
   );
   if (!available.has(refId)) {

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
@@ -1,6 +1,7 @@
 import type { FigureRefId } from "@modeldoctor/contracts";
 import { memo } from "react";
 import { assignRunColors } from "@/components/charts/_shared";
+import { LatencyCDF } from "@/components/charts/LatencyCDF";
 import { PodDistributionChart } from "@/components/charts/PodDistributionChart";
 import {
   StageBarChart,
@@ -111,6 +112,7 @@ export const FigureRenderer = memo(function FigureRenderer({
     runs.map((r) => ({
       summaryMetrics: r.summaryMetrics,
       serverMetrics: r.benchmark?.serverMetrics,
+      hasLatencyCdf: !!r.benchmark?.latencyCdf,
     })),
   );
   if (!available.has(refId)) {
@@ -296,6 +298,12 @@ export const FigureRenderer = memo(function FigureRenderer({
         points: (curve ?? []).map((p) => ({ concurrency: p.concurrency, rps: p.rps })),
       }));
     chart = <ThroughputConcurrencyChart title="Throughput vs concurrency" series={series} />;
+  } else if (refId === "latency-distribution") {
+    const series = summaries
+      .map(({ r }) => ({ r, cdf: r.benchmark?.latencyCdf ?? null }))
+      .filter((x) => x.cdf && x.cdf.samples.length > 0)
+      .map(({ r, cdf }) => ({ runId: r.id, runLabel: r.stageLabel, samples: cdf!.samples }));
+    chart = <LatencyCDF ariaLabel="Latency CDF by stage" series={series} colorMap={colorMap} />;
   } else if (refId === "cold-warm-delta") {
     chart = <ColdWarmDeltaTable runs={runs} baselineId={baselineId} />;
   } else if (refId === "compare-grid") {

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
@@ -299,10 +299,12 @@ export const FigureRenderer = memo(function FigureRenderer({
       }));
     chart = <ThroughputConcurrencyChart title="Throughput vs concurrency" series={series} />;
   } else if (refId === "latency-distribution") {
-    const series = summaries
-      .map(({ r }) => ({ r, cdf: r.benchmark?.latencyCdf ?? null }))
-      .filter((x) => x.cdf && x.cdf.samples.length > 0)
-      .map(({ r, cdf }) => ({ runId: r.id, runLabel: r.stageLabel, samples: cdf!.samples }));
+    const series = summaries.flatMap(({ r }) => {
+      const samples = r.benchmark?.latencyCdf?.samples;
+      return samples && samples.length > 0
+        ? [{ runId: r.id, runLabel: r.stageLabel, samples }]
+        : [];
+    });
     chart = <LatencyCDF ariaLabel="Latency CDF by stage" series={series} colorMap={colorMap} />;
   } else if (refId === "cold-warm-delta") {
     chart = <ColdWarmDeltaTable runs={runs} baselineId={baselineId} />;

--- a/apps/web/src/features/benchmarks/compare/ReportSections.tsx
+++ b/apps/web/src/features/benchmarks/compare/ReportSections.tsx
@@ -50,6 +50,7 @@ export interface ReportBenchmarkSnapshot {
   scenario: string;
   summaryMetrics: unknown;
   serverMetrics: unknown;
+  latencyCdf?: { samples: number[] } | null;
 }
 
 export interface ReportRun extends StageRun {

--- a/apps/web/src/features/benchmarks/compare/client-metrics.ts
+++ b/apps/web/src/features/benchmarks/compare/client-metrics.ts
@@ -32,6 +32,8 @@ export function readCapacityCurve(summaryMetrics: unknown): CapacityPoint[] | nu
 export interface RunMetricBlobs {
   summaryMetrics: unknown;
   serverMetrics?: unknown;
+  /** True when the run carries pre-computed latency CDF samples (guidellm/vegeta). */
+  hasLatencyCdf?: boolean;
 }
 
 /**
@@ -166,6 +168,9 @@ export function availableFigureRefIds(runs: RunMetricBlobs[]): Set<FigureRefId> 
   // `apps/api/src/modules/saved-compares/metrics.ts#availableFigureRefIds`.
   if (runs.some((r) => readCapacityCurve(r.summaryMetrics) !== null)) {
     out.add("throughput-vs-concurrency");
+  }
+  if (runs.length >= 2 && runs.every((r) => r.hasLatencyCdf)) {
+    out.add("latency-distribution");
   }
   // compare-grid only needs any of throughput/err/ttft/e2e — always available
   // when there's at least one summary; degrades cell-by-cell.

--- a/apps/web/src/features/benchmarks/compare/to-report-runs.ts
+++ b/apps/web/src/features/benchmarks/compare/to-report-runs.ts
@@ -46,6 +46,7 @@ export function toReportRuns(benchmarks: HydratedBenchmarkRef[]): ReportRun[] {
           scenario: b.scenario ?? "",
           summaryMetrics: b.summaryMetrics,
           serverMetrics: b.serverMetrics ?? null,
+          latencyCdf: b.latencyCdf ?? null,
         },
     paramsSummary: extractParamsSummary(b.params),
   }));

--- a/docs/superpowers/plans/2026-06-22-latency-distribution-figure.md
+++ b/docs/superpowers/plans/2026-06-22-latency-distribution-figure.md
@@ -1,0 +1,144 @@
+# Latency Distribution Figure (Phase 2 — slice 1) — Implementation Plan
+
+> Executes via superpowers:subagent-driven-development. Checkbox steps.
+
+**Goal:** Add a `latency-distribution` figure (multi-run e2e latency **CDF overlay**) to the SavedCompare deep report, for guidellm/vegeta-based scenarios (inference, gateway).
+
+**Architecture (Approach A — server pre-compute):** `FigureRenderer` is a pure `memo` component and cannot fetch, so distribution data is computed server-side and shipped with the hydrated compare. `getHydrated` already loads each benchmark's `rawOutput`; we call the existing pure `BenchmarkChartsService.extract()` per non-missing benchmark and attach the parsed CDF samples to the hydrated run (downsampled to cap payload). The figure reuses the existing `LatencyCDF` component (already does colored multi-run overlay). **No LLM-prompt data change** — `latency-distribution` is a visual figure; the model only references the refId, gated by availability.
+
+**Tool gating is automatic:** a compare is same-tool (Phase-1 invariant), so `extract()` yields a CDF for all runs (guidellm/vegeta) or none (evalscope/aiperf). Availability requires *every* non-missing run to carry a CDF.
+
+**Worktree:** `/Users/fangyong/vllm/modeldoctor/latency-dist` on `feat/latency-distribution-figure` (set up: deps + .env + prisma generate + build already done).
+
+**Decided:** CDF overlay (reuse `LatencyCDF`), e2e latency only (no TTFT histogram this slice). Downsample cap = 1500 samples/run.
+
+**Key existing pieces:**
+- `apps/api/src/modules/benchmark/benchmark-charts.service.ts` — `BenchmarkChartsService.extract({id,tool,status,rawOutput}) → { latencyCdf: {samples}|null, ttftHistogram: {buckets}|null }`. Pure; guidellm/vegeta only.
+- `packages/contracts/src/benchmark.ts` — `benchmarkChartsResponseSchema`, `BenchmarkChartsResponse`.
+- `apps/web/src/components/charts/LatencyCDF.tsx` — props include `series: {runId, runLabel, samples}[]` (multi-run overlay) + `ariaLabel`, `loading`.
+- `apps/api/src/modules/saved-compares/saved-compares.service.ts` — `getHydrated` builds `HydratedBenchmarkRef[]` from `prisma.benchmark.findMany` (rawOutput already loaded).
+- Mirror availability: `apps/api/.../metrics.ts` + `apps/web/.../compare/client-metrics.ts`.
+- `apps/web/.../compare/to-report-runs.ts` — maps `HydratedBenchmarkRef → ReportRun` (`ReportBenchmarkSnapshot`).
+- `apps/web/.../compare/FigureRenderer.tsx` — pure memo; render branch per refId.
+
+---
+
+## Task L1: contract — refId + carry CDF on hydrated run
+
+**Files:** `packages/contracts/src/saved-compares/compare-narrative.ts`, `packages/contracts/src/saved-compares/saved-compares.ts`; test `packages/contracts/src/saved-compares/compare-narrative.spec.ts`.
+
+- [ ] **Step 1** — In `figureRefIdSchema` add `"latency-distribution"` (keep all existing).
+- [ ] **Step 2** — In `saved-compares.ts`, add an optional field to `HydratedBenchmarkRef`:
+```ts
+  /** Pre-computed latency distribution (e2e CDF samples, ms) for guidellm/vegeta
+   * runs — server attaches via BenchmarkChartsService so the pure FigureRenderer
+   * can draw it without fetching. Null/absent when the tool carries no samples. */
+  latencyCdf?: { samples: number[] } | null;
+```
+- [ ] **Step 3** — Add to `compare-narrative.spec.ts`: `figureRefIdSchema.parse("latency-distribution")` returns it.
+- [ ] **Step 4** — `pnpm -F @modeldoctor/contracts test -- compare-narrative.spec && pnpm -F @modeldoctor/contracts build`.
+- [ ] **Step 5** — Commit: `feat(contracts): latency-distribution refId + latencyCdf on hydrated run`.
+
+## Task L2: server — attach CDF in getHydrated
+
+**Files:** `apps/api/src/modules/saved-compares/saved-compares.service.ts`, `apps/api/src/modules/saved-compares/saved-compares.module.ts` (wire `BenchmarkChartsService`); test `saved-compares.service.spec.ts`.
+
+- [ ] **Step 1** — READ `benchmark-charts.service.ts` (the `extract` signature + its Nest module/export) and `saved-compares.module.ts`. Ensure `BenchmarkChartsService` is providable to `SavedComparesService` (import its module or add it to providers — follow how other cross-module services are wired in this codebase; if it's not exported from its module, export it).
+- [ ] **Step 2** — Inject `BenchmarkChartsService` into `SavedComparesService` constructor.
+- [ ] **Step 3** — In `getHydrated`, for each non-missing benchmark `b`, compute and attach a downsampled CDF. Add a module-scope helper:
+```ts
+const CDF_SAMPLE_CAP = 1500;
+/** Evenly downsample to at most CDF_SAMPLE_CAP points (preserves shape, caps payload). */
+export function downsampleSamples(samples: number[], cap = CDF_SAMPLE_CAP): number[] {
+  if (samples.length <= cap) return samples;
+  const step = samples.length / cap;
+  const out: number[] = [];
+  for (let i = 0; i < cap; i++) out.push(samples[Math.floor(i * step)]);
+  return out;
+}
+```
+In the non-missing branch of the `hydratedBenchmarks` map, after building the ref, set:
+```ts
+      latencyCdf: (() => {
+        const charts = this.charts.extract({ id: b.id, tool: b.tool, status: b.status, rawOutput: b.rawOutput });
+        return charts.latencyCdf ? { samples: downsampleSamples(charts.latencyCdf.samples) } : null;
+      })(),
+```
+(Confirm `b.status` and `b.rawOutput` are present on the Prisma row from `findMany` — they are unless a `select` narrows it; if a `select` exists, add `status`/`rawOutput`.) `extract` is pure/sync, so no await.
+- [ ] **Step 4** — Test in `saved-compares.service.spec.ts`: unit-test `downsampleSamples` (length ≤ cap passes through; > cap returns exactly cap; endpoints preserved-ish). Do not add a DB test.
+- [ ] **Step 5** — `pnpm -F @modeldoctor/api test -- saved-compares.service.spec && pnpm -F @modeldoctor/api build`.
+- [ ] **Step 6** — Commit: `feat(api): attach downsampled latency CDF to hydrated compare runs`.
+
+## Task L3: availability mirror
+
+**Files:** `apps/api/src/modules/saved-compares/metrics.ts`, `apps/web/src/features/benchmarks/compare/client-metrics.ts`; test `apps/api/src/modules/saved-compares/metrics.spec.ts`.
+
+- [ ] **Step 1** — Extend the `RunMetricBlobs` interface (both files, identically) with an optional flag:
+```ts
+  /** True when the run carries pre-computed latency CDF samples (guidellm/vegeta). */
+  hasLatencyCdf?: boolean;
+```
+- [ ] **Step 2** — In `availableFigureRefIds` (both files, identically), add: offer `latency-distribution` when there are ≥2 runs and EVERY run has a CDF:
+```ts
+  if (runs.length >= 2 && runs.every((r) => r.hasLatencyCdf)) {
+    out.add("latency-distribution");
+  }
+```
+- [ ] **Step 3** — Update callers to pass `hasLatencyCdf`:
+  - Server `compare-synthesize.service.ts`: where it builds the `availableFigureRefIds(...)` input from `sc.benchmarks`, add `hasLatencyCdf: !!b.latencyCdf` (both the `buildUserPrompt` call site and `ensurePrefixCacheFigures`' own call site).
+  - Client `FigureRenderer.tsx`: where it calls `availableFigureRefIds(runs.map(...))`, add `hasLatencyCdf: !!r.benchmark?.latencyCdf` (see L4 for the ReportRun field).
+- [ ] **Step 4** — Test in `metrics.spec.ts`: 2 runs both `hasLatencyCdf:true` → set has `latency-distribution`; one missing → absent; single run → absent.
+- [ ] **Step 5** — `pnpm -F @modeldoctor/api test -- saved-compares/metrics.spec && pnpm -F @modeldoctor/web type-check`.
+- [ ] **Step 6** — Commit: `feat: latency-distribution availability (server/client mirror)`.
+
+## Task L4: web render — map CDF through + FigureRenderer branch
+
+**Files:** `apps/web/src/features/benchmarks/compare/to-report-runs.ts`, `apps/web/src/features/benchmarks/compare/FigureRenderer.tsx`; test `FigureRenderer.test.tsx`.
+
+- [ ] **Step 1** — In `to-report-runs.ts`, add `latencyCdf` to `ReportBenchmarkSnapshot` and map it from `HydratedBenchmarkRef`:
+```ts
+  // in ReportBenchmarkSnapshot:
+  latencyCdf?: { samples: number[] } | null;
+  // in the snapshot object built from b:
+  latencyCdf: b.latencyCdf ?? null,
+```
+- [ ] **Step 2** — In `FigureRenderer.tsx`, import `LatencyCDF` from `@/components/charts/LatencyCDF`. Add a render branch:
+```tsx
+  } else if (refId === "latency-distribution") {
+    const series = summaries
+      .map(({ r }) => ({ r, cdf: r.benchmark?.latencyCdf ?? null }))
+      .filter((x) => x.cdf && x.cdf.samples.length > 0)
+      .map(({ r, cdf }) => ({ runId: r.id, runLabel: r.stageLabel, samples: cdf!.samples }));
+    chart = <LatencyCDF ariaLabel="Latency CDF by stage" series={series} />;
+  }
+```
+(Match `LatencyCDF`'s actual prop names — READ the component first; adapt `ariaLabel`/`series`/`loading` to its real signature.)
+- [ ] **Step 3** — Update the `availableFigureRefIds(...)` call in this file to pass `hasLatencyCdf: !!r.benchmark?.latencyCdf` (per L3 Step 3).
+- [ ] **Step 4** — Test in `FigureRenderer.test.tsx`: a 2-run fixture where each `benchmark.latencyCdf = { samples: [...] }` renders `latency-distribution` without the "data unavailable" placeholder.
+- [ ] **Step 5** — `pnpm -F @modeldoctor/web test -- FigureRenderer && pnpm -F @modeldoctor/web build`.
+- [ ] **Step 6** — Commit: `feat(web): latency-distribution CDF-overlay figure`.
+
+## Task L5: profiles + prompt union
+
+**Files:** `apps/api/src/modules/saved-compares/report-scenarios/{gateway,inference}.ts`, `apps/api/src/modules/saved-compares/prompts.ts`; extend `profiles.spec.ts` if useful.
+
+- [ ] **Step 1** — In `gateway.ts` add `"latency-distribution"` to `preferredFigures` (after `stage-bars-e2e-p95`). In `inference.ts` add it to BOTH the multi and single `preferredFigures` arrays (after the ttft/e2e entries).
+- [ ] **Step 2** — In `prompts.ts` `COMMON_SCHEMA_BLOCK`, add `"latency-distribution"` to the `refId` union string (before `compare-grid`).
+- [ ] **Step 3** — `pnpm -F @modeldoctor/api test -- report-scenarios && pnpm -F @modeldoctor/api build`.
+- [ ] **Step 4** — Commit: `feat(api): offer latency-distribution in inference/gateway profiles`.
+
+## Task L6: housekeeping — record Phase-2 verdicts
+
+**Files:** `docs/superpowers/specs/2026-06-22-scenario-aware-ai-reports-design.md` (this branch); + open ONE GitHub issue.
+
+- [ ] **Step 1** — In the spec, update the Phase-2 deferral list with verdicts: `latency-distribution` = DONE (this PR); `aiperf KV field` = tracked (zero-cost when aiperf emits it); `evalscope/aiperf sample histograms` = conditional follow-on (after this, if tools emit samples); `lb traffic-topology` and `lb hit-rate-timeseries` = **WON'T DO for compare reports** with rationale (per-pod distribution already covers the intent; time-series belongs to single-run monitoring, not a comparison deliverable; per-request routing capture fights the self-hosted-OSS thesis).
+- [ ] **Step 2** — Commit: `docs: record Phase-2 verdicts (latency-distribution done; topology/timeseries won't-do)`.
+- [ ] **Step 3** — (controller does this, not a subagent) Open a GitHub issue capturing the remaining tracked/conditional items (aiperf KV field; evalscope/aiperf histograms) so they're not lost.
+
+---
+
+## Final
+- [ ] Whole-workspace `pnpm -r build && pnpm -r lint && pnpm -r test` green.
+- [ ] Final whole-branch review (mirror check; latency-distribution present across enum/prompt/availability/renderer/profile; payload-size sanity).
+- [ ] Push + PR.
+</content>

--- a/docs/superpowers/specs/2026-06-22-scenario-aware-ai-reports-design.md
+++ b/docs/superpowers/specs/2026-06-22-scenario-aware-ai-reports-design.md
@@ -93,12 +93,15 @@ export interface ReportScenarioProfile {
 |---|---|---|
 | `throughput-vs-concurrency` | capacity | 解析 `rawOutput.files.report` 的 guidellm sweep → 新增 `summaryMetrics.capacityCurve[]`（`mapGuidellmRawToReport` 扩展）→ 前端折线图 |
 
-**明确推迟到 Phase 2（不在本期）：**
+**Phase 2 裁决（2026-06-22 复盘后更新）：**
 
-- lb 的 `traffic-topology`（路由拓扑/sticky 验证）——需 request→pod 路由日志，现无。
-- lb 的 `hit-rate-timeseries`——需定时快照，现只存单点。
-- evalscope/aiperf 样本级直方图——需持久化原始样本。
-- aiperf 的 KV cache 字段缺失。
+逐项重新评估「价值」而非仅「可行性」，结论如下：
+
+- ✅ **`latency-distribution`（e2e 延迟 CDF 叠加）—— 已做**（分支 `feat/latency-distribution-figure`）。复用现成的纯函数 `BenchmarkChartsService.extract()`：`getHydrated` 已加载 `rawOutput`，服务端同步解析出 CDF 样本（降采样至 ≤1500 点）挂到每个 hydrated run，前端复用 `LatencyCDF` 多 run 叠加组件渲染（`FigureRenderer` 是纯 memo 组件、不能 fetch，故走服务端预算路线）。接入 inference / gateway profile。
+- ⛔ **lb 的 `traffic-topology`（逐请求路由拓扑/sticky 验证）—— 不做。** Phase 1 的 per-pod 流量分布 + per-pod 命中率已覆盖「流量拓扑感知」的可执行结论（哪些 pod、占比、有无热点）；逐请求 sankey 只是豪华版、不改变判断。且逐请求 pod 归属采集对私有化自托管是侵入式负担，与「易自托管」定位冲突（同否决 C 路线的理由）。除非有客户点名。
+- ⛔ **lb 的 `hit-rate-timeseries`（命中率时序）—— 对对比报告不做。** 它本质是「单次跑测的预热诊断曲线」，属于单 run 监控，不是「对比报告」的一张图；对比报告头条是 OFF vs ON 的稳态命中率差（Phase 1 已有）。将来若做单 run 实时监控，它在那边才有家。
+- 🔵 **evalscope/aiperf 样本级直方图 —— 有条件的跟随项。** 依赖：(a) 这俩工具确实能吐逐请求样本（待确认），(b) latency-distribution 证明有用。条件满足再立项；现不预投入。
+- 🔵 **aiperf 的 KV cache 字段 —— 零成本备忘。** 等 aiperf 版本输出该指标，加一行解析即可；只挂 issue，不立项。
 
 > 按 [[feedback_temp_followups]]：以上每项在对应 GitHub issue 留 follow-up 评论。
 

--- a/packages/contracts/src/saved-compares/compare-narrative.spec.ts
+++ b/packages/contracts/src/saved-compares/compare-narrative.spec.ts
@@ -6,3 +6,7 @@ it("accepts the new phase-1 refIds", () => {
     expect(figureRefIdSchema.parse(r)).toBe(r);
   }
 });
+
+it("accepts the latency-distribution refId", () => {
+  expect(figureRefIdSchema.parse("latency-distribution")).toBe("latency-distribution");
+});

--- a/packages/contracts/src/saved-compares/compare-narrative.ts
+++ b/packages/contracts/src/saved-compares/compare-narrative.ts
@@ -84,6 +84,9 @@ export const figureRefIdSchema = z.enum([
   // Capacity-planning figure — rendered from summaryMetrics.data.capacityCurve
   // (guidellm sweep runs only). Available when any run carries a capacity curve.
   "throughput-vs-concurrency",
+  // Phase-2 figure — rendered from HydratedBenchmarkRef.latencyCdf.samples;
+  // shows the e2e latency CDF across runs for guidellm/vegeta tools.
+  "latency-distribution",
 ]);
 export type FigureRefId = z.infer<typeof figureRefIdSchema>;
 

--- a/packages/contracts/src/saved-compares/saved-compares.ts
+++ b/packages/contracts/src/saved-compares/saved-compares.ts
@@ -90,6 +90,10 @@ export interface HydratedBenchmarkRef {
   /** serverMetrics blob — carries serverMetrics.prefixCache for prefix-cache
    * figures (hit rate / top-pod share) in the compare report. */
   serverMetrics?: unknown;
+  /** Pre-computed latency distribution (e2e CDF samples, ms) for guidellm/vegeta
+   * runs — server attaches via BenchmarkChartsService so the pure FigureRenderer
+   * can draw it without fetching. Null/absent when the tool carries no samples. */
+  latencyCdf?: { samples: number[] } | null;
   params?: unknown;
   createdAt?: string;
 }


### PR DESCRIPTION
## What

给 SavedCompare 深度报告新增 **`latency-distribution` 图**：多 run 的 e2e 延迟 **CDF 叠加**（每个 stage 一条彩色曲线）。这是场景感知报告（#313）规划的 Phase-2 第一刀，也是当初截图诉求里「延迟分布」那一块。

## How — Approach A（服务端预算）

`FigureRenderer` 是纯 `memo` 组件、不能 fetch，所以分布数据在服务端预算后随报告下发：
- `getHydrated` 已加载每个 benchmark 的 `rawOutput`，对每个非缺失 run 同步调用**现成的纯函数** `BenchmarkChartsService.extract()` 解析出 e2e CDF 样本，降采样至 ≤1500 点挂到 hydrated run（`latencyCdf`）。
- 前端复用**现成的** `LatencyCDF` 组件（已支持多 run 彩色叠加），零新增图表逻辑。
- 工具门控自动成立：compare 同工具（#313 不变量），故 guidellm/vegeta 全有样本、evalscope/aiperf 全无；可用性规则要求「≥2 run 且每个 run 都有非空 CDF」。
- **不改 LLM 提示词数据** —— 它是视觉图，模型只引用 refId。接入 inference / gateway profile。

5 层贯通：contract enum → base-prompt refId union → availability（server/client 镜像）→ FigureRenderer 分支 → inference/gateway profile（lb-strategy/capacity/engine-kv-cache 正确不含）。

## Phase-2 其余项裁决（spec 已记录）
- ⛔ lb 逐请求路由拓扑 / 命中率时序：**不做**（per-pod 分布已覆盖意图；逐请求采集与自托管定位冲突；时序属单 run 监控非对比报告）。
- 🔵 evalscope/aiperf 样本直方图、aiperf KV 字段：条件性/零成本备忘，跟踪于 #314。

## 测试 / 验证
- 全工作区 build + lint 通过；测试 contracts 179 / tool-adapters 249 / api 1054 / web 930。
- 新增覆盖：availability 镜像（≥2 + every）、downsample 单测、FigureRenderer CDF 渲染。
- 整分支终审 APPROVE：5 层贯通、mirror PASS、3 个 gate 站点与渲染过滤一致、`extract` 不会在正常行抛错。

Refs #313 · #314. 文档：`docs/superpowers/plans/2026-06-22-latency-distribution-figure.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)