### PR TITLE
feat(benchmark): lb-strategy 工具链 — errorRate 口径修复 + 延迟图 log 轴 + t5/t6 模板

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -225,12 +225,7 @@ const EVALUATION_PROFILES: EvaluationProfileSeed[] = [
 // ---------------------------------------------------------------------------
 
 type Tool = "guidellm" | "evalscope" | "aiperf" | "vegeta";
-type SeedScenario =
-  | "inference"
-  | "engine-kv-cache"
-  | "capacity"
-  | "gateway"
-  | "lb-strategy";
+type SeedScenario = "inference" | "engine-kv-cache" | "capacity" | "gateway" | "lb-strategy";
 interface BenchmarkTemplateSeed {
   id: string;
   name: string;
@@ -839,6 +834,57 @@ const BENCHMARK_TEMPLATES: BenchmarkTemplateSeed[] = [
       extraArgs: '--extra-inputs \'{"chat_template_kwargs":{"enable_thinking":false}}\'',
     },
     tags: ["prefix-cache", "aiperf", "multi-turn", "shallow"],
+    categories: ["chat"],
+  },
+  {
+    id: "tpl_pc_t5_sharegpt",
+    name: "路由粘性 · 真实对话 ShareGPT (t5)",
+    description:
+      "【LB prefix_cache 策略路由验证 · 真实数据】aiperf 内置 ShareGPT 真实人机多轮语料 + 粘性会话路由,业界多轮服务压测事实标准。相比合成 t2_deep,用真实对话分布给客户背书;聊天回答天然较长(decode-bound),收益主要体现在 TTFT 与命中率,e2e 受 decode 主导变化小(物理预期)。",
+    scenario: "lb-strategy",
+    tool: "aiperf",
+    config: {
+      concurrency: 20,
+      requestCount: 300,
+      inputTokensMean: 200,
+      inputTokensStddev: 0,
+      outputTokensMean: 800,
+      outputTokensStddev: 0,
+      endpointType: "chat",
+      streaming: true,
+      dataset: "sharegpt",
+      conversationNum: 30,
+      conversationType: "sticky-user-sessions",
+      seed: 42,
+      extraArgs: '--extra-inputs \'{"chat_template_kwargs":{"enable_thinking":false}}\'',
+    },
+    tags: ["prefix-cache", "aiperf", "multi-turn", "sharegpt", "real-data"],
+    categories: ["chat"],
+  },
+  {
+    id: "tpl_pc_t6_prefill",
+    name: "高并发长前缀 · RAG/Agent 形态 (t6)",
+    description:
+      "【LB prefix_cache 策略路由验证 · prefill-bound】模拟 RAG/Agent:大上下文(in 3000)+ 短回答(out 64)+ 高并发(100,逼近 4×max-num-seqs)。粘性会话把大前缀钉在同一 pod,4 轮复用。与 chat 形态(t2/t5,decode-bound)相反——此处 prefill 占 e2e 大头,争抢下 OFF 反复重算大前缀会排队,ON 命中后 TTFT/e2e/吞吐全面显性受益。注:in3000×4 轮累积约 12k token,需 max-model-len ≥ 16384。",
+    scenario: "lb-strategy",
+    tool: "aiperf",
+    config: {
+      concurrency: 100,
+      requestCount: 480,
+      inputTokensMean: 3000,
+      inputTokensStddev: 0,
+      outputTokensMean: 64,
+      outputTokensStddev: 0,
+      endpointType: "chat",
+      streaming: true,
+      dataset: "synthetic",
+      conversationNum: 120,
+      conversationTurnMean: 4,
+      conversationType: "sticky-user-sessions",
+      seed: 42,
+      extraArgs: '--extra-inputs \'{"chat_template_kwargs":{"enable_thinking":false}}\'',
+    },
+    tags: ["prefix-cache", "aiperf", "prefill-bound", "rag", "high-concurrency"],
     categories: ["chat"],
   },
   {

--- a/apps/web/src/components/charts/StageBarChart.tsx
+++ b/apps/web/src/components/charts/StageBarChart.tsx
@@ -78,6 +78,13 @@ export interface StageBarChartProps {
    */
   variant?: "bar" | "line";
   /**
+   * Logarithmic y-axis. Use for wide-range percentile figures (TTFT/TPOT/E2E
+   * p50→p99 can span an order of magnitude) where a linear axis squashes the
+   * p50 band flat and hides ON/OFF differences. Mainstream for latency
+   * percentile panels (Grafana). Leave off for bounded metrics (%, hit-rate).
+   */
+  logScale?: boolean;
+  /**
    * Shared `PanelUnit` (ms / % / rps / …). When set, the y-axis ticks, tooltip,
    * and bar labels all format through `formatPanelValue` — the same system the
    * time-series charts use — so units and precision stay consistent app-wide
@@ -149,6 +156,7 @@ export function StageBarChart({
   barColors,
   baselineSeriesKey,
   variant = "bar",
+  logScale = false,
   unit,
   valueFormatter,
 }: StageBarChartProps): JSX.Element {
@@ -282,11 +290,17 @@ export function StageBarChart({
           axisLabel: { color: lc.value, fontWeight: 600, fontSize: 12 },
         },
         yAxis: {
-          type: "value",
-          // 20% headroom so the top value labels are not clipped. Keep it
-          // fractional — `Math.ceil` would round sub-1 maxima (small error
-          // rates / throughputs) up to 1 and squash the bars flat.
-          max: (v: { max: number }) => (v.max > 0 ? v.max * 1.2 : 1),
+          // Log axis decompresses the p50 band on wide-range percentile figures
+          // so ON/OFF differences are visible; echarts auto-picks the log min
+          // (power of 10 below the data) and adds its own headroom, so the
+          // linear 20% `max` headroom is skipped in that mode.
+          type: logScale ? "log" : "value",
+          ...(logScale
+            ? {}
+            : // 20% headroom so the top value labels are not clipped. Keep it
+              // fractional — `Math.ceil` would round sub-1 maxima (small error
+              // rates / throughputs) up to 1 and squash the bars flat.
+              { max: (v: { max: number }) => (v.max > 0 ? v.max * 1.2 : 1) }),
           // Format ticks through the same unit-aware formatter so the headroom
           // max never renders as a raw float (e.g. "1.6612971606561588").
           axisLabel: { color: lc.baseline, formatter: (v: number) => fmt(v) },
@@ -307,6 +321,7 @@ export function StageBarChart({
     baselineSeriesKey,
     barColors,
     variant,
+    logScale,
     unit,
     valueFormatter,
     labelColors?.value,

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
@@ -186,6 +186,7 @@ export const FigureRenderer = memo(function FigureRenderer({
         data={rows.length > 0 ? data : []}
         series={series}
         yLabel="ms"
+        logScale
         baselineSeriesKey={baselineKeyOf(rows, baselineId)}
         labelColors={REPORT_LABEL_COLORS}
       />
@@ -210,6 +211,7 @@ export const FigureRenderer = memo(function FigureRenderer({
         data={rows.length > 0 ? data : []}
         series={series}
         yLabel="ms"
+        logScale
         baselineSeriesKey={baselineKeyOf(rows, baselineId)}
         labelColors={REPORT_LABEL_COLORS}
       />
@@ -233,6 +235,7 @@ export const FigureRenderer = memo(function FigureRenderer({
         data={rows.length > 0 ? data : []}
         series={series}
         yLabel="ms"
+        logScale
         baselineSeriesKey={baselineKeyOf(rows, baselineId)}
         labelColors={REPORT_LABEL_COLORS}
       />

--- a/packages/tool-adapters/src/aiperf/runtime.spec.ts
+++ b/packages/tool-adapters/src/aiperf/runtime.spec.ts
@@ -319,10 +319,38 @@ describe("aiperf.parseFinalReport", () => {
     );
     const report = parseFinalReport("", { report: buf });
     if (report.tool !== "aiperf") throw new Error(`expected aiperf, got ${report.tool}`);
-    expect(report.data.requests.total).toBe(100);
+    // aiperf request_count = successes (100), error_request_count = failures (5),
+    // so total attempts = 105 and errorRate = 5/105.
+    expect(report.data.requests.total).toBe(105);
     expect(report.data.requests.error).toBe(5);
-    expect(report.data.requests.success).toBe(95);
-    expect(report.data.requests.errorRate).toBeCloseTo(0.05);
+    expect(report.data.requests.success).toBe(100);
+    expect(report.data.requests.errorRate).toBeCloseTo(5 / 105);
+  });
+
+  it("keeps errorRate in [0,1] when failures exceed successes (regression)", () => {
+    // Real t6 high-load run: 61 successful, 419 failed. The old code computed
+    // errorRate = 419/61 = 6.87 (> 1), which the schema rejected and discarded
+    // the whole run. Correct: total = 61 + 419 = 480, errorRate = 419/480.
+    const buf = Buffer.from(
+      JSON.stringify({
+        request_throughput: { unit: "requests/sec", avg: 2.7 },
+        request_latency: { unit: "ms", avg: 1700, p50: 1600, p90: 2200, p95: 2400, p99: 2800 },
+        time_to_first_token: { unit: "ms", avg: 300, p50: 280, p90: 400, p95: 450, p99: 550 },
+        inter_token_latency: { unit: "ms", avg: 28, p50: 26, p90: 33, p95: 36, p99: 40 },
+        output_token_throughput: { unit: "tokens/sec", avg: 1150 },
+        output_sequence_length: { unit: "tokens", avg: 256 },
+        input_sequence_length: { unit: "tokens", avg: 1020 },
+        request_count: { unit: "requests", avg: 61 },
+        error_request_count: { unit: "requests", avg: 419 },
+      }),
+    );
+    const report = parseFinalReport("", { report: buf });
+    if (report.tool !== "aiperf") throw new Error(`expected aiperf, got ${report.tool}`);
+    expect(report.data.requests.total).toBe(480);
+    expect(report.data.requests.success).toBe(61);
+    expect(report.data.requests.error).toBe(419);
+    expect(report.data.requests.errorRate).toBeCloseTo(419 / 480);
+    expect(report.data.requests.errorRate).toBeLessThanOrEqual(1);
   });
 
   it("throws when the report file is missing", () => {

--- a/packages/tool-adapters/src/aiperf/runtime.ts
+++ b/packages/tool-adapters/src/aiperf/runtime.ts
@@ -228,11 +228,17 @@ export function parseFinalReport(_stdout: string, files: Record<string, Buffer>)
   }
   const raw = JSON.parse(buf.toString("utf8")) as AiperfRawReport;
 
-  // Request counts: aiperf reports them as JsonMetricResult shapes too
-  // (avg = total count). error_request_count.avg holds the failure count.
-  const total = Math.round(raw.request_count?.avg ?? 0);
+  // Request counts: aiperf reports them as JsonMetricResult shapes (avg = count).
+  // IMPORTANT: aiperf's `request_count` counts only SUCCESSFUL requests, and
+  // `error_request_count` counts failures — they are disjoint, NOT total-vs-subset.
+  // So total attempts = success + failed. Treating request_count as the total
+  // (the old bug) made `success = total - failed` go negative and `errorRate =
+  // failed / request_count` exceed 1 under heavy errors (e.g. 419 failed / 61
+  // success → 6.87), which then failed the `errorRate ≤ 1` schema and discarded
+  // the whole run. Computing total as success+failed keeps errorRate in [0,1].
+  const success = Math.round(raw.request_count?.avg ?? 0);
   const failed = Math.round(raw.error_request_count?.avg ?? 0);
-  const success = Math.max(0, total - failed);
+  const total = success + failed;
   const errorRate = total === 0 ? 0 : failed / total;
 
   const outputTps = raw.output_token_throughput?.avg ?? 0;


### PR DESCRIPTION
lb-strategy 压测验证过程中沉淀的 3 个改动(一个 bug fix + 两个增强)。

## 1. `fix(aiperf)`: errorRate 计数口径
aiperf 的 `request_count` 只算**成功**请求,`error_request_count` 算失败,二者不相交。旧代码 `total = request_count`、`errorRate = failed/total`,重负载下 `failed > request_count` → errorRate **>1** → 被 `aiperfReportSchema` 的 `errorRate.max(1)` 拒收 → **整个 run 硬判 Failed、metrics 丢弃**(实测 419 失败 / 61 成功 = 6.87)。同时所有 run 的 `total`/`success` 一直被低算(只是 errorRate 不超 1 时没暴露)。
修复:`success = request_count; total = success + failed; errorRate = failed/total`(恒 [0,1])+ 419/61 高错误回归测试。

## 2. `feat(charts)`: 延迟百分位图 log 轴
TTFT/TPOT/E2E 百分位 p50→p99 跨一个数量级,线性轴把 p50 压平、看不出 ON/OFF 差异。给 `StageBarChart` 加 `logScale` 开关并在三个延迟图启用;百分比类(命中率/错误率)保持线性。Grafana 等延迟面板的主流做法。

## 3. `feat(benchmark)`: t5/t6 lb-strategy 模板
- **t5 `tpl_pc_t5_sharegpt`**:真实 ShareGPT 多轮 + 粘性会话,真实数据背书 LB 路由验证(注:aiperf `--public-dataset` 不接受 `--conversation-turn-mean`)
- **t6 `tpl_pc_t6_prefill`**:prefill-bound RAG/Agent 形态(in3000/out64/conc100)。与 decode-bound 聊天模板相反,此处 prefill 主导 e2e,prefix-cache 路由收益体现在 **e2e/吞吐**而非仅命中率

## 实验佐证
WARM 协议下,t6 (prefill-bound) **ON vs OFF:命中 +45pp、TTFT −58%、e2e −46%**;而 chat (t2/t5) e2e 持平 —— 验证"LB 路由的延迟收益只在 prefill-bound workload 上传导到 e2e"。

> tokenizer 来源(HF 镜像 / ModelScope)另见 #321,本 PR 不含。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
