### PR TITLE
refactor(compare): stage label 编辑直接落库,label 简化为两层

### DIFF
--- a/apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
+++ b/apps/web/src/features/benchmarks/compare/BenchmarkComparePage.tsx
@@ -9,7 +9,7 @@ import { PageHeader } from "@/components/common/page-header";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { benchmarkApi } from "../api";
-import { benchmarkKeys } from "../queries";
+import { benchmarkKeys, useUpdateBenchmark } from "../queries";
 import { AddBenchmarkButton } from "./AddBenchmarkButton";
 import { CompareToolbar } from "./CompareToolbar";
 import { type ReportRun, ReportSections } from "./ReportSections";
@@ -39,17 +39,12 @@ export function BenchmarkComparePage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [saveOpen, setSaveOpen] = useState(false);
   const [generateAfterSave, setGenerateAfterSave] = useState(false);
-  // Per-run stage-label overrides, edited via the always-on inline inputs in the
-  // Test-matrix Label cells (mirrors the SaveCompareDialog editor). Kept in
-  // component state (not the URL) so typing doesn't spam history. The raw value
-  // is stored as-is (empty included, so the field can be cleared and retyped);
-  // it flows into reportRuns → every chart / the metric grid / the
-  // SaveCompareDialog seed, so a rename updates the whole page live without
-  // entering the save flow (#326).
-  const [labelOverrides, setLabelOverrides] = useState<Record<string, string>>({});
-  function handleRelabel(id: string, value: string) {
-    setLabelOverrides((prev) => ({ ...prev, [id]: value }));
-  }
+  // Editing a Test-matrix stage label writes straight to the benchmark's
+  // persistent `label` (same store as the list edit) — no per-compare ephemeral
+  // state. The mutation invalidates the run query, so the new label flows back
+  // through reportRuns into every chart / grid / SaveCompareDialog seed. Empty
+  // → the service clears the label and it falls back to the auto short label.
+  const updateBenchmark = useUpdateBenchmark();
   const ids = useMemo(() => parseIds(searchParams), [searchParams]);
   // URL baseline param has three possible meanings:
   //   - missing            → "user hasn't chosen yet, fall back to inferred default"
