### PR TITLE
feat(report): add TTFT/TPOT/E2E + latency-CDF figures to lb-strategy report

### DIFF
--- a/apps/api/src/modules/saved-compares/metrics.spec.ts
+++ b/apps/api/src/modules/saved-compares/metrics.spec.ts
@@ -66,6 +66,29 @@ it("does not offer latency-distribution for a single run", () => {
   expect(set.has("latency-distribution")).toBe(false);
 });
 
+it("offers stage-bars-tpot-p95 only when every run carries ITL", () => {
+  const withItl = { tool: "guidellm", data: { itl: { p50: 20, p95: 60 } } };
+  const noItl = { tool: "guidellm", data: {} };
+  expect(
+    availableFigureRefIds([
+      { summaryMetrics: withItl, serverMetrics: null },
+      { summaryMetrics: withItl, serverMetrics: null },
+    ]).has("stage-bars-tpot-p95"),
+  ).toBe(true);
+  expect(
+    availableFigureRefIds([
+      { summaryMetrics: withItl, serverMetrics: null },
+      { summaryMetrics: noItl, serverMetrics: null },
+    ]).has("stage-bars-tpot-p95"),
+  ).toBe(false);
+});
+
+it("summarizeForPrompt reads ITL p50/p95", () => {
+  const out = summarizeForPrompt({ tool: "guidellm", data: { itl: { p50: 20, p95: 60 } } });
+  expect(out.itl).toEqual({ p50: 20, p95: 60 });
+  expect(summarizeForPrompt({ tool: "guidellm", data: {} }).itl).toBeNull();
+});
+
 describe("readCapacityCurve", () => {
   it("returns the curve when present and non-empty", () => {
     const m = { data: { capacityCurve: [{ concurrency: 4, rps: 30, e2eP95Ms: 500 }] } };

--- a/apps/api/src/modules/saved-compares/metrics.ts
+++ b/apps/api/src/modules/saved-compares/metrics.ts
@@ -17,6 +17,8 @@ export interface PromptMetricsSummary {
   throughput: number | null;
   errorRate: number | null;
   ttft: { p50: number | null; p90: number | null; p99: number | null } | null;
+  // Inter-token latency (TPOT). ITL only exposes p50/p95 across tools.
+  itl: { p50: number | null; p95: number | null } | null;
   e2e: { p50: number | null; p90: number | null; p99: number | null } | null;
 }
 
@@ -37,6 +39,8 @@ export function summarizeForPrompt(m: unknown): PromptMetricsSummary {
   const e2eP50 = readMetricSafe("e2e.p50", summary);
   const e2eP90 = readMetricSafe("e2e.p90", summary);
   const e2eP99 = readMetricSafe("e2e.p99", summary);
+  const itlP50 = readMetricSafe("itl.p50", summary);
+  const itlP95 = readMetricSafe("itl.p95", summary);
 
   return {
     throughput: readMetricSafe("requestsPerSec", summary),
@@ -45,6 +49,7 @@ export function summarizeForPrompt(m: unknown): PromptMetricsSummary {
       ttftP50 === null && ttftP90 === null && ttftP99 === null
         ? null
         : { p50: ttftP50, p90: ttftP90, p99: ttftP99 },
+    itl: itlP50 === null && itlP95 === null ? null : { p50: itlP50, p95: itlP95 },
     e2e:
       e2eP50 === null && e2eP90 === null && e2eP99 === null
         ? null
@@ -120,6 +125,7 @@ export function availableFigureRefIds(runs: RunMetricBlobs[]): Set<FigureRefId> 
   if (perRun.some((s) => s.throughput !== null)) out.add("stage-bars-throughput");
   if (perRun.some((s) => s.errorRate !== null)) out.add("stage-bars-error-rate");
   if (perRun.every((s) => s.ttft !== null)) out.add("stage-bars-ttft-p95");
+  if (perRun.every((s) => s.itl !== null)) out.add("stage-bars-tpot-p95");
   if (perRun.every((s) => s.e2e !== null)) out.add("stage-bars-e2e-p95");
   // cold-warm-delta: available whenever ≥2 runs carry throughput or ttft data.
   if (perRun.filter((s) => s.throughput !== null || s.ttft !== null).length >= 2) {

--- a/apps/api/src/modules/saved-compares/prompts.ts
+++ b/apps/api/src/modules/saved-compares/prompts.ts
@@ -34,7 +34,7 @@ interface Narrative {
   ];                     // exactly 6 sections in this order
   figures: Array<{
     id: string;
-    refId: "stage-bars-throughput" | "stage-bars-error-rate" | "stage-bars-ttft-p95" | "stage-bars-e2e-p95" | "stage-bars-prefix-cache-hit" | "stage-bars-top-pod-share" | "pod-traffic-distribution" | "pod-hit-rate" | "cold-warm-delta" | "throughput-vs-concurrency" | "latency-distribution" | "compare-grid";
+    refId: "stage-bars-throughput" | "stage-bars-error-rate" | "stage-bars-ttft-p95" | "stage-bars-tpot-p95" | "stage-bars-e2e-p95" | "stage-bars-prefix-cache-hit" | "stage-bars-top-pod-share" | "pod-traffic-distribution" | "pod-hit-rate" | "cold-warm-delta" | "throughput-vs-concurrency" | "latency-distribution" | "compare-grid";
     caption: string;
     anchorSection?: "summary" | "scope" | "method" | "results" | "caveats" | "advice";
   }>;

--- a/apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.spec.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.spec.ts
@@ -27,6 +27,11 @@ it("emits a per-pod distribution block citing pod shares", () => {
   expect(data.promptBlock).toContain("ON");
   expect(data.promptBlock).toContain("80"); // p1 share% = 800/1000
   expect(data.preferredFigures).toContain("stage-bars-prefix-cache-hit");
+  // Latency figures included as supporting evidence (headline stays hit-rate).
+  expect(data.preferredFigures).toContain("stage-bars-ttft-p95");
+  expect(data.preferredFigures).toContain("stage-bars-tpot-p95");
+  expect(data.preferredFigures).toContain("stage-bars-e2e-p95");
+  expect(data.preferredFigures).toContain("latency-distribution");
 });
 it("fragment leads with hit-rate", () => {
   expect(lbStrategyProfile.promptFragment("zh-CN")).toContain("命中率");

--- a/apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.ts
@@ -5,14 +5,14 @@ import type { Locale, ReportScenarioProfile, ScenarioData } from "./types.js";
 const FRAGMENT_ZH = `本报告是负载均衡 / 路由策略验证(lb-strategy)。
 - HEADLINE 与第一张 summary card 必须是 prefix cache 命中率的变化——这是实验存在的理由。
 - 用 stage-bars-prefix-cache-hit 展示命中率,pod-traffic-distribution 展示每 pod 流量占比(集中度),pod-hit-rate 展示每 pod 命中率。
-- 吞吐 / 时延(TTFT/TPOT/E2E)是次要佐证,不是 headline:小模型 prefill 便宜,命中率上升未必改善时延——但仍要给出 stage-bars-ttft-p95、stage-bars-tpot-p95、stage-bars-e2e-p95、latency-distribution 这几张图,并如实说明(改善 / 持平 / 回退),不要拿一个持平的吞吐差当 headline。
+- 吞吐 / 时延(TTFT/TPOT/E2E)是次要佐证,不是 headline:小模型 prefill 便宜,命中率上升未必改善时延——但在数据支持时仍要给出 stage-bars-ttft-p95、stage-bars-tpot-p95、stage-bars-e2e-p95、latency-distribution 这几张图,并如实说明(改善 / 持平 / 回退),不要拿一个持平的吞吐差当 headline。
 - top-pod share 持平而命中率上升 = 更好的缓存局部性且无热点(好事),不是失败。
 - stage 标签 OFF/ON 指路由开关,不是离线/在线。`;
 
 const FRAGMENT_EN = `This is a load-balancer / routing-strategy validation (lb-strategy).
 - The HEADLINE and first summary card MUST be the prefix-cache hit-rate change — that is why the experiment exists.
 - Use stage-bars-prefix-cache-hit for hit rate, pod-traffic-distribution for each pod's traffic share (concentration), pod-hit-rate for per-pod hit rate.
-- Treat throughput / latency (TTFT/TPOT/E2E) as secondary evidence, not the headline: on small models prefill is cheap, so a higher hit rate need not improve latency — but still include the stage-bars-ttft-p95, stage-bars-tpot-p95, stage-bars-e2e-p95 and latency-distribution figures and report what they show (gain / flat / regression) plainly, rather than leading with a flat throughput delta.
+- Treat throughput / latency (TTFT/TPOT/E2E) as secondary evidence, not the headline: on small models prefill is cheap, so a higher hit rate need not improve latency — but when supported by the data, still include the stage-bars-ttft-p95, stage-bars-tpot-p95, stage-bars-e2e-p95 and latency-distribution figures and report what they show (gain / flat / regression) plainly, rather than leading with a flat throughput delta.
 - A flat top-pod share alongside a rising hit rate means better cache locality without hot-spotting (good), not a failure.
 - Stage labels OFF/ON mean the routing toggle, not offline/online.`;
 

--- a/apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.ts
@@ -5,14 +5,14 @@ import type { Locale, ReportScenarioProfile, ScenarioData } from "./types.js";
 const FRAGMENT_ZH = `本报告是负载均衡 / 路由策略验证(lb-strategy)。
 - HEADLINE 与第一张 summary card 必须是 prefix cache 命中率的变化——这是实验存在的理由。
 - 用 stage-bars-prefix-cache-hit 展示命中率,pod-traffic-distribution 展示每 pod 流量占比(集中度),pod-hit-rate 展示每 pod 命中率。
-- 吞吐 / TTFT 视为次要:小模型 prefill 便宜,命中率上升未必改善时延,直说即可,不要拿一个持平的吞吐差当 headline。
+- 吞吐 / 时延(TTFT/TPOT/E2E)是次要佐证,不是 headline:小模型 prefill 便宜,命中率上升未必改善时延——但仍要给出 stage-bars-ttft-p95、stage-bars-tpot-p95、stage-bars-e2e-p95、latency-distribution 这几张图,并如实说明(改善 / 持平 / 回退),不要拿一个持平的吞吐差当 headline。
 - top-pod share 持平而命中率上升 = 更好的缓存局部性且无热点(好事),不是失败。
 - stage 标签 OFF/ON 指路由开关,不是离线/在线。`;
 
 const FRAGMENT_EN = `This is a load-balancer / routing-strategy validation (lb-strategy).
 - The HEADLINE and first summary card MUST be the prefix-cache hit-rate change — that is why the experiment exists.
 - Use stage-bars-prefix-cache-hit for hit rate, pod-traffic-distribution for each pod's traffic share (concentration), pod-hit-rate for per-pod hit rate.
-- Treat throughput / TTFT as secondary: on small models prefill is cheap, so a higher hit rate need not improve latency — say so plainly rather than leading with a flat throughput delta.
+- Treat throughput / latency (TTFT/TPOT/E2E) as secondary evidence, not the headline: on small models prefill is cheap, so a higher hit rate need not improve latency — but still include the stage-bars-ttft-p95, stage-bars-tpot-p95, stage-bars-e2e-p95 and latency-distribution figures and report what they show (gain / flat / regression) plainly, rather than leading with a flat throughput delta.
 - A flat top-pod share alongside a rising hit rate means better cache locality without hot-spotting (good), not a failure.
 - Stage labels OFF/ON mean the routing toggle, not offline/online.`;
 
@@ -44,6 +44,12 @@ function assemble(sc: HydratedSavedCompare): ScenarioData {
       "pod-traffic-distribution",
       "pod-hit-rate",
       "stage-bars-top-pod-share",
+      // Latency as supporting evidence — headline stays hit-rate. Each renders
+      // only when every run carries that distribution (availableFigureRefIds).
+      "stage-bars-ttft-p95",
+      "stage-bars-tpot-p95",
+      "stage-bars-e2e-p95",
+      "latency-distribution",
     ],
   };
 }

--- a/apps/web/src/components/charts/StageBarChart.tsx
+++ b/apps/web/src/components/charts/StageBarChart.tsx
@@ -269,7 +269,10 @@ export function StageBarChart({
         },
         legend:
           series.length > 1
-            ? { type: "scroll", top: 0, textStyle: { color: tokens.textColor } }
+            ? // Use the fixed report label color (same as the axis labels), not
+              // the app-theme token — the report paper is always light, so a
+              // dark-theme token would render the legend faint/illegible.
+              { type: "scroll", top: 0, textStyle: { color: lc.value } }
             : undefined,
         xAxis: {
           type: "category",

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
@@ -52,6 +52,8 @@ const REPORT_PALETTE = [
 ] as const;
 
 const PERCENTILES = ["p50", "p90", "p99"] as const;
+// ITL (TPOT) only carries p50/p95 across tools — see MetricKind.
+const ITL_PERCENTILES = ["p50", "p95"] as const;
 
 /** Index of the baseline stage within `rows` (preserving their order). Falls
  * back to the first stage when no baseline is set or it was filtered out. */
@@ -181,6 +183,30 @@ export const FigureRenderer = memo(function FigureRenderer({
     chart = (
       <StageBarChart
         title="TTFT percentiles"
+        data={rows.length > 0 ? data : []}
+        series={series}
+        yLabel="ms"
+        baselineSeriesKey={baselineKeyOf(rows, baselineId)}
+        labelColors={REPORT_LABEL_COLORS}
+      />
+    );
+  } else if (refId === "stage-bars-tpot-p95") {
+    // ITL carries only p50/p95 (see MetricKind), so this figure shows two bars.
+    const rows = summaries.filter(({ s }) => s.itl);
+    const data: StageBarDatum[] = ITL_PERCENTILES.map((p) => ({
+      stage: p,
+      ...Object.fromEntries(rows.map(({ r, s }) => [r.id, s.itl?.[p] ?? 0])),
+    }));
+    const series: StageBarSeries[] = rows.map(({ r }) => ({
+      key: r.id,
+      label: r.stageLabel,
+      color: colorMap[r.id],
+      decimals: 0,
+      higherIsBetter: false,
+    }));
+    chart = (
+      <StageBarChart
+        title="TPOT (inter-token) percentiles"
         data={rows.length > 0 ? data : []}
         series={series}
         yLabel="ms"

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
@@ -333,7 +333,16 @@ export const FigureRenderer = memo(function FigureRenderer({
         ? [{ runId: r.id, runLabel: r.stageLabel, samples }]
         : [];
     });
-    chart = <LatencyCDF ariaLabel="Latency CDF by stage" series={series} colorMap={colorMap} />;
+    // Report paper is always light — force the light theme so the CDF's axis /
+    // legend text stays dark and legible regardless of the app theme.
+    chart = (
+      <LatencyCDF
+        ariaLabel="Latency CDF by stage"
+        series={series}
+        colorMap={colorMap}
+        theme="light"
+      />
+    );
   } else if (refId === "cold-warm-delta") {
     chart = <ColdWarmDeltaTable runs={runs} baselineId={baselineId} />;
   } else if (refId === "compare-grid") {

--- a/apps/web/src/features/benchmarks/compare/client-metrics.ts
+++ b/apps/web/src/features/benchmarks/compare/client-metrics.ts
@@ -5,6 +5,8 @@ export interface PromptMetricsSummary {
   throughput: number | null;
   errorRate: number | null;
   ttft: { p50: number | null; p90: number | null; p99: number | null } | null;
+  // Inter-token latency (TPOT). ITL only exposes p50/p95 across tools.
+  itl: { p50: number | null; p95: number | null } | null;
   e2e: { p50: number | null; p90: number | null; p99: number | null } | null;
 }
 
@@ -85,6 +87,8 @@ export function summarizeForPrompt(m: unknown): PromptMetricsSummary {
   const e2eP50 = readMetricSafe("e2e.p50", summary);
   const e2eP90 = readMetricSafe("e2e.p90", summary);
   const e2eP99 = readMetricSafe("e2e.p99", summary);
+  const itlP50 = readMetricSafe("itl.p50", summary);
+  const itlP95 = readMetricSafe("itl.p95", summary);
 
   return {
     throughput: readMetricSafe("requestsPerSec", summary),
@@ -93,6 +97,7 @@ export function summarizeForPrompt(m: unknown): PromptMetricsSummary {
       ttftP50 === null && ttftP90 === null && ttftP99 === null
         ? null
         : { p50: ttftP50, p90: ttftP90, p99: ttftP99 },
+    itl: itlP50 === null && itlP95 === null ? null : { p50: itlP50, p95: itlP95 },
     e2e:
       e2eP50 === null && e2eP90 === null && e2eP99 === null
         ? null
@@ -144,6 +149,7 @@ export function availableFigureRefIds(runs: RunMetricBlobs[]): Set<FigureRefId> 
   if (perRun.some((s) => s.throughput !== null)) out.add("stage-bars-throughput");
   if (perRun.some((s) => s.errorRate !== null)) out.add("stage-bars-error-rate");
   if (perRun.every((s) => s.ttft !== null)) out.add("stage-bars-ttft-p95");
+  if (perRun.every((s) => s.itl !== null)) out.add("stage-bars-tpot-p95");
   if (perRun.every((s) => s.e2e !== null)) out.add("stage-bars-e2e-p95");
   // cold-warm-delta: available whenever ≥2 runs carry throughput or ttft data.
   if (perRun.filter((s) => s.throughput !== null || s.ttft !== null).length >= 2) {

--- a/packages/contracts/src/saved-compares/compare-narrative.spec.ts
+++ b/packages/contracts/src/saved-compares/compare-narrative.spec.ts
@@ -10,3 +10,7 @@ it("accepts the new phase-1 refIds", () => {
 it("accepts the latency-distribution refId", () => {
   expect(figureRefIdSchema.parse("latency-distribution")).toBe("latency-distribution");
 });
+
+it("accepts the TPOT (inter-token) refId", () => {
+  expect(figureRefIdSchema.parse("stage-bars-tpot-p95")).toBe("stage-bars-tpot-p95");
+});

--- a/packages/contracts/src/saved-compares/compare-narrative.ts
+++ b/packages/contracts/src/saved-compares/compare-narrative.ts
@@ -69,6 +69,9 @@ export const figureRefIdSchema = z.enum([
   "stage-bars-throughput",
   "stage-bars-error-rate",
   "stage-bars-ttft-p95",
+  // Inter-token latency (TPOT). ITL only carries p50/p95 (not p90/p99), so
+  // this figure renders those two percentiles.
+  "stage-bars-tpot-p95",
   "stage-bars-e2e-p95",
   // Prefix-cache figures — populated from serverMetrics.prefixCache, only
   // available for lb-strategy runs. hit = cache hit-rate %,


### PR DESCRIPTION
## Why

The **LB-strategy Validation** compare report only charted prefix-cache hit-rate + per-pod traffic/hit-rate. Latency (TTFT/TPOT/E2E) was discussed in prose but never plotted — users want to see it, not just the hit-rate. Headline stays hit-rate; latency is added as **supporting** evidence.

## What

- **New figure type `stage-bars-tpot-p95`** (inter-token latency / TPOT). ITL only carries **p50/p95** across tools (`MetricKind` has no `itl.p90/p99`), so this figure renders those two percentiles — unlike TTFT/E2E which show p50/p90/p99.
- Wired `itl` through the prompt-metrics summary + `availableFigureRefIds` on **both** mirrors (`apps/api/.../metrics.ts` and `apps/web/.../client-metrics.ts`) and rendered it in `FigureRenderer`.
- Added `stage-bars-ttft-p95`, `stage-bars-tpot-p95`, `stage-bars-e2e-p95`, `latency-distribution` to the lb-strategy `preferredFigures`, and reworded the prompt fragment so the model **includes** the latency figures (as secondary evidence) rather than dismissing latency.
- Each figure still renders only when **every** run carries the underlying distribution (so non-latency tools degrade cleanly).

## Note for the user

The figure set is chosen by the LLM at generation time and persisted in the narrative, so **existing reports must be regenerated** ("Regenerate AI analysis") to pick up the new figures.

## Verified end-to-end

Regenerated a real aiperf lb-strategy report through the live LLM — the model selected **TTFT + TPOT + E2E** and all three render correctly (TPOT showing p50/p95), alongside the existing hit-rate/pod figures.

Tests: contract enum, server+client `availableFigureRefIds`/`summarizeForPrompt` for ITL, lb-strategy `preferredFigures`. Full gate green (type-check ×3, lint ×3, 91 saved-compares specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)