### PR TITLE
feat(runner): 可配 HF_ENDPOINT 镜像,tokenizer 不再直连 huggingface.co (#339)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -83,7 +83,7 @@ RUNNER_IMAGE_AIPERF=<replace via ./tools/build-runner-images.sh>
 # flakes + air-gapped clusters). Trailing slash is stripped automatically.
 # RUNNER_HF_ENDPOINT=https://hf-mirror.com
 # RUNNER_HF_TOKEN=hf_xxx            # optional: rate limits / gated tokenizers
-# RUNNER_HF_OFFLINE=1               # optional: HF_HUB_OFFLINE (cache-only)
+# RUNNER_HF_OFFLINE=1               # optional: HF_HUB_OFFLINE (cache-only; accepts "1" or "true")
 
 # Optional kubeconfig override for out-of-cluster local dev. Leave unset in
 # production (the API runs as a pod and uses its in-cluster ServiceAccount).

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -77,6 +77,14 @@ RUNNER_IMAGE_VEGETA=<replace via ./tools/build-runner-images.sh>
 RUNNER_IMAGE_EVALSCOPE=<replace via ./tools/build-runner-images.sh>
 RUNNER_IMAGE_AIPERF=<replace via ./tools/build-runner-images.sh>
 
+# Optional HuggingFace tokenizer source for runner Jobs (#339).
+# Point HF_ENDPOINT at a reachable mirror / internal HF proxy so aiperf/guidellm
+# fetch tokenizers from there instead of huggingface.co (fixes per-run fetch
+# flakes + air-gapped clusters). Trailing slash is stripped automatically.
+# RUNNER_HF_ENDPOINT=https://hf-mirror.com
+# RUNNER_HF_TOKEN=hf_xxx            # optional: rate limits / gated tokenizers
+# RUNNER_HF_OFFLINE=1               # optional: HF_HUB_OFFLINE (cache-only)
+
 # Optional kubeconfig override for out-of-cluster local dev. Leave unset in
 # production (the API runs as a pod and uses its in-cluster ServiceAccount).
 # Example for k3d: KUBECONFIG=/Users/you/.kube/k3d-modeldoctor.config

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -87,7 +87,7 @@ export const EnvSchema = z.object({
   RUNNER_HF_ENDPOINT: z.string().url().optional(),
   // Optional HF_TOKEN for the runner (rate limits / gated tokenizers).
   RUNNER_HF_TOKEN: z.string().optional(),
-  // Set to "1" to inject HF_HUB_OFFLINE=1 (use only locally-cached files).
+  // Set to "1" or "true" to inject HF_HUB_OFFLINE=1 (use only locally-cached files).
   RUNNER_HF_OFFLINE: z.string().optional(),
   BENCHMARK_DEFAULT_MAX_DURATION_SECONDS: z.coerce.number().int().positive().default(1800),
   // Optional HuggingFace tokenizer id for guidellm synthetic prompt token

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -79,6 +79,16 @@ export const EnvSchema = z.object({
   RUNNER_IMAGE_VEGETA: z.string().min(1),
   RUNNER_IMAGE_EVALSCOPE: z.string().min(1),
   RUNNER_IMAGE_AIPERF: z.string().min(1),
+  // Optional HuggingFace endpoint injected as HF_ENDPOINT into every runner
+  // Job. Point it at a reachable mirror / internal HF proxy (e.g.
+  // https://hf-mirror.com) so aiperf/guidellm load tokenizers from there
+  // instead of huggingface.co — fixes per-run fetch flakes + air-gapped
+  // clusters (#339). Trailing slash is stripped (huggingface_hub rejects it).
+  RUNNER_HF_ENDPOINT: z.string().url().optional(),
+  // Optional HF_TOKEN for the runner (rate limits / gated tokenizers).
+  RUNNER_HF_TOKEN: z.string().optional(),
+  // Set to "1" to inject HF_HUB_OFFLINE=1 (use only locally-cached files).
+  RUNNER_HF_OFFLINE: z.string().optional(),
   BENCHMARK_DEFAULT_MAX_DURATION_SECONDS: z.coerce.number().int().positive().default(1800),
   // Optional HuggingFace tokenizer id for guidellm synthetic prompt token
   // counting (passed as --processor). Set this when the target gateway

--- a/apps/api/src/modules/benchmark/benchmark.module.ts
+++ b/apps/api/src/modules/benchmark/benchmark.module.ts
@@ -69,12 +69,19 @@ async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeCon
         const ns =
           (config.get("BENCHMARK_K8S_NAMESPACE", { infer: true }) as string | undefined) ??
           "modeldoctor-benchmarks";
+        // Global HF tokenizer-source settings injected into every runner Job (#339).
+        const hf = {
+          endpoint: config.get("RUNNER_HF_ENDPOINT", { infer: true }) as string | undefined,
+          token: config.get("RUNNER_HF_TOKEN", { infer: true }) as string | undefined,
+          offline: (config.get("RUNNER_HF_OFFLINE", { infer: true }) as string | undefined) === "1",
+        };
         const k8s = await import("@kubernetes/client-node");
         const kc = await loadKubeConfig(config);
         return new K8sBenchmarkRunner(
           ns,
           kc.makeApiClient(k8s.BatchV1Api),
           kc.makeApiClient(k8s.CoreV1Api),
+          hf,
         );
       },
     },

--- a/apps/api/src/modules/benchmark/benchmark.module.ts
+++ b/apps/api/src/modules/benchmark/benchmark.module.ts
@@ -70,10 +70,16 @@ async function loadKubeConfig(config: ConfigService<Env, true>): Promise<KubeCon
           (config.get("BENCHMARK_K8S_NAMESPACE", { infer: true }) as string | undefined) ??
           "modeldoctor-benchmarks";
         // Global HF tokenizer-source settings injected into every runner Job (#339).
+        // Accept "1" / "true" (case-insensitive) for the offline flag — users
+        // habitually write boolean-ish strings in .env; a strict "1" check would
+        // silently ignore RUNNER_HF_OFFLINE=true.
+        const hfOffline = (
+          config.get("RUNNER_HF_OFFLINE", { infer: true }) as string | undefined
+        )?.toLowerCase();
         const hf = {
           endpoint: config.get("RUNNER_HF_ENDPOINT", { infer: true }) as string | undefined,
           token: config.get("RUNNER_HF_TOKEN", { infer: true }) as string | undefined,
-          offline: (config.get("RUNNER_HF_OFFLINE", { infer: true }) as string | undefined) === "1",
+          offline: hfOffline === "1" || hfOffline === "true",
         };
         const k8s = await import("@kubernetes/client-node");
         const kc = await loadKubeConfig(config);

--- a/apps/api/src/modules/benchmark/k8s/k8s-benchmark-runner.ts
+++ b/apps/api/src/modules/benchmark/k8s/k8s-benchmark-runner.ts
@@ -43,6 +43,8 @@ export class K8sBenchmarkRunner {
     private readonly namespace: string,
     private readonly batch: BatchV1Api,
     private readonly core: CoreV1Api,
+    /** Global HF tokenizer-source settings injected into every runner Job (#339). */
+    private readonly hf?: { endpoint?: string; token?: string; offline?: boolean },
   ) {}
 
   async start(ctx: BenchmarkRunInput): Promise<{ handle: BenchmarkRunHandle }> {
@@ -52,7 +54,7 @@ export class K8sBenchmarkRunner {
 
     let jobUid: string | undefined;
     try {
-      const job = buildJobManifest(ctx, { namespace: ns });
+      const job = buildJobManifest(ctx, { namespace: ns, hf: this.hf });
       const created = await this.batch.createNamespacedJob(ns, job);
       jobUid = (created as { body?: { metadata?: { uid?: string } } }).body?.metadata?.uid;
     } catch (e) {

--- a/apps/api/src/modules/benchmark/k8s/k8s-job-manifest.spec.ts
+++ b/apps/api/src/modules/benchmark/k8s/k8s-job-manifest.spec.ts
@@ -77,6 +77,39 @@ describe("buildJobManifest", () => {
   });
 });
 
+describe("buildJobManifest HF tokenizer env (#339)", () => {
+  function hfEnv(hf: { endpoint?: string; token?: string; offline?: boolean } | undefined) {
+    const j = buildJobManifest(ctx, { namespace: "ns", hf });
+    const env = j.spec?.template.spec?.containers[0].env ?? [];
+    return (name: string) => env.find((e) => e.name === name);
+  }
+
+  it("injects no HF_* env when hf is absent", () => {
+    const get = hfEnv(undefined);
+    expect(get("HF_ENDPOINT")).toBeUndefined();
+    expect(get("HF_TOKEN")).toBeUndefined();
+    expect(get("HF_HUB_OFFLINE")).toBeUndefined();
+  });
+
+  it("injects HF_ENDPOINT with the trailing slash stripped", () => {
+    const get = hfEnv({ endpoint: "https://hf-mirror.com/" });
+    expect(get("HF_ENDPOINT")).toEqual({ name: "HF_ENDPOINT", value: "https://hf-mirror.com" });
+  });
+
+  it("injects HF_TOKEN when set", () => {
+    const get = hfEnv({ token: "hf_secret" });
+    expect(get("HF_TOKEN")).toEqual({ name: "HF_TOKEN", value: "hf_secret" });
+  });
+
+  it("injects HF_HUB_OFFLINE=1 only when offline is true", () => {
+    expect(hfEnv({ offline: true })("HF_HUB_OFFLINE")).toEqual({
+      name: "HF_HUB_OFFLINE",
+      value: "1",
+    });
+    expect(hfEnv({ offline: false })("HF_HUB_OFFLINE")).toBeUndefined();
+  });
+});
+
 describe("naming helpers", () => {
   it("jobName is run-<id>", () => {
     expect(jobName("xyz")).toBe("run-xyz");

--- a/apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts
+++ b/apps/api/src/modules/benchmark/k8s/k8s-job-manifest.ts
@@ -56,6 +56,10 @@ export function buildSecretManifest(ctx: BenchmarkRunInput, namespace: string): 
 
 export interface JobManifestOptions {
   namespace: string;
+  /** Optional HuggingFace settings injected into the runner Job env so
+   *  HF-based tools (aiperf/guidellm) fetch tokenizers from a reachable
+   *  mirror / internal proxy instead of huggingface.co (#339). */
+  hf?: { endpoint?: string; token?: string; offline?: boolean };
 }
 
 export function buildJobManifest(ctx: BenchmarkRunInput, opts: JobManifestOptions): V1Job {
@@ -74,6 +78,18 @@ export function buildJobManifest(ctx: BenchmarkRunInput, opts: JobManifestOption
   }
   for (const [k, v] of Object.entries(ctx.buildResult.env)) {
     env.push({ name: k, value: v });
+  }
+  // HF tokenizer source (#339): point HF-based tools at a reachable mirror so
+  // they don't hit huggingface.co. Set globally via RUNNER_HF_* env on the API.
+  if (opts.hf?.endpoint) {
+    // huggingface_hub rejects a trailing slash on HF_ENDPOINT.
+    env.push({ name: "HF_ENDPOINT", value: opts.hf.endpoint.replace(/\/+$/, "") });
+  }
+  if (opts.hf?.token) {
+    env.push({ name: "HF_TOKEN", value: opts.hf.token });
+  }
+  if (opts.hf?.offline) {
+    env.push({ name: "HF_HUB_OFFLINE", value: "1" });
   }
 
   const hasInputFiles = Object.keys(ctx.buildResult.inputFiles ?? {}).length > 0;


### PR DESCRIPTION
## 问题
aiperf/guidellm 在 runner Job 里用 huggingface_hub **直连 huggingface.co** 拉 tokenizer → 网络抖动让 run 失败(实测 `Server disconnected`)、私有/air-gap 集群根本不可达。

## 方案(最小,业内标准)
平台部署级 env → 透传进每个 runner Job:
- `RUNNER_HF_ENDPOINT` → `HF_ENDPOINT`(指向可达镜像 / 内网 HF 代理,如 `https://hf-mirror.com`;自动去尾斜杠,huggingface_hub 不接受尾斜杠)
- `RUNNER_HF_TOKEN` → `HF_TOKEN`(可选,限额/gated)
- `RUNNER_HF_OFFLINE=1` → `HF_HUB_OFFLINE=1`(可选,纯缓存)

`huggingface_hub` 自动走 `HF_ENDPOINT`,**工具零改动、argv 不变**。这是 vLLM/SGLang/Ollama 生态的标准做法。

## 不做的
不挂卷、不碰对象存储、不动 runner 脚本、无 UI/迁移 —— 改 mirror 改部署 env 即可。挂载 HF cache 卷 / 平台侧预下载 / 离线导出 / Argo 编排等都讨论过,作为后续按需演进,不在本 PR。

## 改动
`env.schema.ts`(3 个 optional 变量)+ `k8s-job-manifest.ts`(env 注入,`JobManifestOptions.hf`)+ `k8s-benchmark-runner.ts`(透传)+ `benchmark.module.ts`(factory 读 config)+ `.env.example` 文档。

## 验证
api typecheck 干净;`k8s-job-manifest`/`env`/`k8s-benchmark-runner` 53 tests 全过(新增 4 个 HF env 注入测试:无 hf 不注入 / 去尾斜杠 / token / offline 仅 true 时);biome 干净。

closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)