### PR TITLE
fix(web): inline chart canvases as PNG snapshots in HTML export

### DIFF
--- a/apps/web/src/features/benchmarks/compare/exportHtml.test.ts
+++ b/apps/web/src/features/benchmarks/compare/exportHtml.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildExportHtml } from "./exportHtml";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("buildExportHtml", () => {
   it("wraps cloned node in a full HTML document with inline styles", () => {
@@ -17,5 +21,31 @@ describe("buildExportHtml", () => {
     const html = buildExportHtml(root, "evil <script>", "");
     expect(html).not.toContain("<script>");
     expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("replaces each chart canvas with an inline <img> PNG snapshot", () => {
+    vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockReturnValue(
+      "data:image/png;base64,SNAPSHOT",
+    );
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<div class="pr-figure"><canvas class="chart" width="600" height="300"></canvas></div>';
+    const html = buildExportHtml(root, "r", "");
+    expect(html).toContain("<img");
+    expect(html).toContain("data:image/png;base64,SNAPSHOT");
+    expect(html).not.toContain("<canvas");
+  });
+
+  it("leaves the canvas in place when snapshotting fails (does not throw)", () => {
+    vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockImplementation(() => {
+      throw new Error("tainted canvas");
+    });
+    const root = document.createElement("div");
+    root.innerHTML = "<canvas></canvas>";
+    let html = "";
+    expect(() => {
+      html = buildExportHtml(root, "r", "");
+    }).not.toThrow();
+    expect(html).toContain("<canvas");
   });
 });

--- a/apps/web/src/features/benchmarks/compare/exportHtml.ts
+++ b/apps/web/src/features/benchmarks/compare/exportHtml.ts
@@ -49,13 +49,19 @@ function inlineCanvasSnapshots(live: HTMLElement, clone: HTMLElement): void {
     if (!dataUrl || dataUrl === "data:,") continue;
     const img = document.createElement("img");
     img.src = dataUrl;
+    img.className = cloneCanvas.className;
+    // ECharts positions its canvas with inline styles (position/left/top);
+    // carry them over so the image sits where the canvas did.
+    img.style.cssText = cloneCanvas.style.cssText;
     // Display at the on-screen size; cap to the container so it still fits a
-    // narrower page (mirrors the print canvas rule).
-    const displayWidth = liveCanvas.getBoundingClientRect().width || liveCanvas.width;
+    // narrower page (mirrors the print canvas rule). The rect is 0 when the
+    // element is hidden at export time — fall back to the backing-store width
+    // divided by DPR (canvas.width is in device pixels, ~2x on Retina).
+    const displayWidth =
+      liveCanvas.getBoundingClientRect().width || liveCanvas.width / (window.devicePixelRatio || 1);
     img.style.width = `${displayWidth}px`;
     img.style.maxWidth = "100%";
     img.style.height = "auto";
-    img.className = cloneCanvas.className;
     cloneCanvas.replaceWith(img);
   }
 }

--- a/apps/web/src/features/benchmarks/compare/exportHtml.ts
+++ b/apps/web/src/features/benchmarks/compare/exportHtml.ts
@@ -23,8 +23,47 @@ function collectStylesheets(): string {
   return parts.join("\n");
 }
 
+/**
+ * Replace every `<canvas>` in `clone` with a static `<img>` rasterized from the
+ * matching live canvas in `live` (same document order). ECharts draws charts to
+ * a canvas, and a canvas's pixels are NOT part of the DOM — `cloneNode` /
+ * `outerHTML` produce a blank canvas, so a plain serialization loses every
+ * chart. Snapshotting each canvas to an inline PNG data URL keeps the exported
+ * file self-contained (no external JS / CDN, works offline).
+ */
+function inlineCanvasSnapshots(live: HTMLElement, clone: HTMLElement): void {
+  const liveCanvases = live.querySelectorAll("canvas");
+  const cloneCanvases = clone.querySelectorAll("canvas");
+  for (let i = 0; i < cloneCanvases.length; i++) {
+    const cloneCanvas = cloneCanvases[i];
+    const liveCanvas = liveCanvases[i];
+    if (!liveCanvas) continue;
+    let dataUrl: string;
+    try {
+      dataUrl = liveCanvas.toDataURL("image/png");
+    } catch {
+      // Tainted canvas or unsupported env — leave the (blank) canvas rather
+      // than aborting the whole export.
+      continue;
+    }
+    if (!dataUrl || dataUrl === "data:,") continue;
+    const img = document.createElement("img");
+    img.src = dataUrl;
+    // Display at the on-screen size; cap to the container so it still fits a
+    // narrower page (mirrors the print canvas rule).
+    const displayWidth = liveCanvas.getBoundingClientRect().width || liveCanvas.width;
+    img.style.width = `${displayWidth}px`;
+    img.style.maxWidth = "100%";
+    img.style.height = "auto";
+    img.className = cloneCanvas.className;
+    cloneCanvas.replaceWith(img);
+  }
+}
+
 export function buildExportHtml(root: HTMLElement, title: string, css: string): string {
   const clone = root.cloneNode(true) as HTMLElement;
+  // Charts are <canvas>; snapshot them to inline images before serializing.
+  inlineCanvasSnapshots(root, clone);
   // Strip interactive controls — static document, no React.
   clone.querySelectorAll("button").forEach((btn) => {
     const span = document.createElement("span");


### PR DESCRIPTION
## Problem

「Export HTML」 produced a file where every chart was a blank box — only tables/text survived. Root cause: the export serializes the report DOM with `cloneNode`/`outerHTML`, but a `<canvas>`'s pixels are **not** part of the DOM, so each ECharts chart cloned to an empty canvas.

(Print/PDF works because the print engine rasterizes the *live* canvas — DOM serialization can't.)

## Fix

Before serializing, snapshot each live canvas to an inline **PNG data URL** (`canvas.toDataURL`) and swap it for an `<img>`. The exported file is then fully **self-contained** — no external JS / CDN, works offline.

Chose inline-PNG over the alternatives:
- **vs. CDN + re-render**: makes the export depend on a network fetch + re-running JS on open — breaks offline / under CSP, not self-contained.
- **vs. inline SVG**: also self-contained, but requires switching the chart renderer (canvas→svg) across the report components + re-verifying the print/PDF path we just stabilized. Higher blast radius for the same result. Kept canvas everywhere; the change is isolated to `exportHtml.ts`.

Fails safe: a tainted/unsupported canvas is left as-is rather than aborting the whole export.

## Verified end-to-end

Clicked **Export HTML** on a real report and opened the downloaded file:
- Output contains 4 `<img src="data:image/png;base64,…">`, **zero `<canvas>`**.
- Opened in a browser: all four figures (bar + blue/green heatmaps) render as crisp 2x inline images, TOC + captions intact.

Unit tests cover the canvas→img swap and the fail-safe path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)