### PR TITLE
feat(compare): 引擎内部指标喂判官 — KV satFrac + scheduler_waiting + 前缀命中 (refs #343)

### DIFF
--- a/apps/api/src/modules/engine-metrics/engine-metrics-snapshot.reduce.spec.ts
+++ b/apps/api/src/modules/engine-metrics/engine-metrics-snapshot.reduce.spec.ts
@@ -68,6 +68,90 @@ describe("reduceEngineSnapshot", () => {
     expect(out.metrics[0]).toMatchObject({ avg: 3, peak: 6 });
   });
 
+  it("computes satFrac for kv_cache_usage (fraction of window ≥ 90%)", () => {
+    const out = reduceEngineSnapshot(
+      resp([
+        {
+          key: "kv_cache_usage",
+          unit: "%",
+          unavailable: false,
+          series: [
+            {
+              samples: [
+                [1, 40],
+                [2, 90],
+                [3, 95],
+                [4, 100],
+              ],
+            },
+          ],
+        },
+      ]),
+      ["kv_cache_usage"],
+    );
+    // 3 of 4 samples ≥ 90 → 0.75
+    expect(out.metrics[0]).toMatchObject({ key: "kv_cache_usage", peak: 100, satFrac: 0.75 });
+  });
+
+  it("leaves satFrac null for metrics without a saturation threshold", () => {
+    const out = reduceEngineSnapshot(
+      resp([
+        { key: "ttft_p99", unit: "ms", unavailable: false, series: [{ samples: [[1, 300]] }] },
+      ]),
+      ["ttft_p99"],
+    );
+    expect(out.metrics[0]).toMatchObject({ key: "ttft_p99", satFrac: null });
+  });
+
+  it("extracts scheduler_waiting from the waiting series of scheduler_state", () => {
+    const out = reduceEngineSnapshot(
+      resp([
+        {
+          key: "scheduler_state",
+          unit: "count",
+          unavailable: false,
+          series: [
+            {
+              label: "running",
+              samples: [
+                [1, 8],
+                [2, 8],
+              ],
+            },
+            {
+              label: "waiting",
+              samples: [
+                [1, 0],
+                [2, 45],
+              ],
+            },
+            { label: "swapped", samples: [[1, 3]] },
+          ],
+        },
+      ]),
+      // scheduler_state is NOT in the standard keys — extracted regardless.
+      ["kv_cache_usage"],
+    );
+    const waiting = out.metrics.find((m) => m.key === "scheduler_waiting");
+    // only the waiting series (0, 45) → avg 22.5, peak 45; running/swapped ignored
+    expect(waiting).toMatchObject({ key: "scheduler_waiting", unit: "count", avg: 22.5, peak: 45 });
+  });
+
+  it("emits no scheduler_waiting when scheduler_state is absent or has no waiting series", () => {
+    const out = reduceEngineSnapshot(
+      resp([
+        {
+          key: "scheduler_state",
+          unit: "count",
+          unavailable: false,
+          series: [{ label: "running", samples: [[1, 8]] }],
+        },
+      ]),
+      [],
+    );
+    expect(out.metrics.find((m) => m.key === "scheduler_waiting")).toBeUndefined();
+  });
+
   it("drops unavailable / empty / non-finite panels and unselected keys", () => {
     const out = reduceEngineSnapshot(
       resp([

--- a/apps/api/src/modules/engine-metrics/engine-metrics-snapshot.reduce.ts
+++ b/apps/api/src/modules/engine-metrics/engine-metrics-snapshot.reduce.ts
@@ -20,11 +20,66 @@ export const COMPARE_ENGINE_METRIC_KEYS = [
 ] as const;
 
 /**
+ * Saturation thresholds (in the metric's own unit) for metrics where "how long
+ * it stayed pinned" matters more than the bare peak. `satFrac` = fraction of
+ * window samples ≥ threshold. KV cache usage is reported in % (0..100), so the
+ * 90% saturation line is `90`, not `0.9`.
+ */
+const SATURATION_THRESHOLD: Record<string, number> = {
+  kv_cache_usage: 90,
+};
+
+/**
+ * The `scheduler_state` manifest panel bundles three series (running / waiting
+ * / swapped, tagged via the `series` label). We snapshot only `waiting` — the
+ * request-backlog signal — as a standalone durable scalar so the report can
+ * pair queue *time* (request_queue_time, ms) with queue *depth* (count).
+ */
+const SCHEDULER_STATE_KEY = "scheduler_state";
+const SCHEDULER_WAITING_KEY = "scheduler_waiting";
+
+interface SeriesStats {
+  avg: number;
+  peak: number;
+  satFrac: number | null;
+}
+
+/** Reduce a set of series' samples to avg/peak (+ optional saturation
+ * fraction). Returns null when no finite samples are present. */
+function reduceSamples(
+  seriesList: { samples: [number, number][] }[],
+  threshold: number | undefined,
+): SeriesStats | null {
+  let sum = 0;
+  let count = 0;
+  let peak = Number.NEGATIVE_INFINITY;
+  let saturated = 0;
+  for (const series of seriesList) {
+    for (const [, value] of series.samples) {
+      if (!Number.isFinite(value)) continue;
+      sum += value;
+      count += 1;
+      if (value > peak) peak = value;
+      if (threshold !== undefined && value >= threshold) saturated += 1;
+    }
+  }
+  if (count === 0) return null;
+  return {
+    avg: sum / count,
+    peak,
+    satFrac: threshold === undefined ? null : saturated / count,
+  };
+}
+
+/**
  * Reduce a live engine-metrics snapshot (per-metric time-series over the run
  * window) to durable scalars: `avg` (window mean) + `peak` (window max) for
- * each selected metric. Unavailable / empty panels are dropped. The frontend
- * picks avg vs peak per metric (peak for kv-cache / queue saturation, avg for
- * rates). `capturedAt` is the snapshot window end.
+ * each selected metric, plus `satFrac` (fraction of the window at/above the
+ * saturation threshold) for metrics that define one. Unavailable / empty panels
+ * are dropped. The frontend picks avg vs peak per metric (peak for kv-cache /
+ * queue saturation, avg for rates). Additionally extracts the `waiting` series
+ * from the `scheduler_state` panel as a standalone `scheduler_waiting` scalar.
+ * `capturedAt` is the snapshot window end.
  */
 export function reduceEngineSnapshot(
   resp: EngineMetricsSnapshotResponse,
@@ -35,19 +90,32 @@ export function reduceEngineSnapshot(
   for (const key of keys) {
     const panel = byKey.get(key);
     if (!panel || panel.unavailable) continue;
-    let sum = 0;
-    let count = 0;
-    let peak = Number.NEGATIVE_INFINITY;
-    for (const series of panel.series) {
-      for (const [, value] of series.samples) {
-        if (!Number.isFinite(value)) continue;
-        sum += value;
-        count += 1;
-        if (value > peak) peak = value;
-      }
-    }
-    if (count === 0) continue;
-    metrics.push({ key, unit: panel.unit, avg: sum / count, peak });
+    const stats = reduceSamples(panel.series, SATURATION_THRESHOLD[key]);
+    if (!stats) continue;
+    metrics.push({
+      key,
+      unit: panel.unit,
+      avg: stats.avg,
+      peak: stats.peak,
+      satFrac: stats.satFrac,
+    });
   }
+
+  // scheduler_state → scheduler_waiting (waiting series only). vLLM/MindIE
+  // expose running/waiting/swapped; SGLang lacks swapped but still has waiting.
+  const schedPanel = byKey.get(SCHEDULER_STATE_KEY);
+  if (schedPanel && !schedPanel.unavailable) {
+    const waiting = schedPanel.series.filter((s) => s.label === "waiting");
+    const stats = reduceSamples(waiting, undefined);
+    if (stats) {
+      metrics.push({
+        key: SCHEDULER_WAITING_KEY,
+        unit: schedPanel.unit,
+        avg: stats.avg,
+        peak: stats.peak,
+      });
+    }
+  }
+
   return { capturedAt: resp.window.to, metrics };
 }

--- a/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
+++ b/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
@@ -10,7 +10,12 @@ import { Injectable, Logger, NotFoundException, ServiceUnavailableException } fr
 import { LruCache } from "../insights/cache.js";
 import { type ChatMessage, chatCompletion } from "../insights/llm-client.js";
 import { LlmJudgeService } from "../llm-judge/llm-judge.service.js";
-import { availableFigureRefIds, readPrefixCache, summarizeForPrompt } from "./metrics.js";
+import {
+  availableFigureRefIds,
+  readEngineMetric,
+  readPrefixCache,
+  summarizeForPrompt,
+} from "./metrics.js";
 import { isBlockingWarning, lintNarrative } from "./narrative-lint.js";
 import { buildRetryFeedback, buildSystemPrompt } from "./prompts.js";
 import { getReportProfile, resolveReportIntent } from "./report-scenarios/index.js";
@@ -212,6 +217,68 @@ export class CompareSynthesizeService {
     }
   }
 
+  /** Durable engine-internal signals for one run, parsed from
+   * serverMetrics.engineMetrics. All nullable — absent on older snapshots or
+   * when the engine / Prometheus didn't expose the metric. KV is reported in %
+   * (0..100); satFrac is rescaled to a percentage so the report can cite it
+   * directly (e.g. "saturated for 62% of the window"). */
+  private engineInternal(serverMetrics: unknown): {
+    kvPeakPct: number | null;
+    kvSatPct: number | null;
+    waitingPeak: number | null;
+    queuePeakMs: number | null;
+    preemptRps: number | null;
+    prefixHitPct: number | null;
+  } {
+    const kv = readEngineMetric(serverMetrics, "kv_cache_usage");
+    const waiting = readEngineMetric(serverMetrics, "scheduler_waiting");
+    const queue = readEngineMetric(serverMetrics, "request_queue_time");
+    const preempt = readEngineMetric(serverMetrics, "preemption_rate");
+    // Per-run prefix-cache hit rate from the normalized engineMetrics snapshot
+    // (avg over the window = steady-state hit rate). This is the cross-engine
+    // source — distinct from the lb-strategy-only `prefixCache` annotation that
+    // readPrefixCache() reads, which inference runs don't carry.
+    const prefixHit = readEngineMetric(serverMetrics, "prefix_cache_hit_rate");
+    return {
+      kvPeakPct: kv?.peak ?? null,
+      kvSatPct: kv?.satFrac != null ? kv.satFrac * 100 : null,
+      waitingPeak: waiting?.peak ?? null,
+      queuePeakMs: queue?.peak ?? null,
+      preemptRps: preempt?.avg ?? null,
+      prefixHitPct: prefixHit?.avg ?? null,
+    };
+  }
+
+  /** One-line engine-internal summary for a stage's prompt block. Empty string
+   * when the run carries no engine metrics (older snapshot / unsupported). */
+  private engineLine(serverMetrics: unknown, zh: boolean): string {
+    const e = this.engineInternal(serverMetrics);
+    const parts: string[] = [];
+    if (e.kvPeakPct != null) {
+      const sat =
+        e.kvSatPct != null
+          ? zh
+            ? `(饱和≥90% 占 ${e.kvSatPct.toFixed(0)}%)`
+            : ` (≥90% for ${e.kvSatPct.toFixed(0)}% of window)`
+          : "";
+      parts.push(`${zh ? "KV峰值" : "KV peak"} ${e.kvPeakPct.toFixed(0)}%${sat}`);
+    }
+    if (e.waitingPeak != null) {
+      parts.push(`${zh ? "waiting峰值" : "waiting peak"} ${e.waitingPeak.toFixed(0)}`);
+    }
+    if (e.queuePeakMs != null) {
+      parts.push(`${zh ? "queue峰值" : "queue peak"} ${e.queuePeakMs.toFixed(0)}ms`);
+    }
+    if (e.preemptRps != null) {
+      parts.push(`${zh ? "抢占" : "preempt"} ${e.preemptRps.toFixed(2)}/s`);
+    }
+    if (e.prefixHitPct != null) {
+      parts.push(`${zh ? "前缀缓存命中" : "prefix-cache hit"} ${e.prefixHitPct.toFixed(1)}%`);
+    }
+    if (parts.length === 0) return "";
+    return (zh ? "  引擎内部: " : "  engine: ") + parts.join(" · ");
+  }
+
   /**
    * Walk the input metrics summary and collect every number the LLM could
    * legitimately cite. Used by lint number cross-check (lint module reads this
@@ -236,6 +303,17 @@ export class CompareSynthesizeService {
       }
       const pc = readPrefixCache(b.serverMetrics);
       if (pc) nums.push(pc.hitRatePct, pc.topPodSharePct);
+      const e = this.engineInternal(b.serverMetrics);
+      for (const v of [
+        e.kvPeakPct,
+        e.kvSatPct,
+        e.waitingPeak,
+        e.queuePeakMs,
+        e.preemptRps,
+        e.prefixHitPct,
+      ]) {
+        if (v !== null) nums.push(v);
+      }
     }
     return nums;
   }
@@ -298,6 +376,7 @@ export class CompareSynthesizeService {
       lines.push(L.contextHeader, sc.context, "");
     }
     lines.push(L.runsHeader, L.metricsLegend, "");
+    let anyEngine = false;
     for (const b of sc.benchmarks) {
       if (b.missing) {
         lines.push(`- [${b.stageLabel}] ${L.deleted}`);
@@ -319,6 +398,23 @@ export class CompareSynthesizeService {
       lines.push(
         `- [${b.stageLabel}] ${b.name ?? "(unnamed)"} · tool=${b.tool ?? "?"} scenario=${b.scenario ?? "?"}`,
         `  qps=${m.throughput ?? "—"}  err=${m.errorRate ?? "—"}  ${ttftLine}  ${e2eLine}${pcLine}`,
+      );
+      const engineLine = this.engineLine(b.serverMetrics, zh);
+      if (engineLine) {
+        lines.push(engineLine);
+        anyEngine = true;
+      }
+    }
+
+    // Engine-internal causal-chain hint — only when at least one stage carries
+    // engine metrics, so the judge interprets the trend instead of restating it.
+    if (anyEngine) {
+      lines.push(
+        "",
+        zh ? "## 引擎内部分析提示" : "## Engine-internal analysis hint",
+        zh
+          ? "结合每个 stage 的「引擎内部」行分析因果链:高并发档 KV 饱和 → waiting 堆积 → 抢占/queue 时间上升 → TTFT 拐点或吞吐封顶。指出哪个引擎/stage 最先触发该链条,以及谁的 headroom 更大。"
+          : "Using the per-stage `engine:` lines, reason about the causal chain: at high concurrency KV saturates → waiting backlog grows → preemption / queue time rises → TTFT inflects or throughput plateaus. Call out which engine/stage triggers this chain first and which has more headroom.",
       );
     }
     if (sc.baselineId) {

--- a/apps/api/src/modules/saved-compares/metrics.ts
+++ b/apps/api/src/modules/saved-compares/metrics.ts
@@ -105,6 +105,9 @@ export interface EngineMetricValue {
   avg: number | null;
   peak: number | null;
   unit: string;
+  /** Fraction (0..1) of the window at/above the saturation threshold, when the
+   * metric defines one (e.g. KV cache ≥ 90%). Null/absent otherwise. */
+  satFrac?: number | null;
 }
 
 /** Read one durable engine-metric scalar from serverMetrics.engineMetrics.
@@ -115,7 +118,7 @@ export function readEngineMetric(serverMetrics: unknown, key: string): EngineMet
   );
   if (!parsed.success) return null;
   const m = parsed.data.metrics.find((x) => x.key === key);
-  return m ? { avg: m.avg, peak: m.peak, unit: m.unit } : null;
+  return m ? { avg: m.avg, peak: m.peak, unit: m.unit, satFrac: m.satFrac ?? null } : null;
 }
 
 /** refId → which engine metric + scalar to plot. Mirrors the client constant. */

--- a/packages/contracts/src/benchmark.ts
+++ b/packages/contracts/src/benchmark.ts
@@ -269,6 +269,11 @@ export const engineMetricScalarSchema = z.object({
   unit: panelUnitSchema,
   avg: z.number().nullable(),
   peak: z.number().nullable(),
+  // Optional saturation-duration stat: fraction (0..1) of window samples at or
+  // above the metric's saturation threshold — e.g. KV cache ≥ 90%. Lets the
+  // report distinguish a transient peak from a sustained saturation. Only
+  // present for metrics with a defined threshold; absent on older snapshots.
+  satFrac: z.number().nullable().optional(),
 });
 export const engineMetricsAnnotationSchema = z.object({
   capturedAt: z.string(),


### PR DESCRIPTION
## 目标

报告判官此前拿不到引擎内部指标的**实际数值**,只能在「可用图表 refId 列表」里盲选,无法在叙述里解释"为什么 KV 45% 算高/低"。本 PR 把归一化引擎指标的数值 + 关键统计量喂进 synthesize prompt,并补两个诊断量。是 #343 的 **Phase 1(prompt/数据层)**,不动渲染。

## 改动

**数据层**
- `reduceEngineSnapshot`:
  - `kv_cache_usage` 增 `satFrac` —— 窗口内 ≥90% 的样本占比,区分"瞬时尖峰"与"持续打满"(KV 单位是 %,阈值 90)。
  - 从 `scheduler_state` panel 的 `waiting` series 抽出 **`scheduler_waiting`** —— 请求积压**量级**,补 `request_queue_time`(队列**时间**)之外的"队列深度"视角。三引擎在 recording-rule 层已把 `running`/`waiting` 归一化。
- `engineMetricScalarSchema` 增 optional `satFrac` —— 向后兼容,老快照无此字段照常 parse,无 DB 迁移。

**prompt 层**
- 每个 stage 追加「引擎内部」行:`KV峰值 x%(饱和≥90% 占 y%) · waiting峰值 · queue峰值 · 抢占 · 前缀缓存命中`。
- 加**因果链分析提示**:KV 饱和 → waiting 堆积 → 抢占/queue 上升 → TTFT 拐点/吞吐封顶,让判官解读趋势而非复读数字。
- **前缀缓存命中率**改读归一化 `engineMetrics`(跨引擎一致),不再依赖 lb-strategy-only 的 `prefixCache` 注解 —— inference 跑也能喂给判官。
- `collectInputNumbers` 纳入引擎数值,判官引用具体数字不被防幻觉 lint 打回。

## 验证
- reduce 新增 4 个 spec(satFrac / satFrac=null / scheduler_waiting 抽取 / 无 waiting 时不产出);engine-metrics + saved-compares 全套 **115 tests 绿**。
- 一次性脚本回填了 dev 库今天 **27** 个 inference 跑(MindIE+vLLM,Prometheus 仍在保留期内),`gained satFrac=27 · scheduler_waiting=27 · failed=0`。验证 MindIE c128:`scheduler_waiting` peak **107** / avg 36,`kv_cache_usage` peak 62%。回填脚本是 throwaway,不在本 PR。

## 注意(合并顺序)
reduce/prompt 改动与 #341 正交、独立正确。但**完整价值**依赖 #341 的"engine 快照对任意 scenario 生效"(`trySnapshotEngineMetrics`)—— main 上快照仍是 lb-strategy gated,inference 跑要等 #341 合了才会自动采到这些字段(已回填的历史数据不受影响)。

refs #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)