### PR TITLE
fix(engine-metrics): KV 利用率表达式 clamp_max 参数写反导致指标为空

### DIFF
--- a/packages/contracts/src/engine-metrics/manifests/__tests__/__snapshots__/mindie.spec.ts.snap
+++ b/packages/contracts/src/engine-metrics/manifests/__tests__/__snapshots__/mindie.spec.ts.snap
@@ -28,7 +28,7 @@ exports[`mindie manifest > snapshot is stable 1`] = `
   },
   {
     "exprs": [
-      "clamp_max(100, 100 * mindie_kv_cache_usage_ratio{model_name="test-model"})",
+      "clamp_max(100 * mindie_kv_cache_usage_ratio{model_name="test-model"}, 100)",
     ],
     "key": "kv_cache_usage",
   },

--- a/packages/contracts/src/engine-metrics/manifests/__tests__/__snapshots__/sglang.spec.ts.snap
+++ b/packages/contracts/src/engine-metrics/manifests/__tests__/__snapshots__/sglang.spec.ts.snap
@@ -40,7 +40,7 @@ exports[`sglang manifest > snapshot of rendered PromQL is stable 1`] = `
   },
   {
     "exprs": [
-      "clamp_max(100, 100 * sglang:token_usage{model_name="test-model"})",
+      "clamp_max(100 * sglang:token_usage{model_name="test-model"}, 100)",
     ],
     "key": "kv_cache_usage",
   },

--- a/packages/contracts/src/engine-metrics/manifests/__tests__/__snapshots__/vllm.spec.ts.snap
+++ b/packages/contracts/src/engine-metrics/manifests/__tests__/__snapshots__/vllm.spec.ts.snap
@@ -89,8 +89,8 @@ exports[`vllm manifest > snapshot of all rendered PromQL strings is stable 1`] =
   },
   {
     "exprs": [
-      "clamp_max(100, 100 * vllm:kv_cache_usage_perc{model_name="test-model"})",
-      "clamp_max(100, 100 * vllm:gpu_cache_usage_perc{model_name="test-model"})",
+      "clamp_max(100 * vllm:kv_cache_usage_perc{model_name="test-model"}, 100)",
+      "clamp_max(100 * vllm:gpu_cache_usage_perc{model_name="test-model"}, 100)",
     ],
     "key": "kv_cache_usage",
   },

--- a/packages/contracts/src/engine-metrics/manifests/mindie.ts
+++ b/packages/contracts/src/engine-metrics/manifests/mindie.ts
@@ -47,7 +47,7 @@ const metrics: EngineMetricSpec[] = [
     promql: [
       {
         tag: "v1",
-        expr: `clamp_max(100, 100 * mindie_kv_cache_usage_ratio{model_name="${M}"})`,
+        expr: `clamp_max(100 * mindie_kv_cache_usage_ratio{model_name="${M}"}, 100)`,
       },
     ],
   },

--- a/packages/contracts/src/engine-metrics/manifests/sglang.ts
+++ b/packages/contracts/src/engine-metrics/manifests/sglang.ts
@@ -65,7 +65,7 @@ const metrics: EngineMetricSpec[] = [
     promql: [
       {
         tag: "v1",
-        expr: `clamp_max(100, 100 * sglang:token_usage{model_name="${M}"})`,
+        expr: `clamp_max(100 * sglang:token_usage{model_name="${M}"}, 100)`,
       },
     ],
   },

--- a/packages/contracts/src/engine-metrics/manifests/vllm.ts
+++ b/packages/contracts/src/engine-metrics/manifests/vllm.ts
@@ -163,11 +163,11 @@ const metrics: EngineMetricSpec[] = [
     promql: [
       {
         tag: "v1",
-        expr: `clamp_max(100, 100 * vllm:kv_cache_usage_perc{model_name="${M}"})`,
+        expr: `clamp_max(100 * vllm:kv_cache_usage_perc{model_name="${M}"}, 100)`,
       },
       {
         tag: "v0",
-        expr: `clamp_max(100, 100 * vllm:gpu_cache_usage_perc{model_name="${M}"})`,
+        expr: `clamp_max(100 * vllm:gpu_cache_usage_perc{model_name="${M}"}, 100)`,
       },
     ],
   },


### PR DESCRIPTION
## 问题
所有引擎的 KV 利用率指标(`kv_cache_usage` / `token_usage`)在 Prometheus 里**报错为空**,详情页 Engine Metrics tab 的 KV 利用率不显示,#327 的 compare 快照也抓不到它。

## 根因
`clamp_max(v, max)` 第一参数是 instant-vector、第二是 scalar max。这些表达式参数**写反了**:`clamp_max(100, 100 * <metric>)` = `clamp_max(scalar, vector)` → Prometheus 类型错误。

实测原表达式 `status: error`;修正版 `clamp_max(100 * <metric>, 100)` → vLLM 4 pod **36-51%** 有数。

## 修复(4 处)
- `vllm.ts`:kv_cache_usage(v1)+ gpu_cache_usage(v0)
- `sglang.ts`:token_usage
- `mindie.ts`:kv_cache_usage_ratio

既有 bug,#327 把它暴露;修复后 kv_cache 既在详情页显示,也会被 compare 快照捕获。

🤖 Generated with [Claude Code](https://claude.com/claude-code)