### PR TITLE
fix: AI Diagnostics provider — native Anthropic support + blank API key on edit

### DIFF
--- a/apps/api/prisma/migrations/20260622104440_llm_judge_provider_api_style/migration.sql
+++ b/apps/api/prisma/migrations/20260622104440_llm_judge_provider_api_style/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "llm_judge_providers" ADD COLUMN     "api_style" TEXT NOT NULL DEFAULT 'openai';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -283,6 +283,7 @@ model LlmJudgeProvider {
   baseUrl      String  @map("base_url")
   apiKeyCipher String  @map("api_key_cipher")
   model        String
+  apiStyle     String  @default("openai") @map("api_style")
   enabled      Boolean @default(true)
   isDefault    Boolean @default(false) @map("is_default")
 

--- a/apps/api/src/modules/alerts/explainer.service.ts
+++ b/apps/api/src/modules/alerts/explainer.service.ts
@@ -84,7 +84,12 @@ export class AlertExplainerService {
     let parsed: z.infer<typeof explanationResponseSchema>;
     try {
       const res = await chatCompletion(
-        { baseUrl: judge.baseUrl, apiKey: judge.apiKey, model: judge.model },
+        {
+          baseUrl: judge.baseUrl,
+          apiKey: judge.apiKey,
+          model: judge.model,
+          apiStyle: judge.apiStyle,
+        },
         [
           { role: "system", content: SYS_PROMPT_ZH },
           { role: "user", content: prompt },

--- a/apps/api/src/modules/insights/llm-client.spec.ts
+++ b/apps/api/src/modules/insights/llm-client.spec.ts
@@ -60,6 +60,18 @@ describe("chatCompletion", () => {
     expect(body.temperature).toBeUndefined();
   });
 
+  it("anthropic style returns empty string when content is not an array", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ content: "oops-not-an-array" }),
+    } as any);
+    const r = await chatCompletion(
+      { baseUrl: "https://api.anthropic.com", apiKey: "k", model: "m", apiStyle: "anthropic" },
+      [{ role: "user", content: "x" }],
+    );
+    expect(r.content).toBe("");
+  });
+
   it("anthropic style concatenates only text blocks", async () => {
     fetchMock.mockResolvedValueOnce({
       ok: true,

--- a/apps/api/src/modules/insights/llm-client.spec.ts
+++ b/apps/api/src/modules/insights/llm-client.spec.ts
@@ -28,4 +28,53 @@ describe("chatCompletion", () => {
       chatCompletion({ baseUrl: "https://x", apiKey: "k", model: "m" }, []),
     ).rejects.toThrow(/HTTP 401/);
   });
+
+  it("anthropic style posts to /v1/messages with x-api-key, hoists system, no temperature", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ content: [{ type: "text", text: "pong" }] }),
+    } as any);
+    const r = await chatCompletion(
+      {
+        baseUrl: "https://api.anthropic.com",
+        apiKey: "sk-ant",
+        model: "claude-opus-4-8",
+        apiStyle: "anthropic",
+      },
+      [
+        { role: "system", content: "be terse" },
+        { role: "user", content: "ping" },
+      ],
+    );
+    expect(r.content).toBe("pong");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.anthropic.com/v1/messages");
+    const headers = (init as any).headers;
+    expect(headers["x-api-key"]).toBe("sk-ant");
+    expect(headers["anthropic-version"]).toBe("2023-06-01");
+    expect(headers.authorization).toBeUndefined();
+    const body = JSON.parse((init as any).body);
+    expect(body.system).toBe("be terse");
+    expect(body.messages).toEqual([{ role: "user", content: "ping" }]);
+    expect(body.max_tokens).toBeGreaterThan(0);
+    expect(body.temperature).toBeUndefined();
+  });
+
+  it("anthropic style concatenates only text blocks", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        content: [
+          { type: "thinking", thinking: "" },
+          { type: "text", text: "a" },
+          { type: "text", text: "b" },
+        ],
+      }),
+    } as any);
+    const r = await chatCompletion(
+      { baseUrl: "https://api.anthropic.com", apiKey: "k", model: "m", apiStyle: "anthropic" },
+      [{ role: "user", content: "x" }],
+    );
+    expect(r.content).toBe("ab");
+  });
 });