@@ -184,9 +179,8 @@ export function BenchmarkComparePage() {
   const shortLabels = shortRunLabels(runNames);
   const reportRuns: ReportRun[] = successfulBenchmarks.map((b, i) => ({
     id: b.id,
-    // Three-tier precedence: per-compare inline override (#326) > the
-    // benchmark's persistent label (#336) > the auto-derived short label.
-    stageLabel: labelOverrides[b.id] ?? b.label ?? shortLabels[i],
+    // The benchmark's persistent label (#336) wins; otherwise the auto short label.
+    stageLabel: b.label ?? shortLabels[i],
     tool: b.tool,
     scenario: b.scenario,
     summaryMetrics: b.summaryMetrics,
@@ -267,7 +261,7 @@ export function BenchmarkComparePage() {
                 setIds(newIds);
               }}
               onRemove={handleRemove}
-              onRelabel={handleRelabel}
+              onRelabel={(id, label) => updateBenchmark.mutate({ id, body: { label } })}
               matrixActions={
                 <AddBenchmarkButton
                   scenario={successfulBenchmarks[0].scenario}

--- a/apps/web/src/features/benchmarks/compare/ReportSections.test.tsx
+++ b/apps/web/src/features/benchmarks/compare/ReportSections.test.tsx
@@ -65,19 +65,39 @@ describe("ReportSections inline stage-label editing (#326)", () => {
     expect((inputs[1] as HTMLInputElement).value).toBe("ON");
   });
 
-  it("reports the raw value on every keystroke", () => {
+  it("does not commit on keystroke — only on blur (avoids a PATCH per char)", () => {
     const onRelabel = vi.fn();
     renderMatrix(onRelabel);
     const input = screen.getByDisplayValue("OFF");
     fireEvent.change(input, { target: { value: "Baseline" } });
+    expect(onRelabel).not.toHaveBeenCalled();
+    fireEvent.blur(input);
     expect(onRelabel).toHaveBeenCalledWith("a", "Baseline");
   });
 
-  it("reports an empty value as-is (clearable, not reverted)", () => {
+  it("commits on Enter", () => {
+    const onRelabel = vi.fn();
+    renderMatrix(onRelabel);
+    const input = screen.getByDisplayValue("OFF");
+    input.focus();
+    fireEvent.change(input, { target: { value: "X" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onRelabel).toHaveBeenCalledWith("a", "X");
+  });
+
+  it("commits an empty value on blur (clears the persistent label)", () => {
     const onRelabel = vi.fn();
     renderMatrix(onRelabel);
     const input = screen.getByDisplayValue("ON");
     fireEvent.change(input, { target: { value: "" } });
+    fireEvent.blur(input);
     expect(onRelabel).toHaveBeenCalledWith("b", "");
+  });
+
+  it("does not commit when the value is unchanged", () => {
+    const onRelabel = vi.fn();
+    renderMatrix(onRelabel);
+    fireEvent.blur(screen.getByDisplayValue("OFF"));
+    expect(onRelabel).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/benchmarks/compare/ReportSections.tsx
+++ b/apps/web/src/features/benchmarks/compare/ReportSections.tsx
@@ -114,14 +114,22 @@ function MatrixRowCells({
     <>
       <td className="px-3 py-2 font-medium">
         {onRelabel ? (
-          // Always-on inline input (mirrors the SaveCompareDialog's Stage-labels
-          // editor) — type to rename; the value flows through reportRuns.stageLabel
-          // → every chart + the grid + the SaveCompareDialog seed, so the page
-          // relabels live without opening the save flow (#326).
+          // Always-on inline input that PERSISTS to benchmark.label on commit
+          // (blur / Enter), not per keystroke — same store as the list edit, no
+          // separate per-compare state. `key`+`defaultValue` re-seed the field
+          // after the mutation refetches the run (empty commit clears the label
+          // → falls back to the auto short label). Uncontrolled so typing
+          // doesn't fire a PATCH on every keystroke.
           <Input
-            value={r.stageLabel}
+            key={r.stageLabel}
+            defaultValue={r.stageLabel}
             aria-label={t("compare.matrix.editLabel")}
-            onChange={(e) => onRelabel(r.id, e.target.value)}
+            onBlur={(e) => {
+              if (e.target.value !== r.stageLabel) onRelabel(r.id, e.target.value);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") e.currentTarget.blur();
+            }}
             className="h-8 max-w-[14rem]"
           />
         ) : (


### PR DESCRIPTION
按反馈把 label 优先级从三层砍成两层。

## 之前(三层)
`labelOverrides[id] ?? b.label ?? shortRunLabels(name)` —— compare 里改 label 存的是页面临时态(关页面就没),和 benchmark.label 是两套存储,语义重叠。

## 现在(两层)
`b.label ?? shortRunLabels(name)` —— **benchmark.label(持久)→ 自动短标签**。

compare 矩阵的 Label 格**仍是常驻输入框、直接改**(保留你要的交互),但提交时(blur / Enter)**直接 PATCH 到 benchmark.label**(复用 #336 的 `useUpdateBenchmark`)——"在 compare 里改"和"在列表里改"现在是同一个东西,只有一处存储。

- 删掉 `BenchmarkComparePage` 的 `labelOverrides` state + `handleRelabel`。
- 输入框改 uncontrolled(`key`+`defaultValue`)避免逐字符 PATCH;`key` 在 mutation 重取后重新 seed。
- 留空提交 → service 把 label 清成 null → 回落自动短标签。
- `ReportSections.test` 改为断言 commit-on-blur/Enter(不再逐字符回调)+ 未改不提交。

## 验证
web typecheck 干净;compare 全套 **142 passed**;biome 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)