### PR TITLE
chore: gitignore 本地 .experiments/ 实验脚本目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ e2e/.cache/
 apps/benchmark-runner/images/.vegeta-binaries/
 apps/benchmark-runner/images/.sharegpt/
 apps/benchmark-runner/images/.mooncake/
+
+# local benchmark/experiment scratch scripts — not part of the repo (hardcoded
+# cluster/host paths, one-off runs). Kept locally under each worktree.
+.experiments/


### PR DESCRIPTION
把本地一次性 benchmark/实验脚本(`pc-*.sh` / `*.mjs`,硬编码集群+主机路径)统一收到每个 worktree 的 `.experiments/` 目录,并 gitignore 它 —— 不进仓库,但本地保留可复跑。

之前这些脚本散落在仓库根目录(untracked),污染 `git status`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)