### PR TITLE
fix(benchmark): live Engine Metrics during runs + delete orphaned K8s Jobs

### DIFF
--- a/apps/api/src/modules/benchmark/benchmark.service.spec.ts
+++ b/apps/api/src/modules/benchmark/benchmark.service.spec.ts
@@ -310,8 +310,17 @@ describe("BenchmarkService.delete", () => {
     vi.clearAllMocks();
   });
 
-  it("deletes a terminal benchmark without calling driver.cancel", async () => {
-    repo.setup(makeBenchmarkRow({ id: "b1", status: "completed" }));
+  it("deletes a terminal benchmark and still deletes the lingering K8s Job", async () => {
+    // A completed/failed run's Job lingers inside its ttlSecondsAfterFinished
+    // window (1h). Deleting the row must delete that Job too, not orphan it.
+    repo.setup(makeBenchmarkRow({ id: "b1", status: "completed", driverHandle: "k8s:job-0" }));
+    await svc.delete("b1", "u1");
+    expect(mockRunner.cancel).toHaveBeenCalledWith("k8s:job-0");
+    expect(repo.delete).toHaveBeenCalledWith("b1");
+  });
+
+  it("deletes a terminal benchmark without a handle without calling driver.cancel", async () => {
+    repo.setup(makeBenchmarkRow({ id: "b1", status: "completed", driverHandle: null }));
     await svc.delete("b1", "u1");
     expect(repo.delete).toHaveBeenCalledWith("b1");
     expect(mockRunner.cancel).not.toHaveBeenCalled();

--- a/apps/api/src/modules/benchmark/benchmark.service.ts
+++ b/apps/api/src/modules/benchmark/benchmark.service.ts
@@ -266,13 +266,16 @@ export class BenchmarkService {
     if (userId !== undefined && row.userId !== userId) {
       throw new NotFoundException(`Benchmark ${id} not found`);
     }
-    // Non-terminal rows may have a backing driver job (K8s Job, subprocess,
-    // …). Best-effort cancel before DB delete so we don't orphan resources.
-    // The K8sBenchmarkRunner already treats 404 on the Job as idempotent; any
-    // other error is logged and swallowed so a flaky apiserver doesn't
-    // block the user from clearing a stuck row.
-    const isTerminal = (TERMINAL_STATES as readonly string[]).includes(row.status);
-    if (!isTerminal && row.driverHandle) {
+    // Any row with a driver handle may still have a backing K8s Job —
+    // a non-terminal run that's mid-flight, OR a terminal run whose Job
+    // is lingering inside its `ttlSecondsAfterFinished` window (1h). Deleting
+    // the DB row before the TTL fires would orphan that Job (and its pods)
+    // for up to an hour, so we delete the Job on EVERY path, terminal or not.
+    // `runner.cancel()` deletes the Job with Background propagation (cascades
+    // to the owned Secret + pods) and treats a 404 as idempotent; any other
+    // error is logged and swallowed so a flaky apiserver doesn't block the
+    // user from clearing a row.
+    if (row.driverHandle) {
       try {
         await this.runner.cancel(row.driverHandle);
       } catch (e) {

--- a/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
+++ b/apps/web/src/features/benchmarks/BenchmarkDetailPage.tsx
@@ -201,14 +201,13 @@ function BenchmarkDetailTabs({
   const { t } = useTranslation("benchmarks");
   const isTerminal = isTerminalStatus(benchmark.status);
   const showCharts = isTerminal;
-  // Engine Metrics is reachable when the connection is bound to a Prometheus
-  // datasource and the benchmark has a definite time window.
+  // Engine Metrics is reachable whenever the connection is bound to a
+  // Prometheus datasource and the run has actually started. It's live data
+  // scraped from the engine — not the benchmark tool's own result — so it's
+  // useful DURING a run too: a non-terminal run passes finishedAt=null to
+  // EngineMetricsSection, which then tracks "now" and auto-refreshes.
   const showEngineMetrics = Boolean(
-    isTerminal &&
-      connection?.prometheusDatasource &&
-      connection.serverKind &&
-      benchmark.startedAt &&
-      benchmark.completedAt,
+    connection?.prometheusDatasource && connection.serverKind && benchmark.startedAt,
   );
   const [active, setActive] = useState<string>("overview");
 
@@ -250,11 +249,13 @@ function BenchmarkDetailTabs({
         </TabsContent>
       )}
 
-      {showEngineMetrics && benchmark.startedAt && benchmark.completedAt && connection && (
+      {showEngineMetrics && benchmark.startedAt && connection && (
         <TabsContent value="engine" className="space-y-6">
           <EngineMetricsSection
             connectionId={connection.id}
             startedAt={benchmark.startedAt}
+            // null while the run is in flight → EngineMetricsSection renders a
+            // live, auto-refreshing window up to "now".
             finishedAt={benchmark.completedAt}
           />
         </TabsContent>

--- a/apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
+++ b/apps/web/src/features/benchmarks/__tests__/BenchmarkDetailPage.test.tsx
@@ -724,6 +724,32 @@ describe("BenchmarkDetailPage", () => {
     expect(await screen.findByTestId("engine-metrics-section")).toBeInTheDocument();
   });
 
+  it("exposes the Engine Metrics tab while the run is still RUNNING (live metrics)", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(
+      makeBenchmark({
+        status: "running",
+        startedAt: "2026-04-30T12:00:01.000Z",
+        completedAt: null,
+        summaryMetrics: null,
+        rawOutput: null,
+      }),
+    );
+    mockUseConnection.mockReturnValue({
+      data: {
+        ...defaultConnectionData,
+        prometheusDatasourceId: "ds1",
+        prometheusDatasource: { id: "ds1", name: "default", baseUrl: "http://prom:9090" },
+        serverKind: "vllm",
+      },
+    });
+    const user = userEvent.setup();
+    render(<BenchmarkDetailPage />, { wrapper: Wrapper });
+    await screen.findByText(/Running…|运行中…/);
+    const engineTab = await screen.findByRole("tab", { name: /Engine Metrics|推理引擎指标/i });
+    await user.click(engineTab);
+    expect(await screen.findByTestId("engine-metrics-section")).toBeInTheDocument();
+  });
+
   it("does not render <EngineMetricsSection> when prometheusDatasource is missing", async () => {
     vi.mocked(api.get).mockResolvedValueOnce(
       makeBenchmark({

--- a/apps/web/src/features/engine-metrics/EngineMetricsSection.test.tsx
+++ b/apps/web/src/features/engine-metrics/EngineMetricsSection.test.tsx
@@ -77,27 +77,37 @@ describe("<EngineMetricsSection>", () => {
   });
 
   it("shows the live badge and queries a now-bounded window when finishedAt is null", async () => {
-    const { api } = await import("@/lib/api-client");
-    const getSpy = vi.mocked(api.get);
-    getSpy.mockClear();
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    render(
-      <EngineMetricsSection
-        connectionId="c1"
-        startedAt="2026-05-09T00:00:00.000Z"
-        finishedAt={null}
-      />,
-      { wrapper: wrap(qc) },
-    );
-    // Live indicator is present. (This test's i18n returns raw keys, so we
-    // assert on the liveBadge key rather than the translated phrase.)
-    await waitFor(() => expect(screen.getByText(/section\.liveBadge/)).toBeInTheDocument());
-    // The window's upper bound tracks "now", not the fixed startedAt+1min.
-    const url = getSpy.mock.calls.at(-1)?.[0] as string;
-    const to = new URLSearchParams(url.split("?")[1]).get("to");
-    expect(to).toBeTruthy();
-    expect(new Date(to as string).getTime()).toBeGreaterThan(
-      new Date("2026-05-09T00:01:00.000Z").getTime(),
-    );
+    // Pin the clock to just after startedAt so live mode is deterministic
+    // regardless of the host's real date. shouldAdvanceTime keeps waitFor +
+    // react-query timers ticking. setSystemTime fixes Date.now()/new Date().
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-05-09T00:05:00.000Z"));
+    try {
+      const { api } = await import("@/lib/api-client");
+      const getSpy = vi.mocked(api.get);
+      getSpy.mockClear();
+      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      render(
+        <EngineMetricsSection
+          connectionId="c1"
+          startedAt="2026-05-09T00:00:00.000Z"
+          finishedAt={null}
+        />,
+        { wrapper: wrap(qc) },
+      );
+      // Live indicator is present. (This test's i18n returns raw keys, so we
+      // assert on the liveBadge key rather than the translated phrase.)
+      await waitFor(() => expect(screen.getByText(/section\.liveBadge/)).toBeInTheDocument());
+      // The window's upper bound tracks "now" (00:05), not the fixed
+      // startedAt+1min the non-live window would use.
+      const url = getSpy.mock.calls.at(-1)?.[0] as string;
+      const to = new URLSearchParams(url.split("?")[1]).get("to");
+      expect(to).toBeTruthy();
+      expect(new Date(to as string).getTime()).toBeGreaterThan(
+        new Date("2026-05-09T00:01:00.000Z").getTime(),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/web/src/features/engine-metrics/EngineMetricsSection.test.tsx
+++ b/apps/web/src/features/engine-metrics/EngineMetricsSection.test.tsx
@@ -75,4 +75,29 @@ describe("<EngineMetricsSection>", () => {
       ).toBeGreaterThan(0),
     );
   });
+
+  it("shows the live badge and queries a now-bounded window when finishedAt is null", async () => {
+    const { api } = await import("@/lib/api-client");
+    const getSpy = vi.mocked(api.get);
+    getSpy.mockClear();
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <EngineMetricsSection
+        connectionId="c1"
+        startedAt="2026-05-09T00:00:00.000Z"
+        finishedAt={null}
+      />,
+      { wrapper: wrap(qc) },
+    );
+    // Live indicator is present. (This test's i18n returns raw keys, so we
+    // assert on the liveBadge key rather than the translated phrase.)
+    await waitFor(() => expect(screen.getByText(/section\.liveBadge/)).toBeInTheDocument());
+    // The window's upper bound tracks "now", not the fixed startedAt+1min.
+    const url = getSpy.mock.calls.at(-1)?.[0] as string;
+    const to = new URLSearchParams(url.split("?")[1]).get("to");
+    expect(to).toBeTruthy();
+    expect(new Date(to as string).getTime()).toBeGreaterThan(
+      new Date("2026-05-09T00:01:00.000Z").getTime(),
+    );
+  });
 });

--- a/apps/web/src/features/engine-metrics/EngineMetricsSection.tsx
+++ b/apps/web/src/features/engine-metrics/EngineMetricsSection.tsx
@@ -1,7 +1,7 @@
 import type { EngineMetricsPanelResult, EngineMetricsSeries } from "@modeldoctor/contracts";
 import { ENGINE_DISPLAY_NAME } from "@modeldoctor/contracts";
 import { format } from "date-fns";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   BarChartPanel,
@@ -14,12 +14,18 @@ import {
 import { type Group, vizFor } from "./metric-viz.js";
 import { useEngineMetrics } from "./useEngineMetrics.js";
 
+/** How often the live (in-flight) window advances + refetches, in ms. */
+const LIVE_REFRESH_MS = 15_000;
+
 export interface EngineMetricsSectionProps {
   connectionId: string;
   /** ISO datetime — benchmark startedAt */
   startedAt: string;
-  /** ISO datetime — benchmark finishedAt */
-  finishedAt: string;
+  /**
+   * ISO datetime — benchmark finishedAt. Pass `null` for an in-flight run:
+   * the window then tracks "now" and refreshes every {@link LIVE_REFRESH_MS}.
+   */
+  finishedAt: string | null;
 }
 
 // Grafana-style 3-section layout:
@@ -65,21 +71,40 @@ export function EngineMetricsSection({
   finishedAt,
 }: EngineMetricsSectionProps) {
   const { t } = useTranslation("engine-metrics");
+  const isLive = finishedAt == null;
+
+  // In live mode the upper bound tracks wall-clock "now"; otherwise it's the
+  // fixed benchmark end. `nowMs` ticks on the refresh cadence so the derived
+  // window (and the query key) only advance once per interval.
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    if (!isLive) return;
+    const id = setInterval(() => setNowMs(Date.now()), LIVE_REFRESH_MS);
+    return () => clearInterval(id);
+  }, [isLive]);
+
+  const effectiveFinish = useMemo(() => {
+    if (finishedAt != null) return finishedAt;
+    // Quantize to the refresh cadence so unrelated re-renders don't churn the
+    // window — it only steps forward once per LIVE_REFRESH_MS tick.
+    const quantized = Math.floor(nowMs / LIVE_REFRESH_MS) * LIVE_REFRESH_MS;
+    return new Date(quantized).toISOString();
+  }, [finishedAt, nowMs]);
 
   const range = useMemo(() => {
     const from = shiftIso(startedAt, -30);
-    const to = shiftIso(finishedAt, +30);
+    const to = shiftIso(effectiveFinish, +30);
     const span = (new Date(to).getTime() - new Date(from).getTime()) / 1000;
     const step = Math.max(15, Math.floor(span / 200));
     return { from, to, step };
-  }, [startedAt, finishedAt]);
+  }, [startedAt, effectiveFinish]);
 
   const benchmarkWindow = useMemo(
     () => ({
       from: Math.floor(new Date(startedAt).getTime() / 1000),
-      to: Math.floor(new Date(finishedAt).getTime() / 1000),
+      to: Math.floor(new Date(effectiveFinish).getTime() / 1000),
     }),
-    [startedAt, finishedAt],
+    [startedAt, effectiveFinish],
   );
 
   const { data, isLoading, isError } = useEngineMetrics(connectionId, range);
@@ -118,12 +143,23 @@ export function EngineMetricsSection({
 
   return (
     <div className="space-y-6">
-      <div className="text-xs text-muted-foreground">
-        {t("section.subtitle", {
-          engineName: ENGINE_DISPLAY_NAME[data.engineId],
-          from: format(new Date(data.window.from), "yyyy-MM-dd HH:mm:ss"),
-          to: format(new Date(data.window.to), "yyyy-MM-dd HH:mm:ss"),
-        })}
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <span>
+          {t("section.subtitle", {
+            engineName: ENGINE_DISPLAY_NAME[data.engineId],
+            from: format(new Date(data.window.from), "yyyy-MM-dd HH:mm:ss"),
+            to: format(new Date(data.window.to), "yyyy-MM-dd HH:mm:ss"),
+          })}
+        </span>
+        {isLive && (
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2 py-0.5 text-emerald-500">
+            <span className="relative inline-flex h-1.5 w-1.5">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-75" />
+              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
+            </span>
+            {t("section.liveBadge")}
+          </span>
+        )}
       </div>
 
       {stats.length > 0 && (

--- a/apps/web/src/features/engine-metrics/useEngineMetrics.ts
+++ b/apps/web/src/features/engine-metrics/useEngineMetrics.ts
@@ -1,5 +1,5 @@
 import type { EngineMetricsSnapshotResponse } from "@modeldoctor/contracts";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
 
 export interface EngineMetricsRange {
@@ -29,5 +29,10 @@ export function useEngineMetrics(
       );
     },
     staleTime: 30 * 1000,
+    // During a live (in-flight) run the caller advances `range.to` on a fixed
+    // cadence, which changes the query key each tick. keepPreviousData holds
+    // the prior snapshot on screen while the new window loads, so the panels
+    // refresh in place instead of flashing the "Loading…" placeholder.
+    placeholderData: keepPreviousData,
   });
 }

--- a/apps/web/src/locales/en-US/engine-metrics.json
+++ b/apps/web/src/locales/en-US/engine-metrics.json
@@ -2,6 +2,7 @@
   "section": {
     "title": "Engine Metrics",
     "subtitle": "{{engineName}} · live from Prometheus · {{from}} ~ {{to}}",
+    "liveBadge": "Running · auto-refresh every 15s",
     "notConfigured": "This connection has no Prometheus URL — set it in Connection settings.",
     "missingServerKind": "Pick an inference engine in Connection settings.",
     "promError": "Cannot reach Prometheus — check connection config or network."

--- a/apps/web/src/locales/zh-CN/engine-metrics.json
+++ b/apps/web/src/locales/zh-CN/engine-metrics.json
@@ -2,6 +2,7 @@
   "section": {
     "title": "推理引擎指标",
     "subtitle": "{{engineName}} · 实时来自 Prometheus · {{from}} ~ {{to}}",
+    "liveBadge": "运行中 · 每 15 秒自动刷新",
     "notConfigured": "此连接未配置 Prometheus URL — 前往连接设置补齐",
     "missingServerKind": "请在连接设置中选择推理引擎类型",
     "promError": "无法访问 Prometheus，请检查连接配置或网络可达性"


### PR DESCRIPTION
Two fixes to the benchmark run detail page, both from operator reports.

## 1. Live Engine Metrics while a run is in progress (`feat(web)`)

**Before:** a `running` benchmark exposed only **Overview** (a spinner) + **Run Logs**. Distributions / Engine Metrics / Request·Response were all gated behind `isTerminal`, so there was no way to watch indicators during a run.

**After:** the **Engine Metrics** tab is ungated — it shows whenever the connection has a Prometheus datasource + `serverKind` and the run has started. While in flight, `EngineMetricsSection` gets `finishedAt=null` and tracks a window up to "now", advancing + refetching every 15s (quantized to the cadence so unrelated re-renders don't churn the query). `keepPreviousData` keeps panels on screen across refreshes (no loading flash), and a "live" badge marks the mode.

Distributions and Request·Response stay terminal-only — they depend on the benchmark tool's final result file, which doesn't exist until the run ends.

## 2. Delete the backing K8s Job when deleting a terminal run (`fix`)

`delete()` only called `runner.cancel()` (deletes the K8s Job with Background propagation) for **non-terminal** runs, assuming terminal runs' Jobs would be reaped by `ttlSecondsAfterFinished` (1h). So deleting a completed/failed/canceled run before that TTL fired orphaned the Job — and its pods — in `modeldoctor-benchmarks` for up to an hour. (Reported symptom: deleting an errored task left its Job behind.)

Now the Job is deleted on every path whenever a `driverHandle` exists. `runner.cancel()` is idempotent (404 → no-op) and best-effort, so it's safe for already-reaped Jobs and never blocks clearing a stuck row.

## Tests
- `benchmark.service.spec.ts`: terminal run **with** a handle now deletes the Job; terminal **without** a handle still skips. (39 pass)
- `EngineMetricsSection.test.tsx`: live mode renders the badge + queries a now-bounded window.
- `BenchmarkDetailPage.test.tsx`: Engine Metrics tab now appears while `status=running`.
- web + api `type-check` clean; biome clean (3 pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
