### PR TITLE
feat(compare): 引擎指标快照进库 + compare 出图(KV利用率/抢占/排队)

### DIFF
--- a/apps/api/src/modules/benchmark/benchmark.module.ts
+++ b/apps/api/src/modules/benchmark/benchmark.module.ts
@@ -9,6 +9,8 @@ import { PrometheusFetcherService } from "../alerts/prometheus-fetcher.service.j
 import { BaselineModule } from "../baseline/baseline.module.js";
 import { BenchmarkTemplateModule } from "../benchmark-template/benchmark-template.module.js";
 import { ConnectionModule } from "../connection/connection.module.js";
+import { EngineMetricsModule } from "../engine-metrics/engine-metrics.module.js";
+import { EngineMetricsService } from "../engine-metrics/engine-metrics.service.js";
 import { NotificationsModule } from "../notifications/notifications.module.js";
 import { NotifyService } from "../notifications/notify.service.js";
 import { BenchmarkController } from "./benchmark.controller.js";
@@ -49,6 +51,7 @@ async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeCon
     BaselineModule,
     NotificationsModule,
     AlertsModule,
+    EngineMetricsModule,
   ],
   controllers: [BenchmarkController, BenchmarkFilesController],
   providers: [
@@ -97,6 +100,7 @@ async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeCon
         SseHub,
         PrefixCacheSnapshotService,
         PrometheusFetcherService,
+        EngineMetricsService,
       ],
       useFactory: (
         storage: ReportStorage,
@@ -105,8 +109,17 @@ async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeCon
         sse: SseHub,
         prefixCacheSnapshot: PrefixCacheSnapshotService,
         promFetcher: PrometheusFetcherService,
+        engineMetrics: EngineMetricsService,
       ): ReportLoader =>
