### PR TITLE
feat(saved-compare): Sweep/参数扫描报告模式 — metric-vs-并发折线 + 引擎内部归因

### DIFF
--- a/apps/api/prisma/migrations/20260630091215_saved_compare_sweep_fields/migration.sql
+++ b/apps/api/prisma/migrations/20260630091215_saved_compare_sweep_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "saved_compares" ADD COLUMN     "report_kind" TEXT,
+ADD COLUMN     "sweep_axis" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -371,6 +371,13 @@ model SavedCompare {
   clientName       String?   @map("client_name")
   scenario         String?   // derived: shared scenario of all member benchmarks
   tool             String?   // derived: shared tool of all member benchmarks
+  /// Report archetype. null = the default discrete side-by-side stage compare.
+  /// 'sweep' = parametric sweep: members are grouped into series (by connection)
+  /// across a swept axis (sweepAxis) and rendered as metric-vs-axis line charts.
+  reportKind       String?   @map("report_kind")
+  /// For reportKind='sweep': the per-run param forming the x-axis. Currently
+  /// 'parallel' (evalscope concurrency); reserved for other tools' axes later.
+  sweepAxis        String?   @map("sweep_axis")
   /// Monotonically increasing version stamp, bumped by the UI when the
   /// user regenerates or edits the report. Surfaced in Hero meta.
   version          Int       @default(1)

--- a/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
+++ b/apps/api/src/modules/saved-compares/compare-synthesize.service.ts
@@ -67,7 +67,7 @@ export class CompareSynthesizeService {
     }
 
     const runCount = sc.benchmarks.filter((b) => !b.missing).length;
-    const intent = resolveReportIntent(sc.scenario, runCount);
+    const intent = resolveReportIntent(sc.scenario, runCount, sc.reportKind);
     const profile = getReportProfile(intent);
     const scenarioData = profile.dataAssembly(sc);
     const sys = buildSystemPrompt(body.locale, profile.promptFragment(body.locale));
@@ -442,6 +442,13 @@ export class CompareSynthesizeService {
           hasLatencyCdf: !!b.latencyCdf?.samples?.length,
         })),
     );
