### PR TITLE
fix(compare report): en-US prompt 清除残留中文(弱判官输出中文报告的真因)

### DIFF
--- a/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
+++ b/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
@@ -280,15 +280,14 @@ export class CompareSynthesizeService {
       runsHeader: zh ? "## 各 stage 数据" : "## Per-stage data",
       deleted: zh ? "(数据已删除)" : "(data deleted)",
       baselineHeader: zh ? "## 基线" : "## Baseline",
-      // The language directive is repeated here as the FINAL instruction (the
-      // last thing the model reads before generating): the per-stage data above
-      // carries Chinese benchmark names / scenario / user context, and without
-      // a closing reminder the model mirrors that input language regardless of
-      // the system prompt's locale — producing a Chinese body under an en-US
-      // narrative.locale. Stating it last (recency) keeps output in `locale`.
+      // Restate the output language POSITIVELY as the final instruction (last
+      // thing the model reads → recency). Phrased without naming the other
+      // language or using negation ("do not mirror Chinese"): weaker judges
+      // (deepseek-chat) latch onto a named language even under "don't", which
+      // flipped en-US reports to Chinese. Say only the target language.
       reminder: zh
-        ? '## 任务\n请按 system prompt 描述的 JSON schema 与风格规则输出深度报告。\n\n重要:全文(hero 的 kicker/headline/subhead、每个 metaItem 的 label 与 value、章节标题与正文、表格、图注)一律用简体中文输出,即使上方输入的 benchmark 名称 / 场景 / 背景是别的语言也不要照搬;仅保留 vLLM / TTFT / p95 / req/s 等技术术语原文。narrative.locale 必须为 "zh-CN"。'
-        : '## Task\nProduce the deep report following the JSON schema and style rules from the system prompt.\n\nIMPORTANT: Write ALL prose in English — the hero kicker/headline/subhead, every metaItem label and value, section titles and bodies, table cells, and figure captions. The per-stage data above may carry Chinese benchmark names / scenario / context; do NOT mirror that language. Keep only proper nouns and established technical terms (vLLM, TTFT, p95, req/s) as-is. narrative.locale MUST be "en-US".',
+        ? '## 任务\n请按 system prompt 描述的 JSON schema 与风格规则输出深度报告。\n\n全文用简体中文输出(技术术语 vLLM / TTFT / p95 / req/s 等保留英文原文)。narrative.locale 必须为 "zh-CN"。'
+        : '## Task\nProduce the deep report following the JSON schema and style rules from the system prompt.\n\nWrite every word of prose in English (keep established technical terms like vLLM, TTFT, p95, req/s verbatim). narrative.locale MUST be "en-US".',
       metricsLegend: zh
         ? "metric 单位:qps=req/s, err=fraction, ttft/e2e=ms"
         : "metric units: qps=req/s, err=fraction, ttft/e2e=ms",

--- a/apps/api/src/modules/saved-compares/prompts.spec.ts
+++ b/apps/api/src/modules/saved-compares/prompts.spec.ts
@@ -1,6 +1,32 @@
 import { figureRefIdSchema } from "@modeldoctor/contracts";
 import { describe, expect, it } from "vitest";
 import { buildSystemPrompt } from "./prompts.js";
+import { reportScenarioRegistry } from "./report-scenarios/index.js";
+
+const CJK = /[一-鿿]/;
+
+// Language-leak guard: weaker judge models (e.g. deepseek-chat) mirror the
+// language of the PROMPT, not just the locale instruction. A single Chinese
+// example string (the hero eyebrow example was "MODELDOCTOR · 推理引擎对比")
+// made en-US reports come out in Chinese. The en-US prompt — system block +
+// every scenario fragment — must contain zero CJK so the model has nothing
+// Chinese to copy.
+describe("en-US report prompt contains no Chinese", () => {
+  it("the en-US system prompt base is CJK-free", () => {
+    expect(CJK.test(buildSystemPrompt("en-US", ""))).toBe(false);
+  });
+
+  it("every scenario's en-US fragment is CJK-free", () => {
+    for (const profile of Object.values(reportScenarioRegistry)) {
+      const fragment = profile.promptFragment("en-US");
+      expect(CJK.test(fragment), `${profile.intent} en-US fragment has CJK`).toBe(false);
+    }
+  });
+
+  it("the zh-CN system prompt still localizes to Chinese (sanity)", () => {
+    expect(CJK.test(buildSystemPrompt("zh-CN", ""))).toBe(true);
+  });
+});
 
 // Drift guard: the `figures[].refId` union baked into the schema block the LLM
 // fills MUST list every refId the zod schema accepts. When they diverge the

--- a/apps/api/src/modules/saved-compares/prompts.ts
+++ b/apps/api/src/modules/saved-compares/prompts.ts
@@ -5,23 +5,35 @@ import type { LintWarning } from "@modeldoctor/contracts";
 // `docs/saved-compare-report-style.md` — keep both in sync.
 // ────────────────────────────────────────────────────────────────────────
 
-const COMMON_SCHEMA_BLOCK = `Output a single JSON object matching this TypeScript shape exactly:
+// The schema block's EXAMPLE strings are locale-specific: weaker judge models
+// (e.g. deepseek-chat) mirror the language of the examples they're shown, so a
+// Chinese eyebrow/meta/trend example made them emit a Chinese report under an
+// en-US locale. Keep the en-US prompt 100% English so the model has no Chinese
+// to copy.
+function schemaBlock(locale: "zh-CN" | "en-US"): string {
+  const zh = locale !== "en-US";
+  const eyebrowEg = zh ? "MODELDOCTOR · 推理引擎对比" : "MODELDOCTOR · ENGINE COMPARISON";
+  const metaEg = zh
+    ? '{label:"硬件", value:"A100 80G × 1"}'
+    : '{label:"Hardware", value:"A100 80G × 1"}';
+  const trendEg = zh ? "领先 SGLang 38%" : "leads SGLang by 38%";
+  return `Output a single JSON object matching this TypeScript shape exactly:
 
 interface Narrative {
   schemaVersion: 2;
   locale: "zh-CN" | "en-US";
   hero: {
-    eyebrow: string;     // ≤120 chars, mono-style category line (e.g. "MODELDOCTOR · 推理引擎对比")
+    eyebrow: string;     // ≤120 chars, mono-style category line (e.g. "${eyebrowEg}")
     title: string;       // ≤200 chars, headline that includes a number or directional verdict
     subtitle: string;    // 1-3 sentences, ≤500 chars, must include the single most important number
-    metaItems: Array<{ label: string; value: string }>;  // 0-8 items, e.g. {label:"硬件", value:"A100 80G × 1"}
+    metaItems: Array<{ label: string; value: string }>;  // 0-8 items, e.g. ${metaEg}
   };
   summaryCards: Array<{
     label: string;       // ≤80 chars
     value: string;       // ≤40 chars, the headline number
     unit?: string;       // ≤20 chars
     tone: "success" | "danger" | "attention" | "info";
-    trend?: string;      // ≤160 chars, e.g. "领先 SGLang 38%"
+    trend?: string;      // ≤160 chars, e.g. "${trendEg}"
     foot?: string;       // ≤200 chars, single-line caveat
   }>;                    // 2-4 cards, no more
   sections: [
@@ -40,8 +52,22 @@ interface Narrative {
   }>;
   lintWarnings: [];      // always emit empty array; server fills this
 }`;
+}
 
-const COMMON_STYLE_RULES = `Style rules (the report will be auto-rejected if violated):
+// Style rules — most are language-neutral; the four banned-token lines (verdict
+// labels, TL;DR string, AI-tell phrases, banned adverbs) carry locale-specific
+// tokens, so the en-US prompt lists only English ones (no stray CJK to mirror).
+function styleRules(locale: "zh-CN" | "en-US"): string {
+  const zh = locale !== "en-US";
+  const verdictTokens = zh ? '"推荐" / "不建议" / "—"' : '"Recommended" / "Not recommended" / "—"';
+  const tldr = zh ? '"TL;DR(N 条)" or "TL;DR (N items)"' : '"TL;DR (N items)"';
+  const aiTells = zh
+    ? '"值得注意的是", "综上所述", "let\'s dive", "it is worth noting", "in conclusion"'
+    : '"let\'s dive", "it is worth noting", "in conclusion"';
+  const bannedAdverbs = zh
+    ? "significantly, robust, seamlessly, leverage, unlock, empower, comprehensive, 显著地, 鲁棒, 无缝, 充分利用, 释放, 赋能, 全面深入"
+    : "significantly, robust, seamlessly, leverage, unlock, empower, comprehensive";
+  return `Style rules (the report will be auto-rejected if violated):
 
 1. Section titles MUST be conclusions, not topics. Each title MUST contain at least one number or a directional verdict word.
    - Weak: "Performance comparison"
@@ -51,10 +77,10 @@ const COMMON_STYLE_RULES = `Style rules (the report will be auto-rejected if vio
 4. Numbers ≥3 decimal places are forbidden. "+135%" or "~+135% (N=8, σ=4.2%)" instead of "+135.275%".
 5. Tables: max 6 columns. Prefer one figure (figures[].refId) + a short 3-5 number table over a 12-row wide table.
 6. NEVER use decorative emoji (🥇🥈🥉🔥🚀🎯💡🌟⭐❗‼️). Use plain text or <strong>.
-7. NEVER use ✅ or ❌ in tables. Use "推荐" / "不建议" / "—".
-8. NEVER write the literal string "TL;DR(N 条)" or "TL;DR (N items)".
-9. NEVER use these AI-tell phrases at paragraph start: "值得注意的是", "综上所述", "let's dive", "it is worth noting", "in conclusion".
-10. Banned adverbs (use a specific verb instead): significantly, robust, seamlessly, leverage, unlock, empower, comprehensive, 显著地, 鲁棒, 无缝, 充分利用, 释放, 赋能, 全面深入.
+7. NEVER use ✅ or ❌ in tables. Use ${verdictTokens}.
+8. NEVER write the literal string ${tldr}.
+9. NEVER use these AI-tell phrases at paragraph start: ${aiTells}.
+10. Banned adverbs (use a specific verb instead): ${bannedAdverbs}.
 11. At most TWO bold spans (**...** or <strong>) per paragraph.
 12. NEVER self-reference as an AI: no "Generated with Claude", no 🤖, no "as an AI", no "as a language model".
 13. NEVER include repo paths like "apps/api/..." or "packages/..." in prose. Use feature names. Inside fenced code blocks paths are fine.
@@ -68,29 +94,33 @@ Section size targets:
 - 05 caveats: ≤ 1 page, data comparability boundaries, known issues, SLO limits
 - 06 advice:  ≤ half page, scenario → config + 0-5 caveats
 `;
+}
 
-const ZH_SCHEMA_INSTRUCTIONS = `你是一位资深 LLM 推理服务性能分析师。给定多个 benchmark 的对比数据,你要按 ModelDoctor SavedCompare 报告规范产出一份**深度报告**(看起来像分析师手写,不要 AI 味)。
+function schemaInstructions(locale: "zh-CN" | "en-US"): string {
+  if (locale === "en-US") {
+    return `You are a senior LLM serving performance analyst. Given multiple benchmark runs, produce a deep report following the ModelDoctor SavedCompare report convention. The output must read like a human analyst wrote it (no AI tells).
 
-${COMMON_SCHEMA_BLOCK}
+${schemaBlock(locale)}
 
-${COMMON_STYLE_RULES}
+${styleRules(locale)}
 
-输出语言:严格简体中文(英文术语 vLLM / TTFT / p95 / req/s 等保留原文)。
-schemaVersion: 2, locale: "zh-CN"。
-只输出 JSON 对象,不要 \`\`\`json fence,不要解释文字。`;
-
-const EN_SCHEMA_INSTRUCTIONS = `You are a senior LLM serving performance analyst. Given multiple benchmark runs, produce a deep report following the ModelDoctor SavedCompare report convention. The output must read like a human analyst wrote it (no AI tells).
-
-${COMMON_SCHEMA_BLOCK}
-
-${COMMON_STYLE_RULES}
-
-Language: English throughout.
+Language: write every word of prose in English — the hero kicker/title/subtitle, every metaItem label and value, all section titles and bodies, table cells, and figure captions. Keep only established technical terms (vLLM, TTFT, p95, req/s) verbatim.
 schemaVersion: 2, locale: "en-US".
 Emit raw JSON only — no \`\`\`json fence, no preamble.`;
+  }
+  return `你是一位资深 LLM 推理服务性能分析师。给定多个 benchmark 的对比数据,你要按 ModelDoctor SavedCompare 报告规范产出一份**深度报告**(看起来像分析师手写,不要 AI 味)。
+
+${schemaBlock(locale)}
+
+${styleRules(locale)}
+
+输出语言:全文严格简体中文(hero / 各 metaItem / 章节标题与正文 / 表格 / 图注),技术术语 vLLM / TTFT / p95 / req/s 等保留英文原文。
+schemaVersion: 2, locale: "zh-CN"。
+只输出 JSON 对象,不要 \`\`\`json fence,不要解释文字。`;
+}
 
 export function buildSystemPrompt(locale: "zh-CN" | "en-US", scenarioFragment: string): string {
-  const base = locale === "en-US" ? EN_SCHEMA_INSTRUCTIONS : ZH_SCHEMA_INSTRUCTIONS;
+  const base = schemaInstructions(locale);
   if (!scenarioFragment.trim()) return base;
   const header = locale === "en-US" ? "\n\n## Scenario guidance\n" : "\n\n## 场景专项要求\n";
   return `${base}${header}${scenarioFragment}`;


### PR DESCRIPTION
## 现象
app 切到 English、`narrative.locale` 也确为 `en-US`,但 **deepseek-chat** 判官仍把报告正文写成中文;换 **claude-opus-4-8** 就正常英文。

## 根因(不是 locale 没传对)
喂给模型的 **en-US prompt 本身残留中文**,弱模型跟着 prompt 里示例/词表的语言走:
- **schema 示例**(给模型看"长这样输出"):eyebrow=`"MODELDOCTOR · 推理引擎对比"`、meta=`{label:"硬件"}`、trend=`"领先 SGLang 38%"` —— 铁证:DeepSeek 那份报告 eyebrow 直接照抄成中文,Opus 那份是英文。
- **风格规则**里的中文:禁用词 `显著地/鲁棒/...`、AI 腔 `值得注意的是/综上所述`、`推荐·不建议`、`TL;DR(N 条)`。

这些 `COMMON_SCHEMA_BLOCK` / `COMMON_STYLE_RULES` 两个 locale 共用、从没按语言拆。

## 修复
- `prompts.ts`:把 schema 示例 + 风格规则 + schema 指令按 locale 拆成 `schemaBlock(locale)` / `styleRules(locale)` / `schemaInstructions(locale)` —— **en-US 只出英文示例 / 英文禁用词**,zh-CN 保持中文。
- `compare-synthesize.service.ts`:之前 #335 那句 reminder 点名 `"Chinese"` + 否定句("do NOT mirror that language")—— 弱模型对否定里被点名的语言反而 latch。改成**纯正向**:只说目标语言。

## 测试
新增 CJK 守卫:en-US system prompt(base + **每个 scenario fragment**)零 CJK,zh-CN 仍本地化为中文。`saved-compares` 96 tests 全过,typecheck + biome 干净。

## 验证建议
合并 + 重启本地 API 后,把判官**切回 deepseek-chat** + app=English + Regenerate —— 现在应出英文。

🤖 Generated with [Claude Code](https://claude.com/claude-code)