### PR TITLE
feat(web): compare matrix add/remove + Key-metrics outlier heatmap & arrows

### DIFF
--- a/apps/web/src/features/benchmarks/compare/AddBenchmarkButton.tsx
+++ b/apps/web/src/features/benchmarks/compare/AddBenchmarkButton.tsx
@@ -1,0 +1,86 @@
+import type { BenchmarkTool, ScenarioId } from "@modeldoctor/contracts";
+import { Plus } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useBenchmarkList } from "@/features/benchmarks/queries";
+
+export interface AddBenchmarkButtonProps {
+  /** Restrict candidates to the comparison's scenario + tool so the added run
+   *  stays metric-compatible (avoids the mixed-tools / mixed-scenarios guard). */
+  scenario: ScenarioId;
+  tool: BenchmarkTool;
+  /** Already-selected benchmark ids — filtered out of the candidate list. */
+  existingIds: string[];
+  onAdd: (id: string) => void;
+}
+
+export function AddBenchmarkButton({
+  scenario,
+  tool,
+  existingIds,
+  onAdd,
+}: AddBenchmarkButtonProps) {
+  const { t } = useTranslation("benchmarks");
+  const [open, setOpen] = useState(false);
+
+  // Only completed runs carry summaryMetrics worth comparing. limit=100 is a
+  // single page — comparisons span a handful of runs, not hundreds.
+  const { data, isLoading } = useBenchmarkList({
+    scenario,
+    tool,
+    status: "completed",
+    limit: 100,
+  });
+
+  const existing = useMemo(() => new Set(existingIds), [existingIds]);
+  const candidates = useMemo(
+    () => (data?.pages.flatMap((p) => p.items) ?? []).filter((b) => !existing.has(b.id)),
+    [data, existing],
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button type="button" variant="outline" size="sm" className="gap-1">
+          <Plus className="h-4 w-4" />
+          {t("compare.matrix.add")}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80 p-0">
+        <Command
+          // Match on name; ids are opaque cuids and not useful to type.
+          filter={(value, search) => (value.toLowerCase().includes(search.toLowerCase()) ? 1 : 0)}
+        >
+          <CommandInput placeholder={t("compare.matrix.addPlaceholder")} />
+          <CommandList>
+            <CommandEmpty>
+              {isLoading ? t("compare.matrix.addLoading") : t("compare.matrix.addEmpty")}
+            </CommandEmpty>
+            {candidates.map((b) => (
+              <CommandItem
+                key={b.id}
+                value={b.name}
+                onSelect={() => {
+                  onAdd(b.id);
+                  // Keep the popover open so several runs can be added in a row;
+                  // the just-added run drops out of `candidates` on re-render.
+                }}
+              >
+                <span className="truncate">{b.name}</span>
+              </CommandItem>
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
+++ b/apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
@@ -10,6 +10,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { benchmarkApi } from "../api";
 import { benchmarkKeys } from "../queries";
+import { AddBenchmarkButton } from "./AddBenchmarkButton";
 import { CompareToolbar } from "./CompareToolbar";
 import { type ReportRun, ReportSections } from "./ReportSections";
 import { shortRunLabels } from "./run-label";
@@ -111,6 +112,21 @@ export function BenchmarkComparePage() {
     // re-renders. "none" is the sentinel for explicit None selection.
     sp.set("baseline", next ?? "none");
     setSearchParams(sp);
+  }
+
+  // Add / remove rewrite the URL ids — the single source of run membership +
+  // order, exactly like onReorder. `replace` keeps the back button sane.
+  function setIds(next: string[]) {
+    const sp = new URLSearchParams(searchParams);
+    sp.set("ids", next.join(","));
+    setSearchParams(sp, { replace: true });
+  }
+  function handleRemove(id: string) {
+    setIds(ids.filter((x) => x !== id));
+  }
+  function handleAdd(id: string) {
+    if (ids.includes(id)) return;
+    setIds([...ids, id]);
   }
 
   // Unreachable path: BenchmarkCompareGate routes empty `ids` to
@@ -235,10 +251,17 @@ export function BenchmarkComparePage() {
               onReorder={(newIds) => {
                 // URL ids order is the single source of run order — tables,
                 // charts and SaveCompareDialog all follow it via useQueries.
-                const sp = new URLSearchParams(searchParams);
-                sp.set("ids", newIds.join(","));
-                setSearchParams(sp, { replace: true });
+                setIds(newIds);
               }}
+              onRemove={handleRemove}
+              matrixActions={
+                <AddBenchmarkButton
+                  scenario={successfulBenchmarks[0].scenario}
+                  tool={successfulBenchmarks[0].tool}
+                  existingIds={ids}
+                  onAdd={handleAdd}
+                />
+              }
             />
             <SaveCompareDialog
               open={saveOpen}

--- a/apps/web/src/features/benchmarks/compare/MetricRow.tsx
+++ b/apps/web/src/features/benchmarks/compare/MetricRow.tsx
@@ -4,7 +4,9 @@ import { cn } from "@/lib/utils";
 import { formatLatencyMs, formatPct, formatPercentFromFraction, formatThroughput } from "./format";
 import { deltaText, type MetricRowDescriptor } from "./metrics";
 import type { ReportBenchmarkSnapshot } from "./ReportSections";
-import { VerdictBadge } from "./VerdictBadge";
+import { isOutlier, rowStats } from "./row-stats";
+import { VERDICT_COLOR_CLASSES, VerdictBadge, verdictIcon } from "./VerdictBadge";
+import type { Verdict } from "./verdict";
 import { verdictFor } from "./verdict";
 
 export interface MetricRowProps {
@@ -33,31 +35,74 @@ function fmtCell(n: number | null, descriptor: MetricRowDescriptor): string {
   }
 }
 
+// Background tint for a strong outlier cell (no-baseline mode). Direction comes
+// from the metric's verdictKind vs the row mean: a worse-direction outlier is
+// red, a better-direction one green; a metric with no direction (raw rows) gets
+// a neutral amber wash so it still stands out without implying good/bad.
+const OUTLIER_TINT: Record<Verdict, string> = {
+  regressed: "bg-red-50 dark:bg-red-950/30",
+  improved: "bg-green-50 dark:bg-green-950/30",
+  unchanged: "bg-amber-50 dark:bg-amber-950/30",
+};
+
 export function MetricRow({ descriptor, runs, baselineId }: MetricRowProps) {
   const { t } = useTranslation("benchmarks");
   const baseline = baselineId ? runs.find((r) => r.id === baselineId) : null;
   const baselineValue = baseline ? descriptor.read(baseline.summaryMetrics) : null;
   const verdictKind = descriptor.verdictKind;
 
+  const values = runs.map((run) => descriptor.read(run.summaryMetrics));
+  // Mean-relative orientation (arrows + outlier heatmap) only kicks in when no
+  // baseline is chosen — with a baseline the vs-baseline VerdictBadge owns the
+  // good/bad story, and mixing two reference frames would be confusing.
+  const meanMode = baselineId === null;
+  const stats = meanMode ? rowStats(values) : null;
+
   return (
     <TableRow>
       <TableCell className="text-xs text-muted-foreground">
         {t(`compare.metricRowLabel.${descriptor.labelKey}`)}
       </TableCell>
-      {runs.map((run) => {
-        const v = descriptor.read(run.summaryMetrics);
+      {runs.map((run, i) => {
+        const v = values[i];
         const isBaseline = run.id === baselineId;
+
+        // No-baseline orientation vs the row mean.
+        const meanVerdict =
+          stats && v !== null && verdictKind ? verdictFor(verdictKind, stats.mean, v) : null;
+        const outlier = stats !== null && v !== null && isOutlier(v, stats);
+        const Arrow =
+          meanVerdict && meanVerdict !== "unchanged" && verdictKind
+            ? verdictIcon(meanVerdict, verdictKind)
+            : null;
+        const outlierTint = outlier ? OUTLIER_TINT[meanVerdict ?? "unchanged"] : undefined;
+        const outlierTitle =
+          outlier && stats && v !== null && verdictKind
+            ? t("compare.outlierTitle", {
+                delta: deltaText(verdictKind, stats.mean, v),
+                defaultValue: `${deltaText(verdictKind, stats.mean, v)} vs mean`,
+              })
+            : undefined;
 
         return (
           <TableCell
             key={run.id}
+            title={outlierTitle}
             className={cn(
               "text-right tabular-nums",
-              isBaseline && "bg-amber-50 dark:bg-amber-950/30",
+              isBaseline ? "bg-amber-50 dark:bg-amber-950/30" : outlierTint,
             )}
           >
             <div className="flex flex-col items-end gap-0.5">
-              <span>{fmtCell(v, descriptor)}</span>
+              <span className="inline-flex items-center justify-end gap-1">
+                {Arrow && meanVerdict && (
+                  <Arrow
+                    className={cn("h-3 w-3 shrink-0", VERDICT_COLOR_CLASSES[meanVerdict])}
+                    aria-hidden="true"
+                  />
+                )}
+                <span>{fmtCell(v, descriptor)}</span>
+              </span>
               {/* Inline predicate so TS narrows verdictKind / baselineValue / v
                   through the && chain — see PR review on Task 5. */}
               {verdictKind !== undefined && !isBaseline && baselineValue !== null && v !== null && (

--- a/apps/web/src/features/benchmarks/compare/ReportSections.tsx
+++ b/apps/web/src/features/benchmarks/compare/ReportSections.tsx
@@ -15,7 +15,8 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { GripVertical } from "lucide-react";
+import { GripVertical, X } from "lucide-react";
+import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { CompareGrid } from "./CompareGrid";
@@ -69,6 +70,14 @@ export interface ReportSectionsProps {
    * this component never keeps a local copy.
    */
   onReorder?: (orderedIds: string[]) => void;
+  /**
+   * When provided, each Test-matrix row gets a remove button. Disabled once
+   * only two runs remain (a comparison needs ≥2). The caller drops the id from
+   * the URL ids.
+   */
+  onRemove?: (id: string) => void;
+  /** Rendered at the top-right of the Test-matrix section (e.g. an Add button). */
+  matrixActions?: ReactNode;
 }
 
 // Static sensor options hoisted to module scope: dnd-kit's `useSensor` depends
@@ -82,10 +91,14 @@ function MatrixRowCells({
   r,
   t,
   showPrefixCache,
+  onRemove,
+  removeDisabled,
 }: {
   r: ReportRun;
   t: (key: string) => string;
   showPrefixCache: boolean;
+  onRemove?: (id: string) => void;
+  removeDisabled?: boolean;
 }) {
   const pc = showPrefixCache ? readPrefixCache(r.serverMetrics) : null;
   return (
@@ -111,6 +124,20 @@ function MatrixRowCells({
           </td>
         </>
       ) : null}
+      {onRemove ? (
+        <td className="w-8 px-2 py-2 text-right">
+          <button
+            type="button"
+            aria-label={t("compare.matrix.remove")}
+            title={removeDisabled ? t("compare.matrix.removeDisabled") : t("compare.matrix.remove")}
+            disabled={removeDisabled}
+            onClick={() => onRemove(r.id)}
+            className="rounded-sm p-1 text-muted-foreground hover:bg-muted hover:text-destructive disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </td>
+      ) : null}
     </>
   );
 }
@@ -122,11 +149,15 @@ function SortableMatrixRow({
   t,
   handleLabel,
   showPrefixCache,
+  onRemove,
+  removeDisabled,
 }: {
   r: ReportRun;
   t: (key: string) => string;
   handleLabel: string;
   showPrefixCache: boolean;
+  onRemove?: (id: string) => void;
+  removeDisabled?: boolean;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: r.id,
@@ -148,7 +179,13 @@ function SortableMatrixRow({
           <GripVertical className="h-4 w-4" />
         </button>
       </td>
-      <MatrixRowCells r={r} t={t} showPrefixCache={showPrefixCache} />
+      <MatrixRowCells
+        r={r}
+        t={t}
+        showPrefixCache={showPrefixCache}
+        onRemove={onRemove}
+        removeDisabled={removeDisabled}
+      />
     </tr>
   );
 }
@@ -163,7 +200,13 @@ function SortableMatrixRow({
  *
  * `data-report-root` is exposed for the export-as-HTML utility.
  */
-export function ReportSections({ runs, baselineId, onReorder }: ReportSectionsProps) {
+export function ReportSections({
+  runs,
+  baselineId,
+  onReorder,
+  onRemove,
+  matrixActions,
+}: ReportSectionsProps) {
   const { t } = useTranslation("benchmarks");
   // Type-guard predicate (not just `!== null`) so `r.benchmark` narrows to
   // non-null below — lets `CompareGrid` receive `ReportBenchmarkSnapshot[]`
@@ -179,6 +222,8 @@ export function ReportSections({ runs, baselineId, onReorder }: ReportSectionsPr
     livingRuns.length > 0 &&
     livingRuns.every((r) => readPrefixCache(r.serverMetrics) !== null);
   const sortable = onReorder !== undefined;
+  // A comparison needs ≥2 runs; block removing the second-to-last.
+  const removeDisabled = runs.length <= 2;
   const sensors = useSensors(
     useSensor(PointerSensor, POINTER_SENSOR_OPTIONS),
     useSensor(KeyboardSensor, KEYBOARD_SENSOR_OPTIONS),
@@ -208,6 +253,7 @@ export function ReportSections({ runs, baselineId, onReorder }: ReportSectionsPr
               <th className="px-3 py-2 text-right">{t("compare.matrixCol.topPodShare")}</th>
             </>
           ) : null}
+          {onRemove ? <th className="w-8 px-2 py-2" aria-hidden /> : null}
         </tr>
       </thead>
       <tbody>
@@ -219,11 +265,19 @@ export function ReportSections({ runs, baselineId, onReorder }: ReportSectionsPr
                 t={t}
                 handleLabel={t("compare.dragHandle")}
                 showPrefixCache={showPrefixCache}
+                onRemove={onRemove}
+                removeDisabled={removeDisabled}
               />
             ))
           : runs.map((r) => (
               <tr key={r.id} className="border-border border-t">
-                <MatrixRowCells r={r} t={t} showPrefixCache={showPrefixCache} />
+                <MatrixRowCells
+                  r={r}
+                  t={t}
+                  showPrefixCache={showPrefixCache}
+                  onRemove={onRemove}
+                  removeDisabled={removeDisabled}
+                />
               </tr>
             ))}
       </tbody>
@@ -234,7 +288,10 @@ export function ReportSections({ runs, baselineId, onReorder }: ReportSectionsPr
     <div data-report-root className="space-y-8">
       {/* 1. Test matrix */}
       <section>
-        <h2 className="mb-3 text-lg font-semibold">{t("savedCompare.report.sectionMatrix")}</h2>
+        <div className="mb-3 flex items-center justify-between gap-2">
+          <h2 className="text-lg font-semibold">{t("savedCompare.report.sectionMatrix")}</h2>
+          {matrixActions}
+        </div>
         <div className="overflow-x-auto rounded-md border border-border">
           {sortable ? (
             <DndContext

--- a/apps/web/src/features/benchmarks/compare/VerdictBadge.tsx
+++ b/apps/web/src/features/benchmarks/compare/VerdictBadge.tsx
@@ -11,7 +11,9 @@ export interface VerdictBadgeProps {
   deltaText: string;
 }
 
-function iconFor(verdict: Verdict, kind: VerdictKind) {
+/** Icon for a verdict, oriented by metric kind. Exported so the no-baseline
+ *  mean-trend arrow in MetricRow shares one direction convention. */
+export function verdictIcon(verdict: Verdict, kind: VerdictKind) {
   if (verdict === "unchanged") return Minus;
   // Higher = worse for latency/errorRate; higher = better for throughput.
   const upIsBad = kind === "latency" || kind === "errorRate";
@@ -19,17 +21,20 @@ function iconFor(verdict: Verdict, kind: VerdictKind) {
   return upIsBad ? TrendingDown : TrendingUp;
 }
 
-const COLOR_CLASSES: Record<Verdict, string> = {
+export const VERDICT_COLOR_CLASSES: Record<Verdict, string> = {
   regressed: "text-destructive",
   improved: "text-green-700 dark:text-green-400",
   unchanged: "text-muted-foreground",
 };
 
 export function VerdictBadge({ verdict, verdictKind, deltaText }: VerdictBadgeProps) {
-  const Icon = iconFor(verdict, verdictKind);
+  const Icon = verdictIcon(verdict, verdictKind);
   return (
     <span
-      className={cn("inline-flex items-center gap-1 text-xs tabular-nums", COLOR_CLASSES[verdict])}
+      className={cn(
+        "inline-flex items-center gap-1 text-xs tabular-nums",
+        VERDICT_COLOR_CLASSES[verdict],
+      )}
     >
       <Icon className="h-3 w-3" aria-hidden="true" />
       {deltaText}

--- a/apps/web/src/features/benchmarks/compare/__tests__/AddBenchmarkButton.test.tsx
+++ b/apps/web/src/features/benchmarks/compare/__tests__/AddBenchmarkButton.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@/lib/i18n";
+import { AddBenchmarkButton } from "../AddBenchmarkButton";
+
+const useBenchmarkListMock = vi.fn();
+vi.mock("@/features/benchmarks/queries", () => ({
+  useBenchmarkList: (q: unknown) => useBenchmarkListMock(q),
+}));
+
+function page(items: { id: string; name: string }[]) {
+  return { data: { pages: [{ items, nextCursor: null }] }, isLoading: false };
+}
+
+describe("<AddBenchmarkButton>", () => {
+  beforeEach(() => useBenchmarkListMock.mockReset());
+
+  it("queries completed runs scoped to scenario + tool", () => {
+    useBenchmarkListMock.mockReturnValue(page([]));
+    render(
+      <AddBenchmarkButton scenario="lb-strategy" tool="aiperf" existingIds={[]} onAdd={() => {}} />,
+    );
+    expect(useBenchmarkListMock).toHaveBeenCalledWith(
+      expect.objectContaining({ scenario: "lb-strategy", tool: "aiperf", status: "completed" }),
+    );
+  });
+
+  it("lists candidates excluding already-selected ids and calls onAdd on click", async () => {
+    useBenchmarkListMock.mockReturnValue(
+      page([
+        { id: "a", name: "run-A" },
+        { id: "b", name: "run-B" },
+        { id: "c", name: "run-C" },
+      ]),
+    );
+    const onAdd = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AddBenchmarkButton scenario="lb-strategy" tool="aiperf" existingIds={["b"]} onAdd={onAdd} />,
+    );
+    await user.click(screen.getByRole("button", { name: /Add benchmark|添加/i }));
+    // run-B is already selected → excluded; run-A / run-C are offered.
+    await waitFor(() => expect(screen.getByText("run-A")).toBeInTheDocument());
+    expect(screen.queryByText("run-B")).not.toBeInTheDocument();
+    await user.click(screen.getByText("run-C"));
+    expect(onAdd).toHaveBeenCalledWith("c");
+  });
+});

--- a/apps/web/src/features/benchmarks/compare/__tests__/MetricRow.test.tsx
+++ b/apps/web/src/features/benchmarks/compare/__tests__/MetricRow.test.tsx
@@ -95,6 +95,41 @@ describe("MetricRow", () => {
     expect(container.querySelector("svg")).toBeNull();
   });
 
+  it("no-baseline: tints a worse-direction outlier red and shows a trend arrow", () => {
+    // Mirrors the screenshot TTFT-p99 row: one huge value, rest clustered.
+    const vals = [4571, 1973, 442, 413, 1448, 317, 318, 463];
+    const runs = vals.map((v, i) => makeBenchmark(`r${i}`, v));
+    render(
+      <table>
+        <tbody>
+          <MetricRow descriptor={p95Descriptor} runs={runs} baselineId={null} />
+        </tbody>
+      </table>,
+    );
+    const outlierCell = screen.getByText("4571 ms").closest("td");
+    expect(outlierCell).not.toBeNull();
+    // latency above mean = worse → red tint + a direction arrow icon.
+    expect(outlierCell?.className).toMatch(/bg-red-50/);
+    expect(outlierCell?.querySelector("svg")).not.toBeNull();
+    // A clustered (non-outlier) value is not tinted.
+    const normalCell = screen.getByText("442 ms").closest("td");
+    expect(normalCell?.className).not.toMatch(/bg-red-50|bg-green-50/);
+  });
+
+  it("no-baseline: does not tint when all values are within band", () => {
+    // Tight cluster — high z but <25% relative dev, so no outliers.
+    const vals = [29.9, 27.1, 24.9, 25.1, 25.3, 25.0, 24.8, 24.9];
+    const runs = vals.map((v, i) => makeBenchmark(`r${i}`, v));
+    const { container } = render(
+      <table>
+        <tbody>
+          <MetricRow descriptor={p95Descriptor} runs={runs} baselineId={null} />
+        </tbody>
+      </table>,
+    );
+    expect(container.querySelector("td.bg-red-50, td.bg-green-50")).toBeNull();
+  });
+
   it("renders em dash when reader returns null", () => {
     const baseline = makeBenchmark("b", 200);
     const current = {

--- a/apps/web/src/features/benchmarks/compare/row-stats.test.ts
+++ b/apps/web/src/features/benchmarks/compare/row-stats.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { isOutlier, OUTLIER_REL, OUTLIER_Z, rowStats } from "./row-stats";
+
+describe("rowStats", () => {
+  it("returns null below the minimum sample count", () => {
+    expect(rowStats([])).toBeNull();
+    expect(rowStats([1, 2])).toBeNull();
+    expect(rowStats([1, null])).toBeNull();
+  });
+
+  it("ignores null / non-finite values", () => {
+    const s = rowStats([10, null, 20, 30]);
+    expect(s).not.toBeNull();
+    expect(s?.n).toBe(3);
+    expect(s?.mean).toBe(20);
+  });
+
+  it("computes mean + population std", () => {
+    const s = rowStats([2, 4, 6]);
+    expect(s?.mean).toBe(4);
+    // population variance = ((2-4)^2 + 0 + (6-4)^2)/3 = 8/3
+    expect(s?.std).toBeCloseTo(Math.sqrt(8 / 3), 6);
+  });
+});
+
+describe("isOutlier", () => {
+  it("flags a value that is far in BOTH spread and magnitude", () => {
+    // TTFT p99 row from the screenshot: one huge value, rest clustered.
+    const values = [4571, 1973, 442, 413, 1448, 317, 318, 463];
+    const s = rowStats(values);
+    if (!s) throw new Error("expected stats");
+    expect(isOutlier(4571, s)).toBe(true); // ~2.4σ and +269%
+    expect(isOutlier(442, s)).toBe(false);
+  });
+
+  it("does NOT flag a tight cluster even when z-score is high", () => {
+    // ITL mean row: +15% is ~2.5σ but only 15% off — below the relative floor.
+    const values = [29.9, 27.1, 24.9, 25.1, 25.3, 25.0, 24.8, 24.9];
+    const s = rowStats(values);
+    if (!s) throw new Error("expected stats");
+    expect(isOutlier(29.9, s)).toBe(false);
+  });
+
+  it("never flags when std is 0 (all equal)", () => {
+    const s = rowStats([5, 5, 5]);
+    if (!s) throw new Error("expected stats");
+    expect(isOutlier(5, s)).toBe(false);
+  });
+
+  it("requires both gates: high relative dev but low z does not flag", () => {
+    // Two values far apart → the far one is +50% but only ~1σ (n=3 spread is wide).
+    const s = rowStats([100, 150, 200]);
+    if (!s) throw new Error("expected stats");
+    // 200 is +33% over mean 150; z = 50/40.8 ≈ 1.22 < OUTLIER_Z → not an outlier.
+    expect(OUTLIER_Z).toBe(2);
+    expect(OUTLIER_REL).toBe(0.25);
+    expect(isOutlier(200, s)).toBe(false);
+  });
+});

--- a/apps/web/src/features/benchmarks/compare/row-stats.ts
+++ b/apps/web/src/features/benchmarks/compare/row-stats.ts
@@ -1,0 +1,43 @@
+/**
+ * Per-row distribution stats for the compare Key-metrics grid.
+ *
+ * When no baseline is selected, cells are oriented against the row mean: an
+ * arrow shows direction vs mean and strong outliers get a heatmap tint. These
+ * helpers are pure so the thresholds stay unit-tested and out of the render.
+ */
+
+export interface RowStats {
+  mean: number;
+  /** Population standard deviation. */
+  std: number;
+  n: number;
+}
+
+/**
+ * Mean + population std over the finite values in a row. Returns null when
+ * fewer than {@link MIN_SAMPLES} values are present — a "mean" over one or two
+ * points isn't a meaningful reference, so the grid skips arrows/highlight then.
+ */
+export const MIN_SAMPLES = 3;
+
+export function rowStats(values: readonly (number | null)[]): RowStats | null {
+  const nums = values.filter((v): v is number => v !== null && Number.isFinite(v));
+  if (nums.length < MIN_SAMPLES) return null;
+  const mean = nums.reduce((a, b) => a + b, 0) / nums.length;
+  const variance = nums.reduce((a, b) => a + (b - mean) ** 2, 0) / nums.length;
+  return { mean, std: Math.sqrt(variance), n: nums.length };
+}
+
+// Outlier gate: BOTH a spread test (z-score) AND a magnitude test (relative
+// deviation). The z-score alone over-flags tightly-clustered rows (e.g. ITL
+// 24.8–29.9 ms, where +15% reads as ~2.5σ); the relative floor keeps "modest
+// but technically far" values from lighting up. A value must clear both.
+export const OUTLIER_Z = 2;
+export const OUTLIER_REL = 0.25;
+
+export function isOutlier(value: number, stats: RowStats): boolean {
+  if (stats.std === 0) return false;
+  const z = Math.abs(value - stats.mean) / stats.std;
+  const rel = stats.mean !== 0 ? Math.abs(value - stats.mean) / Math.abs(stats.mean) : 0;
+  return z >= OUTLIER_Z && rel >= OUTLIER_REL;
+}

--- a/apps/web/src/locales/en-US/benchmarks.json
+++ b/apps/web/src/locales/en-US/benchmarks.json
@@ -366,7 +366,16 @@
       "concurrency": "concurrency",
       "hitRate": "Hit Rate",
       "topPodShare": "Top Pod Share"
-    }
+    },
+    "matrix": {
+      "add": "Add benchmark",
+      "addPlaceholder": "Search benchmarks…",
+      "addEmpty": "No comparable benchmarks to add",
+      "addLoading": "Loading…",
+      "remove": "Remove from comparison",
+      "removeDisabled": "A comparison needs at least 2 benchmarks"
+    },
+    "outlierTitle": "{{delta}} vs row mean"
   },
   "savedCompare": {
     "savedListLink": "Saved comparisons",

--- a/apps/web/src/locales/zh-CN/benchmarks.json
+++ b/apps/web/src/locales/zh-CN/benchmarks.json
@@ -366,7 +366,16 @@
       "concurrency": "并发",
       "hitRate": "命中率",
       "topPodShare": "最热 Pod 占比"
-    }
+    },
+    "matrix": {
+      "add": "添加 benchmark",
+      "addPlaceholder": "搜索 benchmark…",
+      "addEmpty": "没有可添加的同类 benchmark",
+      "addLoading": "加载中…",
+      "remove": "从对比中移除",
+      "removeDisabled": "对比至少需要 2 个 benchmark"
+    },
+    "outlierTitle": "{{delta}}（相对本行均值）"
   },
   "savedCompare": {
     "savedListLink": "历史对比",


### PR DESCRIPTION
Compare-page (ad-hoc `/benchmarks/compare`) enhancements from operator feedback. Two independent commits.

## 1. Edit the Test matrix in place — add / remove benchmarks

The matrix was reorder-only, locked to the `?ids=` you arrived with.

- **Remove**: each row gets a × button → drops the id from the URL ids. Disabled once two runs remain (a comparison needs ≥2).
- **Add**: an "Add benchmark" button (top-right of the matrix) opens a searchable popover of candidates — **completed** runs scoped to the comparison's own **scenario + tool**, excluding already-selected ids — so additions stay metric-compatible and never trip the mixed-tools / mixed-scenarios guard. Stays open for adding several.

Both rewrite the URL ids exactly like the existing drag-reorder, so matrix / charts / grid / SaveCompareDialog all follow via `useQueries`. Scoped to the ad-hoc compare page; saved reports stay read-only snapshots.

## 2. Key-metrics grid: outlier heatmap + mean-trend arrows

With **Baseline = None** the grid was a wall of plain numbers. When no baseline is selected, each metric row is now oriented against its **own mean**:

- **Arrows**: cells that differ meaningfully from the row mean get a direction arrow, colored good/bad by the metric's `verdictKind` (latency/errorRate: higher = worse; throughput: higher = better). Reuses the existing verdict logic.
- **Heatmap**: strong outliers get a tint — worse-direction **red**, better-direction **green**, direction-less raw rows neutral **amber**. Outlier gate = `|z| ≥ 2` **AND** `≥25%` off the mean (dual gate: tight clusters like ITL 24.8–29.9 stay quiet; real spikes like TTFT p99 4571 ms light up).

When a baseline **is** selected, behavior is unchanged — the vs-baseline `VerdictBadge` keeps owning the good/bad story (no mixed reference frames). Stats need ≥3 finite values, so 2-run compares are unaffected.

## Tests
- `row-stats.test.ts`: outlier dual-gate (spikes flagged, tight clusters not, std=0 safe).
- `MetricRow.test.tsx`: no-baseline tint + arrow on a worse-direction outlier; no tint for within-band rows; baseline-mode behavior unchanged.
- `AddBenchmarkButton.test.tsx`: scope query (scenario+tool+completed); excludes selected ids; onAdd fires.
- web `type-check` clean; 131 compare tests pass; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