--- a/apps/api/src/modules/insights/llm-client.ts
+++ b/apps/api/src/modules/insights/llm-client.ts
@@ -5,6 +5,8 @@ export interface LlmClientConfig {
   baseUrl: string;
   apiKey: string;
   model: string;
+  /** Wire protocol. Defaults to "openai" (OpenAI-compatible /chat/completions). */
+  apiStyle?: "openai" | "anthropic";
 }
 
 export interface ChatMessage {
@@ -18,18 +20,34 @@ export interface ChatResponse {
 }
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+// Anthropic requires max_tokens; the 180s caller timeout comfortably covers a
+// non-streaming response of this size on Opus-tier models.
+const ANTHROPIC_DEFAULT_MAX_TOKENS = 16_000;
+const ANTHROPIC_VERSION = "2023-06-01";
+
+interface ChatOptions {
+  timeoutMs?: number;
+  jsonMode?: boolean;
+  signal?: AbortSignal;
+  /** Anthropic-only: caps the response. Ignored on the OpenAI path. */
+  maxTokens?: number;
+}
 
 export async function chatCompletion(
   cfg: LlmClientConfig,
   messages: ChatMessage[],
-  options: { timeoutMs?: number; jsonMode?: boolean; signal?: AbortSignal } = {},
+  options: ChatOptions = {},
 ): Promise<ChatResponse> {
-  const url = `${cfg.baseUrl.replace(/\/$/, "")}/chat/completions`;
   const ctl = new AbortController();
   const timeout = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const timer = wait(timeout).then(() => ctl.abort());
   const onUserAbort = () => ctl.abort();
   options.signal?.addEventListener("abort", onUserAbort);
+
+  const anthropic = cfg.apiStyle === "anthropic";
+  const url = anthropic
+    ? `${cfg.baseUrl.replace(/\/$/, "")}/v1/messages`
+    : `${cfg.baseUrl.replace(/\/$/, "")}/chat/completions`;
 
   const t0 = Date.now();
   let res: Response;
@@ -37,16 +55,24 @@ export async function chatCompletion(
     res = await fetch(url, {
       method: "POST",
       signal: ctl.signal,
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${cfg.apiKey}`,
-      },
-      body: JSON.stringify({
-        model: cfg.model,
-        messages,
-        temperature: 0.2,
-        ...(options.jsonMode ? { response_format: { type: "json_object" } } : {}),
-      }),
+      headers: anthropic
+        ? {
+            "content-type": "application/json",
+            "x-api-key": cfg.apiKey,
+            "anthropic-version": ANTHROPIC_VERSION,
+          }
+        : {
+            "content-type": "application/json",
+            authorization: `Bearer ${cfg.apiKey}`,
+          },
+      body: anthropic
+        ? JSON.stringify(buildAnthropicBody(cfg.model, messages, options.maxTokens))
+        : JSON.stringify({
+            model: cfg.model,
+            messages,
+            temperature: 0.2,
+            ...(options.jsonMode ? { response_format: { type: "json_object" } } : {}),
+          }),
     });
   } finally {
     options.signal?.removeEventListener("abort", onUserAbort);
@@ -58,7 +84,40 @@ export async function chatCompletion(
     const body = await res.text().catch(() => "");
     throw new Error(`LLM HTTP ${res.status}: ${body.slice(0, 500)}`);
   }
+
+  if (anthropic) {
+    const data = (await res.json()) as { content?: Array<{ type?: string; text?: string }> };
+    // Concatenate text blocks; non-text blocks (thinking, tool_use) carry no text.
+    const content = (data.content ?? [])
+      .filter((b) => b.type === "text" && typeof b.text === "string")
+      .map((b) => b.text)
+      .join("");
+    return { content, latencyMs };
+  }
+
   const data = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> };
   const content = data.choices?.[0]?.message?.content ?? "";
   return { content, latencyMs };
+}
+
+/**
+ * Build an Anthropic Messages API body. System messages are hoisted to the
+ * top-level `system` field (Anthropic does not accept a "system" role inside
+ * `messages`). No `temperature` — Opus 4.x rejects sampling params; JSON output
+ * is steered by the prompt, not a response_format flag.
+ */
+function buildAnthropicBody(model: string, messages: ChatMessage[], maxTokens?: number) {
+  const system = messages
+    .filter((m) => m.role === "system")
+    .map((m) => m.content)
+    .join("\n\n");
+  const rest = messages
+    .filter((m) => m.role !== "system")
+    .map((m) => ({ role: m.role, content: m.content }));
+  return {
+    model,
+    max_tokens: maxTokens ?? ANTHROPIC_DEFAULT_MAX_TOKENS,
+    ...(system ? { system } : {}),
+    messages: rest,
+  };
 }

--- a/apps/api/src/modules/insights/llm-client.ts
+++ b/apps/api/src/modules/insights/llm-client.ts
@@ -88,8 +88,10 @@ export async function chatCompletion(
   if (anthropic) {
     const data = (await res.json()) as { content?: Array<{ type?: string; text?: string }> };
     // Concatenate text blocks; non-text blocks (thinking, tool_use) carry no text.
-    const content = (data.content ?? [])
-      .filter((b) => b.type === "text" && typeof b.text === "string")
+    // Guard the shape — a misconfigured gateway could return a non-array body.
+    const blocks = Array.isArray(data.content) ? data.content : [];
+    const content = blocks
+      .filter((b) => b && b.type === "text" && typeof b.text === "string")
       .map((b) => b.text)
       .join("");
     return { content, latencyMs };

--- a/apps/api/src/modules/insights/synthesize.service.ts
+++ b/apps/api/src/modules/insights/synthesize.service.ts
@@ -142,7 +142,12 @@ export class SynthesizeService {
     let raw: string;
     try {
       const r = await chatCompletion(
-        { baseUrl: provider.baseUrl, apiKey: provider.apiKey, model: provider.model },
+        {
+          baseUrl: provider.baseUrl,
+          apiKey: provider.apiKey,
+          model: provider.model,
+          apiStyle: provider.apiStyle,
+        },
         [
           { role: "system", content: systemPrompt(body.locale) },
           { role: "user", content: userPrompt },

--- a/apps/api/src/modules/llm-judge/llm-judge.controller.ts
+++ b/apps/api/src/modules/llm-judge/llm-judge.controller.ts
@@ -111,7 +111,7 @@ export class LlmJudgeController {
     }
     try {
       const r = await chatCompletion(
-        { baseUrl: body.baseUrl, apiKey, model: body.model },
+        { baseUrl: body.baseUrl, apiKey, model: body.model, apiStyle: body.apiStyle },
         [{ role: "user", content: "ping" }],
         { timeoutMs: 10_000 },
       );

--- a/apps/api/src/modules/llm-judge/llm-judge.service.spec.ts
+++ b/apps/api/src/modules/llm-judge/llm-judge.service.spec.ts
@@ -18,11 +18,15 @@ const TEST_KEY_B64 = Buffer.alloc(32, 7).toString("base64");
 const ADMIN: LlmJudgeActor = { sub: "u_admin", isAdmin: true };
 const USER: LlmJudgeActor = { sub: "u_normal", isAdmin: false };
 
-const base = (name: string, over: Partial<{ enabled: boolean; isDefault: boolean }> = {}) => ({
+const base = (
+  name: string,
+  over: Partial<{ enabled: boolean; isDefault: boolean; apiStyle: "openai" | "anthropic" }> = {},
+) => ({
   name,
   baseUrl: "https://api.example.com",
   apiKey: "sk-secret-key",
   model: "gpt-x",
+  apiStyle: "openai" as const,
   enabled: true,
   isDefault: false,
   ...over,

--- a/apps/api/src/modules/llm-judge/llm-judge.service.ts
+++ b/apps/api/src/modules/llm-judge/llm-judge.service.ts
@@ -2,6 +2,7 @@
 import type {
   CreateLlmJudgeProvider,
   ListLlmJudgeProvidersResponse,
+  LlmApiStyle,
   LlmJudgeProviderPublic,
   UpdateLlmJudgeProvider,
 } from "@modeldoctor/contracts";
@@ -24,6 +25,7 @@ export interface DecryptedLlmJudgeProvider {
   baseUrl: string;
   apiKey: string;
   model: string;
+  apiStyle: LlmApiStyle;
   enabled: boolean;
   isDefault: boolean;
 }
@@ -103,6 +105,7 @@ export class LlmJudgeService {
             baseUrl: input.baseUrl,
             apiKeyCipher,
             model: input.model,
+            apiStyle: input.apiStyle ?? "openai",
             enabled,
             isDefault: input.isDefault ?? false,
           },
@@ -128,6 +131,7 @@ export class LlmJudgeService {
     if (input.name !== undefined) data.name = input.name;
     if (input.baseUrl !== undefined) data.baseUrl = input.baseUrl;
     if (input.model !== undefined) data.model = input.model;
+    if (input.apiStyle !== undefined) data.apiStyle = input.apiStyle;
     if (input.apiKey !== undefined) data.apiKeyCipher = encrypt(input.apiKey, this.key);
 
     // Resolve the post-update (isDefault, enabled) pair so we can enforce the
@@ -207,6 +211,7 @@ export class LlmJudgeService {
       baseUrl: row.baseUrl,
       apiKey: decrypt(row.apiKeyCipher, this.key),
       model: row.model,
+      apiStyle: (row.apiStyle as LlmApiStyle) ?? "openai",
       enabled: row.enabled,
       isDefault: row.isDefault,
     };
@@ -222,6 +227,7 @@ export class LlmJudgeService {
       name: row.name,
       baseUrl: row.baseUrl,
       model: row.model,
+      apiStyle: (row.apiStyle as LlmApiStyle) ?? "openai",
       enabled: row.enabled,
       isDefault: row.isDefault,
       apiKeyPreview: row.apiKeyCipher ? makePreview(decrypt(row.apiKeyCipher, this.key)) : "",

--- a/apps/api/src/modules/quality-gate/judges/judges.service.ts
+++ b/apps/api/src/modules/quality-gate/judges/judges.service.ts
@@ -25,7 +25,12 @@ export class JudgesService {
           );
         }
         const result = await chatCompletion(
-          { baseUrl: provider.baseUrl, apiKey: provider.apiKey, model: provider.model },
+          {
+            baseUrl: provider.baseUrl,
+            apiKey: provider.apiKey,
+            model: provider.model,
+            apiStyle: provider.apiStyle,
+          },
           [
             { role: "system", content: input.systemPrompt },
             { role: "user", content: input.userPrompt },

--- a/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
+++ b/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
@@ -168,14 +168,19 @@ export class CompareSynthesizeService {
   }
 
   private async callAndParse(
-    provider: { baseUrl: string; apiKey: string; model: string },
+    provider: { baseUrl: string; apiKey: string; model: string; apiStyle?: "openai" | "anthropic" },
     _locale: "zh-CN" | "en-US",
     messages: ChatMessage[],
   ): Promise<CompareNarrative> {
     let raw: string;
     try {
       const out = await chatCompletion(
-        { baseUrl: provider.baseUrl, apiKey: provider.apiKey, model: provider.model },
+        {
+          baseUrl: provider.baseUrl,
+          apiKey: provider.apiKey,
+          model: provider.model,
+          apiStyle: provider.apiStyle,
+        },
         messages,
         { jsonMode: true, timeoutMs: LLM_TIMEOUT_MS },
       );

--- a/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
+++ b/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
@@ -182,7 +182,9 @@ export class CompareSynthesizeService {
           apiStyle: provider.apiStyle,
         },
         messages,
-        { jsonMode: true, timeoutMs: LLM_TIMEOUT_MS },
+        // maxTokens only applies on the Anthropic path (required there); the
+        // deep report can run long, so give it headroom above the 16k default.
+        { jsonMode: true, timeoutMs: LLM_TIMEOUT_MS, maxTokens: 32_000 },
       );
       raw = out.content;
     } catch (e) {

--- a/apps/web/src/features/llm-judge-providers/ProviderSheet.tsx
+++ b/apps/web/src/features/llm-judge-providers/ProviderSheet.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import type {
   CreateLlmJudgeProvider,
+  LlmApiStyle,
   LlmJudgeProviderPublic,
   UpdateLlmJudgeProvider,
 } from "@modeldoctor/contracts";
@@ -10,6 +11,7 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { z } from "zod";
 import { FormActions } from "@/components/common/form-actions";
 import { FormSection } from "@/components/common/form-section";
 import { Button } from "@/components/ui/button";
@@ -23,6 +25,13 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Sheet, SheetContent, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { ApiError } from "@/lib/api-client";
 import { toastLlmJudgeError } from "./errors";
@@ -32,10 +41,17 @@ interface ProviderInput {
   name: string;
   baseUrl: string;
   model: string;
+  apiStyle: LlmApiStyle;
   apiKey: string;
   enabled: boolean;
   isDefault: boolean;
 }
+
+// Edit-mode resolver: a blank API Key means "keep the saved key", so unlike the
+// create schema (which requires a key) the form must accept an empty string.
+const editFormSchema = updateLlmJudgeProviderSchema.extend({
+  apiKey: z.string().max(500).optional(),
+});
 
 export type ProviderSheetMode =
   | { kind: "create"; initial?: Partial<ProviderInput> }
@@ -51,6 +67,7 @@ const empty: ProviderInput = {
   name: "",
   baseUrl: "",
   model: "",
+  apiStyle: "openai",
   apiKey: "",
   enabled: true,
   isDefault: false,
@@ -61,6 +78,7 @@ function existingToFormValues(p: LlmJudgeProviderPublic): ProviderInput {
     name: p.name,
     baseUrl: p.baseUrl,
     model: p.model,
+    apiStyle: p.apiStyle,
     apiKey: "", // never sent on PATCH unless rotate toggle is on
     enabled: p.enabled,
     isDefault: p.isDefault,
@@ -81,9 +99,7 @@ export function ProviderSheet({ open, onOpenChange, mode }: ProviderSheetProps) 
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   const form = useForm<ProviderInput>({
-    resolver: zodResolver(
-      isEdit ? updateLlmJudgeProviderSchema : createLlmJudgeProviderSchema,
-    ) as never,
+    resolver: zodResolver(isEdit ? editFormSchema : createLlmJudgeProviderSchema) as never,
     mode: "onTouched",
     defaultValues: existing
       ? existingToFormValues(existing)
@@ -125,6 +141,7 @@ export function ProviderSheet({ open, onOpenChange, mode }: ProviderSheetProps) 
           name: values.name,
           baseUrl,
           model: values.model,
+          apiStyle: values.apiStyle,
           enabled: values.enabled,
           isDefault: values.isDefault,
         };
@@ -145,6 +162,7 @@ export function ProviderSheet({ open, onOpenChange, mode }: ProviderSheetProps) 
           name: values.name,
           baseUrl,
           model: values.model,
+          apiStyle: values.apiStyle,
           apiKey: values.apiKey.trim(),
           enabled: values.enabled,
           isDefault: values.isDefault,
@@ -167,6 +185,7 @@ export function ProviderSheet({ open, onOpenChange, mode }: ProviderSheetProps) 
     const baseUrl = baseUrlValue?.trim();
     const model = modelValue?.trim();
     const key = apiKeyValue?.trim();
+    const apiStyle = form.getValues("apiStyle");
     // Need baseUrl + model always. apiKey may be omitted only when editing an
     // existing provider (the saved key is resolved server-side by id).
     if (!baseUrl || !model || (!key && !existing)) {
@@ -177,6 +196,7 @@ export function ProviderSheet({ open, onOpenChange, mode }: ProviderSheetProps) 
       const r = await testMut.mutateAsync({
         baseUrl,
         model,
+        apiStyle,
         ...(key ? { apiKey: key } : {}),
         ...(existing && !key ? { id: existing.id } : {}),
       });
@@ -244,6 +264,35 @@ export function ProviderSheet({ open, onOpenChange, mode }: ProviderSheetProps) 
                     )}
                   />
                 </div>
+
+                <FormField
+                  control={form.control}
+                  name="apiStyle"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel required>{t("sheet.fields.apiStyle.label")}</FormLabel>
+                      <Select value={field.value} onValueChange={field.onChange}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="openai">
+                            {t("sheet.fields.apiStyle.openai")}
+                          </SelectItem>
+                          <SelectItem value="anthropic">
+                            {t("sheet.fields.apiStyle.anthropic")}
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {t("sheet.fields.apiStyle.help")}
+                      </p>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
                 <FormField
                   control={form.control}

--- a/apps/web/src/locales/en-US/llm-judge-providers.json
+++ b/apps/web/src/locales/en-US/llm-judge-providers.json
@@ -36,6 +36,12 @@
       "name": { "label": "Name", "placeholder": "e.g. deepseek-primary" },
       "baseUrl": { "label": "Base URL", "placeholder": "https://api.deepseek.com" },
       "model": { "label": "Model", "placeholder": "deepseek-chat" },
+      "apiStyle": {
+        "label": "API style",
+        "openai": "OpenAI-compatible (/chat/completions)",
+        "anthropic": "Anthropic (/v1/messages)",
+        "help": "OpenAI-compatible covers vLLM / SGLang / MindIE / OpenAI / most gateways. Pick Anthropic only when Base URL points at https://api.anthropic.com."
+      },
       "apiKey": { "label": "API Key", "placeholder": "sk-..." },
       "enabled": {
         "label": "Enabled",

--- a/apps/web/src/locales/zh-CN/llm-judge-providers.json
+++ b/apps/web/src/locales/zh-CN/llm-judge-providers.json
@@ -36,6 +36,12 @@
       "name": { "label": "名称", "placeholder": "例如 deepseek-primary" },
       "baseUrl": { "label": "Base URL", "placeholder": "https://api.deepseek.com" },
       "model": { "label": "模型", "placeholder": "deepseek-chat" },
+      "apiStyle": {
+        "label": "API 风格",
+        "openai": "OpenAI 兼容 (/chat/completions)",
+        "anthropic": "Anthropic (/v1/messages)",
+        "help": "OpenAI 兼容适用于 vLLM / SGLang / MindIE / OpenAI 及大多数网关；仅当 Base URL 指向 https://api.anthropic.com 时选 Anthropic。"
+      },
       "apiKey": { "label": "API Key", "placeholder": "sk-..." },
       "enabled": {
         "label": "启用",

--- a/packages/contracts/src/insights/llm-judge.ts
+++ b/packages/contracts/src/insights/llm-judge.ts
@@ -6,6 +6,16 @@ const modelSchema = z.string().min(1).max(200);
 const apiKeySchema = z.string().min(1).max(500);
 
 /**
+ * Wire protocol the provider speaks. `openai` (default) → OpenAI-compatible
+ * `POST {baseUrl}/chat/completions` with a Bearer key — covers vLLM / SGLang /
+ * MindIE / OpenAI / most gateways. `anthropic` → native Messages API
+ * `POST {baseUrl}/v1/messages` with `x-api-key` + `anthropic-version` headers
+ * (point baseUrl at `https://api.anthropic.com`).
+ */
+export const llmApiStyleSchema = z.enum(["openai", "anthropic"]);
+export type LlmApiStyle = z.infer<typeof llmApiStyleSchema>;
+
+/**
  * Public view of a workspace-wide LLM-judge provider (apiKey omitted, replaced
  * by a masked preview). Multiple providers may exist; at most one is the
  * default. The service guarantees `isDefault === true` implies `enabled === true`.
@@ -15,6 +25,7 @@ export const llmJudgeProviderPublicSchema = z.object({
   name: nameSchema,
   baseUrl: z.string(),
   model: z.string(),
+  apiStyle: llmApiStyleSchema,
   enabled: z.boolean(),
   isDefault: z.boolean(),
   /** Masked key, e.g. "sk-...abcd". Empty string when no key is stored. */
@@ -30,6 +41,8 @@ export const createLlmJudgeProviderSchema = z.object({
   /** Required on create. */
   apiKey: apiKeySchema,
   model: modelSchema,
+  /** Defaults to OpenAI-compatible so existing callers/rows are unaffected. */
+  apiStyle: llmApiStyleSchema.default("openai"),
   enabled: z.boolean().default(true),
   isDefault: z.boolean().default(false),
 });
@@ -53,6 +66,7 @@ export const testLlmJudgeRequestSchema = z.object({
   /** Omit to test using a saved key. When omitted, `id` resolves which row's key to use. */
   apiKey: apiKeySchema.optional(),
   model: z.string().min(1),
+  apiStyle: llmApiStyleSchema.default("openai"),
   /** Existing provider id whose saved key should be used when `apiKey` is omitted. */
   id: z.string().optional(),
 });


### PR DESCRIPTION
修复「Edit AI Diagnostics provider」对话框的两个 bug。

## Bug 1 — Test connection 对 Anthropic 报 404
底层 LLM-judge 客户端只会讲 OpenAI 格式（`POST {baseUrl}/chat/completions` + `Authorization: Bearer`）。填 `https://api.anthropic.com` 时拼成 `/chat/completions` → 404（Anthropic 原生 API 是 `POST /v1/messages`）。

**修法**：给 provider 加 `apiStyle` 字段（`openai` | `anthropic`，默认 `openai`，存量行/调用方不受影响）。`anthropic` 分支：
- `POST {baseUrl}/v1/messages`，头 `x-api-key` + `anthropic-version: 2023-06-01`
- 把 `system` 角色消息提升到顶层 `system` 字段（Anthropic 不接受 messages[] 里的 system 角色）
- 不发 `temperature`（Opus 4.x 拒绝采样参数），设 `max_tokens`
- 解析 `content[]` 的 text block
- 贯通：contract schema、Prisma `api_style` 列（schema-only 加列迁移，默认 `openai`）、service 读写、test 端点、以及 4 个 chatCompletion 调用点（insights synthesize / compare-synthesize / quality-gate judge / alert explainer）。深度报告路径给 Anthropic 32k max_tokens headroom。

## Bug 2 — 编辑时不填 API Key 误报 "This field is required"
`updateLlmJudgeProviderSchema.partial()` 让 `apiKey` 变成 `z.string().min(1).optional()`，会拒绝表单的空串。给编辑表单专用 resolver 接受空 key（空 = 保留已存 key，与提示文案一致）；不勾 rotate 时 PATCH body 本就不带 apiKey。

## 测试 / 验证
- 全工作区 build + 两包 lint 通过；测试 contracts 179 / api 332 / web 930。
- 新增 llm-client 单测覆盖 Anthropic 分支（端点/头/system 提升/无 temperature/text-block 拼接）。
- 终审 APPROVE：Anthropic 线格式逐项核对正确、apiStyle 端到端贯通、key 仅经 encrypt/decrypt 不泄漏、迁移仅加列。

🤖 Generated with [Claude Code](https://claude.com/claude-code)