+    // Sweep figures aren't in the per-run availability set (they need the
+    // cross-run aggregation). The sweep profile's preferredFigures are already
+    // availability-filtered (via availableSweepFigures in dataAssembly), so
+    // fold them into the offered set for sweep reports.
+    if (sc.reportKind === "sweep") {
+      for (const r of scenarioData.preferredFigures) available.add(r);
+    }
     const preferred = scenarioData.preferredFigures.filter((r) => available.has(r));
     const offered = preferred.length > 0 ? preferred : [...available];
     lines.push(

--- a/apps/api/src/modules/saved-compares/prompts.ts
+++ b/apps/api/src/modules/saved-compares/prompts.ts
@@ -46,7 +46,7 @@ interface Narrative {
   ];                     // exactly 6 sections in this order
   figures: Array<{
     id: string;
-    refId: "stage-bars-throughput" | "stage-bars-error-rate" | "stage-bars-ttft-p95" | "stage-bars-tpot-p95" | "stage-bars-e2e-p95" | "stage-bars-prefix-cache-hit" | "stage-bars-top-pod-share" | "stage-bars-kv-cache" | "stage-bars-preemption" | "stage-bars-queue" | "pod-traffic-distribution" | "pod-hit-rate" | "cold-warm-delta" | "throughput-vs-concurrency" | "latency-distribution" | "compare-grid";
+    refId: "stage-bars-throughput" | "stage-bars-error-rate" | "stage-bars-ttft-p95" | "stage-bars-tpot-p95" | "stage-bars-e2e-p95" | "stage-bars-prefix-cache-hit" | "stage-bars-top-pod-share" | "stage-bars-kv-cache" | "stage-bars-preemption" | "stage-bars-queue" | "pod-traffic-distribution" | "pod-hit-rate" | "cold-warm-delta" | "throughput-vs-concurrency" | "latency-distribution" | "compare-grid" | "sweep-throughput" | "sweep-ttft" | "sweep-itl" | "sweep-e2e" | "sweep-kv-cache" | "sweep-queue";
     caption: string;
     anchorSection?: "summary" | "scope" | "method" | "results" | "caveats" | "advice";
   }>;

--- a/apps/api/src/modules/saved-compares/prompts.ts
+++ b/apps/api/src/modules/saved-compares/prompts.ts
@@ -46,7 +46,7 @@ interface Narrative {
   ];                     // exactly 6 sections in this order
   figures: Array<{
     id: string;
-    refId: "stage-bars-throughput" | "stage-bars-error-rate" | "stage-bars-ttft-p95" | "stage-bars-tpot-p95" | "stage-bars-e2e-p95" | "stage-bars-prefix-cache-hit" | "stage-bars-top-pod-share" | "stage-bars-kv-cache" | "stage-bars-preemption" | "stage-bars-queue" | "pod-traffic-distribution" | "pod-hit-rate" | "cold-warm-delta" | "throughput-vs-concurrency" | "latency-distribution" | "compare-grid" | "sweep-throughput" | "sweep-ttft" | "sweep-itl" | "sweep-e2e" | "sweep-kv-cache" | "sweep-queue";
+    refId: "stage-bars-throughput" | "stage-bars-error-rate" | "stage-bars-ttft-p95" | "stage-bars-tpot-p95" | "stage-bars-e2e-p95" | "stage-bars-prefix-cache-hit" | "stage-bars-top-pod-share" | "stage-bars-kv-cache" | "stage-bars-preemption" | "stage-bars-queue" | "pod-traffic-distribution" | "pod-hit-rate" | "cold-warm-delta" | "throughput-vs-concurrency" | "latency-distribution" | "compare-grid" | "sweep-throughput" | "sweep-ttft" | "sweep-itl" | "sweep-e2e" | "sweep-kv-cache" | "sweep-queue" | "sweep-peak" | "sweep-matrix";
     caption: string;
     anchorSection?: "summary" | "scope" | "method" | "results" | "caveats" | "advice";
   }>;

--- a/apps/api/src/modules/saved-compares/report-scenarios/index.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/index.ts
@@ -4,12 +4,17 @@ import { engineKvCacheProfile } from "./engine-kv-cache.js";
 import { gatewayProfile } from "./gateway.js";
 import { inferenceMultiProfile, inferenceSingleProfile } from "./inference.js";
 import { lbStrategyProfile } from "./lb-strategy.js";
+import { sweepProfile } from "./sweep.js";
 import type { ReportIntent, ReportScenarioProfile } from "./types.js";
 
 export function resolveReportIntent(
   scenario: string | null | undefined,
   runCount: number,
+  reportKind?: string | null,
 ): ReportIntent {
+  // Report archetype wins over scenario: a sweep compare always narrates as a
+  // parametric sweep regardless of which scenario its runs share.
+  if (reportKind === "sweep") return "sweep";
   switch (scenario) {
     case "lb-strategy":
       return "lb-strategy";
@@ -34,6 +39,7 @@ const REGISTRY: Record<ReportIntent, ReportScenarioProfile> = {
   gateway: gatewayProfile,
   "inference-single": inferenceSingleProfile,
   "inference-multi": inferenceMultiProfile,
+  sweep: sweepProfile,
 };
 
 export function getReportProfile(intent: ReportIntent): ReportScenarioProfile {

--- a/apps/api/src/modules/saved-compares/report-scenarios/sweep.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/sweep.ts
@@ -1,0 +1,30 @@
+import { availableSweepFigures, type HydratedSavedCompare } from "@modeldoctor/contracts";
+import { buildSweepSeries, formatSweepMatrix } from "../sweep-prompt.js";
+import type { Locale, ReportScenarioProfile, ScenarioData } from "./types.js";
+
+const ZH = `本报告是参数扫描(sweep):同一 workload 在多个并发档上跑,按引擎分 series。
+- 主轴是并发(concurrency);图是 metric-vs-并发折线,一条线一个引擎。
+- 叙述要讲清:① 吞吐随并发的扩展曲线与饱和/回退拐点;② 引擎间的交叉点(谁在低并发领先、谁在高并发反超);③ 用引擎内部指标(KV cache 使用率、调度排队深度)对延迟/吞吐拐点做根因归因(如"排队深度暴涨→首字延迟崩"、"KV 打满→吞吐回退")。
+- HEADLINE 用最高并发档的吞吐领先幅度 + 一个引擎内部归因点。务必引用 Sweep matrix 里的具体数值。
+- 不要逐 stage 罗列;以"引擎 × 并发曲线"组织。`;
+
+const EN = `This is a parametric sweep report: one workload across several concurrency levels, grouped into series by engine.
+- The axis is concurrency; figures are metric-vs-concurrency lines, one line per engine.
+- The narrative must cover: (1) the throughput scaling curve and its saturation/regression knee; (2) cross-engine crossover points (who leads at low concurrency, who overtakes at high); (3) root-cause attribution of latency/throughput knees using engine-internal metrics (KV-cache usage, scheduler waiting-queue depth) — e.g. "waiting depth explodes → TTFT collapses", "KV saturates → throughput regresses".
+- Headline with the top-concurrency throughput lead plus one engine-internal attribution. Always cite concrete numbers from the Sweep matrix.
+- Do NOT enumerate stage-by-stage; organize around engine × concurrency curves.`;
+
+function assemble(sc: HydratedSavedCompare): ScenarioData {
+  const series = buildSweepSeries(sc);
+  return {
+    promptBlock: formatSweepMatrix(series),
+    // Only offer the sweep figures the aggregated data can actually fill.
+    preferredFigures: [...availableSweepFigures(series)],
+  };
+}
+
+export const sweepProfile: ReportScenarioProfile = {
+  intent: "sweep",
+  promptFragment: (l: Locale) => (l === "en-US" ? EN : ZH),
+  dataAssembly: assemble,
+};

--- a/apps/api/src/modules/saved-compares/report-scenarios/sweep.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/sweep.ts
@@ -1,25 +1,46 @@
-import { availableSweepFigures, type HydratedSavedCompare } from "@modeldoctor/contracts";
+import {
+  availableSweepFigures,
+  type FigureRefId,
+  type HydratedSavedCompare,
+} from "@modeldoctor/contracts";
 import { buildSweepSeries, formatSweepMatrix } from "../sweep-prompt.js";
 import type { Locale, ReportScenarioProfile, ScenarioData } from "./types.js";
+
+// Figure hierarchy (mirrors lb-strategy's headline→support→mechanism→data shape,
+// mixing chart types instead of all-lines): trend-line headline → verdict BARS
+// at peak concurrency → latency lines → engine-internal mechanism lines → the
+// data-matrix table. Filtered to what the aggregated data can fill.
+const FIGURE_ORDER: FigureRefId[] = [
+  "sweep-throughput",
+  "sweep-peak",
+  "sweep-ttft",
+  "sweep-kv-cache",
+  "sweep-queue",
+  "sweep-e2e",
+  "sweep-matrix",
+];
 
 const ZH = `本报告是参数扫描(sweep):同一 workload 在多个并发档上跑,按引擎分 series。
 - 主轴是并发(concurrency);图是 metric-vs-并发折线,一条线一个引擎。
 - 叙述要讲清:① 吞吐随并发的扩展曲线与饱和/回退拐点;② 引擎间的交叉点(谁在低并发领先、谁在高并发反超);③ 用引擎内部指标(KV cache 使用率、调度排队深度)对延迟/吞吐拐点做根因归因(如"排队深度暴涨→首字延迟崩"、"KV 打满→吞吐回退")。
 - HEADLINE 用最高并发档的吞吐领先幅度 + 一个引擎内部归因点。务必引用 Sweep matrix 里的具体数值。
+- 图表分层(混用图型,别全折线):趋势折线(sweep-throughput)打头 → sweep-peak 柱给"峰值并发谁赢"的判决快照 → sweep-ttft 等时延折线佐证 → sweep-kv-cache/sweep-queue 折线做机制归因 → sweep-matrix 表给全量数据。
 - 不要逐 stage 罗列;以"引擎 × 并发曲线"组织。`;
 
 const EN = `This is a parametric sweep report: one workload across several concurrency levels, grouped into series by engine.
 - The axis is concurrency; figures are metric-vs-concurrency lines, one line per engine.
 - The narrative must cover: (1) the throughput scaling curve and its saturation/regression knee; (2) cross-engine crossover points (who leads at low concurrency, who overtakes at high); (3) root-cause attribution of latency/throughput knees using engine-internal metrics (KV-cache usage, scheduler waiting-queue depth) — e.g. "waiting depth explodes → TTFT collapses", "KV saturates → throughput regresses".
 - Headline with the top-concurrency throughput lead plus one engine-internal attribution. Always cite concrete numbers from the Sweep matrix.
+- Figure hierarchy (mix chart types, not all lines): the trend line (sweep-throughput) leads → sweep-peak BARS give the "who wins at peak concurrency" verdict snapshot → latency lines (sweep-ttft, …) as support → sweep-kv-cache / sweep-queue lines for mechanism attribution → sweep-matrix table for the full data.
 - Do NOT enumerate stage-by-stage; organize around engine × concurrency curves.`;
 
 function assemble(sc: HydratedSavedCompare): ScenarioData {
   const series = buildSweepSeries(sc);
+  const avail = availableSweepFigures(series);
   return {
     promptBlock: formatSweepMatrix(series),
-    // Only offer the sweep figures the aggregated data can actually fill.
-    preferredFigures: [...availableSweepFigures(series)],
+    // Offer in hierarchy order, filtered to what the data can fill.
+    preferredFigures: FIGURE_ORDER.filter((r) => avail.has(r)),
   };
 }
 

--- a/apps/api/src/modules/saved-compares/report-scenarios/types.ts
+++ b/apps/api/src/modules/saved-compares/report-scenarios/types.ts
@@ -10,6 +10,7 @@ export type ReportIntent =
   | "gateway"
   | "inference-single"
   | "inference-multi"
+  | "sweep"
   | "default";
 
 /** Scenario-specific data the profile assembled from the hydrated compare,

--- a/apps/api/src/modules/saved-compares/saved-compares.service.ts
+++ b/apps/api/src/modules/saved-compares/saved-compares.service.ts
@@ -3,7 +3,9 @@ import type {
   CreateSavedCompareRequest,
   HydratedBenchmarkRef,
   HydratedSavedCompare,
+  ReportKind,
   SavedCompare,
+  SweepAxis,
   UpdateSavedCompareRequest,
 } from "@modeldoctor/contracts";
 import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
@@ -46,6 +48,8 @@ export class SavedComparesService {
     version: number;
     scenario: string | null;
     tool: string | null;
+    reportKind: string | null;
+    sweepAxis: string | null;
     narrative: unknown;
     narrativeAt: Date | null;
     createdAt: Date;
@@ -64,6 +68,8 @@ export class SavedComparesService {
       version: row.version,
       scenario: row.scenario,
       tool: row.tool,
+      reportKind: (row.reportKind as ReportKind | null) ?? null,
+      sweepAxis: (row.sweepAxis as SweepAxis | null) ?? null,
       narrative: row.narrative,
       narrativeAt: row.narrativeAt ? row.narrativeAt.toISOString() : null,
       createdAt: row.createdAt.toISOString(),
@@ -99,6 +105,8 @@ export class SavedComparesService {
         clientName: body.clientName ?? null,
         scenario: members.length > 0 ? ([...scenarios][0] ?? null) : null,
         tool: members.length > 0 ? ([...tools][0] ?? null) : null,
+        reportKind: body.reportKind ?? null,
+        sweepAxis: body.reportKind === "sweep" ? (body.sweepAxis ?? "parallel") : null,
       },
     });
     return this.serialize(row);
@@ -126,6 +134,9 @@ export class SavedComparesService {
 
     const benchmarks = await this.prisma.benchmark.findMany({
       where: { id: { in: sc.benchmarkIds } },
+      // Sweep mode groups runs into series by connection; pull the connection's
+      // serverKind so each series can be labelled by engine (vllm/mindie/sglang).
+      include: { connection: { select: { serverKind: true } } },
     });
     const benchmarkById = new Map(benchmarks.map((b) => [b.id, b]));
     const hydratedBenchmarks: HydratedBenchmarkRef[] = sc.benchmarkIds.map((bid) => {
@@ -138,6 +149,8 @@ export class SavedComparesService {
         name: b.name,
         tool: b.tool,
         scenario: b.scenario,
+        connectionId: b.connectionId,
+        engineKind: b.connection?.serverKind ?? null,
         summaryMetrics: b.summaryMetrics,
         serverMetrics: b.serverMetrics,
         params: b.params,
@@ -181,6 +194,8 @@ export class SavedComparesService {
         context: body.context === undefined ? undefined : body.context,
         classification: body.classification ?? undefined,
         clientName: body.clientName === undefined ? undefined : body.clientName,
+        reportKind: body.reportKind === undefined ? undefined : body.reportKind,
+        sweepAxis: body.sweepAxis === undefined ? undefined : body.sweepAxis,
       },
     });
     return this.serialize(row);

--- a/apps/api/src/modules/saved-compares/sweep-prompt.spec.ts
+++ b/apps/api/src/modules/saved-compares/sweep-prompt.spec.ts
@@ -1,0 +1,47 @@
+import type { SweepSeries } from "@modeldoctor/contracts";
+import { describe, expect, it } from "vitest";
+import { resolveReportIntent } from "./report-scenarios/index.js";
+import { formatSweepMatrix } from "./sweep-prompt.js";
+
+describe("resolveReportIntent", () => {
+  it("reportKind='sweep' wins over scenario", () => {
+    expect(resolveReportIntent("inference", 9, "sweep")).toBe("sweep");
+    expect(resolveReportIntent("lb-strategy", 2, "sweep")).toBe("sweep");
+  });
+  it("falls back to scenario mapping when reportKind is null", () => {
+    expect(resolveReportIntent("inference", 9, null)).toBe("inference-multi");
+    expect(resolveReportIntent("inference", 1, null)).toBe("inference-single");
+    expect(resolveReportIntent("capacity", 3)).toBe("capacity");
+    expect(resolveReportIntent("nope", 3)).toBe("default");
+  });
+});
+
+describe("formatSweepMatrix", () => {
+  const series: SweepSeries[] = [
+    {
+      seriesKey: "c-v",
+      seriesLabel: "vllm",
+      points: [
+        { x: 8, values: { outTps: 145, rps: 0.29, ttftP50: 283, ttftP95: 545, kvAvg: 4.5 }, n: 3 },
+        { x: 128, values: { outTps: 1228, ttftP50: 1200, queueDepth: 3.1 }, n: 3 },
+      ],
+    },
+  ];
+  it("renders a markdown table row per (series, x)", () => {
+    const md = formatSweepMatrix(series);
+    expect(md).toContain("Sweep matrix");
+    expect(md).toContain("| vllm | 8 |");
+    expect(md).toContain("| vllm | 128 |");
+    expect(md).toContain("145"); // outTps
+    expect(md).toContain("1228");
+  });
+  it("renders em-dash for absent metrics", () => {
+    const md = formatSweepMatrix(series);
+    // c128 row has no rps → em-dash placeholder
+    const c128 = md.split("\n").find((l) => l.includes("| 128 |")) ?? "";
+    expect(c128).toContain("—");
+  });
+  it("returns empty string for no series", () => {
+    expect(formatSweepMatrix([])).toBe("");
+  });
+});

--- a/apps/api/src/modules/saved-compares/sweep-prompt.ts
+++ b/apps/api/src/modules/saved-compares/sweep-prompt.ts
@@ -1,0 +1,78 @@
+import {
+  aggregateSweep,
+  type HydratedSavedCompare,
+  type SweepRunInput,
+  type SweepSeries,
+} from "@modeldoctor/contracts";
+import { readMetricSafe } from "@modeldoctor/tool-adapters/schemas";
+import { readEngineMetric } from "./metrics.js";
+
+/** Per-run concurrency that forms the sweep x-axis: aiperf/genai-perf use
+ * `concurrency`, evalscope uses `parallel`. */
+function extractAxis(params: unknown): number | undefined {
+  if (!params || typeof params !== "object") return undefined;
+  const p = params as Record<string, unknown>;
+  const c = typeof p.concurrency === "number" ? p.concurrency : p.parallel;
+  return typeof c === "number" ? c : undefined;
+}
+
+/** Server mirror of the client's buildSweepRuns + aggregation: group the
+ * compare's members into per-connection series over the concurrency axis,
+ * median across repeats. Series labelled by engine kind. */
+export function buildSweepSeries(sc: HydratedSavedCompare): SweepSeries[] {
+  const runs: SweepRunInput[] = [];
+  for (const b of sc.benchmarks) {
+    if (b.missing) continue;
+    const x = extractAxis(b.params);
+    if (x === undefined) continue;
+    const sm = b.summaryMetrics as { tool?: unknown; data?: unknown } | null;
+    const num = (kind: Parameters<typeof readMetricSafe>[0]): number | null => {
+      const v = readMetricSafe(kind, sm);
+      return typeof v === "number" ? v : null;
+    };
+    const kv = readEngineMetric(b.serverMetrics, "kv_cache_usage");
+    const queue = readEngineMetric(b.serverMetrics, "scheduler_waiting");
+    runs.push({
+      seriesKey: b.connectionId ?? b.id,
+      seriesLabel: b.engineKind ?? b.stageLabel,
+      x,
+      metrics: {
+        outTps: num("outputTokensPerSec"),
+        rps: num("requestsPerSec"),
+        ttftP50: num("ttft.p50"),
+        ttftP95: num("ttft.p95"),
+        itlP50: num("itl.p50"),
+        e2eP50: num("e2e.p50"),
+        kvAvg: kv?.avg ?? null,
+        queueDepth: queue?.avg ?? null,
+      },
+    });
+  }
+  return aggregateSweep(runs);
+}
+
+const f = (v: number | null | undefined, d = 0): string =>
+  typeof v === "number" ? v.toFixed(d) : "—";
+
+/** Render the aggregated sweep as a markdown table for the user prompt, so the
+ * judge reasons over the FULL sweep (every series × concurrency point), not
+ * just the per-stage lines. English headers (data); prose is localized by the
+ * profile's promptFragment. */
+export function formatSweepMatrix(series: SweepSeries[]): string {
+  if (series.length === 0) return "";
+  const lines = [
+    "## Sweep matrix (median per engine × concurrency)",
+    "",
+    "| engine | concurrency | out tok/s | req/s | TTFT p50 (ms) | TTFT p95 (ms) | ITL p50 (ms) | E2E p50 (ms) | KV cache (%) | queue depth |",
+    "|---|---|---|---|---|---|---|---|---|---|",
+  ];
+  for (const s of series) {
+    for (const p of s.points) {
+      const v = p.values;
+      lines.push(
+        `| ${s.seriesLabel} | ${p.x} | ${f(v.outTps)} | ${f(v.rps, 2)} | ${f(v.ttftP50)} | ${f(v.ttftP95)} | ${f(v.itlP50, 1)} | ${f(v.e2eP50)} | ${f(v.kvAvg, 1)} | ${f(v.queueDepth, 1)} |`,
+      );
+    }
+  }
+  return lines.join("\n");
+}

--- a/apps/api/src/modules/saved-compares/sweep-prompt.ts
+++ b/apps/api/src/modules/saved-compares/sweep-prompt.ts
@@ -4,7 +4,7 @@ import {
   type SweepRunInput,
   type SweepSeries,
 } from "@modeldoctor/contracts";
-import { readMetricSafe } from "@modeldoctor/tool-adapters/schemas";
+import { readMetricSafe } from "@modeldoctor/tool-adapters";
 import { readEngineMetric } from "./metrics.js";
 
 /** Per-run concurrency that forms the sweep x-axis: aiperf/genai-perf use

--- a/apps/web/src/components/charts/SweepLineChart.tsx
+++ b/apps/web/src/components/charts/SweepLineChart.tsx
@@ -1,0 +1,153 @@
+import type { EChartsOption } from "echarts";
+import ReactECharts from "echarts-for-react";
+import { useMemo } from "react";
+import { ChartFrame, themed, useChartTokens } from "./_shared";
+
+export interface SweepLinePoint {
+  x: number;
+  y: number | null;
+}
+
+export interface SweepLineSeries {
+  /** Series identity label (engine, e.g. "vLLM-Ascend"). */
+  label: string;
+  /** Series-identity color (assigned by caller; sweep colors BY ENGINE, so a
+   * 3-engine sweep needs only 3 colors — the 8-color palette never wraps). */
+  color: string;
+  /** Primary line (solid) — e.g. p50, or the sole metric. */
+  points: SweepLinePoint[];
+  /** Optional secondary line (dashed, same color, no point labels) — e.g. p95. */
+  secondary?: SweepLinePoint[];
+}
+
+export interface SweepLineChartProps {
+  title?: string;
+  series: SweepLineSeries[];
+  /** y-axis label (e.g. "Output tok/s", "TTFT (ms)"). */
+  yLabel: string;
+  /** x-axis label (default "concurrency"). */
+  xLabel?: string;
+  /** log x (concurrency spans octaves — default true). */
+  logX?: boolean;
+  /** log y (e.g. TTFT spans orders of magnitude — default false). */
+  logY?: boolean;
+  /** higher-is-better → headroom above max; charts read top-down otherwise. */
+  height?: number;
+  /** Format a value for tooltip + point labels (default 1 decimal). */
+  valueFormatter?: (v: number) => string;
+  /** Legend hint for the dashed secondary line (e.g. "p95"); primary "p50". */
+  primaryName?: string;
+  secondaryName?: string;
+}
+
+const LABEL = { value: "#1f2328", baseline: "#59636e" };
+
+/**
+ * Generic metric-vs-parameter line chart for sweep reports: x = a swept param
+ * (concurrency), one (optionally two) line(s) per series (engine). Markers +
+ * static value labels on every primary point so it reads in print/PDF without
+ * hover. Colors are passed in BY SERIES (engine) — no per-run palette wrap.
+ * Generalizes ThroughputConcurrencyChart (single rps metric) to any metric,
+ * unit, log/linear axes, and an optional dashed secondary line (p95 alongside
+ * p50). Always-light report paper, independent of app theme.
+ */
+export function SweepLineChart({
+  title,
+  series,
+  yLabel,
+  xLabel = "concurrency",
+  logX = true,
+  logY = false,
+  height = 320,
+  valueFormatter = (v) => v.toFixed(1),
+  primaryName,
+  secondaryName,
+}: SweepLineChartProps): JSX.Element {
+  const tokens = useChartTokens();
+  const isEmpty = series.length === 0 || series.every((s) => s.points.every((p) => p.y === null));
+
+  const option = useMemo<EChartsOption>(() => {
+    const ecSeries = series.flatMap((s) => {
+      const toData = (pts: SweepLinePoint[]) =>
+        [...pts]
+          .filter((p) => p.y !== null)
+          .sort((a, b) => a.x - b.x)
+          .map((p) => [p.x, p.y] as [number, number]);
+      const solid = {
+        name: secondaryName && primaryName ? `${s.label} · ${primaryName}` : s.label,
+        type: "line" as const,
+        data: toData(s.points),
+        itemStyle: { color: s.color },
+        lineStyle: { color: s.color, width: 2 },
+        symbol: "circle" as const,
+        symbolSize: 6,
+        label: {
+          show: true,
+          position: "top" as const,
+          color: LABEL.value,
+          fontSize: 10,
+          fontWeight: 500 as const,
+          formatter: (p: { value: [number, number] | unknown }) =>
+            Array.isArray(p.value) && typeof p.value[1] === "number"
+              ? valueFormatter(p.value[1])
+              : "",
+        },
+      };
+      if (!s.secondary) return [solid];
+      const dashed = {
+        name: `${s.label} · ${secondaryName ?? "p95"}`,
+        type: "line" as const,
+        data: toData(s.secondary),
+        itemStyle: { color: s.color },
+        lineStyle: { color: s.color, width: 1.4, type: "dashed" as const, opacity: 0.75 },
+        symbol: "rect" as const,
+        symbolSize: 5,
+      };
+      return [solid, dashed];
+    });
+
+    const multi = ecSeries.length > 1;
+    return themed(
+      {
+        tooltip: {
+          trigger: "axis",
+          valueFormatter: (val: unknown) =>
+            typeof val === "number" ? valueFormatter(val) : String(val ?? ""),
+        },
+        legend: multi ? { type: "scroll", top: 0, textStyle: { color: LABEL.value } } : undefined,
+        xAxis: {
+          type: logX ? ("log" as const) : ("value" as const),
+          name: xLabel,
+          nameLocation: "middle" as const,
+          nameGap: 28,
+          axisLabel: { color: LABEL.baseline, formatter: (v: number) => String(v) },
+        },
+        yAxis: {
+          type: logY ? ("log" as const) : ("value" as const),
+          name: yLabel,
+          nameLocation: "middle" as const,
+          nameGap: 48,
+          ...(logY ? {} : { min: 0, max: (v: { max: number }) => (v.max > 0 ? v.max * 1.18 : 1) }),
+          axisLabel: { color: LABEL.baseline, formatter: (v: number) => valueFormatter(v) },
+        },
+        grid: { left: 70, right: 28, top: multi ? 52 : 28, bottom: 48 },
+        series: ecSeries,
+      },
+      tokens,
+    );
+  }, [series, yLabel, xLabel, logX, logY, valueFormatter, primaryName, secondaryName, tokens]);
+
+  return (
+    <div className="rounded-md border border-border p-4">
+      {title ? <div className="mb-2 text-sm font-medium">{title}</div> : null}
+      <ChartFrame ariaLabel={title ?? yLabel} height={height} empty={isEmpty}>
+        <ReactECharts
+          option={option}
+          style={{ height: "100%", width: "100%" }}
+          notMerge
+          lazyUpdate
+        />
+      </ChartFrame>
+    </div>
+  );
+}

--- a/apps/web/src/components/charts/SweepLineChart.tsx
+++ b/apps/web/src/components/charts/SweepLineChart.tsx
@@ -73,25 +73,31 @@ export function SweepLineChart({
           .filter((p) => p.y !== null)
           .sort((a, b) => a.x - b.x)
           .map((p) => [p.x, p.y] as [number, number]);
+      // Static value labels ONLY on the rightmost (highest-concurrency) point of
+      // each line: at low concurrency the engines bunch together (e.g. 177/175/
+      // 144) and per-point labels overlap into mush; at the right edge the
+      // values are spread apart and read cleanly — same choice as the reference
+      // matplotlib report. Tooltip still shows every point on hover.
+      const solidPts = [...s.points].filter((p) => p.y !== null).sort((a, b) => a.x - b.x);
       const solid = {
         name: secondaryName && primaryName ? `${s.label} · ${primaryName}` : s.label,
         type: "line" as const,
-        data: toData(s.points),
+        data: solidPts.map((p, i) => ({
+          value: [p.x, p.y] as [number, number],
+          label: {
+            show: i === solidPts.length - 1,
+            position: "top" as const,
+            color: s.color,
+            fontSize: 10,
+            fontWeight: 600 as const,
+            formatter: () => (typeof p.y === "number" ? valueFormatter(p.y) : ""),
+          },
+        })),
         itemStyle: { color: s.color },
         lineStyle: { color: s.color, width: 2 },
         symbol: "circle" as const,
         symbolSize: 6,
-        label: {
-          show: true,
-          position: "top" as const,
-          color: LABEL.value,
-          fontSize: 10,
-          fontWeight: 500 as const,
-          formatter: (p: { value: [number, number] | unknown }) =>
-            Array.isArray(p.value) && typeof p.value[1] === "number"
-              ? valueFormatter(p.value[1])
-              : "",
-        },
+        labelLayout: { hideOverlap: true },
       };
       if (!s.secondary) return [solid];
       const dashed = {

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
@@ -3,6 +3,7 @@ import {
   availableSweepFigures,
   type FigureRefId,
   type SweepMetricKey,
+  type SweepSeries,
 } from "@modeldoctor/contracts";
 import { memo } from "react";
 import { assignRunColors } from "@/components/charts/_shared";
@@ -459,6 +460,31 @@ export const FigureRenderer = memo(function FigureRenderer({
         secondaryName={spec.secondaryName}
       />
     );
+  } else if (refId === "sweep-peak") {
+    // Verdict snapshot: one bar per engine at its highest-concurrency point.
+    const peakX = Math.max(0, ...sweepSeries.flatMap((s) => s.points.map((p) => p.x)));
+    const rows = sweepSeries
+      .map((s) => ({
+        s,
+        pt: [...s.points].reverse().find((p) => typeof p.values.outTps === "number"),
+      }))
+      .filter(
+        (x): x is { s: (typeof sweepSeries)[number]; pt: NonNullable<typeof x.pt> } => !!x.pt,
+      );
+    chart = (
+      <StageBarChart
+        title={`Output tok/s · peak concurrency (c${peakX})`}
+        data={rows.map(({ s, pt }) => ({ stage: s.seriesLabel, v: pt.values.outTps as number }))}
+        series={[
+          { key: "v", label: "out tok/s", color: "#2980b9", decimals: 0, higherIsBetter: true },
+        ]}
+        barColors={rows.map(({ s }) => seriesColor[s.seriesKey])}
+        yLabel="out tok/s"
+        labelColors={REPORT_LABEL_COLORS}
+      />
+    );
+  } else if (refId === "sweep-matrix") {
+    chart = <SweepMatrixTable series={sweepSeries} />;
   }
 
   return (
@@ -507,6 +533,45 @@ function FourMetricTable({ runs }: { runs: ReportRun[] }) {
             </td>
           </tr>
         ))}
+      </tbody>
+    </table>
+  );
+}
+
+/** Sweep data matrix: one row per (engine, concurrency) median — the full
+ * engine × concurrency grid in the report body (sweep-matrix figure). */
+function SweepMatrixTable({ series }: { series: SweepSeries[] }) {
+  const fmt = (v: number | null | undefined, d = 0) => (typeof v === "number" ? v.toFixed(d) : "—");
+  const num = { textAlign: "right" as const, fontFamily: "var(--pr-mono)" };
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Engine</th>
+          <th style={num}>Conc</th>
+          <th style={num}>out tok/s</th>
+          <th style={num}>TTFT p50</th>
+          <th style={num}>E2E p50</th>
+          <th style={num}>KV %</th>
+          <th style={num}>Queue</th>
+        </tr>
+      </thead>
+      <tbody>
+        {series.flatMap((s) =>
+          s.points.map((p) => (
+            <tr key={`${s.seriesKey}-${p.x}`}>
+              <td>
+                <strong>{s.seriesLabel}</strong>
+              </td>
+              <td style={num}>{p.x}</td>
+              <td style={num}>{fmt(p.values.outTps)}</td>
+              <td style={num}>{fmt(p.values.ttftP50)}</td>
+              <td style={num}>{fmt(p.values.e2eP50)}</td>
+              <td style={num}>{fmt(p.values.kvAvg, 1)}</td>
+              <td style={num}>{fmt(p.values.queueDepth, 1)}</td>
+            </tr>
+          )),
+        )}
       </tbody>
     </table>
   );

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
@@ -1,4 +1,4 @@
-import type { FigureRefId } from "@modeldoctor/contracts";
+import { aggregateSweep, type FigureRefId, type SweepMetricKey } from "@modeldoctor/contracts";
 import { memo } from "react";
 import { assignRunColors } from "@/components/charts/_shared";
 import { LatencyCDF } from "@/components/charts/LatencyCDF";
@@ -9,6 +9,7 @@ import {
   type StageBarLabelColors,
   type StageBarSeries,
 } from "@/components/charts/StageBarChart";
+import { SweepLineChart } from "@/components/charts/SweepLineChart";
 import { ThroughputConcurrencyChart } from "@/components/charts/ThroughputConcurrencyChart";
 import {
   availableFigureRefIds,
@@ -20,6 +21,7 @@ import {
   summarizeForPrompt,
 } from "./client-metrics";
 import type { ReportRun } from "./ReportSections";
+import { availableSweepFigures, buildSweepRuns, toSweepLineSeries } from "./sweep-data";
 
 export interface FigureRendererProps {
   refId: FigureRefId;
@@ -56,6 +58,36 @@ const REPORT_PALETTE = [
 const PERCENTILES = ["p50", "p90", "p99"] as const;
 // ITL (TPOT) only carries p50/p95 across tools — see MetricKind.
 const ITL_PERCENTILES = ["p50", "p95"] as const;
+
+/** Sweep figure refId → how to render its line chart (metric, axis label,
+ * log-y for wide-dynamic-range latency, optional dashed secondary line). */
+const SWEEP_FIGURE_SPEC: Record<
+  "sweep-throughput" | "sweep-ttft" | "sweep-itl" | "sweep-e2e" | "sweep-kv-cache" | "sweep-queue",
+  {
+    metric: SweepMetricKey;
+    secondary?: SweepMetricKey;
+    yLabel: string;
+    logY?: boolean;
+    decimals: number;
+    primaryName?: string;
+    secondaryName?: string;
+  }
+> = {
+  "sweep-throughput": { metric: "outTps", yLabel: "Output tok/s", decimals: 0 },
+  "sweep-ttft": {
+    metric: "ttftP50",
+    secondary: "ttftP95",
+    yLabel: "TTFT (ms)",
+    logY: true,
+    decimals: 0,
+    primaryName: "p50",
+    secondaryName: "p95",
+  },
+  "sweep-itl": { metric: "itlP50", yLabel: "ITL p50 (ms)", decimals: 1 },
+  "sweep-e2e": { metric: "e2eP50", yLabel: "E2E p50 (ms)", decimals: 0 },
+  "sweep-kv-cache": { metric: "kvAvg", yLabel: "KV cache (%)", decimals: 0 },
+  "sweep-queue": { metric: "queueDepth", yLabel: "Queue depth", decimals: 1 },
+};
 
 /** Index of the baseline stage within `rows` (preserving their order). Falls
  * back to the first stage when no baseline is set or it was filtered out. */
@@ -119,6 +151,26 @@ export const FigureRenderer = memo(function FigureRenderer({
       hasLatencyCdf: !!r.benchmark?.latencyCdf?.samples?.length,
     })),
   );
+  // Sweep figures: aggregate runs into per-engine series over the concurrency
+  // axis. Colors are keyed by SERIES (engine) so a 3-engine sweep uses 3 colors,
+  // never wrapping the 8-color palette. Merge the renderable sweep refIds into
+  // the availability set so the gate below passes for them.
+  const sweepSeries = aggregateSweep(
+    buildSweepRuns(
+      runs.map((r) => ({
+        x: r.paramsSummary.concurrency,
+        series: r.series,
+        summaryMetrics: r.summaryMetrics,
+        serverMetrics: r.benchmark?.serverMetrics,
+      })),
+    ),
+  );
+  const seriesColor = assignRunColors(
+    sweepSeries.map((s) => s.seriesKey),
+    REPORT_PALETTE,
+  );
+  for (const id of availableSweepFigures(sweepSeries)) available.add(id);
+
   if (!available.has(refId)) {
     return (
       <figure className="pr-figure">
@@ -385,6 +437,23 @@ export const FigureRenderer = memo(function FigureRenderer({
     chart = <ColdWarmDeltaTable runs={runs} baselineId={baselineId} />;
   } else if (refId === "compare-grid") {
     chart = <FourMetricTable runs={runs} />;
+  } else if (refId in SWEEP_FIGURE_SPEC) {
+    const spec = SWEEP_FIGURE_SPEC[refId as keyof typeof SWEEP_FIGURE_SPEC];
+    chart = (
+      <SweepLineChart
+        series={toSweepLineSeries(
+          sweepSeries,
+          spec.metric,
+          (key) => seriesColor[key] ?? REPORT_PALETTE[0],
+          spec.secondary,
+        )}
+        yLabel={spec.yLabel}
+        logY={spec.logY}
+        valueFormatter={(v) => v.toFixed(spec.decimals)}
+        primaryName={spec.primaryName}
+        secondaryName={spec.secondaryName}
+      />
+    );
   }
 
   return (

--- a/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
+++ b/apps/web/src/features/benchmarks/compare/FigureRenderer.tsx
@@ -1,4 +1,9 @@
-import { aggregateSweep, type FigureRefId, type SweepMetricKey } from "@modeldoctor/contracts";
+import {
+  aggregateSweep,
+  availableSweepFigures,
+  type FigureRefId,
+  type SweepMetricKey,
+} from "@modeldoctor/contracts";
 import { memo } from "react";
 import { assignRunColors } from "@/components/charts/_shared";
 import { LatencyCDF } from "@/components/charts/LatencyCDF";
@@ -21,7 +26,7 @@ import {
   summarizeForPrompt,
 } from "./client-metrics";
 import type { ReportRun } from "./ReportSections";
-import { availableSweepFigures, buildSweepRuns, toSweepLineSeries } from "./sweep-data";
+import { buildSweepRuns, toSweepLineSeries } from "./sweep-data";
 
 export interface FigureRendererProps {
   refId: FigureRefId;

--- a/apps/web/src/features/benchmarks/compare/ReportSections.tsx
+++ b/apps/web/src/features/benchmarks/compare/ReportSections.tsx
@@ -60,6 +60,9 @@ export interface ReportRun extends StageRun {
    *  underlying benchmark was deleted. */
   benchmark: ReportBenchmarkSnapshot | null;
   paramsSummary: { concurrency?: number };
+  /** Sweep series identity — set in sweep mode so runs group into lines by
+   *  engine/connection. key = connectionId (stable), label = engine kind. */
+  series?: { key: string; label: string };
 }
 
 export interface ReportSectionsProps {

--- a/apps/web/src/features/benchmarks/compare/SaveCompareDialog.tsx
+++ b/apps/web/src/features/benchmarks/compare/SaveCompareDialog.tsx
@@ -133,6 +133,9 @@ export function SaveCompareDialog({
   const [ctx, setCtx] = useState(context);
   const [classification, setClassification] = useState<Classification>("internal");
   const [clientName, setClientName] = useState("");
+  // Sweep mode: render the report as metric-vs-concurrency line charts grouped
+  // by engine (instead of per-run bars), and lift the run cap to 50.
+  const [sweepMode, setSweepMode] = useState(false);
 
   // Re-seed order + labels from the latest matrix order/labels on the
   // closed→open transition only. The component stays mounted across open/close,
@@ -184,6 +187,8 @@ export function SaveCompareDialog({
       context: ctx.trim() || undefined,
       classification,
       clientName: clientName.trim() || undefined,
+      reportKind: sweepMode ? "sweep" : undefined,
+      sweepAxis: sweepMode ? "parallel" : undefined,
     });
     onOpenChange(false);
     const suffix = generateAfterSave ? "?generate=1" : "";
@@ -282,6 +287,28 @@ export function SaveCompareDialog({
               />
             </div>
           </div>
+          <label className="flex items-start gap-2 text-sm" htmlFor="sc-sweep">
+            <input
+              id="sc-sweep"
+              type="checkbox"
+              className="mt-0.5"
+              checked={sweepMode}
+              onChange={(e) => setSweepMode(e.target.checked)}
+            />
+            <span>
+              <span className="font-medium">
+                {t("savedCompare.dialog.sweepLabel", {
+                  defaultValue: "Sweep mode (concurrency curves)",
+                })}
+              </span>
+              <span className="block text-muted-foreground">
+                {t("savedCompare.dialog.sweepHint", {
+                  defaultValue:
+                    "Plot metric-vs-concurrency lines grouped by engine; allows up to 50 runs. Use when comparing one workload swept across concurrency levels.",
+                })}
+              </span>
+            </span>
+          </label>
           {create.error ? (
             <div className="text-sm text-rose-600">{create.error.message}</div>
           ) : null}

--- a/apps/web/src/features/benchmarks/compare/sweep-data.test.ts
+++ b/apps/web/src/features/benchmarks/compare/sweep-data.test.ts
@@ -1,0 +1,74 @@
+import type { SweepSeries } from "@modeldoctor/contracts";
+import { describe, expect, it } from "vitest";
+import { availableSweepFigures, buildSweepRuns, toSweepLineSeries } from "./sweep-data";
+
+describe("buildSweepRuns", () => {
+  it("drops runs without an x value or series identity", () => {
+    const out = buildSweepRuns([
+      { x: 8, series: { key: "c-v", label: "vLLM" }, summaryMetrics: null },
+      { x: undefined, series: { key: "c-v", label: "vLLM" }, summaryMetrics: null },
+      { x: 16, series: undefined, summaryMetrics: null },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ seriesKey: "c-v", x: 8 });
+  });
+});
+
+const series: SweepSeries[] = [
+  {
+    seriesKey: "c-v",
+    seriesLabel: "vLLM",
+    points: [
+      { x: 8, values: { outTps: 145, ttftP50: 283, ttftP95: 545, kvAvg: 4 }, n: 1 },
+      { x: 16, values: { outTps: 280, ttftP50: 803, ttftP95: 1963, kvAvg: 6 }, n: 1 },
+    ],
+  },
+  {
+    seriesKey: "c-m",
+    seriesLabel: "MindIE",
+    points: [
+      { x: 8, values: { outTps: 177, ttftP50: 456, ttftP95: 1166, kvAvg: 5 }, n: 1 },
+      { x: 16, values: { outTps: 296, ttftP50: 1150, ttftP95: 6245, kvAvg: 8 }, n: 1 },
+    ],
+  },
+];
+
+describe("availableSweepFigures", () => {
+  it("offers a figure when ≥2 series each have ≥2 points for the metric", () => {
+    const out = availableSweepFigures(series);
+    expect(out.has("sweep-throughput")).toBe(true);
+    expect(out.has("sweep-ttft")).toBe(true);
+    expect(out.has("sweep-kv-cache")).toBe(true);
+    // No itl/e2e/queue data → not offered.
+    expect(out.has("sweep-itl")).toBe(false);
+    expect(out.has("sweep-queue")).toBe(false);
+  });
+
+  it("withholds a figure when only one series has the metric", () => {
+    const oneSided: SweepSeries[] = [
+      series[0],
+      { seriesKey: "c-m", seriesLabel: "MindIE", points: [{ x: 8, values: {}, n: 0 }] },
+    ];
+    expect(availableSweepFigures(oneSided).has("sweep-throughput")).toBe(false);
+  });
+});
+
+describe("toSweepLineSeries", () => {
+  it("maps the primary metric + optional dashed secondary, with per-series color", () => {
+    const out = toSweepLineSeries(series, "ttftP50", (k) => (k === "c-v" ? "#blue" : "#green"), "ttftP95");
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({ label: "vLLM", color: "#blue" });
+    expect(out[0].points).toEqual([
+      { x: 8, y: 283 },
+      { x: 16, y: 803 },
+    ]);
+    expect(out[0].secondary).toEqual([
+      { x: 8, y: 545 },
+      { x: 16, y: 1963 },
+    ]);
+    // Missing metric → null y (no dropped points; the chart filters nulls).
+    const noSecondary = toSweepLineSeries(series, "itlP50", () => "#x");
+    expect(noSecondary[0].points.every((p) => p.y === null)).toBe(true);
+    expect(noSecondary[0].secondary).toBeUndefined();
+  });
+});

--- a/apps/web/src/features/benchmarks/compare/sweep-data.test.ts
+++ b/apps/web/src/features/benchmarks/compare/sweep-data.test.ts
@@ -73,6 +73,7 @@ describe("toSweepLineSeries", () => {
     ]);
     // Missing metric → null y (no dropped points; the chart filters nulls).
     const noSecondary = toSweepLineSeries(series, "itlP50", () => "#x");
+    expect(noSecondary[0].points).toHaveLength(2);
     expect(noSecondary[0].points.every((p) => p.y === null)).toBe(true);
     expect(noSecondary[0].secondary).toBeUndefined();
   });

--- a/apps/web/src/features/benchmarks/compare/sweep-data.test.ts
+++ b/apps/web/src/features/benchmarks/compare/sweep-data.test.ts
@@ -1,6 +1,6 @@
-import type { SweepSeries } from "@modeldoctor/contracts";
+import { availableSweepFigures, type SweepSeries } from "@modeldoctor/contracts";
 import { describe, expect, it } from "vitest";
-import { availableSweepFigures, buildSweepRuns, toSweepLineSeries } from "./sweep-data";
+import { buildSweepRuns, toSweepLineSeries } from "./sweep-data";
 
 describe("buildSweepRuns", () => {
   it("drops runs without an x value or series identity", () => {
@@ -55,7 +55,12 @@ describe("availableSweepFigures", () => {
 
 describe("toSweepLineSeries", () => {
   it("maps the primary metric + optional dashed secondary, with per-series color", () => {
-    const out = toSweepLineSeries(series, "ttftP50", (k) => (k === "c-v" ? "#blue" : "#green"), "ttftP95");
+    const out = toSweepLineSeries(
+      series,
+      "ttftP50",
+      (k) => (k === "c-v" ? "#blue" : "#green"),
+      "ttftP95",
+    );
     expect(out).toHaveLength(2);
     expect(out[0]).toMatchObject({ label: "vLLM", color: "#blue" });
     expect(out[0].points).toEqual([

--- a/apps/web/src/features/benchmarks/compare/sweep-data.ts
+++ b/apps/web/src/features/benchmarks/compare/sweep-data.ts
@@ -1,9 +1,4 @@
-import type {
-  FigureRefId,
-  SweepMetricKey,
-  SweepRunInput,
-  SweepSeries,
-} from "@modeldoctor/contracts";
+import type { SweepMetricKey, SweepRunInput, SweepSeries } from "@modeldoctor/contracts";
 import { readMetricSafe } from "@modeldoctor/tool-adapters/schemas";
 import type { SweepLineSeries } from "../../../components/charts/SweepLineChart";
 import { readEngineMetric } from "./client-metrics";
@@ -46,33 +41,6 @@ export function buildSweepRuns(runs: SweepRunSource[]): SweepRunInput[] {
         queueDepth: queue?.avg ?? null,
       },
     });
-  }
-  return out;
-}
-
-/** Each sweep figure → the primary metric it plots (sweep-ttft adds a p95
- * dashed line, handled in the renderer). */
-export const SWEEP_FIGURE_METRIC: Record<
-  "sweep-throughput" | "sweep-ttft" | "sweep-itl" | "sweep-e2e" | "sweep-kv-cache" | "sweep-queue",
-  SweepMetricKey
-> = {
-  "sweep-throughput": "outTps",
-  "sweep-ttft": "ttftP50",
-  "sweep-itl": "itlP50",
-  "sweep-e2e": "e2eP50",
-  "sweep-kv-cache": "kvAvg",
-  "sweep-queue": "queueDepth",
-};
-
-/** A sweep figure is renderable when ≥2 series each carry ≥2 points for that
- * metric (a single point or a single series isn't a curve worth a line chart). */
-export function availableSweepFigures(series: SweepSeries[]): Set<FigureRefId> {
-  const out = new Set<FigureRefId>();
-  const seriesWith = (metric: SweepMetricKey) =>
-    series.filter((s) => s.points.filter((p) => typeof p.values[metric] === "number").length >= 2)
-      .length;
-  for (const [refId, metric] of Object.entries(SWEEP_FIGURE_METRIC)) {
-    if (seriesWith(metric) >= 2) out.add(refId as FigureRefId);
   }
   return out;
 }

--- a/apps/web/src/features/benchmarks/compare/sweep-data.ts
+++ b/apps/web/src/features/benchmarks/compare/sweep-data.ts
@@ -1,0 +1,96 @@
+import type {
+  FigureRefId,
+  SweepMetricKey,
+  SweepRunInput,
+  SweepSeries,
+} from "@modeldoctor/contracts";
+import { readMetricSafe } from "@modeldoctor/tool-adapters/schemas";
+import type { SweepLineSeries } from "../../../components/charts/SweepLineChart";
+import { readEngineMetric } from "./client-metrics";
+
+/** Minimal per-run shape buildSweepRuns needs (subset of ReportRun) — avoids a
+ * type cycle with ReportSections while staying structurally compatible. */
+export interface SweepRunSource {
+  x?: number;
+  series?: { key: string; label: string };
+  summaryMetrics: unknown;
+  serverMetrics?: unknown;
+}
+
+/** Extract each run's sweep metrics (client mirror of the server extractor).
+ * Runs without an x value or series identity are dropped — they can't sit on a
+ * sweep axis. Throughput is output tok/s (the headline metric); rps kept too. */
+export function buildSweepRuns(runs: SweepRunSource[]): SweepRunInput[] {
+  const out: SweepRunInput[] = [];
+  for (const r of runs) {
+    if (typeof r.x !== "number" || !r.series) continue;
+    const sm = r.summaryMetrics;
+    const num = (kind: Parameters<typeof readMetricSafe>[0]): number | null => {
+      const v = readMetricSafe(kind, sm as { tool?: unknown; data?: unknown } | null);
+      return typeof v === "number" ? v : null;
+    };
+    const kv = readEngineMetric(r.serverMetrics, "kv_cache_usage");
+    const queue = readEngineMetric(r.serverMetrics, "scheduler_waiting");
+    out.push({
+      seriesKey: r.series.key,
+      seriesLabel: r.series.label,
+      x: r.x,
+      metrics: {
+        outTps: num("outputTokensPerSec"),
+        rps: num("requestsPerSec"),
+        ttftP50: num("ttft.p50"),
+        ttftP95: num("ttft.p95"),
+        itlP50: num("itl.p50"),
+        e2eP50: num("e2e.p50"),
+        kvAvg: kv?.avg ?? null,
+        queueDepth: queue?.avg ?? null,
+      },
+    });
+  }
+  return out;
+}
+
+/** Each sweep figure → the primary metric it plots (sweep-ttft adds a p95
+ * dashed line, handled in the renderer). */
+export const SWEEP_FIGURE_METRIC: Record<
+  "sweep-throughput" | "sweep-ttft" | "sweep-itl" | "sweep-e2e" | "sweep-kv-cache" | "sweep-queue",
+  SweepMetricKey
+> = {
+  "sweep-throughput": "outTps",
+  "sweep-ttft": "ttftP50",
+  "sweep-itl": "itlP50",
+  "sweep-e2e": "e2eP50",
+  "sweep-kv-cache": "kvAvg",
+  "sweep-queue": "queueDepth",
+};
+
+/** A sweep figure is renderable when ≥2 series each carry ≥2 points for that
+ * metric (a single point or a single series isn't a curve worth a line chart). */
+export function availableSweepFigures(series: SweepSeries[]): Set<FigureRefId> {
+  const out = new Set<FigureRefId>();
+  const seriesWith = (metric: SweepMetricKey) =>
+    series.filter((s) => s.points.filter((p) => typeof p.values[metric] === "number").length >= 2)
+      .length;
+  for (const [refId, metric] of Object.entries(SWEEP_FIGURE_METRIC)) {
+    if (seriesWith(metric) >= 2) out.add(refId as FigureRefId);
+  }
+  return out;
+}
+
+/** Map aggregated sweep series → SweepLineChart series for one metric, assigning
+ * each series its identity color. `secondaryMetric` adds a dashed line (p95). */
+export function toSweepLineSeries(
+  series: SweepSeries[],
+  metric: SweepMetricKey,
+  colorFor: (seriesKey: string) => string,
+  secondaryMetric?: SweepMetricKey,
+): SweepLineSeries[] {
+  return series.map((s) => ({
+    label: s.seriesLabel,
+    color: colorFor(s.seriesKey),
+    points: s.points.map((p) => ({ x: p.x, y: p.values[metric] ?? null })),
+    secondary: secondaryMetric
+      ? s.points.map((p) => ({ x: p.x, y: p.values[secondaryMetric] ?? null }))
+      : undefined,
+  }));
+}

--- a/apps/web/src/features/benchmarks/compare/to-report-runs.ts
+++ b/apps/web/src/features/benchmarks/compare/to-report-runs.ts
@@ -9,8 +9,11 @@ import type { ReportRun } from "./ReportSections";
 export function extractParamsSummary(params: unknown): ReportRun["paramsSummary"] {
   if (!params || typeof params !== "object") return {};
   const p = params as Record<string, unknown>;
+  // aiperf/genai-perf use `concurrency`; evalscope uses `parallel` — both are
+  // the per-run concurrency that forms the sweep x-axis.
+  const c = typeof p.concurrency === "number" ? p.concurrency : p.parallel;
   return {
-    concurrency: typeof p.concurrency === "number" ? p.concurrency : undefined,
+    concurrency: typeof c === "number" ? c : undefined,
   };
 }
 
@@ -49,5 +52,11 @@ export function toReportRuns(benchmarks: HydratedBenchmarkRef[]): ReportRun[] {
           latencyCdf: b.latencyCdf ?? null,
         },
     paramsSummary: extractParamsSummary(b.params),
+    // Sweep series identity: group by connection, label by engine kind. Falls
+    // back to stageLabel when a run has no connection (won't sweep-group, but
+    // stays a distinct series rather than collapsing).
+    series: b.connectionId
+      ? { key: b.connectionId, label: b.engineKind ?? b.connectionId }
+      : { key: b.id, label: b.engineKind ?? b.stageLabel },
   }));
 }

--- a/apps/web/src/locales/en-US/common.json
+++ b/apps/web/src/locales/en-US/common.json
@@ -93,7 +93,7 @@
     "apiKeyControlChar": "API key must not contain control characters",
     "apiKeyTrim": "API key must not have leading or trailing whitespace",
     "compareMinRuns": "A compare requires at least 2 benchmarks",
-    "compareMaxRuns": "A compare can include at most 10 benchmarks",
+    "compareMaxRuns": "Too many benchmarks (at most 10 for a discrete compare, 50 in sweep mode)",
     "invalidCompareConfiguration": "Invalid compare configuration: every benchmark needs a stage label, and the baseline must be one of the selected benchmarks",
     "runDualVsBaselineExclusive": "Cannot enable dual-endpoint and baseline-run comparison at the same time",
     "endpointABMustDiffer": "Endpoint A and Endpoint B must be different connections"

--- a/apps/web/src/locales/zh-CN/common.json
+++ b/apps/web/src/locales/zh-CN/common.json
@@ -93,7 +93,7 @@
     "apiKeyControlChar": "API Key 不能包含控制字符",
     "apiKeyTrim": "API Key 不能含首尾空白",
     "compareMinRuns": "对比至少需要 2 个基准",
-    "compareMaxRuns": "对比最多包含 10 个基准",
+    "compareMaxRuns": "对比基准数超出上限(普通对比最多 10 个,扫描模式最多 50 个)",
     "invalidCompareConfiguration": "对比配置无效：每个基准都要有 stage label，baseline（若设置）必须在选中的基准里",
     "runDualVsBaselineExclusive": "双端点对比与历史 baseline 对比不能同时启用",
     "endpointABMustDiffer": "Endpoint A 和 Endpoint B 不能选择同一个连接"

--- a/packages/contracts/src/saved-compares/compare-narrative.ts
+++ b/packages/contracts/src/saved-compares/compare-narrative.ts
@@ -97,6 +97,17 @@ export const figureRefIdSchema = z.enum([
   // Phase-2 figure — rendered from HydratedBenchmarkRef.latencyCdf.samples;
   // shows the e2e latency CDF across runs for guidellm/vegeta tools.
   "latency-distribution",
+  // Sweep figures (reportKind="sweep") — metric-vs-axis line charts across the
+  // whole sweep, one line per SERIES (engine/connection), aggregated to the
+  // per-(series,x) median. Distinct from the guidellm-only
+  // `throughput-vs-concurrency` (single-run capacityCurve): these are cross-run.
+  // sweep-ttft draws p50 solid + p95 dashed; the rest are single lines.
+  "sweep-throughput",
+  "sweep-ttft",
+  "sweep-itl",
+  "sweep-e2e",
+  "sweep-kv-cache",
+  "sweep-queue",
 ]);
 export type FigureRefId = z.infer<typeof figureRefIdSchema>;
 

--- a/packages/contracts/src/saved-compares/compare-narrative.ts
+++ b/packages/contracts/src/saved-compares/compare-narrative.ts
@@ -108,6 +108,12 @@ export const figureRefIdSchema = z.enum([
   "sweep-e2e",
   "sweep-kv-cache",
   "sweep-queue",
+  // sweep-peak: one bar per engine at the highest concurrency point (the
+  // "who-wins-at-peak-load" verdict snapshot — bars complement the trend
+  // lines). sweep-matrix: the full engine × concurrency median table in the
+  // report body.
+  "sweep-peak",
+  "sweep-matrix",
 ]);
 export type FigureRefId = z.infer<typeof figureRefIdSchema>;
 

--- a/packages/contracts/src/saved-compares/index.ts
+++ b/packages/contracts/src/saved-compares/index.ts
@@ -1,2 +1,3 @@
 export * from "./compare-narrative.js";
 export * from "./saved-compares.js";
+export * from "./sweep.js";

--- a/packages/contracts/src/saved-compares/saved-compares.ts
+++ b/packages/contracts/src/saved-compares/saved-compares.ts
@@ -6,6 +6,23 @@ export type StageLabels = z.infer<typeof stageLabelsSchema>;
 export const classificationSchema = z.enum(["public", "partner", "internal"]);
 export type Classification = z.infer<typeof classificationSchema>;
 
+// Report archetype. null/absent = the default discrete side-by-side stage
+// compare (one bar per run). "sweep" = parametric sweep: members are grouped
+// into series (by connection) across a swept axis and rendered as
+// metric-vs-axis line charts (see report-scenarios/sweep + SweepLineChart).
+export const reportKindSchema = z.enum(["sweep"]);
+export type ReportKind = z.infer<typeof reportKindSchema>;
+
+// The per-run param forming the sweep x-axis. Currently only evalscope's
+// `parallel` (concurrency); reserved for other tools' axes later.
+export const sweepAxisSchema = z.enum(["parallel"]);
+export type SweepAxis = z.infer<typeof sweepAxisSchema>;
+
+// A compare in sweep mode is grouped by series (not capped per-run), so it
+// admits many more members than the discrete side-by-side compare.
+export const COMPARE_MAX_RUNS = 10;
+export const SWEEP_MAX_RUNS = 50;
+
 // Defense-in-depth: each benchmark must have a stage label, and the baseline
 // (when set) must reference one of the benchmarks. The UI's create flows
 // already build stageLabels from benchmarkIds, but this guards the server
@@ -25,7 +42,7 @@ export const savedCompareSchema = z
     id: z.string(),
     userId: z.string(),
     name: z.string().min(1).max(200),
-    benchmarkIds: z.array(z.string()).max(10),
+    benchmarkIds: z.array(z.string()).max(SWEEP_MAX_RUNS),
     stageLabels: stageLabelsSchema,
     baselineId: z.string().nullable(),
     context: z.string().nullable(),
@@ -34,6 +51,8 @@ export const savedCompareSchema = z
     version: z.number().int().positive().default(1),
     scenario: z.string().nullable().optional(),
     tool: z.string().nullable().optional(),
+    reportKind: reportKindSchema.nullable().optional(),
+    sweepAxis: sweepAxisSchema.nullable().optional(),
     narrative: z.unknown().nullable(), // shape lives in compare-narrative.ts; kept loose here
     narrativeAt: z.string().datetime().nullable(),
     createdAt: z.string().datetime(),
@@ -43,10 +62,13 @@ export const savedCompareSchema = z
     message: "validation.compareMinRuns",
     path: ["benchmarkIds"],
   })
-  .refine((s) => s.benchmarkIds.length <= 10, {
-    message: "validation.compareMaxRuns",
-    path: ["benchmarkIds"],
-  })
+  .refine(
+    (s) => s.benchmarkIds.length <= (s.reportKind === "sweep" ? SWEEP_MAX_RUNS : COMPARE_MAX_RUNS),
+    {
+      message: "validation.compareMaxRuns",
+      path: ["benchmarkIds"],
+    },
+  )
   .refine(isValidCompareConfig, {
     message: "validation.invalidCompareConfiguration",
     path: ["benchmarkIds"],
@@ -56,21 +78,28 @@ export type SavedCompare = z.infer<typeof savedCompareSchema>;
 export const createSavedCompareRequestSchema = z
   .object({
     name: z.string().min(1).max(200),
-    benchmarkIds: z.array(z.string()).max(10),
+    benchmarkIds: z.array(z.string()).max(SWEEP_MAX_RUNS),
     stageLabels: stageLabelsSchema,
     baselineId: z.string().nullable().optional(),
     context: z.string().max(10_000).nullable().optional(),
     classification: classificationSchema.optional(),
     clientName: z.string().max(120).nullable().optional(),
+    reportKind: reportKindSchema.nullable().optional(),
+    sweepAxis: sweepAxisSchema.nullable().optional(),
   })
   .refine((s) => s.benchmarkIds.length >= 2, {
     message: "validation.compareMinRuns",
     path: ["benchmarkIds"],
   })
-  .refine((s) => s.benchmarkIds.length <= 10, {
-    message: "validation.compareMaxRuns",
-    path: ["benchmarkIds"],
-  })
+  // Discrete compares cap at COMPARE_MAX_RUNS (one bar per run stays readable);
+  // sweep compares group by series, so they admit up to SWEEP_MAX_RUNS.
+  .refine(
+    (s) => s.benchmarkIds.length <= (s.reportKind === "sweep" ? SWEEP_MAX_RUNS : COMPARE_MAX_RUNS),
+    {
+      message: "validation.compareMaxRuns",
+      path: ["benchmarkIds"],
+    },
+  )
   .refine(isValidCompareConfig, {
     message: "validation.invalidCompareConfiguration",
     path: ["benchmarkIds"],
@@ -86,6 +115,11 @@ export interface HydratedBenchmarkRef {
   name?: string | null;
   tool?: string;
   scenario?: string;
+  /** Source connection id + resolved engine kind (Connection.serverKind, e.g.
+   * "vllm" | "mindie" | "sglang"). Sweep mode groups runs into series by
+   * connectionId and labels each series by engineKind. */
+  connectionId?: string | null;
+  engineKind?: string | null;
   summaryMetrics?: unknown;
   /** serverMetrics blob — carries serverMetrics.prefixCache for prefix-cache
    * figures (hit rate / top-pod share) in the compare report. */
@@ -109,6 +143,8 @@ export const updateSavedCompareRequestSchema = z.object({
   context: z.string().max(10_000).nullable().optional(),
   classification: classificationSchema.optional(),
   clientName: z.string().max(120).nullable().optional(),
+  reportKind: reportKindSchema.nullable().optional(),
+  sweepAxis: sweepAxisSchema.nullable().optional(),
 });
 export type UpdateSavedCompareRequest = z.infer<typeof updateSavedCompareRequestSchema>;
 

--- a/packages/contracts/src/saved-compares/sweep.spec.ts
+++ b/packages/contracts/src/saved-compares/sweep.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { aggregateSweep, median, type SweepRunInput } from "./sweep.js";
+
+describe("median", () => {
+  it("returns null for empty", () => {
+    expect(median([])).toBeNull();
+  });
+  it("odd count → middle", () => {
+    expect(median([3, 1, 2])).toBe(2);
+  });
+  it("even count → average of two middles", () => {
+    expect(median([1, 2, 3, 4])).toBe(2.5);
+  });
+  it("ignores non-finite", () => {
+    expect(median([1, Number.NaN, 5])).toBe(3);
+  });
+});
+
+describe("aggregateSweep", () => {
+  const run = (seriesKey: string, x: number, outTps: number, kvAvg?: number): SweepRunInput => ({
+    seriesKey,
+    seriesLabel: seriesKey === "c-v" ? "vLLM" : "MindIE",
+    x,
+    metrics: { outTps, ...(kvAvg !== undefined ? { kvAvg } : {}) },
+  });
+
+  it("groups by series then x, medians repeats per cell", () => {
+    const out = aggregateSweep([
+      run("c-v", 8, 100),
+      run("c-v", 8, 110),
+      run("c-v", 8, 120), // median 110
+      run("c-v", 16, 200),
+      run("c-m", 8, 90),
+    ]);
+    expect(out.map((s) => s.seriesKey)).toEqual(["c-v", "c-m"]); // first-seen order
+    const v = out[0];
+    expect(v.points.map((p) => p.x)).toEqual([8, 16]); // sorted asc
+    expect(v.points[0].values.outTps).toBe(110);
+    expect(v.points[0].n).toBe(3);
+    expect(v.points[1].values.outTps).toBe(200);
+    expect(out[1].points[0].values.outTps).toBe(90);
+  });
+
+  it("sorts points ascending regardless of input order", () => {
+    const out = aggregateSweep([run("c-v", 128, 1), run("c-v", 8, 2), run("c-v", 32, 3)]);
+    expect(out[0].points.map((p) => p.x)).toEqual([8, 32, 128]);
+  });
+
+  it("medians each metric independently; null when a metric is absent", () => {
+    const out = aggregateSweep([run("c-v", 8, 100, 40), run("c-v", 8, 200)]);
+    const p = out[0].points[0];
+    expect(p.values.outTps).toBe(150); // both present → median
+    expect(p.values.kvAvg).toBe(40); // only one had kv → that value
+    expect(p.values.ttftP50).toBeNull(); // none had it
+  });
+});

--- a/packages/contracts/src/saved-compares/sweep.ts
+++ b/packages/contracts/src/saved-compares/sweep.ts
@@ -122,5 +122,13 @@ export function availableSweepFigures(series: SweepSeries[]): Set<FigureRefId> {
   for (const [refId, metric] of Object.entries(SWEEP_FIGURE_METRIC)) {
     if (seriesWith(metric) >= 2) out.add(refId as FigureRefId);
   }
+  // sweep-peak (bars, one engine per bar at its highest-concurrency point):
+  // needs ≥2 series carrying throughput at any point.
+  if (series.filter((s) => s.points.some((p) => typeof p.values.outTps === "number")).length >= 2) {
+    out.add("sweep-peak");
+  }
+  // sweep-matrix (the engine × concurrency data table): renders whenever ≥2
+  // series have any aggregated point.
+  if (series.filter((s) => s.points.length > 0).length >= 2) out.add("sweep-matrix");
   return out;
 }

--- a/packages/contracts/src/saved-compares/sweep.ts
+++ b/packages/contracts/src/saved-compares/sweep.ts
@@ -1,3 +1,5 @@
+import type { FigureRefId } from "./compare-narrative.js";
+
 // Pure sweep aggregation: group benchmark runs into series (by connection) over
 // a swept x-axis (concurrency), taking the median per (series, x) cell across
 // repeats. Metric EXTRACTION (reading summaryMetrics / serverMetrics) stays in
@@ -93,4 +95,32 @@ export function aggregateSweep(runs: SweepRunInput[]): SweepSeries[] {
     series.push({ seriesKey, seriesLabel: s.label, points });
   }
   return series;
+}
+
+/** Each sweep figure refId → the primary metric it plots. sweep-ttft also draws
+ * a p95 dashed line (handled in the renderer). Shared client↔server so the
+ * availability gate + offered-to-LLM list + renderer all agree. */
+export const SWEEP_FIGURE_METRIC: Record<
+  "sweep-throughput" | "sweep-ttft" | "sweep-itl" | "sweep-e2e" | "sweep-kv-cache" | "sweep-queue",
+  SweepMetricKey
+> = {
+  "sweep-throughput": "outTps",
+  "sweep-ttft": "ttftP50",
+  "sweep-itl": "itlP50",
+  "sweep-e2e": "e2eP50",
+  "sweep-kv-cache": "kvAvg",
+  "sweep-queue": "queueDepth",
+};
+
+/** A sweep figure is renderable when ≥2 series each carry ≥2 points for its
+ * metric (a single point or single series isn't a curve worth a line chart). */
+export function availableSweepFigures(series: SweepSeries[]): Set<FigureRefId> {
+  const out = new Set<FigureRefId>();
+  const seriesWith = (metric: SweepMetricKey) =>
+    series.filter((s) => s.points.filter((p) => typeof p.values[metric] === "number").length >= 2)
+      .length;
+  for (const [refId, metric] of Object.entries(SWEEP_FIGURE_METRIC)) {
+    if (seriesWith(metric) >= 2) out.add(refId as FigureRefId);
+  }
+  return out;
 }

--- a/packages/contracts/src/saved-compares/sweep.ts
+++ b/packages/contracts/src/saved-compares/sweep.ts
@@ -1,0 +1,96 @@
+// Pure sweep aggregation: group benchmark runs into series (by connection) over
+// a swept x-axis (concurrency), taking the median per (series, x) cell across
+// repeats. Metric EXTRACTION (reading summaryMetrics / serverMetrics) stays in
+// the per-side readers (api metrics.ts / web client-metrics.ts) which already
+// differ; this module only owns the shared grouping+median so both sides agree.
+
+/** Metric keys a sweep can plot vs the x-axis. Latency in ms, throughput in
+ * tok/s or req/s, kv in %, queueDepth = scheduler waiting count. */
+export const SWEEP_METRIC_KEYS = [
+  "outTps",
+  "rps",
+  "ttftP50",
+  "ttftP95",
+  "itlP50",
+  "e2eP50",
+  "e2eP95",
+  "kvAvg",
+  "kvPeak",
+  "queueDepth",
+] as const;
+export type SweepMetricKey = (typeof SWEEP_METRIC_KEYS)[number];
+
+export type SweepMetricValues = Partial<Record<SweepMetricKey, number | null>>;
+
+/** One run's contribution to a sweep, after the caller extracted its metrics. */
+export interface SweepRunInput {
+  /** Stable series identity — connectionId (falls back to engineKind/label). */
+  seriesKey: string;
+  /** Display label for the series (engine kind, e.g. "vLLM-Ascend"). */
+  seriesLabel: string;
+  /** x-axis value for this run (e.g. params.parallel). */
+  x: number;
+  metrics: SweepMetricValues;
+}
+
+export interface SweepPoint {
+  x: number;
+  /** repeats collapsed to the per-metric median; null when no run had it. */
+  values: SweepMetricValues;
+  /** how many repeats fed this point (per the densest metric). */
+  n: number;
+}
+
+export interface SweepSeries {
+  seriesKey: string;
+  seriesLabel: string;
+  points: SweepPoint[]; // sorted ascending by x
+}
+
+/** Median of finite numbers; null when empty. Average of the two middles for
+ * even counts. Does not mutate the input. */
+export function median(nums: number[]): number | null {
+  const xs = nums.filter((n) => Number.isFinite(n)).sort((a, b) => a - b);
+  if (xs.length === 0) return null;
+  const mid = Math.floor(xs.length / 2);
+  return xs.length % 2 === 0 ? (xs[mid - 1] + xs[mid]) / 2 : xs[mid];
+}
+
+/** Group runs by series, then by x; median each metric across repeats in a cell.
+ * Series are returned in first-seen order; points are sorted ascending by x. */
+export function aggregateSweep(runs: SweepRunInput[]): SweepSeries[] {
+  // Map preserves insertion order → series come out in first-seen order with
+  // no index bookkeeping (and no non-null assertions).
+  const bySeries = new Map<string, { label: string; byX: Map<number, SweepRunInput[]> }>();
+
+  for (const r of runs) {
+    let s = bySeries.get(r.seriesKey);
+    if (!s) {
+      s = { label: r.seriesLabel, byX: new Map() };
+      bySeries.set(r.seriesKey, s);
+    }
+    const cell = s.byX.get(r.x);
+    if (cell) cell.push(r);
+    else s.byX.set(r.x, [r]);
+  }
+
+  const series: SweepSeries[] = [];
+  for (const [seriesKey, s] of bySeries) {
+    const points: SweepPoint[] = [...s.byX.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map(([x, cell]) => {
+        const values: SweepMetricValues = {};
+        let n = 0;
+        for (const key of SWEEP_METRIC_KEYS) {
+          const present = cell
+            .map((r) => r.metrics[key])
+            .filter((v): v is number => typeof v === "number" && Number.isFinite(v));
+          values[key] = median(present);
+          n = Math.max(n, present.length);
+        }
+        return { x, values, n };
+      });
+    series.push({ seriesKey, seriesLabel: s.label, points });
+  }
+  return series;
+}


### PR DESCRIPTION
## 背景

实现 #345:给 SavedCompare 增加 **Sweep / 参数扫描报告模式**。复现三引擎横评(45 轮)时平台报告的 4 个硬伤——c8/c32/c128 看不懂、KV/排队没体现、45 组只显 10、叙述单薄——根因是 SavedCompare 只会"并排比 N 个离散 run(柱)",缺"沿参数轴扫描(折线)"这种报告范式。本 PR 补上它。

单 PR、phase-per-commit(结构垂直耦合,拆多 PR 会合入暂时死代码)。

## 改动(4 commit)

1. **数据底座** — `reportKind`/`sweepAxis` 字段(migration 纯加列,默认 null=旧行为零回归);`COMPARE_MAX_RUNS=10`/`SWEEP_MAX_RUNS=50` + cap refine 改 mode 感知;`HydratedBenchmarkRef` 加 `connectionId`/`engineKind`(getHydrated join `Connection.serverKind`);纯聚合 `aggregateSweep`(按 series×并发取中位数,client↔server 共用)。
2. **折线图** — `SweepLineChart`(泛化 `ThroughputConcurrencyChart`:任意指标/单位/log 轴 + p50 实线/p95 虚线;**按引擎取色 → 3 引擎仅 3 色,8 色板不循环**);6 个 `sweep-*` figure refId(4 处接线);`sweep-data` 抽取(output tok/s 为吞吐头条)+ availability gate;FigureRenderer dispatch。
3. **profile + 服务端叙述** — `sweep` intent/profile;`sweep-prompt` 把全量 series×并发中位数表喂判官;promptFragment 指示叙述扩展曲线/拐点/跨引擎交叉 + KV·排队根因归因;`resolveReportIntent` 增 reportKind 参(sweep 优先);offered-list 并入 sweep 图。
4. **UI 开关** — SaveCompareDialog「Sweep mode」勾选框 → create 带 reportKind;run 上限放 50;cap 文案不再硬编码 10。

## 对照 #345 验收

- ① c8/c32/c128 → 并发成 x 轴折线,自解释 ✓
- ② KV/排队 → `sweep-kv-cache` + `sweep-queue` 折线 + 叙述归因 ✓
- ③ 45 组只显 10 → 按 series 折线 + cap 放 50 ✓
- ④ 太单薄 → sweep profile 聚合矩阵喂判官,讲曲线/拐点 ✓
- `reportKind=null` 既有对比零回归 ✓

#343(引擎内部**时序**进报告)与本 PR 解耦,留独立 PR。

## 验证

- `pnpm -r lint` + `pnpm -r type-check` 均 EXIT=0
- 新增/相关测试:contracts 11 · api saved-compares 106 · web compare 146 全过
- 新增单测:`aggregateSweep`/`median`(7)、`sweep-data`(4)、`sweep-prompt`/`resolveReportIntent`(5)

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)