-        new ReportLoader({ storage, repo, notify, sse, prefixCacheSnapshot, promFetcher }),
+        new ReportLoader({
+          storage,
+          repo,
+          notify,
+          sse,
+          prefixCacheSnapshot,
+          promFetcher,
+          engineMetrics,
+        }),
     },
     {
       provide: K8S_NAMESPACE,

--- a/apps/api/src/modules/benchmark/storage/report-loader.ts
+++ b/apps/api/src/modules/benchmark/storage/report-loader.ts
@@ -3,6 +3,8 @@ import { byTool as defaultByTool, type ToolName } from "@modeldoctor/tool-adapte
 import { Injectable, Logger } from "@nestjs/common";
 import type { Prisma } from "@prisma/client";
 import type { PrometheusFetcherService } from "../../alerts/prometheus-fetcher.service.js";
+import type { EngineMetricsService } from "../../engine-metrics/engine-metrics.service.js";
+import { reduceEngineSnapshot } from "../../engine-metrics/engine-metrics-snapshot.reduce.js";
 import type { NotifyService } from "../../notifications/notify.service.js";
 import type { BenchmarkRepository } from "../benchmark.repository.js";
 import { IN_PROGRESS_STATES } from "../constants.js";
@@ -26,6 +28,10 @@ export interface ReportLoaderDeps {
    *  the hook is silently skipped if either is absent. */
   prefixCacheSnapshot?: PrefixCacheSnapshotService;
   promFetcher?: PrometheusFetcherService;
+  /** Optional: when provided, an engine-metrics snapshot (live manifest reduced
+   *  to durable scalars) is taken after completion for the same lb-strategy +
+   *  Prometheus-datasource runs, stored under `serverMetrics.engineMetrics`. */
+  engineMetrics?: EngineMetricsService;
 }
 
 @Injectable()
@@ -88,6 +94,8 @@ export class ReportLoader {
         await this.trySnapshotPrefixCache({
           runId,
           scenario: bench.scenario,
+          userId: bench.userId ?? null,
+          connectionId: bench.connectionId ?? null,
           prometheusDatasourceId: bench.connection?.prometheusDatasourceId ?? null,
           connectionModel: bench.connection?.model ?? null,
           completedAt: updated.completedAt ?? null,
@@ -139,13 +147,23 @@ export class ReportLoader {
   private async trySnapshotPrefixCache(opts: {
     runId: string;
     scenario: string;
+    userId: string | null;
+    connectionId: string | null;
     prometheusDatasourceId: string | null;
     connectionModel: string | null;
     completedAt: Date | null;
     startedAt: Date | null;
   }): Promise<void> {
-    const { runId, scenario, prometheusDatasourceId, connectionModel, completedAt, startedAt } =
-      opts;
+    const {
+      runId,
+      scenario,
+      userId,
+      connectionId,
+      prometheusDatasourceId,
+      connectionModel,
+      completedAt,
+      startedAt,
+    } = opts;
     if (!this.deps.prefixCacheSnapshot || !this.deps.promFetcher) return;
     try {
       if (scenario !== "lb-strategy") return;
@@ -168,6 +186,26 @@ export class ReportLoader {
       const ann = await this.deps.prefixCacheSnapshot.snapshot({ ds, model, windowSec, at: end });
       if (ann) {
         await this.deps.repo.mergeServerMetrics(runId, { prefixCache: ann });
+      }
+
+      // Engine metrics: reuse the live snapshot manifest (fetchSnapshot resolves
+      // connection → datasource → all manifest queries) and reduce to durable
+      // scalars so historical compares survive Prometheus retention. Isolated
+      // try/catch — an engine-metrics failure must not undo the prefix-cache
+      // snapshot already merged above.
+      if (this.deps.engineMetrics && userId && connectionId) {
+        try {
+          const snap = await this.deps.engineMetrics.fetchSnapshot(userId, connectionId, {
+            from: startedAt.toISOString(),
+            to: end.toISOString(),
+          });
+          const engineAnn = reduceEngineSnapshot(snap);
+          if (engineAnn.metrics.length > 0) {
+            await this.deps.repo.mergeServerMetrics(runId, { engineMetrics: engineAnn });
+          }
+        } catch (e) {
+          this.log.warn(`engine-metrics snapshot(${runId}) failed: ${(e as Error).message}`);
+        }
       }
     } catch (e) {
       this.log.warn(`trySnapshotPrefixCache(${runId}) failed: ${(e as Error).message}`);

--- a/apps/api/src/modules/engine-metrics/engine-metrics-snapshot.reduce.spec.ts
+++ b/apps/api/src/modules/engine-metrics/engine-metrics-snapshot.reduce.spec.ts
@@ -1,0 +1,102 @@
+import type { EngineMetricsSnapshotResponse } from "@modeldoctor/contracts";
+import { describe, expect, it } from "vitest";
+import { reduceEngineSnapshot } from "./engine-metrics-snapshot.reduce.js";
+
+function resp(panels: EngineMetricsSnapshotResponse["panels"]): EngineMetricsSnapshotResponse {
+  return {
+    engineId: "vllm",
+    capability: "generative",
+    window: { from: "2026-06-24T00:00:00.000Z", to: "2026-06-24T00:05:00.000Z", step: 15 },
+    panels,
+  } as EngineMetricsSnapshotResponse;
+}
+
+describe("reduceEngineSnapshot", () => {
+  it("computes avg + peak over the window samples and stamps capturedAt = window.to", () => {
+    const out = reduceEngineSnapshot(
+      resp([
+        {
+          key: "kv_cache_usage",
+          unit: "%",
+          unavailable: false,
+          series: [
+            {
+              samples: [
+                [1, 10],
+                [2, 40],
+                [3, 70],
+              ],
+            },
+          ],
+        },
+      ]),
+      ["kv_cache_usage"],
+    );
+    expect(out.capturedAt).toBe("2026-06-24T00:05:00.000Z");
+    expect(out.metrics).toHaveLength(1);
+    expect(out.metrics[0]).toMatchObject({ key: "kv_cache_usage", unit: "%", avg: 40, peak: 70 });
+  });
+
+  it("flattens multi-series (per-pod) into one avg/peak", () => {
+    const out = reduceEngineSnapshot(
+      resp([
+        {
+          key: "preemption_rate",
+          unit: "rps",
+          unavailable: false,
+          series: [
+            {
+              label: "pod-0",
+              samples: [
+                [1, 2],
+                [2, 4],
+              ],
+            },
+            {
+              label: "pod-1",
+              samples: [
+                [1, 0],
+                [2, 6],
+              ],
+            },
+          ],
+        },
+      ]),
+      ["preemption_rate"],
+    );
+    // values 2,4,0,6 → avg 3, peak 6
+    expect(out.metrics[0]).toMatchObject({ avg: 3, peak: 6 });
+  });
+
+  it("drops unavailable / empty / non-finite panels and unselected keys", () => {
+    const out = reduceEngineSnapshot(
+      resp([
+        { key: "kv_cache_usage", unit: "%", unavailable: true, reason: "no_data", series: [] },
+        { key: "ttft_p99", unit: "ms", unavailable: false, series: [{ samples: [] }] },
+        {
+          key: "success_rate",
+          unit: "ratio",
+          unavailable: false,
+          series: [
+            {
+              samples: [
+                [1, Number.NaN],
+                [2, Number.POSITIVE_INFINITY],
+              ],
+            },
+          ],
+        },
+        {
+          key: "system_efficiency",
+          unit: "ratio",
+          unavailable: false,
+          series: [{ samples: [[1, 0.8]] }],
+        },
+      ]),
+      ["kv_cache_usage", "ttft_p99", "success_rate", "system_efficiency", "preemption_rate"],
+    );
+    // only system_efficiency survives (others unavailable/empty/non-finite/missing)
+    expect(out.metrics).toHaveLength(1);
+    expect(out.metrics[0]).toMatchObject({ key: "system_efficiency", avg: 0.8, peak: 0.8 });
+  });
+});

--- a/apps/api/src/modules/engine-metrics/engine-metrics-snapshot.reduce.ts
+++ b/apps/api/src/modules/engine-metrics/engine-metrics-snapshot.reduce.ts
@@ -1,0 +1,53 @@
+import type {
+  EngineMetricsAnnotation,
+  EngineMetricsSnapshotResponse,
+} from "@modeldoctor/contracts";
+
+/**
+ * The subset of engine-metric manifest keys we snapshot into
+ * `serverMetrics.engineMetrics` at benchmark completion and surface in
+ * compare (key-metrics table + cross-run bars). Kept small + cross-run
+ * meaningful — full time-series stay live on the detail-page tab.
+ */
+export const COMPARE_ENGINE_METRIC_KEYS = [
+  "success_rate",
+  "system_efficiency",
+  "ttft_p99",
+  "preemption_rate",
+  "kv_cache_usage",
+  "prefix_cache_hit_rate",
+  "request_queue_time",
+] as const;
+
+/**
+ * Reduce a live engine-metrics snapshot (per-metric time-series over the run
+ * window) to durable scalars: `avg` (window mean) + `peak` (window max) for
+ * each selected metric. Unavailable / empty panels are dropped. The frontend
+ * picks avg vs peak per metric (peak for kv-cache / queue saturation, avg for
+ * rates). `capturedAt` is the snapshot window end.
+ */
+export function reduceEngineSnapshot(
+  resp: EngineMetricsSnapshotResponse,
+  keys: readonly string[] = COMPARE_ENGINE_METRIC_KEYS,
+): EngineMetricsAnnotation {
+  const byKey = new Map(resp.panels.map((p) => [p.key, p]));
+  const metrics: EngineMetricsAnnotation["metrics"] = [];
+  for (const key of keys) {
+    const panel = byKey.get(key);
+    if (!panel || panel.unavailable) continue;
+    let sum = 0;
+    let count = 0;
+    let peak = Number.NEGATIVE_INFINITY;
+    for (const series of panel.series) {
+      for (const [, value] of series.samples) {
+        if (!Number.isFinite(value)) continue;
+        sum += value;
+        count += 1;
+        if (value > peak) peak = value;
+      }
+    }
+    if (count === 0) continue;
+    metrics.push({ key, unit: panel.unit, avg: sum / count, peak });
+  }
+  return { capturedAt: resp.window.to, metrics };
+}

--- a/apps/api/src/modules/saved-compares/metrics.ts
+++ b/apps/api/src/modules/saved-compares/metrics.ts
@@ -1,4 +1,8 @@
-import { type FigureRefId, prefixCacheAnnotationSchema } from "@modeldoctor/contracts";
+import {
+  engineMetricsAnnotationSchema,
+  type FigureRefId,
+  prefixCacheAnnotationSchema,
+} from "@modeldoctor/contracts";
 import { readMetricSafe } from "@modeldoctor/tool-adapters";
 
 export function readP95Latency(m: unknown): number | null {
@@ -97,6 +101,33 @@ export interface CapacityPoint {
 
 /** Read guidellm capacityCurve from a run's summaryMetrics ({tool,data}).
  * Mirrors the client-side `client-metrics.ts#readCapacityCurve`. */
+export interface EngineMetricValue {
+  avg: number | null;
+  peak: number | null;
+  unit: string;
+}
+
+/** Read one durable engine-metric scalar from serverMetrics.engineMetrics.
+ * Mirrors the client's `client-metrics.ts#readEngineMetric`. */
+export function readEngineMetric(serverMetrics: unknown, key: string): EngineMetricValue | null {
+  const parsed = engineMetricsAnnotationSchema.safeParse(
+    (serverMetrics as { engineMetrics?: unknown } | null)?.engineMetrics,
+  );
+  if (!parsed.success) return null;
+  const m = parsed.data.metrics.find((x) => x.key === key);
+  return m ? { avg: m.avg, peak: m.peak, unit: m.unit } : null;
+}
+
+/** refId → which engine metric + scalar to plot. Mirrors the client constant. */
+export const ENGINE_BAR_FIGURES: Record<
+  "stage-bars-kv-cache" | "stage-bars-preemption" | "stage-bars-queue",
+  { metricKey: string; pick: "avg" | "peak" }
+> = {
+  "stage-bars-kv-cache": { metricKey: "kv_cache_usage", pick: "peak" },
+  "stage-bars-preemption": { metricKey: "preemption_rate", pick: "avg" },
+  "stage-bars-queue": { metricKey: "request_queue_time", pick: "peak" },
+};
+
 export function readCapacityCurve(summaryMetrics: unknown): CapacityPoint[] | null {
   const m = summaryMetrics as { data?: { capacityCurve?: CapacityPoint[] } } | null;
   const c = m?.data?.capacityCurve;
@@ -143,6 +174,14 @@ export function availableFigureRefIds(runs: RunMetricBlobs[]): Set<FigureRefId> 
       out.add("pod-traffic-distribution");
       out.add("pod-hit-rate");
     }
+  }
+  // Engine-metrics figures need EVERY run to carry that durable scalar.
+  for (const [refId, spec] of Object.entries(ENGINE_BAR_FIGURES)) {
+    const present = runs.every((r) => {
+      const m = readEngineMetric(r.serverMetrics, spec.metricKey);
+      return m !== null && m[spec.pick] !== null;
+    });
+    if (present) out.add(refId as FigureRefId);
   }
   if (runs.some((r) => readCapacityCurve(r.summaryMetrics) !== null)) {
     out.add("throughput-vs-concurrency");

--- a/apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/lb-strategy.ts
@@ -50,6 +50,11 @@ function assemble(sc: HydratedSavedCompare): ScenarioData {
       "stage-bars-tpot-p95",
       "stage-bars-e2e-p95",
       "latency-distribution",
+      // Engine-metric mechanism evidence (durable serverMetrics.engineMetrics
+      // snapshot): why latency moved — KV-cache pressure / preemption / queueing.
+      "stage-bars-kv-cache",
+      "stage-bars-preemption",
+      "stage-bars-queue",
     ],
   };
 }

--- a/apps/web/src/features/benchmarks/compare/CompareGrid.tsx
+++ b/apps/web/src/features/benchmarks/compare/CompareGrid.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Table, TableBody, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { MetricRow } from "./MetricRow";
-import { rowDescriptorsForTool } from "./metrics";
+import { engineRowDescriptors, rowDescriptorsForTool } from "./metrics";
 import type { ReportBenchmarkSnapshot } from "./ReportSections";
 
 export interface CompareGridProps {
@@ -21,7 +21,10 @@ export function CompareGrid({ runs, baselineId, labels }: CompareGridProps) {
   // All runs share one tool by the time CompareGrid mounts (validated upstream).
   // If the array is empty just render nothing — BenchmarkComparePage shows EmptyState.
   const tool = runs[0]?.tool;
-  const descriptors = useMemo(() => (tool ? rowDescriptorsForTool(tool) : []), [tool]);
+  const descriptors = useMemo(
+    () => [...(tool ? rowDescriptorsForTool(tool) : []), ...engineRowDescriptors(runs)],
+    [tool, runs],
+  );
 
   if (descriptors.length === 0) return null;
 

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
@@ -12,7 +12,9 @@ import {
 import { ThroughputConcurrencyChart } from "@/components/charts/ThroughputConcurrencyChart";
 import {
   availableFigureRefIds,
+  ENGINE_BAR_FIGURES,
   readCapacityCurve,
+  readEngineMetric,
   readPodDistribution,
   readPrefixCache,
   summarizeForPrompt,
@@ -255,6 +257,39 @@ export const FigureRenderer = memo(function FigureRenderer({
         series={[{ key: "hit", label: "%", color: "#1a7f37", decimals: 1, higherIsBetter: true }]}
         barColors={rows.map(({ r }) => colorMap[r.id])}
         yLabel="%"
+        baselineIndex={baselineIndexOf(rows, baselineId)}
+        labelColors={REPORT_LABEL_COLORS}
+      />
+    );
+  } else if (
+    refId === "stage-bars-kv-cache" ||
+    refId === "stage-bars-preemption" ||
+    refId === "stage-bars-queue"
+  ) {
+    // Engine-metric cross-run bar from the durable serverMetrics.engineMetrics
+    // snapshot. Lower is better (less KV pressure / preemption / queueing).
+    const spec = ENGINE_BAR_FIGURES[refId];
+    const title =
+      refId === "stage-bars-kv-cache"
+        ? "KV cache utilization (peak)"
+        : refId === "stage-bars-preemption"
+          ? "Preemption rate"
+          : "Request queue time (peak)";
+    const rows = summaries
+      .map(({ r }) => ({ r, v: readEngineMetric(r.benchmark?.serverMetrics, spec.metricKey) }))
+      .filter((x) => x.v !== null && x.v[spec.pick] !== null);
+    const unit = rows[0]?.v?.unit ?? "";
+    const data: StageBarDatum[] = rows.map(({ r, v }) => ({
+      stage: r.stageLabel,
+      val: v?.[spec.pick] ?? 0,
+    }));
+    chart = (
+      <StageBarChart
+        title={title}
+        data={data}
+        series={[{ key: "val", label: unit, color: "#bf8700", decimals: 1, higherIsBetter: false }]}
+        barColors={rows.map(({ r }) => colorMap[r.id])}
+        yLabel={unit}
         baselineIndex={baselineIndexOf(rows, baselineId)}
         labelColors={REPORT_LABEL_COLORS}
       />

--- a/apps/web/src/features/benchmarks/compare/MetricRow.tsx
+++ b/apps/web/src/features/benchmarks/compare/MetricRow.tsx
@@ -49,13 +49,13 @@ export function MetricRow({ descriptor, runs, baselineId }: MetricRowProps) {
   const { t } = useTranslation("benchmarks");
   // Engine-metric rows read the whole run (serverMetrics); tool-metric rows read
   // summaryMetrics. `readRun` wins when present.
-  const valueOf = (run: (typeof runs)[number]): number | null =>
+  const readValue = (run: (typeof runs)[number]): number | null =>
     descriptor.readRun ? descriptor.readRun(run) : descriptor.read(run.summaryMetrics);
   const baseline = baselineId ? runs.find((r) => r.id === baselineId) : null;
-  const baselineValue = baseline ? valueOf(baseline) : null;
+  const baselineValue = baseline ? readValue(baseline) : null;
   const verdictKind = descriptor.verdictKind;
 
-  const values = runs.map((run) => valueOf(run));
+  const values = runs.map((run) => readValue(run));
   // Mean-relative orientation (arrows + outlier heatmap) only kicks in when no
   // baseline is chosen — with a baseline the vs-baseline VerdictBadge owns the
   // good/bad story, and mixing two reference frames would be confusing.

--- a/apps/web/src/features/benchmarks/compare/MetricRow.tsx
+++ b/apps/web/src/features/benchmarks/compare/MetricRow.tsx
@@ -47,11 +47,15 @@ const OUTLIER_TINT: Record<Verdict, string> = {
 
 export function MetricRow({ descriptor, runs, baselineId }: MetricRowProps) {
   const { t } = useTranslation("benchmarks");
+  // Engine-metric rows read the whole run (serverMetrics); tool-metric rows read
+  // summaryMetrics. `readRun` wins when present.
+  const valueOf = (run: (typeof runs)[number]): number | null =>
+    descriptor.readRun ? descriptor.readRun(run) : descriptor.read(run.summaryMetrics);
   const baseline = baselineId ? runs.find((r) => r.id === baselineId) : null;
-  const baselineValue = baseline ? descriptor.read(baseline.summaryMetrics) : null;
+  const baselineValue = baseline ? valueOf(baseline) : null;
   const verdictKind = descriptor.verdictKind;
 
-  const values = runs.map((run) => descriptor.read(run.summaryMetrics));
+  const values = runs.map((run) => valueOf(run));
   // Mean-relative orientation (arrows + outlier heatmap) only kicks in when no
   // baseline is chosen — with a baseline the vs-baseline VerdictBadge owns the
   // good/bad story, and mixing two reference frames would be confusing.
@@ -61,7 +65,7 @@ export function MetricRow({ descriptor, runs, baselineId }: MetricRowProps) {
   return (
     <TableRow>
       <TableCell className="text-xs text-muted-foreground">
-        {t(`compare.metricRowLabel.${descriptor.labelKey}`)}
+        {descriptor.label ?? t(`compare.metricRowLabel.${descriptor.labelKey}`)}
       </TableCell>
       {runs.map((run, i) => {
         const v = values[i];

--- a/apps/web/src/features/benchmarks/compare/client-metrics.ts
+++ b/apps/web/src/features/benchmarks/compare/client-metrics.ts
@@ -1,4 +1,8 @@
-import { type FigureRefId, prefixCacheAnnotationSchema } from "@modeldoctor/contracts";
+import {
+  engineMetricsAnnotationSchema,
+  type FigureRefId,
+  prefixCacheAnnotationSchema,
+} from "@modeldoctor/contracts";
 import { readMetricSafe } from "@modeldoctor/tool-adapters/schemas";
 
 export interface PromptMetricsSummary {
@@ -68,6 +72,36 @@ export function readPodDistribution(serverMetrics: unknown): PodDatum[] | null {
   const pods = (parsed.data as { perPod?: PodDatum[] }).perPod;
   return Array.isArray(pods) ? pods : [];
 }
+
+export interface EngineMetricValue {
+  avg: number | null;
+  peak: number | null;
+  unit: string;
+}
+
+/** Read one durable engine-metric scalar (avg + peak) from a run's
+ * `serverMetrics.engineMetrics` snapshot. Null when absent/malformed or the
+ * key wasn't captured. Mirrors the server's `metrics.ts#readEngineMetric`. */
+export function readEngineMetric(serverMetrics: unknown, key: string): EngineMetricValue | null {
+  const parsed = engineMetricsAnnotationSchema.safeParse(
+    (serverMetrics as { engineMetrics?: unknown } | null)?.engineMetrics,
+  );
+  if (!parsed.success) return null;
+  const m = parsed.data.metrics.find((x) => x.key === key);
+  return m ? { avg: m.avg, peak: m.peak, unit: m.unit } : null;
+}
+
+/** The three engine-only cross-run bar figures: refId → which manifest metric +
+ * which scalar to plot (peak for saturation gauges, avg for rates). ttft /
+ * prefix-cache already have dedicated figures, so they are NOT duplicated here. */
+export const ENGINE_BAR_FIGURES: Record<
+  "stage-bars-kv-cache" | "stage-bars-preemption" | "stage-bars-queue",
+  { metricKey: string; pick: "avg" | "peak" }
+> = {
+  "stage-bars-kv-cache": { metricKey: "kv_cache_usage", pick: "peak" },
+  "stage-bars-preemption": { metricKey: "preemption_rate", pick: "avg" },
+  "stage-bars-queue": { metricKey: "request_queue_time", pick: "peak" },
+};
 
 /**
  * Client-side mirror of `apps/api/src/modules/saved-compares/metrics.ts#summarizeForPrompt`.
@@ -169,6 +203,16 @@ export function availableFigureRefIds(runs: RunMetricBlobs[]): Set<FigureRefId> 
       out.add("pod-traffic-distribution");
       out.add("pod-hit-rate");
     }
+  }
+  // Engine-metrics figures (durable serverMetrics.engineMetrics snapshot) —
+  // each available only when EVERY run carries that scalar (mixed gaps would
+  // render misleading bars). Mirror in the server's availableFigureRefIds.
+  for (const [refId, spec] of Object.entries(ENGINE_BAR_FIGURES)) {
+    const present = runs.every((r) => {
+      const m = readEngineMetric(r.serverMetrics, spec.metricKey);
+      return m !== null && m[spec.pick] !== null;
+    });
+    if (present) out.add(refId as FigureRefId);
   }
   // Capacity-curve figure — keep in sync with server mirror
   // `apps/api/src/modules/saved-compares/metrics.ts#availableFigureRefIds`.

--- a/apps/web/src/features/benchmarks/compare/metrics.ts
+++ b/apps/web/src/features/benchmarks/compare/metrics.ts
@@ -6,6 +6,8 @@ import {
   rowDescriptorsByTool,
   type VerdictKind,
 } from "@modeldoctor/tool-adapters/schemas";
+import { readEngineMetric } from "./client-metrics";
+import type { ReportBenchmarkSnapshot } from "./ReportSections";
 
 // summaryMetrics is the discriminated union written by tool-adapter
 // parseFinalReport: { tool, data } (see
@@ -44,10 +46,71 @@ export interface MetricRowDescriptor {
   // SavedCompare hydration path under-types it). Every `read` impl already casts
   // its arg internally via `readMetricSafe` / `readRawField`, so this is honest.
   read: (m: unknown) => number | null;
+  /** When set, takes precedence over `read` and receives the whole run so the
+   *  value can come from `serverMetrics` (engine-metric rows), not just
+   *  `summaryMetrics`. */
+  readRun?: (run: ReportBenchmarkSnapshot) => number | null;
+  /** Literal label (engine rows) — bypasses the `compare.metricRowLabel.*`
+   *  i18n lookup when present. */
+  label?: string;
   verdictKind?: VerdictKind;
   digits?: number; // default 1
   unitSuffix?: string; // for the cell display (e.g. "ms", "%")
   format?: MetricFormat; // named formatter; takes precedence over digits/unitSuffix
+}
+
+/** Durable engine-metric rows (serverMetrics.engineMetrics) appended to the
+ * compare key-metrics grid. `scale` normalises 0-1 ratios to percent. Lower is
+ * better for the pressure metrics (kv-cache / preemption / queue). */
+const ENGINE_TABLE_ROWS: ReadonlyArray<{
+  key: string;
+  label: string;
+  pick: "avg" | "peak";
+  scale: number;
+  unitSuffix: string;
+  digits: number;
+}> = [
+  {
+    key: "success_rate",
+    label: "Success rate",
+    pick: "avg",
+    scale: 100,
+    unitSuffix: "%",
+    digits: 1,
+  },
+  // biome-ignore format: keep one row per line for readability
+  { key: "system_efficiency", label: "System efficiency", pick: "avg", scale: 100, unitSuffix: "%", digits: 1 },
+  { key: "ttft_p99", label: "TTFT P99", pick: "avg", scale: 1, unitSuffix: "ms", digits: 0 },
+  // biome-ignore format: keep one row per line for readability
+  { key: "preemption_rate", label: "Preemption rate", pick: "avg", scale: 1, unitSuffix: "rps", digits: 2 },
+  // biome-ignore format: keep one row per line for readability
+  { key: "kv_cache_usage", label: "KV cache util (peak)", pick: "peak", scale: 1, unitSuffix: "%", digits: 1 },
+  // biome-ignore format: keep one row per line for readability
+  { key: "prefix_cache_hit_rate", label: "Prefix hit rate", pick: "avg", scale: 1, unitSuffix: "%", digits: 1 },
+  // biome-ignore format: keep one row per line for readability
+  { key: "request_queue_time", label: "Queue time (peak)", pick: "peak", scale: 1, unitSuffix: "ms", digits: 0 },
+];
+
+/** Engine-metric descriptors for the runs that carry the durable snapshot —
+ * only rows whose metric is present in EVERY run are returned (complete rows). */
+export function engineRowDescriptors(runs: ReportBenchmarkSnapshot[]): MetricRowDescriptor[] {
+  if (runs.length === 0) return [];
+  return ENGINE_TABLE_ROWS.filter((row) =>
+    runs.every((run) => {
+      const m = readEngineMetric(run.serverMetrics, row.key);
+      return m !== null && m[row.pick] !== null;
+    }),
+  ).map((row) => ({
+    labelKey: `engine.${row.key}`,
+    label: row.label,
+    read: () => null,
+    readRun: (run) => {
+      const v = readEngineMetric(run.serverMetrics, row.key)?.[row.pick];
+      return v == null ? null : v * row.scale;
+    },
+    digits: row.digits,
+    unitSuffix: row.unitSuffix,
+  }));
 }
 
 function readRawField(metrics: unknown, section: string, field: string): number | null {

--- a/apps/web/src/styles/primer-report.css
+++ b/apps/web/src/styles/primer-report.css
@@ -460,6 +460,7 @@
      `.primer-report` (e.g. the app shell sidebar that may still be in the DOM
      on the embedded-report path). */
   .pr-app-bar,
+  /* biome-ignore lint/style/noDescendingSpecificity: intentional print-hide override of an earlier higher-specificity .pr-toc rule */
   .pr-toc {
     display: none !important;
   }

--- a/packages/contracts/src/benchmark.ts
+++ b/packages/contracts/src/benchmark.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { baselineSummarySchema } from "./baseline.js";
+import { panelUnitSchema } from "./engine-metrics.js";
 import { ModalityCategorySchema } from "./modality.js";
 
 // ── Discriminators ───────────────────────────────────────────────────
@@ -245,3 +246,23 @@ export const prefixCacheAnnotationSchema = z.object({
   metricTag: z.enum(["v1", "v0"]),
 });
 export type PrefixCacheAnnotation = z.infer<typeof prefixCacheAnnotationSchema>;
+
+// Prometheus-derived engine-metrics annotation, snapshotted at benchmark
+// completion (reusing the live EngineMetricsService.fetchSnapshot manifest)
+// and stored under `serverMetrics.engineMetrics`. Each manifest metric is
+// reduced to scalar `avg` + `peak` over the run window so historical compares
+// survive Prometheus retention (the detail-page Engine Metrics tab stays live;
+// compare/reports read this durable snapshot). `key` is the manifest's stable
+// cross-engine key (e.g. "kv_cache_usage", "preemption_rate").
+export const engineMetricScalarSchema = z.object({
+  key: z.string(),
+  unit: panelUnitSchema,
+  avg: z.number().nullable(),
+  peak: z.number().nullable(),
+});
+export const engineMetricsAnnotationSchema = z.object({
+  capturedAt: z.string(),
+  metrics: z.array(engineMetricScalarSchema),
+});
+export type EngineMetricScalar = z.infer<typeof engineMetricScalarSchema>;
+export type EngineMetricsAnnotation = z.infer<typeof engineMetricsAnnotationSchema>;

--- a/packages/contracts/src/saved-compares/compare-narrative.ts
+++ b/packages/contracts/src/saved-compares/compare-narrative.ts
@@ -78,6 +78,13 @@ export const figureRefIdSchema = z.enum([
   // top-pod = the busiest pod's share of queries (routing concentration).
   "stage-bars-prefix-cache-hit",
   "stage-bars-top-pod-share",
+  // Engine-metrics figures — populated from the durable serverMetrics.engineMetrics
+  // snapshot (Prometheus, reduced to avg/peak scalars). kv-cache = KV cache
+  // utilization peak %, preemption = preemption rate, queue = request queue-time
+  // peak. Cross-run bars; available when every run carries that engine scalar.
+  "stage-bars-kv-cache",
+  "stage-bars-preemption",
+  "stage-bars-queue",
   "compare-grid",
   // Phase-1 figures — rendered from serverMetrics.prefixCache.perPod and
   // cold/warm delta computations.


### PR DESCRIPTION
实现 #324:把推理引擎指标(KV 利用率/抢占/排队…)带进 compare,且**对历史 run 持久可比**。

## 问题
详情页的 "Engine Metrics" tab 是 **live from Prometheus**(view 时查),compare 看历史 run / 分享报告会因 Prometheus 保留期过期而空;而 `server_metrics` 此前只存了 `prefixCache`。

## 方案(复用现有,不造轮子)
**run 完成时复用现成的 `EngineMetricsService.fetchSnapshot`**(详情页同款 manifest),归约为 durable 标量(avg+peak)存进 `serverMetrics.engineMetrics`;compare 读这个快照。详情页保持 live。

## 改动(两阶段,各一 commit)
**① 数据层** `feat(benchmark): snapshot engine metrics …`
- contracts `engineMetricsAnnotationSchema`(每指标 avg+peak)
- 归约 helper `reduceEngineSnapshot` + 7 指标常量(+单测)
- `report-loader` 完成 hook:复用 fetchSnapshot → 归约 → 存(独立 try/catch,不影响 prefixCache);module DI 注入

**② 前端 compare** `feat(compare): surface engine metrics …`
- `client-metrics` + 服务端 `metrics.ts` 镜像:`readEngineMetric` + 引擎柱图可用性
- key-metrics 表:加引擎标量行(MetricRow 加可选 `readRun` 读 serverMetrics,不动现有 tool 行)
- 3 张跨 run 对比柱:`stage-bars-kv-cache` / `-preemption` / `-queue`(ttft/prefix 已有图不重复)
- `figureRefIdSchema` 加 refId;lb-strategy `preferredFigures` 挂上,AI 报告可引用

## 设计要点
- **快照而非 live**:报告可分享、抗 Prometheus 过期
- **标量为主**(avg+peak),不存全量时序 → payload 可控
- **机理证据**:这些图回答"延迟为什么动"(t6 实测 ON 把 KV 压力/抢占/排队压下来)
- 与 #325(指标选择器)解耦:#324 出数据+默认图,#325 让用户自选

## 验收
api/web/contracts typecheck 0 error;reduce 单测 3 pass + saved-compares/contracts 既有测试 94+3 pass;biome clean。新 lb-strategy run 自动快照,历史 compare 即可见引擎对比。

refs #324
🤖 Generated with [Claude Code](https://claude.com/claude-code)
